### PR TITLE
use `flask.safe_join` instead of `os.path.join`

### DIFF
--- a/olive/web/backend/app.py
+++ b/olive/web/backend/app.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from flask import Flask, jsonify, request, send_file, url_for, send_from_directory
+from flask import Flask, jsonify, request, send_file, url_for, send_from_directory, safe_join
 from flask_cors import CORS
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../utils'))
@@ -343,7 +343,7 @@ def get_job_name(task_id):
 @app.route('/download/<path:filename>', methods=['POST', 'GET'])
 def download(filename):
     try:
-        return send_file(os.path.join(app.root_path, filename), filename)
+        return send_file(safe_join(app.root_path, filename), filename)
     except Exception as e:
         return str(e)
 


### PR DESCRIPTION
I had submitted a security disclosure earlier via huntr.io . Since that has remained pending for quite some time now, I am sending a PR with the proposed fix.

There is a path traversal bug in this project due to the use of `os.path.join` call with untrusted input. This can be fixed by using `flask.safe_join` instead.