### PR TITLE
Support run with no search strategy

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -275,6 +275,10 @@ This is a dictionary that contains the information of the engine. The informatio
     - `max_time: [int]` The maximum time of the search in seconds. Only valid for `joint` execution order. By default, there is no
     maximum time.
 
+  If `search_strategy` is `null`, the engine will run the passes in the order they were registered without. Thus, the passes must have empty
+  search spaces. The output of the final pass will be evaluated if there is a valid evaluator. The output of the engine will be the output model
+  of the final pass and its evaluation result.
+
 - `host: [str | Dict]` The host of the engine. It can be a string or a dictionary. If it is a string, it is the name of a system in `systems`.
     If it is a dictionary, it contains the system information. If not specified, it is the local system.
 
@@ -288,6 +292,13 @@ This is a dictionary that contains the information of the engine. The informatio
 
 - `clean_evaluation_cache: [Boolean]` This decides whether to clean the evaluation cache of the engine before running the engine. This is
 `false` by default.
+
+- `output_dir: [str]` The directory to store the output of the engine. If not specified, the output will be stored in the current working
+    directory. For a run with no search, the output is the output model of the final pass and its evaluation result. For a run with search, the
+    output is a json file with the search results.
+
+- `output_name: [str]` The name of the output. This string will be used as the prefix of the output file name. If not specified, there is no
+    prefix.
 
 Please find the detailed config options from following table for each search algorithm:
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -257,7 +257,7 @@ Please also find the detailed options from following table for each pass:
 
 This is a dictionary that contains the information of the engine. The information of the engine contains following items:
 
-- `search_strategy: [Dict]` The search strategy of the engine. It contains the following items:
+- `search_strategy: [Dict | Boolean | None]` The search strategy of the engine. It contains the following items:
 
     - `execution_order: [str]` The execution order of the optimizations of passes. The options are `pass-by-pass` and `joint`.
 
@@ -275,9 +275,12 @@ This is a dictionary that contains the information of the engine. The informatio
     - `max_time: [int]` The maximum time of the search in seconds. Only valid for `joint` execution order. By default, there is no
     maximum time.
 
-  If `search_strategy` is `null`, the engine will run the passes in the order they were registered without. Thus, the passes must have empty
-  search spaces. The output of the final pass will be evaluated if there is a valid evaluator. The output of the engine will be the output model
-  of the final pass and its evaluation result.
+  If `search_strategy` is `null` or `false`, the engine will run the passes in the order they were registered without. Thus, the passes must
+  have empty search spaces. The output of the final pass will be evaluated if there is a valid evaluator. The output of the engine will be
+  the output model of the final pass and its evaluation result.
+
+  If `search_strategy` is `true`, the search strategy will be the default search strategy. The default search strategy is `exhaustive` search
+  algorithm with `joint` execution order.
 
 - `host: [str | Dict]` The host of the engine. It can be a string or a dictionary. If it is a string, it is the name of a system in `systems`.
     If it is a dictionary, it contains the system information. If not specified, it is the local system.

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -144,7 +144,7 @@ def save_model(
         if model_path.is_dir():
             shutil.copytree(model_path, output_path, dirs_exist_ok=True)
         elif model_path.is_file():
-            output_path = output_path.with_suffix(model_path.suffi)
+            output_path = output_path.with_suffix(model_path.suffix)
             shutil.copy(model_path, output_path)
         output_path = str(output_path)
     else:

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 from typing import Union
 
+from olive.common.config_utils import serialize_to_json
 from olive.passes import REGISTRY as PASS_REGISTRY
 
 logger = logging.getLogger(__name__)
@@ -113,3 +114,44 @@ def clean_pass_run_cache(pass_type: str, cache_dir: Union[str, Path] = ".olive-c
     run_jsons = list(run_cache_dir.glob(f"{pass_type}-*.json"))
     for run_json in run_jsons:
         _delete_run(run_json.stem, cache_dir)
+
+
+def save_model(
+    model_number: str,
+    output_dir: Union[str, Path] = None,
+    output_name: Union[str, Path] = None,
+    cache_dir: Union[str, Path] = ".olive-cache",
+):
+    """
+    Saves a model from the cache to a given path.
+    """
+    model_number = model_number.split("_")[0]
+    output_dir = Path(output_dir) if output_dir else Path.cwd()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_name = output_name if output_name else "model"
+
+    model_cache_dir = get_cache_sub_dirs(cache_dir)[0]
+    model_jsons = list(model_cache_dir.glob(f"{model_number}_*.json"))
+    assert len(model_jsons) == 1, f"No model found for {model_number}"
+
+    model_json = serialize_to_json(json.load(open(model_jsons[0], "r")))
+
+    # save model file/folder
+    model_path = model_json["config"]["model_path"]
+    if model_path is not None and Path(model_path).exists():
+        model_path = Path(model_path)
+        output_path = (output_dir / output_name).resolve()
+        if model_path.is_dir():
+            shutil.copytree(model_path, output_path, dirs_exist_ok=True)
+        elif model_path.is_file():
+            output_path = output_path.with_suffix(model_path.suffi)
+            shutil.copy(model_path, output_path)
+        output_path = str(output_path)
+    else:
+        output_path = model_path
+
+    # save model json
+    model_json["config"]["model_path"] = output_path
+    json.dump(model_json, open(output_dir / f"{output_name}.json", "w"), indent=4)
+
+    return model_json

--- a/olive/engine.py
+++ b/olive/engine.py
@@ -152,7 +152,7 @@ class Engine:
                 if name not in self.passes:
                     break
 
-        if self.search_strategy is None and len(p.search_space()) > 0:
+        if self.no_search and len(p.search_space()) > 0:
             raise ValueError(f"Search strategy is None but pass {name} has search space")
 
         self.passes[name] = {

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -42,20 +42,6 @@ class RunConfig(ConfigBase):
         v = _resolve_system(v, values, "host")
         return _resolve_evaluator(v, values)
 
-    @validator("passes", pre=True, each_item=True)
-    def validate_pass_search(cls, v, values):
-        if "engine" not in values:
-            raise ValueError("Invalid engine")
-        search = values["engine"].search_strategy is not None
-
-        pass_search = v.get("default_to_search")
-
-        # if pass_search is None, set it to search
-        # pass_search overrides search
-        if pass_search is None:
-            v["default_to_search"] = search
-        return v
-
 
 def _resolve_system(v, values, system_alias):
     if not isinstance(v, dict):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -34,18 +34,11 @@ class RunConfig(ConfigBase):
 
     @validator("engine", pre=True)
     def validate_engine(cls, v, values):
-        search_strategy = None
-        if isinstance(v, dict):
-            search_strategy = v.get("search_strategy")
-        elif isinstance(v, EngineConfig):
-            search_strategy = v.search_strategy
-        if search_strategy is None:
-            raise ValueError("search_strategy must be specified in engine config")
         v = _resolve_system(v, values, "host")
         return _resolve_evaluator(v, values)
 
     @validator("passes", pre=True, each_item=True)
-    def validate_passes(cls, v, values):
+    def validate_pass_host(cls, v, values):
         v = _resolve_system(v, values, "host")
         return _resolve_evaluator(v, values)
 
@@ -58,6 +51,7 @@ class RunConfig(ConfigBase):
         pass_search = v.get("default_to_search")
 
         # if pass_search is None, set it to search
+        # pass_search overrides search
         if pass_search is None:
             v["default_to_search"] = search
         return v

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -2,7 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Union
 
 from pydantic import validator
 
@@ -20,12 +21,17 @@ class RunPassConfig(FullPassConfig):
     clean_run_cache: bool = False
 
 
+class RunEngineConfig(EngineConfig):
+    output_dir: Union[Path, str] = None
+    output_name: str = None
+
+
 class RunConfig(ConfigBase):
     verbose: bool = False
     input_model: ModelConfig
     systems: Dict[str, SystemConfig] = None
     evaluators: Dict[str, OliveEvaluatorConfig] = None
-    engine: EngineConfig
+    engine: RunEngineConfig
     passes: Dict[str, RunPassConfig]
 
     @validator("evaluators", pre=True, each_item=True)

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -68,6 +68,6 @@ def run(config: Union[str, Path, dict]):
         engine.register(p, pass_name, host, evaluator, pass_config.clean_run_cache)
 
     # run
-    best_execution = engine.run(input_model, config.verbose)
+    best_execution = engine.run(input_model, config.verbose, config.engine.output_dir, config.engine.output_name)
     logger.info(best_execution)
     return best_execution

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -56,7 +56,7 @@ def run(config: Union[str, Path, dict]):
     input_model = config.input_model.create_model()
 
     # engine
-    engine = Engine(config.engine)
+    engine = Engine(config.engine.dict())
 
     if config.passes is None or not config.passes:
         engine, config = automatically_insert_passes(engine, config)

--- a/test/unit_test/test_cache.py
+++ b/test/unit_test/test_cache.py
@@ -93,7 +93,7 @@ class TestCache:
         json.dump(model_json, open(model_cache_file_path, "w"))
 
         # output model to output_dir
-        output_dir = Path("output_dir")
+        output_dir = cache_dir / "output"
         shutil.rmtree(output_dir, ignore_errors=True)
         output_name = "test_model"
         output_json = save_model(model_id, output_dir, output_name, cache_dir)
@@ -109,4 +109,3 @@ class TestCache:
 
         # cleanup
         shutil.rmtree(cache_dir)
-        shutil.rmtree(output_dir)

--- a/test/unit_test/test_engine.py
+++ b/test/unit_test/test_engine.py
@@ -74,7 +74,7 @@ class TestEngine:
         assert name in engine.passes
         assert name in engine.pass_order
 
-    def test_register_with_search_fail(self):
+    def test_register_no_search_fail(self):
         # setup
         p = get_onnx_dynamic_quantization_pass(default_to_search=True)
         name = p.__class__.__name__

--- a/test/unit_test/test_engine.py
+++ b/test/unit_test/test_engine.py
@@ -150,7 +150,7 @@ class TestEngine:
         output_dir = Path("cache") / "output"
         shutil.rmtree(output_dir, ignore_errors=True)
 
-        expected_res = {"model": onnx_model.to_json(), "results": {metric.name: 0.998}}
+        expected_res = {"model": onnx_model.to_json(), "metrics": {metric.name: 0.998}}
         expected_res["model"]["config"]["model_path"] = str(Path(output_dir / "model.onnx").resolve())
 
         # execute
@@ -161,9 +161,9 @@ class TestEngine:
         model_json_path = Path(output_dir / "model.json")
         assert model_json_path.is_file()
         assert json.load(open(model_json_path, "r")) == actual_res["model"]
-        result_json_path = Path(output_dir / "results.json")
+        result_json_path = Path(output_dir / "metrics.json")
         assert result_json_path.is_file()
-        assert json.load(open(result_json_path, "r")) == actual_res["results"]
+        assert json.load(open(result_json_path, "r")) == actual_res["metrics"]
 
         # clean up
         shutil.rmtree(output_dir, ignore_errors=True)

--- a/test/unit_test/test_engine.py
+++ b/test/unit_test/test_engine.py
@@ -2,15 +2,21 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 import logging
+import shutil
+from pathlib import Path
 from test.unit_test.utils import (
     get_accuracy_metric,
+    get_onnx_dynamic_quantization_pass,
     get_onnx_model,
     get_onnxconversion_pass,
     get_pytorch_model,
     pytorch_model_loader,
 )
 from unittest.mock import patch
+
+import pytest
 
 from olive.common.utils import hash_dict
 from olive.engine import Engine
@@ -44,11 +50,45 @@ class TestEngine:
         engine.register(p, host=system, evaluator=evaluator)
 
         # assert
-        assert (name, p) in engine._passes.items()
-        assert name in engine._pass_order
-        assert (name, system) in engine.hosts.items()
-        assert (name, evaluator) in engine._evaluators.items()
-        assert (name, False) in engine._clean_pass_run_cache.items()
+        assert name in engine.passes
+        assert name in engine.pass_order
+        assert engine.passes[name]["pass"] == p
+        assert engine.passes[name]["host"] == system
+        assert engine.passes[name]["evaluator"] == evaluator
+        assert engine.passes[name]["clean_run_cache"] is False
+
+    def test_register_no_search(self):
+        # setup
+        p = get_onnx_dynamic_quantization_pass(default_to_search=False)
+        name = p.__class__.__name__
+
+        options = {
+            "search_strategy": None,
+        }
+        engine = Engine(options)
+
+        # execute
+        engine.register(p)
+
+        # assert
+        assert name in engine.passes
+        assert name in engine.pass_order
+
+    def test_register_with_search_fail(self):
+        # setup
+        p = get_onnx_dynamic_quantization_pass(default_to_search=True)
+        name = p.__class__.__name__
+
+        options = {
+            "search_strategy": None,
+        }
+        engine = Engine(options)
+
+        # execute
+        with pytest.raises(ValueError) as exc_info:
+            engine.register(p)
+
+        assert str(exc_info.value) == f"Search strategy is None but pass {name} has search space"
 
     @patch("olive.engine.LocalSystem")
     def test_run(self, mock_local_system):
@@ -86,6 +126,47 @@ class TestEngine:
         assert model_id in actual_res["model_ids"][0]
         mock_local_system.run_pass.assert_called_once()
         mock_local_system.evaluate_model.assert_called_once_with(onnx_model, [metric])
+
+    @patch("olive.engine.LocalSystem")
+    def test_run_no_search(self, mock_local_system):
+        # setup
+        pytorch_model = get_pytorch_model()
+        p = get_onnxconversion_pass()
+        metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
+        evaluator = OliveEvaluator(metrics=[metric], target=mock_local_system)
+        options = {
+            "cache_dir": "./cache",
+            "clean_cache": True,
+            "search_strategy": None,
+            "clean_evaluation_cache": True,
+        }
+        engine = Engine(options, host=mock_local_system, evaluator=evaluator)
+        engine.register(p, clean_run_cache=True)
+        onnx_model = get_onnx_model()
+        mock_local_system.run_pass.return_value = onnx_model
+        mock_local_system.evaluate_model.return_value = {metric.name: 0.998}
+
+        # output model to output_dir
+        output_dir = Path("cache") / "output"
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+        expected_res = {"model": onnx_model.to_json(), "results": {metric.name: 0.998}}
+        expected_res["model"]["config"]["model_path"] = str(Path(output_dir / "model.onnx").resolve())
+
+        # execute
+        actual_res = engine.run(pytorch_model, output_dir=output_dir)
+
+        assert expected_res == actual_res
+        assert Path(actual_res["model"]["config"]["model_path"]).is_file()
+        model_json_path = Path(output_dir / "model.json")
+        assert model_json_path.is_file()
+        assert json.load(open(model_json_path, "r")) == actual_res["model"]
+        result_json_path = Path(output_dir / "results.json")
+        assert result_json_path.is_file()
+        assert json.load(open(result_json_path, "r")) == actual_res["results"]
+
+        # clean up
+        shutil.rmtree(output_dir, ignore_errors=True)
 
     def test_pass_exception(self, caplog):
         # Need explicitly set the propagate to allow the message to be logged into caplog

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -12,7 +12,7 @@ from torch.utils.data import DataLoader, Dataset
 from olive.evaluator.metric import Metric, MetricType
 from olive.evaluator.metric_config import MetricGoal
 from olive.model import ONNXModel, PyTorchModel
-from olive.passes.onnx.conversion import OnnxConversion
+from olive.passes.onnx import OnnxConversion, OnnxDynamicQuantization
 
 ONNX_MODEL_PATH = Path(__file__).absolute().parent / "dummy_model.onnx"
 
@@ -106,4 +106,9 @@ def get_onnxconversion_pass():
         "output_names": ["output"],
     }
     p = OnnxConversion(onnx_conversion_config)
+    return p
+
+
+def get_onnx_dynamic_quantization_pass(default_to_search=False):
+    p = OnnxDynamicQuantization({}, default_to_search=default_to_search)
     return p


### PR DESCRIPTION
This PR adds support for running passes without search strategy. If `search_stategy` is `None`, the passes are run on the input_model and the final output model is evaluated if there is a valid evaluator. The output of the run is the final output model and evaluation results. 

## Tests 
Added tests for the new functionalities introduced. 
Updated relevant pre-existing tests. 