### PR TITLE
Fixed exception when olive is invoked without parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .pytest_cache/
 .idea/
+__pycache__/
+*.egg-info/

--- a/olive/__main__.py
+++ b/olive/__main__.py
@@ -428,6 +428,10 @@ def main():
     parser_server.set_defaults(func=run_server)
 
     options = parser.parse_args()
+    if not getattr(options, 'func', None):
+        parser.print_help()
+        return
+
     options.func(options)
 
 


### PR DESCRIPTION
If olive is invoked without any parameters it throws an exception. This PR fixes that.
I also updated .gitignore to include files to ignore during local development. 