### PR TITLE
Support Pickle Files As Test Data Format Alternative in Web App

### DIFF
--- a/docker-images/onnx-converter/README.md
+++ b/docker-images/onnx-converter/README.md
@@ -12,7 +12,7 @@ Supported frameworks are -
 
 ## How to Run 
 
-### Microsoft Container Registry
+### Prebuilt Docker Image in Microsoft Container Registry
 
 A pre-built version of the image is available at Microsoft Container Registry. Once you have docker installed, you can easily pull and run the image on Linux as well as on Windows. 
 

--- a/utils/convert_test_data.py
+++ b/utils/convert_test_data.py
@@ -1,0 +1,55 @@
+import argparse
+import sys
+import os
+import pickle
+import onnx
+from onnx import helper, numpy_helper
+from onnx import TensorProto
+
+def convert_data_to_pb(pickle_path, output_folder="test_data_set_0"):
+    extension = pickle_path.split(".")[1]
+    if extension == "pb":
+        print("Test Data already in .pb format. ")
+    try:
+        test_data_dict = pickle.load(open(pickle_path, "rb"))
+    except:
+        raise ValueError("Cannot load test data with pickle. ")
+    # Type check for the pickle file. Expect a dictionary with input names as keys and data as values.
+    if type(test_data_dict) is not dict:
+        raise ValueError("Data type error. Expect a dictionary with input names as keys and data as values.")
+
+    # Create a test_data_set folder if not exists
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+
+    idx = 0
+    for name, data in test_data_dict.items():
+        print(data)
+        tensor = numpy_helper.from_array(data)
+        tensor.name = name
+        pb_file_name = "input_{}.pb".format(idx)
+        pb_file_location = os.path.join(output_folder, pb_file_name)
+        with open(pb_file_location, 'wb') as f:
+            f.write(tensor.SerializeToString())
+            print("Successfully store input {} in {}".format(name, pb_file_location))
+        idx += 1
+    
+def get_args():
+    """Parse commandline."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("test_data", 
+        type=str,
+        help="A pickle file storing a dictionary with input names and data. ")
+    parser.add_argument("--output_folder", 
+        required=False,
+        default="test_data_set_0",
+        help="An output folder to store the output .pb files. Default: test_data_set_0. ")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = get_args()
+    convert_data_to_pb(args.test_data, args.output_folder)
+
+if __name__ == "__main__":
+    main()

--- a/utils/convert_test_data.py
+++ b/utils/convert_test_data.py
@@ -7,6 +7,19 @@ from onnx import helper, numpy_helper
 from onnx import TensorProto
 
 def convert_data_to_pb(pickle_path, output_folder="test_data_set_0"):
+    """
+    Convert pickle test data file to ONNX .pb files.
+    Args:
+        pickle_path: The path to your pickle file. The pickle file should contain
+        a dictionary with the following format: 
+            {
+                input_name_1: test_data_1,
+                input_name_2: test_data_2,
+                ...
+            }
+        output_folder: The folder to store .pb files. The folder should be empty 
+        and its name starts with test_data_*. 
+    """
     extension = pickle_path.split(".")[1]
     if extension == "pb":
         print("Test Data already in .pb format. ")
@@ -14,7 +27,8 @@ def convert_data_to_pb(pickle_path, output_folder="test_data_set_0"):
         test_data_dict = pickle.load(open(pickle_path, "rb"))
     except:
         raise ValueError("Cannot load test data with pickle. ")
-    # Type check for the pickle file. Expect a dictionary with input names as keys and data as values.
+    # Type check for the pickle file. Expect a dictionary with input names as keys 
+    # and data as values.
     if type(test_data_dict) is not dict:
         raise ValueError("Data type error. Expect a dictionary with input names as keys and data as values.")
 

--- a/utils/convert_test_data.py
+++ b/utils/convert_test_data.py
@@ -18,11 +18,12 @@ def convert_data_to_pb(pickle_path, output_folder="test_data_set_0"):
                 ...
             }
         output_folder: The folder to store .pb files. The folder should be empty 
-        and its name starts with test_data_*. 
+        and its name starts with test_data_*. Default is "test_data_set_0". 
     """
     extension = pickle_path.split(".")[1]
     if extension == "pb":
         print("Test Data already in .pb format. ")
+        return
     try:
         test_data_dict = pickle.load(open(pickle_path, "rb"))
     except:
@@ -38,7 +39,6 @@ def convert_data_to_pb(pickle_path, output_folder="test_data_set_0"):
 
     idx = 0
     for name, data in test_data_dict.items():
-        print(data)
         tensor = numpy_helper.from_array(data)
         tensor.name = name
         pb_file_name = "input_{}.pb".format(idx)

--- a/web/backend/app.py
+++ b/web/backend/app.py
@@ -63,7 +63,6 @@ def store_file_from_request(request, file_key, save_to_dir):
     return ''
 
 def store_files_from_request(request, file_key, save_to_dir, isTestData=False):
-    
     if file_key in request.files:
         if os.path.exists(save_to_dir):
             rmtree(save_to_dir)
@@ -92,6 +91,7 @@ def get_convert_json(request, test_data_root_path):
     # Save files passed from request
     model_name = store_file_from_request(request, 'file', file_input_dir)
     json_data['model'] = model_name
+    print
 
     # Store test data files if any
     test_data_dir = os.path.join(test_data_root_path, app_config.TEST_DATA_DIR)
@@ -100,6 +100,10 @@ def get_convert_json(request, test_data_root_path):
     # Store tensorflow savedmodel files if any
     variables_dir = os.path.join(file_input_dir, 'variables')
     store_files_from_request(request, 'savedModel[]', variables_dir)
+    # If using tensorflow saved model, change model path to the directory containing the model files.
+    if os.path.exists(variables_dir):
+        print("exist!")
+        json_data['model'] = os.path.dirname(os.path.abspath(json_data['model']))
 
     # remove empty input folder
     if len(os.listdir(file_input_dir)) == 0:
@@ -330,7 +334,7 @@ def send_perf_job():
     #     # If model path is provided, add test data if neccessary to the model directory path
     #     _, temp_json, input_params = get_params(request, '')
     _, temp_json, input_params = get_perf_json(request)
-    job_name = "perf_tuning." + request.form.get('job_name')
+    job_name = 'perf_tuning.' + request.form.get('job_name')
     job = perf_tuning.apply_async(args=[temp_json, input_params], shadow=job_name)
     return jsonify({'Location': url_for('perf_status', task_id=job.id), 'job_id': job.id}), 202
 

--- a/web/frontend/src/components/Convert.vue
+++ b/web/frontend/src/components/Convert.vue
@@ -69,7 +69,8 @@
             </b-form-file>
             </b-form-group>
             <b-form-group id="form-model-group"
-                        label="[OPTIONAL] Model Input/Output Test Data Files(.pb files or a pickle file):"
+                        label=
+                        "[OPTIONAL] Model Input/Output Test Data Files(.pb files or a pickle file):"
                         label-for="form-model-input"
                         label-class="font-weight-bold">
             <b-form-file multiple id="form-model-input"

--- a/web/frontend/src/components/Convert.vue
+++ b/web/frontend/src/components/Convert.vue
@@ -69,12 +69,12 @@
             </b-form-file>
             </b-form-group>
             <b-form-group id="form-model-group"
-                        label="Model Input/Output Test Data Files:"
+                        label="Model Input/Output Test Data Files(.pb files or a pickle file):"
                         label-for="form-model-input"
                         label-class="font-weight-bold">
             <b-form-file multiple id="form-model-input"
                             v-model="test_data"
-                            placeholder="Select your input/output.pbs...">
+                            placeholder="Select your input/output files...">
             </b-form-file>
             </b-form-group>
         <b-form-group v-if="convert_form.model_type === 'tensorflow'

--- a/web/frontend/src/components/Convert.vue
+++ b/web/frontend/src/components/Convert.vue
@@ -69,7 +69,7 @@
             </b-form-file>
             </b-form-group>
             <b-form-group id="form-model-group"
-                        label="Model Input/Output Test Data Files(.pb files or a pickle file):"
+                        label="[OPTIONAL] Model Input/Output Test Data Files(.pb files or a pickle file):"
                         label-for="form-model-input"
                         label-class="font-weight-bold">
             <b-form-file multiple id="form-model-input"

--- a/web/frontend/src/components/ConvertResult.vue
+++ b/web/frontend/src/components/ConvertResult.vue
@@ -20,9 +20,8 @@
                 {{convert_result['output_json']['correctness_verified']}}
             </b-badge>
             </h5>
-            <h5 v-if="convert_result['output_json']['error_message'].length > 0">Error:
-            <b-badge variant="danger">{{convert_result['output_json']['error_message']}}</b-badge>
-            </h5>
+            <h5 v-if="convert_result['output_json']['error_message'].length > 0">Error:</h5>            
+            <b-alert show variant="danger">{{convert_result['output_json']['error_message']}}</b-alert>
             <div v-if="convert_result['output_json']['conversion_status'] == 'SUCCESS'">
                 <h5>Download: </h5>
                 <a :href="host + ':5000/' + convert_result['input_path']" download>[input] </a>

--- a/web/frontend/src/components/ConvertResult.vue
+++ b/web/frontend/src/components/ConvertResult.vue
@@ -20,8 +20,9 @@
                 {{convert_result['output_json']['correctness_verified']}}
             </b-badge>
             </h5>
-            <h5 v-if="convert_result['output_json']['error_message'].length > 0">Error:</h5>            
-            <b-alert show variant="danger">{{convert_result['output_json']['error_message']}}</b-alert>
+            <h5 v-if="convert_result['output_json']['error_message'].length > 0">Error:</h5>
+            <b-alert show variant="danger">
+              {{convert_result['output_json']['error_message']}}</b-alert>
             <div v-if="convert_result['output_json']['conversion_status'] == 'SUCCESS'">
                 <h5>Download: </h5>
                 <a :href="host + ':5000/' + convert_result['input_path']" download>[input] </a>

--- a/web/frontend/src/components/PerfResult.vue
+++ b/web/frontend/src/components/PerfResult.vue
@@ -172,8 +172,8 @@ export default {
           } else if (res.data.state == 'STARTED') {
             // rerun in 2 seconds
             this.show_message = true;
-            this.message = 'Job running. Auto refreshing the page in 10 seconds. ';
-            setTimeout(() => this.update_result(this.id), 10000);
+            this.message = 'Job running. Auto refreshing the page in 40 seconds. ';
+            setTimeout(() => this.update_result(this.id), 40000);
           } else {
             // rerun in 2 seconds
             this.show_message = true;


### PR DESCRIPTION
This PR adds a script (utils/convert_test_data.py) to convert pickle test data file to ONNX .pb files as an alternative data format for onnx-converter and perf-tuning test data. A valid pickle file should be stored from a dictionary like the following
{
   "input_name_0": test_input_np
    ...
}

This PR also enables web app support for the feature above. User may upload a pickle file instead of pb files in the "convert" and "perf" steps.
