### PR TITLE
Add test_data_path Parameter to onnx-converter

### DIFF
--- a/docker-images/onnx-converter/README.md
+++ b/docker-images/onnx-converter/README.md
@@ -61,6 +61,25 @@ For detailed description of all available parameters, refer to the following.
 
 `--model_type`: Required or specified in input json. The name of original model framework. Available types are cntk, coreml, keras, scikit-learn, tensorflow and pytorch.
 
+`--test_data_path`: Optional. The parent folder containing user specified test data folders. If not specified, the program will look for potential test data folders with name "test_data_*" under the input model directory. If specified, the folder structure should be 
+
+    -- test_data_path
+        -- test_data_set_0
+            -- input_0.pb
+            -- input_1.pb
+            ...
+            -- output_0.pb
+            ...
+        -- test_data_set_1
+            ...
+        ...
+
+Note that ONNX pb files are expected in the test data folders. For help to create pb files, [convert_test_data.py](https://github.com/microsoft/OLive/blob/master/utils/convert_test_data.py) is available for use to generate pb files from PICKLE files.
+
+        ```
+        convert_test_data.py <your_input_pickle_file> --output_folder <output_folder> --is_input=True
+        ```
+
 `--target_opset`: Optional. The opset for ONNX, for example, 7 for ONNX 1.2, and 8 for ONNX 1.3. Latest Opset is recommanded. Refer to [ONNX Opset](https://github.com/microsoft/onnxruntime/blob/master/docs/Versioning.md#version-matrix) for the latest Opset. 
 
 `--model_inputs_names`: Required for tensorflow frozen models and checkpoints. The model's input names. 

--- a/docker-images/onnx-converter/requirements.txt
+++ b/docker-images/onnx-converter/requirements.txt
@@ -8,7 +8,7 @@ keras==2.2.4
 
 # https://cntk.ai/PythonWheel/CPU-Only/cntk-2.6-cp36-cp36m-linux_x86_64.whl
 cntk
-numpy==1.16.0
+numpy==1.18.0
 
 torch
 torchvision

--- a/docker-images/onnx-converter/src/create_input.py
+++ b/docker-images/onnx-converter/src/create_input.py
@@ -34,31 +34,61 @@ TYPE_MAP = {
     'tensor(double)': np.float64, 
 }
 
-def generate_inputs(model):
-    
-    # Create a test folder path
-    model_dir = os.path.dirname(os.path.abspath(model))
-
-    # Check if test folder and test data already exists
+def search_for_existing_test_data(user_data_path, output_data_path):
+    if not os.path.exists(user_data_path):
+        print('No data found under user provided folder. Generating random input data.')
+        return
     regex = re.compile("test_data*")
-    for f in os.listdir(model_dir):
+    test_folder_name = 'test_data_set_'
+    test_folder_idx = 0
+    for f in os.listdir(user_data_path):
         if regex.match(f):
-            test_path = os.path.join(model_dir, f)
-            for inputFiles in os.listdir(test_path):
-                if inputFiles.endswith('.pb') and inputFiles.startswith("input"):
-                    print("Input.pb already exists. Skipping dummy input generation. ")
-                    return test_path    
-                    
-    test_path = os.path.join(model_dir, "test_data_set_0")
+            cur_user_data_path = os.path.join(user_data_path, f)
+            for inputFiles in os.listdir(cur_user_data_path):
+                if inputFiles.endswith('.pb') == False:
+                    print('No data found under user provided folder. Generating random input data.')
+                    return                  
+            print('Test data .pb files found under {}. '.format(cur_user_data_path))
+            # Copy the test data to the ONNX output dir. Overwrite if already exists.
+            cur_test_folder_path = os.path.join(output_data_path, test_folder_name + str(test_folder_idx))
+            print('copying {} to {}'.format(cur_user_data_path, os.path.join(output_data_path, test_folder_name + str(test_folder_idx))))
+            if os.path.exists(cur_test_folder_path):
+                shutil.rmtree(cur_test_folder_path)
+            shutil.copytree(cur_user_data_path, cur_test_folder_path)
+            test_folder_idx += 1
+
+def generate_inputs(input_model_path, src_test_data, output_model_path):
+    # Create a test folder path
+    output_test_data_dir = os.path.dirname(os.path.abspath(output_model_path))
+    test_path = os.path.join(output_test_data_dir, 'test_data_set_0')
+    
+    regex = re.compile("test_data*")
+    # Find and copy over the user specified test data
+    if src_test_data:
+        search_for_existing_test_data(src_test_data, output_test_data_dir)
+    else:
+        potential_data_dir = os.path.dirname(os.path.abspath(input_model_path))
+        search_for_existing_test_data(potential_data_dir, output_test_data_dir)
+    
     if not os.path.exists(test_path):
         os.mkdir(test_path)
         os.chmod(test_path, 0o644)
-    # Get the input model
-    sess = rt.InferenceSession(model)
+    # Check if test folder and test data already exists
+    regex = re.compile("test_data*")
+    for f in os.listdir(output_test_data_dir):
+        if regex.match(f):
+            user_data_path = os.path.join(output_test_data_dir, f)
+            for inputFiles in os.listdir(user_data_path):
+                if inputFiles.endswith('.pb'):
+                    print("Test data .pb files already exist. Skipping dummy input generation. ")
+                    return test_path
+
+    # Get input names from converted model
+    sess = rt.InferenceSession(output_model_path)
 
     #########################
     # Let's see the input name and shape.
-    print("%s inputs: " % model)
+    print("%s inputs: " % output_model_path)
     inputs = sess.get_inputs()
     for i in range(0, len(inputs)):
         print("input name: %s, shape: %s, type: %s" % (inputs[i].name, inputs[i].shape, inputs[i].type))

--- a/docker-images/onnx-converter/src/onnx_converter.py
+++ b/docker-images/onnx-converter/src/onnx_converter.py
@@ -35,6 +35,13 @@ def get_args():
             Available types are cntk, coreml, keras, scikit-learn, tensorflow and pytorch."
     )
     parser.add_argument(
+        "--test_data_path",
+        required=False,
+        default=None,
+        help="Test folder that contains input/output.pb files. If not specified, \
+            search for \"test_data_*\" under the model folder."
+    )
+    parser.add_argument(
         "--model_inputs_names", 
         required=False,
         help="Required for tensorflow frozen models and checkpoints. The model's input names."
@@ -83,6 +90,7 @@ class ConverterParamsFromJson():
             raise ValueError("Please specified \"output_onnx_path\" in the input json. ")
         self.model = loaded_json["model"]
         self.model_type = loaded_json["model_type"]
+        self.test_data_path = loaded_json["test_data_path"] if loaded_json.get("test_data_path") else None
         self.output_onnx_path = loaded_json["output_onnx_path"]
         self.model_inputs_names = loaded_json["model_inputs_names"] if loaded_json.get("model_inputs_names") else None
         self.model_outputs_names = loaded_json["model_outputs_names"] if loaded_json.get("model_outputs_names") else None
@@ -318,7 +326,7 @@ def main():
     print("\n-------------\nMODEL INPUT GENERATION(if needed)\n")
     # Generate random inputs for the model if input files are not provided
     try:
-        inputs_path = generate_inputs(args.output_onnx_path)
+        inputs_path = generate_inputs(args.model, args.test_data_path, args.output_onnx_path)
         output_template["input_folder"] = inputs_path
     except Exception as e:
         output_template["error_message"]= str(e)

--- a/docker-images/perf-tuning/README.md
+++ b/docker-images/perf-tuning/README.md
@@ -25,17 +25,21 @@ docker run [--gpus all] -v <local_directory_to_your_models>:/mnt/ mcr.microsoft.
 
 `<local_directory_to_your_models>` is the folder you'd like to share with the docker container. By mounting this folder to `/mnt` folder, the docker container can access everything in your mounted local directory. 
 
-`<path_to_onnx_model>` is the ONNX model path relative to `<local_directory_to_your_models>`. Note that input data must also be provided in the same folder, and the folder must contain nothing but the model file and its input/output data. Model path and input data need to be stored in the directory trees as below:
+`<path_to_onnx_model>` is the ONNX model path relative to `<local_directory_to_your_models>`. **Note** that input data must also be provided in the same folder, and the folder must contain nothing but the model file and its input/output data. Model path and input data need to be stored in the directory trees as below:
 
-    --local_directory_to_your_models
-        --ModelDir
-            --test_data_set_0
-                --input_0.pb
-            --test_data_set_1
-                --input_0.pb
-            --model.onnx
+    -- local_directory_to_your_models
+        -- ModelDir
+            -- model.onnx
+            -- test_data_set_0
+                -- input_0.pb
+                ...
+            -- test_data_set_1
+                -- input_0.pb
+                ...
 
 In this case, `<path_to_onnx_model>` = ModelDir/model.onnx
+
+**Note** that ONNX pb files are expected in the test data folders. For help to create pb files, [convert_test_data.py](https://github.com/microsoft/OLive/blob/master/utils/convert_test_data.py) is available for use to generate pb files from PICKLE files.
 
 ### perf-tuning Image Options
 


### PR DESCRIPTION
- Add test_data_path to `onnx-converter` docker image. This allows user to specify test data folder if not in the same folder as the input model file. The test data in the user specified folder will then be copied over to the  `onnx-converter` output folder so that the folder will have the following format that is ready to be consumed by the `perf-tuning` image. 

    ```
    -- output_folder 
       -- model.onnx 
       -- test_data_set_0
           -- input_0.pb
           ...
       -- test_data_set_1
           ...
       ...
   ```
- Update `onnx-converter` dependency to use latest packages
- Update README for instructions on how to generate pb files from PICKLE file using python script.    

These changes have been reflected in the latest `mcr.microsoft.com/onnxruntime/onnx-converter` public docker image and ready for use. 