### PR TITLE
 Build nGraph Separately in Perf-tuning Docker Image

### DIFF
--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -70,17 +70,14 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
                 else:
                     copy(os.path.join(args.tensorrt_home, "lib/libnvinfer.so*"), target_dir)
                     copy(os.path.join(args.tensorrt_home, "lib/libnvinfer_plugin.so*"), target_dir)
-            if args.use_ngraph:
-                if is_windows():
-                    pass
-                else:
-                    copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external/ngraph/lib/lib*.so*"), target_dir)
+            
         if "mklml" in build_name:
             if "--use_tvm" in build_args:
                 copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external", "tvm", "libtvm.so*"), target_dir)
             if "--use_nuphar" in build_args:
                 copy(os.path.join(onnxruntime_dir, "onnxruntime", "core", "providers", "nuphar", "scripts", "symbolic_shape_infer.py"), target_dir)
-
+        if "--use_ngraph" in build_args:
+            copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external/ngraph/lib/lib*.so*"), target_dir)
 def parse_arguments():
     parser = argparse.ArgumentParser()
 

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -115,6 +115,7 @@ if __name__ == "__main__":
         if args.llvm_path:
             nuphar_args = nuphar_args + ["--llvm_path", args.llvm_path]
     if args.use_ngraph:
+        # Build ngraph as a separate build
         build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_ngraph", "--use_openmp"] + nuphar_args, "ngraph", args)
     if args.use_mklml:
         # Build mklml + nuphar in one build

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -89,14 +89,13 @@ def parse_arguments():
     parser.add_argument("--config", default="RelWithDebInfo",
                         choices=["Debug", "MinSizeRel", "Release", "RelWithDebInfo"],
                         help="Configuration to build.")
-
+    parser.add_argument("--use_openmp", action='store_true', help="Enable OpenMP.")
     parser.add_argument("--use_cuda", action='store_true', help="Enable CUDA.")
     parser.add_argument("--cuda_version", help="The version of CUDA toolkit to use. Auto-detect if not specified. e.g. 9.0")
     parser.add_argument("--cuda_home", help="Path to CUDA home."
                                             "Read from CUDA_HOME environment variable if --use_cuda is true and --cuda_home is not specified.")
     parser.add_argument("--cudnn_home", help="Path to CUDNN home. "
                                              "Read from CUDNN_HOME environment variable if --use_cuda is true and --cudnn_home is not specified.")
-
     parser.add_argument("--use_tensorrt", action='store_true', help="Build with TensorRT")
     parser.add_argument("--tensorrt_home", help="Path to TensorRT installation dir")
 
@@ -112,9 +111,11 @@ def parse_arguments():
 if __name__ == "__main__":
     args = parse_arguments()
 
-    build_args = ["--parallel", "--use_dnnl", "--use_openmp"]
+    build_args = ["--parallel", "--use_dnnl"]
     nuphar_args = []
 
+    if args.use_openmp:
+        build_args += ["--use_openmp"]
     if args.use_nuphar:
         nuphar_args += ["--use_tvm", "--use_llvm", "--use_nuphar"]
         if args.llvm_path:

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -89,7 +89,6 @@ def parse_arguments():
     parser.add_argument("--config", default="RelWithDebInfo",
                         choices=["Debug", "MinSizeRel", "Release", "RelWithDebInfo"],
                         help="Configuration to build.")
-    parser.add_argument("--use_openmp", action='store_true', help="Enable OpenMP.")
     parser.add_argument("--use_cuda", action='store_true', help="Enable CUDA.")
     parser.add_argument("--cuda_version", help="The version of CUDA toolkit to use. Auto-detect if not specified. e.g. 9.0")
     parser.add_argument("--cuda_home", help="Path to CUDA home."
@@ -111,20 +110,19 @@ def parse_arguments():
 if __name__ == "__main__":
     args = parse_arguments()
 
-    build_args = ["--parallel", "--use_dnnl"]
+    build_args = ["--parallel", "--use_dnnl", "--use_openmp"]
     nuphar_args = []
 
-    if args.use_openmp:
-        build_args += ["--use_openmp"]
     if args.use_nuphar:
         nuphar_args += ["--use_tvm", "--use_llvm", "--use_nuphar"]
         if args.llvm_path:
             nuphar_args = nuphar_args + ["--llvm_path", args.llvm_path]
+    if args.use_ngraph:
+        nuphar_args += ["--use_ngraph"]
     if args.use_mklml:
         # Build mklml + nuphar in one build
         build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_mklml"] + nuphar_args, "mklml", args)
-    if args.use_ngraph:
-        build_args += ["--use_ngraph"]
+    
 
     if args.use_cuda:
         build_args += ["--use_cuda"]

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -120,7 +120,6 @@ if __name__ == "__main__":
     if args.use_mklml:
         # Build mklml + nuphar in one build
         build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_mklml"] + nuphar_args, "mklml", args)
-    
 
     if args.use_cuda:
         build_args += ["--use_cuda"]

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         if args.llvm_path:
             nuphar_args = nuphar_args + ["--llvm_path", args.llvm_path]
     if args.use_ngraph:
-        nuphar_args += ["--use_ngraph"]
+        build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_ngraph", "--use_openmp"] + nuphar_args, "ngraph", args)
     if args.use_mklml:
         # Build mklml + nuphar in one build
         build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_mklml"] + nuphar_args, "mklml", args)

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -76,8 +76,10 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
                 copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external", "tvm", "libtvm.so*"), target_dir)
             if "--use_nuphar" in build_args:
                 copy(os.path.join(onnxruntime_dir, "onnxruntime", "core", "providers", "nuphar", "scripts", "symbolic_shape_infer.py"), target_dir)
-        if "--use_ngraph" in build_args:
+        if "ngraph" in build_name:
             copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external/ngraph/lib/lib*.so*"), target_dir)
+            copy(os.path.join(onnxruntime_dir, "build/Linux", config, "external", "tvm", "libtvm.so*"), target_dir)
+
 def parse_arguments():
     parser = argparse.ArgumentParser()
 
@@ -116,7 +118,7 @@ if __name__ == "__main__":
             nuphar_args = nuphar_args + ["--llvm_path", args.llvm_path]
     if args.use_ngraph:
         # Build ngraph as a separate build
-        build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_ngraph", "--use_openmp"] + nuphar_args, "ngraph", args)
+        build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_ngraph", "--use_openmp"], "ngraph", args)
     if args.use_mklml:
         # Build mklml + nuphar in one build
         build_onnxruntime(args.onnxruntime_home, args.config, ["--parallel", "--use_mklml"] + nuphar_args, "mklml", args)

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -439,6 +439,8 @@ if __name__ == "__main__":
     for build_name in providers:
         if "mklml" in build_name or "nuphar" in build_name:
             build_path = os.path.join(bin_dir, "mklml")
+        elif "ngraph" in build_name:
+            build_path = os.path.join(bin_dir, "ngraph")
         elif build_name in allProviders:
             build_path = os.path.join(bin_dir, "all_eps")
         else:


### PR DESCRIPTION
Build nGraph execution provider separately from other execution providers in `build_perf_tuning.py` in `perf-tuning` image. This change is to avoid possible nGraph build compatibility issue under different CPUs. 

Updated `mcr.microsoft.com/onnxruntime/perf-tuning` docker image to reflect this change.