### PR TITLE
Update onnx-converter and perf-tuning to onnxruntime 1.1.2

### DIFF
--- a/docker-images/onnx-converter/Dockerfile
+++ b/docker-images/onnx-converter/Dockerfile
@@ -8,18 +8,23 @@ COPY src/check_model.py src/check_model.py
 COPY src/create_input.py src/create_input.py
 
 # Install OpenMp dependency
-ARG OPENMPI_VERSION=1.10.7
-RUN wget -q -O - https://cntkbuildstorage.blob.core.windows.net/cntk-ci-dependencies/openmpi/$OPENMPI_VERSION/openmpi-$OPENMPI_VERSION.tar.gz | tar -xzf - && \
-    cd openmpi-${OPENMPI_VERSION} && \
-    apt-get -y update && \
+# ARG OPENMPI_VERSION=1.10.7
+# RUN wget -q -O - https://cntkbuildstorage.blob.core.windows.net/cntk-ci-dependencies/openmpi/$OPENMPI_VERSION/openmpi-$OPENMPI_VERSION.tar.gz | tar -xzf - && \
+#     cd openmpi-${OPENMPI_VERSION} && \
+#     apt-get -y update && \
+#     apt-get -y -f install && \
+#     apt-get -y install libsysfs2 libsysfs-dev && \
+#     ./configure --prefix=/usr/local/mpi && \
+#     make -j $(nproc) install && \
+#     cd .. && \
+#     rm -rf openmpi-${OPENMPI_VERSION}
+RUN apt-get -y update && \
     apt-get -y -f install && \
-    apt-get -y install libsysfs2 libsysfs-dev && \
-    ./configure --prefix=/usr/local/mpi && \
-    make -j $(nproc) install && \
-    cd .. && \
-    rm -rf openmpi-${OPENMPI_VERSION}
+    apt-get -y install openmpi-bin
+RUN ln -s /usr/lib/x86_64-linux-gnu/libmpi_cxx.so.40 /usr/lib/x86_64-linux-gnu/libmpi_cxx.so.1 && \
+    ln -s /usr/lib/x86_64-linux-gnu/libmpi.so.40.10.3 /usr/lib/x86_64-linux-gnu/libmpi.so.12
 ENV PATH /usr/local/mpi/bin:$PATH
-ENV LD_LIBRARY_PATH /usr/local/mpi/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/mpi/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
 # Install Python Requirements
 RUN pip3 install --upgrade pip \ 

--- a/docker-images/onnx-converter/requirements.txt
+++ b/docker-images/onnx-converter/requirements.txt
@@ -1,19 +1,19 @@
-tensorflow==1.14
+tensorflow==1.15
 onnxmltools
 
 coremltools
 sklearn
 pandas
-keras
+keras==2.2.4
 
-https://cntk.ai/PythonWheel/CPU-Only/cntk-2.6-cp36-cp36m-linux_x86_64.whl
-mxnet==1.4.0
+# https://cntk.ai/PythonWheel/CPU-Only/cntk-2.6-cp36-cp36m-linux_x86_64.whl
+cntk
 numpy==1.16.0
 
-torch==1.0.1
-torchvision==0.2.1
+torch
+torchvision
 
-xgboost==0.81
-lightgbm==2.2.3
+# xgboost==0.81
+# lightgbm==2.2.3
 tf2onnx
 onnxruntime

--- a/docker-images/onnx-converter/src/onnx_converter.py
+++ b/docker-images/onnx-converter/src/onnx_converter.py
@@ -32,7 +32,7 @@ def get_args():
         "--model_type", 
         required=False,
         help="The type of original model. \
-            Available types are caffe, cntk, coreml, keras, libsvm, lightgbm, mxnet, pytorch, scikit-learn, tensorflow and xgboost"
+            Available types are cntk, coreml, keras, scikit-learn, tensorflow and pytorch."
     )
     parser.add_argument(
         "--model_inputs_names", 
@@ -264,7 +264,7 @@ def convert_models(args):
     if converters.get(args.model_type) == None:
         raise ValueError('Model type {} is not currently supported. \n\
             Please select one of the following model types -\n\
-                caffe, cntk, coreml, keras, libsvm, lightgbm, mxnet, pytorch, scikit-learn, tensorflow or xgboost'.format(args.model_type))
+                cntk, coreml, keras, pytorch, scikit-learn, tensorflow'.format(args.model_type))
     
     suffix = suffix_format_map.get(model_extension)
 

--- a/docker-images/perf-tuning/src/maps.py
+++ b/docker-images/perf-tuning/src/maps.py
@@ -7,17 +7,23 @@ model_ep_map = {
 
 ep_graphOptimizer_map = {
     # Placeholder for assigning graph optimizer to executer provider
-    "cpu": 2,
-    "cpu_openmp": 2,
-    "cuda": 2,
-    "mkldnn": 2,
-    "ngraph": 2,
-    "tensorrt": 2
 }
 
 ep_envvar_map = {
-    # Placeholder to tune environment variables based on execution provid
+    # Placeholder to tune environment variables based on execution provider
     "cpu_openmp": {
+        "OMP_WAIT_POLICY": ["active", "passive"],
+        },
+    "mklml": {
+        "OMP_WAIT_POLICY": ["active", "passive"],
+        },
+    "dnnl": {
+        "OMP_WAIT_POLICY": ["active", "passive"],
+        },
+    "ngraph": {
+        "OMP_WAIT_POLICY": ["active", "passive"],
+        },
+    "nuphar": {
         "OMP_WAIT_POLICY": ["active", "passive"],
         }
 }

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -5190,13 +5190,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5209,18 +5207,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5323,8 +5318,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5334,7 +5328,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5347,20 +5340,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5377,7 +5367,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5450,8 +5439,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5461,7 +5449,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5567,7 +5554,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/web/frontend/src/components/ConvertResult.vue
+++ b/web/frontend/src/components/ConvertResult.vue
@@ -23,7 +23,7 @@
             <h5>Error:
             <b-badge variant="danger">{{convert_result['output_json']['error_message']}}</b-badge>
             </h5>
-            <div v-if="convert_result['output_json']['error_message'].length == 0">
+            <div v-if="convert_result['output_json']['conversion_status'] == 'SUCCESS'">
                 <h5>Download</h5>
                 <a :href="host + ':5000/' + convert_result['input_path']" download>[input] </a>
                 <a :href="host + ':5000/' + convert_result['model_path']" download>[model]</a>


### PR DESCRIPTION
- Updated `mcr.microsoft.com/onnxruntime/onnx-converter` docker image to use the latest converter modules.
- Updated `mcr.microsoft.com/onnxruntime/perf-tuning` to use build onnxruntime 1.1.2
        - Set "-x 1" when tuning OMP_NUM_THREADS
        - Fix code snippet to correctly generate code for parallel execution mode
        - Add OMP environment variables tuning for Nuphar, DNNL and nGraph
        - Tune "-x" in sequential execution mode before parallel execution mode
- Fixed support for Nuphar execution provider. 
        - Build Nuphar with MKLML instead of MLAS.
        - Use OpenMP environment variables for Nuphar thread pool tuning. 
- Improved web app UI to generate model download link in onnx-converter even when the inputs are not successfully generated
