### PR TITLE
Fix onnx-converter image dependency

### DIFF
--- a/docker-images/onnx-converter/README.md
+++ b/docker-images/onnx-converter/README.md
@@ -23,7 +23,7 @@ docker pull mcr.microsoft.com/onnxruntime/onnx-converter
 
 Upon success, run Docker onnx-converter image by
 ```
-docker run mcr.microsoft.com/onnxruntime/onnx-converter --model <model_path> --output_onnx_path <output_path_to_.onnx> --model_type <input_model_framework_name> [optional args]
+docker run -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.com/onnxruntime/onnx-converter --model <model_path> --output_onnx_path <output_path_to_.onnx> --model_type <input_model_framework_name> [optional args]
 ```
 
 ### Run With Docker
@@ -34,7 +34,7 @@ docker build -t onnx-converter .
 Then, you can run the docker image with customized parameters. 
 
 ```
-docker run onnx-converter --model <model_path> --output_onnx_path <output_path_to_.onnx> --model_type <input_model_framework_name> [optional args]
+docker run -v <local_directory_to_your_models>:/mnt/ onnx-converter --model <model_path> --output_onnx_path <output_path_to_.onnx> --model_type <input_model_framework_name> [optional args]
 ```
 
 ### Run With Python

--- a/docker-images/onnx-converter/requirements.txt
+++ b/docker-images/onnx-converter/requirements.txt
@@ -1,9 +1,10 @@
-tensorflow
+tensorflow==1.14
 onnxmltools
 
 coremltools
 sklearn
 pandas
+keras
 
 https://cntk.ai/PythonWheel/CPU-Only/cntk-2.6-cp36-cp36m-linux_x86_64.whl
 mxnet==1.4.0


### PR DESCRIPTION
- Fix Keras dependency as pointed out in #15 
- Fix tensorflow version to 1.14 as the newest Tensorflow version is incompatible with the other packages.
- Updated mcr.microsoft.com/onnxruntime/onnx-converter to reflect the changes.