### PR TITLE
Web App Perf-tuning Support Job Selection From Previous Step

### DIFF
--- a/utils/onnxpipeline.py
+++ b/utils/onnxpipeline.py
@@ -145,7 +145,6 @@ class Pipeline:
             arguments = docker_config.arg('input_json', input_json)
         # load by JSON file and handle missing parameters with default path, add mounted path into original path
         elif input_json is not None:
-            console.log("pipeline convert path ", posixpath.join(self.path, local_input_json))
             with open(posixpath.join(self.path, local_input_json), 'r') as f:
                 json_data = json.load(f)
 

--- a/utils/onnxpipeline.py
+++ b/utils/onnxpipeline.py
@@ -145,6 +145,7 @@ class Pipeline:
             arguments = docker_config.arg('input_json', input_json)
         # load by JSON file and handle missing parameters with default path, add mounted path into original path
         elif input_json is not None:
+            console.log("pipeline convert path ", posixpath.join(self.path, local_input_json))
             with open(posixpath.join(self.path, local_input_json), 'r') as f:
                 json_data = json.load(f)
 

--- a/web/backend/app_config.py
+++ b/web/backend/app_config.py
@@ -3,16 +3,11 @@
 
 import os
 
-# is Windows
-if os.name == 'nt':
-    STATIC_DIR = 'static'
-else:
-    STATIC_DIR = 'static'
-
-FILE_INPUTS_DIR = 'io_files/inputs'
+STATIC_DIR = 'static'
+FILE_INPUTS_DIR = os.path.join('io_files', 'inputs')
 TEST_DATA_DIR = 'test_data_set_0'
 COMPRESS_NAME = 'input.tar.gz'
-DOWNLOAD_DIR = 'static/download'
-CONVERT_RES_DIR = 'io_files/convert'
-PERF_RES_DIR = 'io_files/perf'
-MOUNT_PATH = 'mnt/model/'
+DOWNLOAD_DIR = os.path.join('static', 'download')
+CONVERT_RES_DIR = os.path.join('io_files', 'convert')
+PERF_RES_DIR = os.path.join('io_files', 'perf')
+MOUNT_PATH = os.path.join('mnt', 'model')

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -27,7 +27,7 @@
           </button>
         </router-link>
         <hr/>
-        <keep-alive >
+        <keep-alive>
           <router-view
             v-on:update_model="updateModelHandler"
             :converted_model="converted_model"/>
@@ -48,6 +48,7 @@ export default {
   },
   methods: {
     updateModelHandler(value) {
+      console.log("updateModelHandler ", value)
       this.converted_model = value;
     },
   },

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -48,7 +48,6 @@ export default {
   },
   methods: {
     updateModelHandler(value) {
-      console.log("updateModelHandler ", value)
       this.converted_model = value;
     },
   },

--- a/web/frontend/src/components/Convert.vue
+++ b/web/frontend/src/components/Convert.vue
@@ -9,12 +9,14 @@
         <b-form @submit="convert" @reset="onReset" class="w-100">
             <b-form-group id="form-model_type-group"
                         label="Job Name:"
-                        label-for="form-model_type-input">
+                        label-for="form-model_type-input"
+                        label-class="font-weight-bold">
               <b-form-input v-model="job_name" placeholder="onnx-converter"></b-form-input>
             </b-form-group>
             <b-form-group id="form-model_type-group"
                         label="Model type:"
-                        label-for="form-model_type-input">
+                        label-for="form-model_type-input"
+                        label-class="font-weight-bold">
 
             <b-form-select v-model="convert_form.model_type"
                         required
@@ -29,7 +31,8 @@
             <b-form-group v-if="convert_form.model_type == 'tensorflow'"
                         id="form-tf_model_type-group"
                         label="Tensorflow model type:"
-                        label-for="form-tf_model_type-input">
+                        label-for="form-tf_model_type-input"
+                        label-class="font-weight-bold">
 
             <b-form-select v-model="tf_model_type"
                         :options="options.tf_model_type"
@@ -43,7 +46,8 @@
 
             <b-form-group id="form-model-group"
                         label="Model:"
-                        label-for="form-model-input">
+                        label-for="form-model-input"
+                        label-class="font-weight-bold">
             <b-form-file id="form-model-input"
                             v-model="convert_form.model"
                             required
@@ -55,7 +59,8 @@
                           && tf_model_type === 'savedModel'"
                         id="form-model-group"
                         label="Tensorflow SavedModel Variable Files:"
-                        label-for="form-model-input">
+                        label-for="form-model-input"
+                        label-class="font-weight-bold">
             <b-form-file id="form-model-input"
                         multiple
                         v-model="savedModel_vars"
@@ -65,7 +70,8 @@
             </b-form-group>
             <b-form-group id="form-model-group"
                         label="Model Input/Output Test Data Files:"
-                        label-for="form-model-input">
+                        label-for="form-model-input"
+                        label-class="font-weight-bold">
             <b-form-file multiple id="form-model-input"
                             v-model="test_data"
                             placeholder="Select your input/output.pbs...">
@@ -75,7 +81,8 @@
                         && tf_model_type != 'savedModel' && tf_model_type.length > 0"
                         id="form-model_inputs_names-group"
                         label="Model inputs names:"
-                        label-for="form-model_inputs_names-input">
+                        label-for="form-model_inputs_names-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-model_inputs_names-input"
                             type="text"
                             v-model="convert_form.model_inputs_names"
@@ -86,7 +93,8 @@
                         && tf_model_type != 'savedModel' && tf_model_type.length > 0"
                         id="form-model_outputs_names-group"
                         label="Model outputs names:"
-                        label-for="form-model_outputs_names-input">
+                        label-for="form-model_outputs_names-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-model_outputs_names-input"
                             type="text"
                             v-model="convert_form.model_outputs_names"
@@ -96,7 +104,8 @@
         <b-form-group v-if="convert_form.model_type === 'mxnet'"
                         id="form-model_params-group"
                         label="Model params:"
-                        label-for="form-model_params-input">
+                        label-for="form-model_params-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-model_params-input"
                             type="text"
                             v-model="convert_form.model_params"
@@ -107,7 +116,8 @@
         <b-form-group v-if="convert_form.model_type === 'caffe'"
                         id="form-caffe_model_prototxt-group"
                         label="Caffe model prototxt:"
-                        label-for="form-caffe_model_prototxt-input">
+                        label-for="form-caffe_model_prototxt-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-caffe_model_prototxt-input"
                             type="text"
                             v-model="convert_form.caffe_model_prototxt"
@@ -118,7 +128,8 @@
         <b-form-group v-if="convert_form.model_type === 'scikit-learn'"
                         id="form-initial_types-group"
                         label="Initial types:"
-                        label-for="form-initial_types-input">
+                        label-for="form-initial_types-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-initial_types-input"
                             type="text"
                             v-model="convert_form.initial_types"
@@ -129,7 +140,8 @@
         <b-form-group v-if="convert_form.model_type === 'pytorch'"
                         id="form-model_input_shapes-group"
                         label="Model input shapes:"
-                        label-for="form-model_input_shapes-input">
+                        label-for="form-model_input_shapes-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-model_input_shapes-input"
                             type="text"
                             v-model="convert_form.model_input_shapes"
@@ -140,7 +152,8 @@
 
         <b-form-group id="form-target_opset-group"
                         label="Target Opset:"
-                        label-for="form-target_opset-input">
+                        label-for="form-target_opset-input"
+                        label-class="font-weight-bold">
             <b-form-input id="form-target_opset-input"
                             type="text"
                             v-model="convert_form.target_opset"
@@ -196,7 +209,7 @@ export default {
       model_running: false,
       link: '',
       job_id: '',
-      job_name: 'onnx-converter',
+      job_name: `onnx-converter-${Date.now()}`,
     };
   },
   components: {
@@ -210,10 +223,13 @@ export default {
       evt.preventDefault();
       this.initForm();
       this.convert_result = null;
+      this.job_name = `onnx-converter-${Date.now()}`;
     },
     convert(evt) {
       this.close_all();
-      // this.model_running = true;
+      this.model_running = true;
+      this.show_message = true;
+      this.message = `Submitting job ${this.job_name}`;
       evt.preventDefault();
       const metadata = this.convert_form;
       const json = JSON.stringify(metadata);
@@ -237,6 +253,7 @@ export default {
         .then((res) => {
           this.link = `${this.host}:8000/convertresult/${res.data.job_id}`;
           this.show_message = true;
+          this.model_running = false;
           this.message = 'Running job at ';
           this.update_result(res.data.job_id);
         })
@@ -245,6 +262,7 @@ export default {
           this.model_running = false;
           this.message = error;
         });
+      this.job_name = `onnx-converter-${Date.now()}`;
     },
     update_result(location) {
       axios.get(`${this.host}:5000/convertstatus/${location}`)

--- a/web/frontend/src/components/Convert.vue
+++ b/web/frontend/src/components/Convert.vue
@@ -10,7 +10,7 @@
             <b-form-group id="form-model_type-group"
                         label="Job Name:"
                         label-for="form-model_type-input">
-              <b-form-input v-model="job_name" placeholder="app.convert"></b-form-input>
+              <b-form-input v-model="job_name" placeholder="onnx-converter"></b-form-input>
             </b-form-group>
             <b-form-group id="form-model_type-group"
                         label="Model type:"
@@ -64,7 +64,7 @@
             </b-form-file>
             </b-form-group>
             <b-form-group id="form-model-group"
-                        label="Model Input Test Data Files:"
+                        label="Model Input/Output Test Data Files:"
                         label-for="form-model-input">
             <b-form-file multiple id="form-model-input"
                             v-model="test_data"
@@ -196,7 +196,7 @@ export default {
       model_running: false,
       link: '',
       job_id: '',
-      job_name: 'app.convert',
+      job_name: 'onnx-converter',
     };
   },
   components: {

--- a/web/frontend/src/components/ConvertResult.vue
+++ b/web/frontend/src/components/ConvertResult.vue
@@ -27,7 +27,7 @@
                 <h5>Download: </h5>
                 <a :href="host + ':5000/' + convert_result['input_path']" download>[input] </a>
                 <a :href="host + ':5000/' + convert_result['model_path']" download>[model]</a>
-            </div>                
+            </div>
             <br>
         </div>
         <alert :message=message :link=link v-if="show_message"></alert>
@@ -110,7 +110,6 @@ export default {
             this.message = 'Job running. Auto refreshing the page in 2 seconds. ';
             setTimeout(() => this.update_result(this.id), 2000);
           } else {
-            // rerun in 2 seconds
             this.show_message = true;
             this.message = 'Job is pending or the job does not exist. Try refreshing the page or browse all available jobs at ';
             this.link = `${this.host}:8000/jobmonitor`;

--- a/web/frontend/src/components/ConvertResult.vue
+++ b/web/frontend/src/components/ConvertResult.vue
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 <template>
     <div class="container">
-        <h3>Job {{job_name}}</h3>
+        <h3>Job "{{job_name}}"</h3>
         <b-table style="table-layout: fixed"
             :items="args"
             :fields="fields"
@@ -20,14 +20,15 @@
                 {{convert_result['output_json']['correctness_verified']}}
             </b-badge>
             </h5>
-            <h5>Error:
+            <h5 v-if="convert_result['output_json']['error_message'].length > 0">Error:
             <b-badge variant="danger">{{convert_result['output_json']['error_message']}}</b-badge>
             </h5>
             <div v-if="convert_result['output_json']['conversion_status'] == 'SUCCESS'">
-                <h5>Download</h5>
+                <h5>Download: </h5>
                 <a :href="host + ':5000/' + convert_result['input_path']" download>[input] </a>
                 <a :href="host + ':5000/' + convert_result['model_path']" download>[model]</a>
-            </div>
+            </div>                
+            <br>
         </div>
         <alert :message=message :link=link v-if="show_message"></alert>
     </div>

--- a/web/frontend/src/components/Perf.vue
+++ b/web/frontend/src/components/Perf.vue
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 <template>
-    <div class="container">
+    <div class="container" style="margin-top: 2%">
         <!-- perf test-->
         <div ref="perf_tuningModal"
                 id="perf_tuning-modal"
@@ -13,16 +13,27 @@
               <option value=0>Run With Model Converted From Previous Step</option>
               <option value=1>Run With Customized Model</option>
             </b-form-select>
-            <b-form @submit="perf_tuning" @reset="onReset_perf_tuning" style="margin-top: 2%">
+
+            <b-form-group v-if="run_option == 0"
+                          label="Select a successful 'CONVERT' run from last step:"
+                          label-for="form-model"
+                          label-class="font-weight-bold">
+              <b-form-select v-model="selected_converter_job" :options="prev_job_list">
+              </b-form-select>
+            </b-form-group>
+
+            <b-form @submit="perf_tuning" @reset="onReset_perf_tuning">
               <b-form-group id="form-model_type-group"
-                        label="Job Name:"
-                        label-for="form-model_type-input">
-              <b-form-input v-model="job_name" placeholder="perf-tuning"></b-form-input>
+                        label="Performance Tuning Job Name:"
+                        label-for="form-model_type-input"
+                        label-class="font-weight-bold">
+              <b-form-input v-model="job_name"></b-form-input>
             </b-form-group>
                 <b-form-group id="form-model-group"
                               v-if="run_option == 0"
                               label="Model From Previous Step:"
-                              label-for="form-model">
+                              label-for="form-model"
+                              label-class="font-weight-bold">
                     <b-form-input id="form-model"
                                     type="text"
                                     v-model="perf_tuning_form.model"
@@ -32,7 +43,8 @@
                 <b-form-group id="form-model-group"
                         v-if="run_option == 1"
                         label="Model:"
-                        label-for="form-model">
+                        label-for="form-model"
+                        label-class="font-weight-bold">
                   <b-form-file id="form-model"
                                   v-model="customized_model"
                                   required
@@ -43,10 +55,15 @@
                 <!--TODO: DISABLE THIS WHEN PREVIOUS MODEL HAS PROVIDED INPUT -->
                 <b-form-group id="form-model-group"
                         label="Model Input/Output Test Data Files:"
-                        label-for="form-model-input">
+                        label-for="form-model-input"
+                        label-class="font-weight-bold">
+                <b-form-checkbox v-if="run_option == 0" v-model="use_prev_input"
+                >Use test data from the selected job. Unselect to upload different test data.
+                </b-form-checkbox>
                 <b-form-file multiple id="form-model-input"
                                 v-model="test_data"
-                                placeholder="Select your input/output.pbs...">
+                                placeholder="Select your input/output.pbs..."
+                                :disabled="use_prev_input">
                 </b-form-file>
                 </b-form-group>
 
@@ -63,11 +80,13 @@
                 <div v-if="adv_setting">
                     <b-form-group id="form-execution_provider-group"
                                 label="Execution Providers (choose multiple):"
-                                label-for="form-execution_provider-input">
+                                label-for="form-execution_provider-input"
+                                label-class="font-weight-bold">
                     <b-form-select multiple class="form-control" v-model="selected_eps"
                                     required
                                     :options="options.execution_provider"
-                                    label="Execution Providers (choose multiple):">
+                                    label="Execution Providers (choose multiple):"
+                                    >
                         <template slot="first">
                         </template>
                         </b-form-select>
@@ -75,7 +94,8 @@
 
                     <b-form-group id="form-intra_op_num_threads-group"
                                 label="Number of Threads:"
-                                label-for="form-intra_op_num_threads-input">
+                                label-for="form-intra_op_num_threads-input"
+                                label-class="font-weight-bold">
                         <b-form-input id="form-intra_op_num_threads-input"
                             type="text"
                             v-model="perf_tuning_form.intra_op_num_threads"
@@ -87,7 +107,8 @@
 
                     <b-form-group id="form-top_n-group"
                                 label="Top N results:"
-                                label-for="form-top_n-input">
+                                label-for="form-top_n-input"
+                                label-class="font-weight-bold">
                         <b-form-input id="form-top_n-input"
                                     type="text"
                                     v-model="perf_tuning_form.top_n"
@@ -98,7 +119,8 @@
 
                     <b-form-group id="form-optimization-level-group"
                                 label="optimization_level:"
-                                label-for="form-optimization_level-input">
+                                label-for="form-optimization_level-input"
+                                label-class="font-weight-bold">
                         <b-form-input id="form-optimization_level-input"
                                     type="text"
                                     v-model="perf_tuning_form.optimization_level">
@@ -107,7 +129,8 @@
 
                     <b-form-group id="form-mode-group"
                                 label="Mode:"
-                                label-for="form-mode-input">
+                                label-for="form-mode-input"
+                                label-class="font-weight-bold">
                     <b-form-select v-model="perf_tuning_form.test_mode"
                                     required
                                     :options="options.test_mode"
@@ -121,6 +144,7 @@
                     <b-form-group id="form-repeated_times-group"
                                 label="Repeated times:"
                                 label-for="form-repeated_times-input"
+                                label-class="font-weight-bold"
                                 v-if="perf_tuning_form.test_mode == 'times'">
                         <b-form-input id="form-repeated_times-input"
                                     type="text"
@@ -131,6 +155,7 @@
                     <b-form-group id="form-duration_times-group"
                                 label="Duration times:"
                                 label-for="form-duration_times-input"
+                                label-class="font-weight-bold"
                                 v-if="perf_tuning_form.test_mode == 'duration'">
                         <b-form-input id="form-duration_times-input"
                                     type="text"
@@ -149,7 +174,8 @@
                     <b-form-group v-if="perf_tuning_form.parallel"
                                 id="form-intra_op_num_threads-group"
                                 label="inter_op_num_threads:"
-                                label-for="form-inter_op_num_threads-input">
+                                label-for="form-inter_op_num_threads-input"
+                                label-class="font-weight-bold">
                         <b-form-input id="form-inter_op_num_threads-input"
                           type="text"
                           v-model="perf_tuning_form.inter_op_num_threads"
@@ -177,17 +203,6 @@ import Alert from './Alert.vue';
 import { perf_tuning_form } from '../utils/const';
 
 const origin_perf_tuning_form = Object.assign({}, perf_tuning_form);
-const ep_map = {
-  ALL: '',
-  CPU: 'cpu',
-  CPU_OpenMP: 'cpu_openmp',
-  MKLML: 'mklml',
-  DNNL: 'dnnl',
-  CUDA: 'cuda',
-  TensorRT: 'tensorrt',
-  nGraph: 'ngraph',
-  Nuphar: 'nuphar',
-};
 export default {
   name: 'Perf',
   props: ['converted_model'],
@@ -202,7 +217,17 @@ export default {
       customized_model: null,
       options: {
         test_mode: ['duration', 'times'],
-        execution_provider: Object.keys(ep_map),
+        execution_provider: [
+          { value: '', text: 'Run all EPs (default)' },
+          { value: 'cpu', text: 'CPU' },
+          { value: 'cpu_openmp', text: 'CPU OpenMP' },
+          { value: 'mklml', text: 'MKLML' },
+          { value: 'dnnl', text: 'DNNL' },
+          { value: 'cuda', text: 'CUDA' },
+          { value: 'tensorrt', text: 'TensorRT' },
+          { value: 'ngraph', text: 'nGraph' },
+          { value: 'nuphar', text: 'Nuphar' },
+        ],
       },
       message: '',
       show_message: false,
@@ -214,7 +239,11 @@ export default {
       host: `${window.location.protocol}//${window.location.host.split(':')[0]}`,
       link: '',
       job_id: '',
-      job_name: 'perf-tuning',
+      job_name: `perf-tuning-${Date.now()}`,
+      prev_job_list: [],
+      selected_converter_job: '',
+      test_data_path: '',
+      use_prev_input: false,
     };
   },
 
@@ -222,8 +251,8 @@ export default {
     alert: Alert,
   },
 
-  created: function() {
-    this.update_model_path()
+  created() {
+    this.update_model_path();
   },
 
   watch: {
@@ -233,10 +262,12 @@ export default {
     run_option(newVal) {
       this.model_missing = '';
       this.test_data_missing = '';
-      console.log("run_option ", newVal);
       if (newVal == 0) {
-        this.perf_tuning_form.model = this.converted_model;
+        this.get_jobs();
       }
+    },
+    selected_converter_job(newVal) {
+      this.get_model_path_from_job(newVal);
     },
   },
 
@@ -248,15 +279,53 @@ export default {
       this.selected_eps = [];
       this.test_data = [];
       this.run_option = 0;
+      this.selected_converter_job = '';
     },
 
     update_model_path() {
-      this.perf_tuning_form.model = this.converted_model;
-      console.log("converted_model ", this.converted_model);
       if (this.converted_model.length > 0) {
         this.run_option = 0;
+        this.get_jobs();
       }
-    }, 
+    },
+
+    get_jobs() {
+      axios.get(`${this.host}:5000/gettasks`)
+        .then((res) => {
+          this.prev_job_list = [];
+          for (let i = 0; i < Object.keys(res.data).length; i++) {
+            const t = res.data[Object.keys(res.data)[i]];
+            const nameBrkIndex = t.name.indexOf('.');
+            if (t.state == 'SUCCESS' && t.name.substring(0, nameBrkIndex) == 'convert') {
+              if ((Date.now() / 1000 - t.timestamp) / 3600 < 24 * 7) {
+                this.prev_job_list.push({
+                  value: Object.keys(res.data)[i],
+                  text: t.name.substring(nameBrkIndex + 1),
+                  timestamp: t.timestamp,
+                });
+              }
+            }
+          }
+          this.prev_job_list.sort((a, b) => a.timestamp - b.timestamp);
+          if (this.prev_job_list.length > 0) {
+            this.selected_converter_job = this.prev_job_list[this.prev_job_list.length - 1].value;
+          }
+        });
+    },
+
+    get_model_path_from_job(cur_job_id) {
+      axios.get(`${this.host}:5000/convertstatus/${cur_job_id}`)
+        .then((res) => {
+          this.perf_tuning_form.model = res.data.output_json.output_onnx_path;
+          if (res.data.output_json.input_folder.length > 0) {
+            this.use_prev_input = true;
+          }
+        })
+        .catch((error) => {
+          this.show_message = true;
+          this.message = error.toString();
+        });
+    },
 
     perf_tuning(evt) {
       this.close_all();
@@ -278,7 +347,7 @@ export default {
       if (this.selected_eps.length > 0) {
         this.perf_tuning_form.execution_provider = '';
         for (let i = 0; i < this.selected_eps.length; i++) {
-          this.perf_tuning_form.execution_provider += ep_map[this.selected_eps[i]];
+          this.perf_tuning_form.execution_provider += this.selected_eps[i].value;
           if (i < this.selected_eps.length - 1) {
             this.perf_tuning_form.execution_provider += ',';
           }

--- a/web/frontend/src/components/Perf.vue
+++ b/web/frontend/src/components/Perf.vue
@@ -17,13 +17,13 @@
               <b-form-group id="form-model_type-group"
                         label="Job Name:"
                         label-for="form-model_type-input">
-              <b-form-input v-model="job_name" placeholder="app.convert"></b-form-input>
+              <b-form-input v-model="job_name" placeholder="perf-tuning"></b-form-input>
             </b-form-group>
                 <b-form-group id="form-model-group"
                               v-if="run_option == 0"
                               label="Model From Previous Step:"
-                              label-for="form-model-input">
-                    <b-form-input id="form-model-input"
+                              label-for="form-model">
+                    <b-form-input id="form-model"
                                     type="text"
                                     v-model="perf_tuning_form.model"
                                     readonly>
@@ -32,16 +32,17 @@
                 <b-form-group id="form-model-group"
                         v-if="run_option == 1"
                         label="Model:"
-                        label-for="form-model-input">
-                  <b-form-file id="form-model-input"
+                        label-for="form-model">
+                  <b-form-file id="form-model"
                                   v-model="customized_model"
                                   required
                                   placeholder="Choose a model...">
                   </b-form-file>
                 </b-form-group>
 
+                <!--TODO: DISABLE THIS WHEN PREVIOUS MODEL HAS PROVIDED INPUT -->
                 <b-form-group id="form-model-group"
-                        label="Model Input Test Data Files:"
+                        label="Model Input/Output Test Data Files:"
                         label-for="form-model-input">
                 <b-form-file multiple id="form-model-input"
                                 v-model="test_data"
@@ -145,7 +146,6 @@
                     Use parallel executor
                     </b-form-checkbox>
 
-
                     <b-form-group v-if="perf_tuning_form.parallel"
                                 id="form-intra_op_num_threads-group"
                                 label="inter_op_num_threads:"
@@ -214,7 +214,7 @@ export default {
       host: `${window.location.protocol}//${window.location.host.split(':')[0]}`,
       link: '',
       job_id: '',
-      job_name: 'app.perf_tuning',
+      job_name: 'perf-tuning',
     };
   },
 
@@ -222,21 +222,24 @@ export default {
     alert: Alert,
   },
 
+  created: function() {
+    this.update_model_path()
+  },
+
   watch: {
     converted_model() {
-      this.perf_tuning_form.model = this.converted_model;
-      if (this.converted_model.length > 0) {
-        this.run_option = 0;
-      }
+      this.update_model_path();
     },
     run_option(newVal) {
       this.model_missing = '';
       this.test_data_missing = '';
+      console.log("run_option ", newVal);
       if (newVal == 0) {
         this.perf_tuning_form.model = this.converted_model;
       }
     },
   },
+
   methods: {
     init_perf_tuning_form() {
       this.perf_tuning_form = Object.assign({}, origin_perf_tuning_form);
@@ -246,6 +249,14 @@ export default {
       this.test_data = [];
       this.run_option = 0;
     },
+
+    update_model_path() {
+      this.perf_tuning_form.model = this.converted_model;
+      console.log("converted_model ", this.converted_model);
+      if (this.converted_model.length > 0) {
+        this.run_option = 0;
+      }
+    }, 
 
     perf_tuning(evt) {
       this.close_all();

--- a/web/frontend/src/components/PerfResult.vue
+++ b/web/frontend/src/components/PerfResult.vue
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 <template>
     <div class='container'>
-        <h3>Job {{job_name}}</h3>
+        <h3>Job "{{job_name}}"</h3>
         <b-table style="table-layout: fixed"
             :items="args"
             :fields="arg_fields"

--- a/web/frontend/src/utils/const.js
+++ b/web/frontend/src/utils/const.js
@@ -3,7 +3,7 @@
 export const convert_form = {
   model: null,
   model_type: 'tensorflow',
-  target_opset: '10',
+  target_opset: '11',
   model_inputs_names: '',
   model_input_shapes: '',
   model_outputs_names: '',


### PR DESCRIPTION
- Previously the "perf-tuning" feature in the web app only supports running with model from the most recent "convert" run. This PR extends this feature to supporting all previously successful "convert" runs.
- Disable "upload input" button by default if previously converted model and test data are used for the perf run.
- Update paths to render better ui for Windows