### PR TITLE
Update Docker Images to use ONNX Runtime 1.2.0

### DIFF
--- a/docker-images/perf-tuning/Dockerfile
+++ b/docker-images/perf-tuning/Dockerfile
@@ -5,12 +5,12 @@ FROM nvidia/cuda:10.2-base
 RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 libcublas10 cuda-curand-10-2 python3-pip 
 RUN python3.7 -m pip install psutil gputil numpy onnx packaging sympy
 
-RUN mkdir /perf_tuning
+RUN mkdir /perf_tuning /perf_tuning/src
 COPY bin /perf_tuning/bin
-COPY src/perf_tuning.py /perf_tuning
-COPY src/monitor.py /perf_tuning
-COPY src/maps.py /perf_tuning
+COPY src/perf_tuning.py /perf_tuning/src
+COPY src/monitor.py /perf_tuning/src
+COPY src/maps.py /perf_tuning/src
 
 WORKDIR /
 
-ENTRYPOINT [ "python3.7", "/perf_tuning/perf_tuning.py"]
+ENTRYPOINT [ "python3.7", "/perf_tuning/src/perf_tuning.py"]

--- a/docker-images/perf-tuning/Dockerfile
+++ b/docker-images/perf-tuning/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 FROM nvidia/cuda:10.2-base
 
-RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 libcublas10 python3-pip 
+RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 libcublas10 cuda-curand-10-2 python3-pip 
 RUN python3.7 -m pip install psutil gputil numpy onnx packaging sympy
 
 RUN mkdir /perf_tuning

--- a/docker-images/perf-tuning/Dockerfile
+++ b/docker-images/perf-tuning/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 FROM nvidia/cuda:10.2-base
 
-RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 cuda-cublas-10-2 python3-pip 
+RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 libcublas10 python3-pip 
 RUN python3.7 -m pip install psutil gputil numpy onnx packaging sympy
 
 RUN mkdir /perf_tuning

--- a/docker-images/perf-tuning/Dockerfile
+++ b/docker-images/perf-tuning/Dockerfile
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-FROM nvidia/cuda:10.0-base
+FROM nvidia/cuda:10.2-base
 
-RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 cuda-cublas-10-0 python3-pip 
+RUN apt-get update && apt-get install -y python3.7 python3.7-dev libgomp1 cuda-cublas-10-2 python3-pip 
 RUN python3.7 -m pip install psutil gputil numpy onnx packaging sympy
 
 RUN mkdir /perf_tuning

--- a/docker-images/perf-tuning/README.md
+++ b/docker-images/perf-tuning/README.md
@@ -17,11 +17,11 @@ docker pull mcr.microsoft.com/onnxruntime/perf-tuning
 
 Upon success, run Docker perf-tuning image by
 ```
-docker run [--runtime=nvidia] -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.com/onnxruntime/perf-tuning --model mnt/<path_to_onnx_model> --result mnt/<path_to_result_dir> [other optional args]
+docker run [--gpus all] -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.com/onnxruntime/perf-tuning --model mnt/<path_to_onnx_model> --result mnt/<path_to_result_dir> [other optional args]
 ```
 or 
 ```
-docker run [--runtime=nvidia] -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.com/onnxruntime/perf-tuning --input_json mnt/<input_json_file>
+docker run [--gpus all] -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.com/onnxruntime/perf-tuning --input_json mnt/<input_json_file>
 ```
 
 ### perf-tuning Image Arguments
@@ -135,11 +135,11 @@ If ONNX Runtime is built on Windows, jump to [Run perf-tuning Without Docker](#4
 
 ### 3. Run Docker Image
 ```
-docker run [--runtime=nvidia] -v <local_directory_to_your_models>:/mnt perf-tuning --model /mnt/<path_to_onnx_model> --result mnt/<path_to_result_dir> [other optional args]
+docker run [--gpus all] -v <local_directory_to_your_models>:/mnt perf-tuning --model /mnt/<path_to_onnx_model> --result mnt/<path_to_result_dir> [other optional args]
 ```
 or
 ```
-docker run [--runtime=nvidia] -v <local_directory_to_your_models>:/mnt perf-tuning --input_json /mnt/<input_json_file>
+docker run [--gpus all] -v <local_directory_to_your_models>:/mnt perf-tuning --input_json /mnt/<input_json_file>
 ```
 
 ### 4. Run `perf-tuning` Without Docker

--- a/docker-images/perf-tuning/README.md
+++ b/docker-images/perf-tuning/README.md
@@ -8,9 +8,8 @@ To use the image, you can either [pull from Microsoft Container Registry](#Pull-
 
 ## Pull and Run the Image From Microsoft Container Registry
 
-A pre-built version of the image is available at Microsoft Container Registry. Once you have docker installed, you can easily pull and run the image on Linux as well as on Windows. 
+A pre-built version of the image is available at Microsoft Container Registry. Make sure you have [Docker](https://www.docker.com/get-started) installed. If GPU is available on your device, install [NVIDIA-Docker](https://github.com/NVIDIA/nvidia-docker) to enable accelerated GPU performance tuning. Then you can easily pull and run the image on Linux as well as on Windows. 
 
-With the correct credentials, you can pull the image directly using 
 ```
 docker pull mcr.microsoft.com/onnxruntime/perf-tuning
 ```
@@ -24,18 +23,23 @@ or
 docker run [--gpus all] -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.com/onnxruntime/perf-tuning --input_json mnt/<input_json_file>
 ```
 
-### perf-tuning Image Arguments
+`<local_directory_to_your_models>` is the folder you'd like to share with the docker container. By mounting this folder to `/mnt` folder, the docker container can access everything in your mounted local directory. 
 
-`--model`: Requried or specify in --input_json. The ONNX model to perform performance tuning. 
+`<path_to_onnx_model>` is the ONNX model path relative to `<local_directory_to_your_models>`. Note that input data must also be provided in the same folder, and the folder must contain nothing but the model file and its input/output data. Model path and input data need to be stored in the directory trees as below:
 
-NOTE: Model path and input data need to be stored in the directory trees as below:
+    --local_directory_to_your_models
+        --ModelDir
+            --test_data_set_0
+                --input_0.pb
+            --test_data_set_1
+                --input_0.pb
+            --model.onnx
 
-    --ModelName
-        --test_data_set_0
-            --input0.pb
-        --test_data_set_2
-            --input0.pb
-        --model.onnx
+In this case, `<path_to_onnx_model>` = ModelDir/model.onnx
+
+### perf-tuning Image Options
+
+`--model`: Requried or specify in --input_json. Path to the ONNX model to perform performance tuning. Input data must be present in the same folder as the ONNX model. 
 
 `--result`: Required or specify in --input_json. The directory to put output files. 
 

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -64,7 +64,7 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
             if args.use_tensorrt:
                 copy(os.path.join(args.tensorrt_home, "lib/libnvinfer.so*"), target_dir)
                 copy(os.path.join(args.tensorrt_home, "lib/libnvinfer_plugin.so*"), target_dir)
-                copy(os.path.join(args.tensorrt_home, "libmyelin.so*"), target_dir)
+                copy(os.path.join(args.tensorrt_home, "lib/libmyelin.so*"), target_dir)
             
         if "mklml" in build_name:
             if "--use_tvm" in build_args:

--- a/docker-images/perf-tuning/build_perf_tuning.py
+++ b/docker-images/perf-tuning/build_perf_tuning.py
@@ -44,7 +44,7 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
     else:
         build_env = os.environ.copy()
         lib_path = os.path.join(onnxruntime_dir, "build/Linux", config, "mklml/src/project_mklml/lib/")
-        build_env["LD_LIBRARY_PATH"] = lib_path
+        build_env["LD_LIBRARY_PATH"] += ":" + lib_path
         subprocess.run([os.path.join(onnxruntime_dir, "build.sh"), "--config", config, "--build_shared_lib"] + build_args, cwd=onnxruntime_dir, check=True, env=build_env)
         target_dir = os.path.join("bin", config, build_name)
         
@@ -59,17 +59,12 @@ def build_onnxruntime(onnxruntime_dir, config, build_args, build_name, args):
             if "--use_dnnl" in build_args:
                 copy(os.path.join(onnxruntime_dir, "build/Linux", config, "dnnl/install/lib/libdnnl.so*"), target_dir)
             if args.use_cuda or args.use_tensorrt:
-                if is_windows():
-                    copy(os.path.join(args.cudnn_home, "bin/cudnn*.dll"), target_dir)
-                else:
-                    copy(os.path.join(args.cudnn_home, "lib64/libcudnn.so*"), target_dir)
-                    copy(os.path.join(args.cudnn_home, "lib64/libnvrtc.so*"), target_dir)
+                copy(os.path.join(args.cudnn_home, "lib64/libcudnn.so*"), target_dir)
+                copy(os.path.join(args.cudnn_home, "lib64/libnvrtc.so*"), target_dir)
             if args.use_tensorrt:
-                if is_windows():
-                    copy(os.path.join(args.tensorrt_home, "lib/nvinfer.dll"), target_dir)
-                else:
-                    copy(os.path.join(args.tensorrt_home, "lib/libnvinfer.so*"), target_dir)
-                    copy(os.path.join(args.tensorrt_home, "lib/libnvinfer_plugin.so*"), target_dir)
+                copy(os.path.join(args.tensorrt_home, "lib/libnvinfer.so*"), target_dir)
+                copy(os.path.join(args.tensorrt_home, "lib/libnvinfer_plugin.so*"), target_dir)
+                copy(os.path.join(args.tensorrt_home, "libmyelin.so*"), target_dir)
             
         if "mklml" in build_name:
             if "--use_tvm" in build_args:

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -461,7 +461,7 @@ if __name__ == "__main__":
                     build_name,
                     build_path,
                     test_args + ["-x", "1"],
-                    env.copy(),
+                    {},
                     args,
                     build_name)
                 tests.append(params)

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -526,7 +526,9 @@ if __name__ == "__main__":
                     env.copy(),
                     args,
                     build_name)
-                tests.append(params)                    
+                if is_omp:
+                    params.test_args += ["-x", "1"]
+                tests.append(params)                       
 
             # Run the tests under current execution provider.
             for test in tests:

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -413,10 +413,11 @@ if __name__ == "__main__":
     build_dirs = os.listdir(bin_dir)
 
     allProviders = ["cpu_openmp", "mklml", "dnnl", "cpu", "tensorrt", "ngraph", "cuda", "nuphar"]
-    # Get all execution providers needed to run in current context
-    providers = [p for p in args.execution_provider.split(",") if p != ""] if len(args.execution_provider) > 0 else allProviders
     parallel_eps = ["cpu_openmp", "mklml", "dnnl", "cpu", "ngraph"]
     omp_eps = ["cpu_openmp", "mklml", "dnnl", "ngraph", "nuphar"]
+
+    # Get all execution providers needed to run in current context
+    providers = [p for p in args.execution_provider.split(",") if p != ""] if len(args.execution_provider) > 0 else allProviders    
 
     if len(GPUtil.getGPUs()) == 0:
         print("No GPU found on current device. Cuda and TensorRT performance tuning might not be available. ")

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -334,7 +334,7 @@ class ConverterParamsFromJson():
     def __init__(self):
         with open(parse_arguments().input_json) as f:
             loaded_json = json.load(f)
-        cores = os.cpu_count() // 2
+        cores = os.cpu_count()
         # Check the required inputs
         if loaded_json.get("model") == None:
             raise ValueError("Please specified \"model\" in the input json. ")
@@ -360,7 +360,7 @@ class ConverterParamsFromJson():
 def parse_arguments():
     parser = argparse.ArgumentParser()
 
-    cores = os.cpu_count() // 2
+    cores = os.cpu_count()
     print("Cores: ", cores)
     parser.add_argument("--input_json", 
                         help="A JSON file specifying the run specs. ")

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -454,6 +454,18 @@ if __name__ == "__main__":
                 test_args = ["-e", build_name]
             successful = []
             tests = []
+            is_omp = build_name in omp_eps
+            if is_omp:
+                params = PerfTestParams(
+                    build_name + env_option,
+                    build_name + " " + env_option,
+                    build_path,
+                    test_args + ["-x", "1"],
+                    env.copy(),
+                    args,
+                    build_name)
+                tests.append(params)
+                
             # Tune inter_op_num_threads using parallel execution mode with default environment variables. 
             best_inter_op_num_threads = -1
             if args.parallel and build_name in parallel_eps:                 
@@ -482,7 +494,7 @@ if __name__ == "__main__":
                     env_option += "_" + e + "_" + env.get(e)
 
                 best_thread_pool_size = -1
-                is_omp = build_name in omp_eps
+                
                 num_threads = int(args.intra_op_num_threads)
                 name_suffix = "_intra_threads" if not is_omp else "_OMP_threads"
                 desc_suffix = " intra_op_num_threads, " if not is_omp else " OMP_NUM_THREADS, "

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -457,8 +457,8 @@ if __name__ == "__main__":
             is_omp = build_name in omp_eps
             if is_omp:
                 params = PerfTestParams(
-                    build_name + env_option,
-                    build_name + " " + env_option,
+                    build_name,
+                    build_name,
                     build_path,
                     test_args + ["-x", "1"],
                     env.copy(),

--- a/docker-images/perf-tuning/src/perf_tuning.py
+++ b/docker-images/perf-tuning/src/perf_tuning.py
@@ -409,7 +409,7 @@ if __name__ == "__main__":
     if not os.path.exists(args.result):
         os.mkdir(args.result)
     
-    bin_dir = os.path.join(os.path.dirname(__file__), "bin", args.config)
+    bin_dir = os.path.join(os.path.dirname(__file__), "../bin", args.config)
     build_dirs = os.listdir(bin_dir)
 
     allProviders = ["cpu_openmp", "mklml", "dnnl", "cpu", "tensorrt", "ngraph", "cuda", "nuphar"]

--- a/web/readme.md
+++ b/web/readme.md
@@ -10,6 +10,14 @@ This repository shows how to use ONNX pipeline by a web interface in built local
 # Prerequisites
 - Install [Docker](https://docs.docker.com/install/).
 
+    Note if you're running Docker 19.03 and up, and would like to use GPU, run 
+
+    ```bash
+    apt-get install nvidia-docker2
+    ``` 
+    
+    to support `runtime=nvidia` API from [docker python SDK](https://github.com/docker/docker-py). `--runtime=nvidia` has been replaced by `--gpus all` since Docker 19.03 and as of now the Docker python SDK hasn't reflected this change. 
+
 - Install project dependencies by running 
 ## Windows
 ```bash

--- a/web/readme.md
+++ b/web/readme.md
@@ -10,13 +10,9 @@ This repository shows how to use ONNX pipeline by a web interface in built local
 # Prerequisites
 - Install [Docker](https://docs.docker.com/install/).
 
-    Note if you're running Docker 19.03 and up, and would like to use GPU, run 
+- Install [NVIDIA docker](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)
 
-    ```bash
-    apt-get install nvidia-docker2
-    ``` 
-    
-    to support `runtime=nvidia` API from [docker python SDK](https://github.com/docker/docker-py). `--runtime=nvidia` has been replaced by `--gpus all` since Docker 19.03 and as of now the Docker python SDK hasn't reflected this change. 
+    Note that NVIDIA docker 2 is needed to support `runtime=nvidia` API from [Docker python SDK](https://github.com/docker/docker-py), which this web app depends on. `--runtime=nvidia` has been replaced by `--gpus all` since Docker 19.03 and as of now the Docker python SDK hasn't reflected this change. 
 
 - Install project dependencies by running 
 ## Windows


### PR DESCRIPTION
- Update perf-tuning docker image
   - Update to use ONNX Runtime 1.2.0 build
   - Update perf-tuning docker image to use CUDA 10.2 to meet the ONNX Runtime 1.2.0 requirements
   - Update README to reflect the latest Docker command - "--runtime=nvidia" --> "--gpus all"
   - Tune threads up to number of logical cores instead of number of physical cores.
   - Add unsetting all OMP environment variables to perf test candidates in the OpenMP enabled execution providers 