### PR TITLE
Initial support for Nuphar execution provider

### DIFF
--- a/docker-images/perf-tuning/Dockerfile
+++ b/docker-images/perf-tuning/Dockerfile
@@ -3,7 +3,7 @@
 FROM nvidia/cuda:10.0-base
 
 RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 cuda-cublas-10-0 python3-pip 
-RUN python3.7 -m pip install psutil gputil numpy onnx packaging
+RUN python3.7 -m pip install psutil gputil numpy onnx packaging sympy
 
 RUN mkdir /perf_tuning
 COPY bin /perf_tuning/bin

--- a/docker-images/perf-tuning/Dockerfile
+++ b/docker-images/perf-tuning/Dockerfile
@@ -3,7 +3,7 @@
 FROM nvidia/cuda:10.0-base
 
 RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 cuda-cublas-10-0 python3-pip 
-RUN python3.7 -m pip install psutil gputil
+RUN python3.7 -m pip install psutil gputil numpy onnx packaging
 
 RUN mkdir /perf_tuning
 COPY bin /perf_tuning/bin

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -36,6 +36,10 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
                 copy(os.path.join(args.cudnn_home, "bin/cudnn*.dll"), target_dir)
             if args.use_tensorrt:
                 copy(os.path.join(args.tensorrt_home, "lib/nvinfer.dll"), target_dir)
+            if "--use_tvm" in build_args:
+                copy(os.path.join(onnxruntime_dir, "build", "Windows", config, config, "tvm.dll"), target_dir)
+            if "--use_nuphar" in build_args:
+                copy(os.path.join(onnxruntime_dir, "onnxruntime", "core", "providers", "nuphar", "scripts", "symbolic_shape_infer.py"), target_dir)
     else:
         build_env = os.environ.copy()
         lib_path = os.path.join(onnxruntime_dir, "build/Linux", config, "mklml/src/project_mklml/lib/")
@@ -65,6 +69,10 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
                 else:
                     copy(os.path.join(args.tensorrt_home, "lib/libnvinfer.so*"), target_dir)
                     copy(os.path.join(args.tensorrt_home, "lib/libnvinfer_plugin.so*"), target_dir)
+            if "--use_tvm" in build_args:
+                copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external", "tvm", "libtvm.so*"), target_dir)
+            if "--use_nuphar" in build_args:
+                copy(os.path.join(onnxruntime_dir, "onnxruntime", "core", "providers", "nuphar", "scripts", "symbolic_shape_infer.py"), target_dir)
         if "ngraph" in build_name:
             if is_windows():
                 pass
@@ -92,6 +100,8 @@ def parse_arguments():
 
     parser.add_argument("--use_ngraph", action='store_true', help="Build with nGraph")
     parser.add_argument("--use_mklml", action='store_true', help="Build with mklml")
+    parser.add_argument("--use_nuphar", action='store_true', help="Build with Nuphar")
+    parser.add_argument("--llvm_path", help="Path to llvm-build/lib/cmake/llvm")
 
     parser.add_argument("--variants", help="Variants to build. Will build all by default")
 
@@ -127,6 +137,11 @@ if __name__ == "__main__":
                 build_args = build_args + ["--cuda_home", args.cuda_home]
             if args.cudnn_home:
                 build_args = build_args + ["--cudnn_home", args.cudnn_home]
-    
+
+    if args.use_nuphar:
+        build_args += ["--use_tvm", "--use_llvm", "--use_nuphar"]
+        if args.llvm_path:
+            build_args = build_args + ["--llvm_path", args.llvm_path]
+
     build_onnxruntime(args.onnxruntime_home, args.config, build_args, "all_eps", args)
 

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -398,7 +398,7 @@ if __name__ == "__main__":
     bin_dir = os.path.join(os.path.dirname(__file__), "bin", args.config)
     build_dirs = os.listdir(bin_dir)
 
-    allProviders = ["mklml", "cpu_openmp", "dnnl", "cpu", "tensorrt", "ngraph", "cuda"]
+    allProviders = ["mklml", "cpu_openmp", "dnnl", "cpu", "tensorrt", "ngraph", "cuda", "nuphar"]
     # Get all execution providers needed to run in current context
     providers = [p for p in args.execution_provider.split(",") if p != ""] if len(args.execution_provider) > 0 else allProviders
 
@@ -427,7 +427,7 @@ if __name__ == "__main__":
             build_path = os.path.join(bin_dir, "all_eps")
         else:
             raise ValueError("Provider %s is not currently supported. \
-                Please choose one of cpu, cpu_openmp, dnnl, mklml, cuda, tensorrt or ngraph",
+                Please choose one of cpu, cpu_openmp, dnnl, mklml, cuda, tensorrt, ngraph or nuphar",
                 build_name)
         if os.path.isdir(build_path):
             # If current build is requested by user, run perf tuning
@@ -443,7 +443,9 @@ if __name__ == "__main__":
                 test_args = test_args + ["-e", "tensorrt"]
             if "ngraph" in build_name:
                 test_args = test_args + ["-e", "ngraph"]
-            
+            if "nuphar" in build_name:
+                test_args = test_args + ["-e", "nuphar"]
+
             env_vars = ep_envvar_map.get(build_name)
             env_var_combos = get_env_var_combos(env_vars)
             env_names = list(env_vars.keys()) if env_vars is not None else []


### PR DESCRIPTION
Steps to try it out:
1. Build onnxruntime with Nuphar:
```
python ./build_perf_tuning.py --onnxruntime_home /path/to/ort --use_nuphar
```
You may specify --llvm_path /path/to/llvm-build/lib/cmake/llvm if llvm is not found. Linux prebuilt could be downloaded [here](http://releases.llvm.org/download.html)

2. build docker image with onnxruntime binaries:
```
cd /OLive_root/docker-images/perf-tuning
docker build -t perf_tuning -f Dockerfile .
```

3. run symbolic shape inference on input model using the image (mounting data which holds the models):
```
 docker run -v ~/data:/data --entrypoint python3.7 -t perf_tuning /perf_tuning/bin/RelWithDebInfo/all_eps/symbolic_shape_infer.py --input /data/path/to/model --output /data/path/to/shape_inferred_model --auto_merge
```

4. run perf_tuning with nuphar:
```
docker run -v ~/data:/data -t perf_tuning -e nuphar --model /data/path/to/shape_inferred_model  --result /data
```

Note that other scripts for model-editing/quantization/AOT are not included yet in this initial step.