### PR TITLE
PassConfigParam: rename `default` -> `default_value`, `default_search` -> `searchable_values`. Introduce `ConditionalDefault`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ It is initialized using:
 
 Optional parameters can be fixed values or search values which are prescribed using `SearchParameter`.
 
-Searchable parameters have default search values which can be used by assigning the config value as `DEFAULT_SEARCH`. Optional parameters use the default fixed value, also assignable using `DEFAULT`, if not assigned.
+Searchable parameters have default search values which can be used by assigning the config value as `SEARCHABLE_VALUES`. Optional parameters use the default fixed value, also assignable using `DEFAULT`, if not assigned.
 
 During initialization, the pass compares the user provided config and pass config class to create a dictionary for fixed parameters (`_fixed_params`) and search parameters (`_search_space`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ It is initialized using:
 
 Optional parameters can be fixed values or search values which are prescribed using `SearchParameter`.
 
-Searchable parameters have default search values which can be used by assigning the config value as `SEARCHABLE_VALUES`. Optional parameters use the default fixed value, also assignable using `DEFAULT`, if not assigned.
+Searchable parameters have default search values which can be used by assigning the config value as `SEARCHABLE_VALUES`. Optional parameters use the default fixed value, also assignable using `DEFAULT_VALUE`, if not assigned.
 
 During initialization, the pass compares the user provided config and pass config class to create a dictionary for fixed parameters (`_fixed_params`) and search parameters (`_search_space`).
 

--- a/docs/source/api/passes.rst
+++ b/docs/source/api/passes.rst
@@ -27,7 +27,7 @@ OrtPerfTuning
 
 .. _onnx_float_to_float16:
 OnnxFloatToFloat16
-----------------
+-------------------
 .. autoconfigclass:: olive.passes.OnnxFloatToFloat16
 
 .. _onnx_dynamic_quantization:

--- a/docs/source/exts/auto_config_doc/__init__.py
+++ b/docs/source/exts/auto_config_doc/__init__.py
@@ -49,7 +49,7 @@ class AutoConfigDirective(Directive):
             if param.required:
                 lines += ["", "   **required:** True"]
             else:
-                lines += ["", f"   **default:** {param.default}"]
+                lines += ["", f"   **default_value:** {param.default_value}"]
                 if hasattr(param, "searchable_values"):
                     lines += ["", f"   **searchable_values:** {param.searchable_values}"]
 

--- a/docs/source/exts/auto_config_doc/__init__.py
+++ b/docs/source/exts/auto_config_doc/__init__.py
@@ -50,8 +50,8 @@ class AutoConfigDirective(Directive):
                 lines += ["", "   **required:** True"]
             else:
                 lines += ["", f"   **default:** {param.default}"]
-                if hasattr(param, "default_search"):
-                    lines += ["", f"   **default_search:** {param.default_search}"]
+                if hasattr(param, "searchable_values"):
+                    lines += ["", f"   **searchable_values:** {param.searchable_values}"]
 
         return lines
 

--- a/docs/source/overview/design.md
+++ b/docs/source/overview/design.md
@@ -27,8 +27,8 @@ Passes are the building blocks of an Olive workflow. A Pass performs a specific 
 conversion or ONNX quantization.
 
 Each pass is configured using a set of required and optional parameters. A Pass config parameter might have a
-default value and pre-defined search space. When initializing a pass, the user can chose to set the values of parameters to
-their default value (no search), pre-defined search space (search for the best value from the possible options) or a
+default value and default searchable values. When initializing a pass, the user can chose to set the values of parameters to
+their default value (no search), default searchable values (search for the best value from the possible options) or a
 combination of the two (fix some parameters to a certain value, default or user provided, and/or search for other parameters).
 
 ## System

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -189,7 +189,7 @@ another dictionary that contains the information of the pass. The information of
 
 - `type: [str]` The type of the pass.
 
-- `disable_search: [Boolean]` This decides whether to use the default value (`true`) or the default search space,
+- `disable_search: [Boolean]` This decides whether to use the default value (`true`) or the default searchable values,
   if any, (`false`) for the optional parameters. This is `false` by default and can be overridden if `search_strategy` under `engine` is
   specified. Otherwise, it is always `true`.
 

--- a/docs/source/tutorials/configure_pass.rst
+++ b/docs/source/tutorials/configure_pass.rst
@@ -17,7 +17,7 @@ To fully configure a Pass, we require three things: :code:`type`, :code:`disable
 * :code:`config`: This is a dictionary of the config parameters and values. It must contain all required parameters. For optional parameters
   the default value or default search space (depending on whether :code:`disable_search` is :code:`True` or :code:`False`) can be
   overridden by providing user defined values. You can also assign the value for a specific parameter as :code:`"DEFAULT"` to use the default
-  value or :code:`"DEFAULT_SEARCH"` to use the default search values (if available).
+  value or :code:`"SEARCHABLE_VALUES"` to use the default search values (if available).
 
 Let's take the example of the :ref:`onnx_quantization` Pass:
 
@@ -34,9 +34,9 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
                     "dataloader_func": "glue_calibration_reader",
                     // set per_channel to "DEFAULT" value
                     "per_channel": "DEFAULT",
-                    // set reduce_range to "DEFAULT_SEARCH" value
+                    // set reduce_range to "SEARCHABLE_VALUES" value
                     // redundant since disable_search is false
-                    "reduce_range": "DEFAULT_SEARCH",
+                    "reduce_range": "SEARCHABLE_VALUES",
                     // user defined value for weight_type
                     "weight_type": "QUInt8"
                 }
@@ -59,9 +59,9 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
                     "dataloader_func": "glue_calibration_reader",
                     # set per_channel to "DEFAULT" value
                     "per_channel": "DEFAULT",
-                    # set reduce_range to "DEFAULT_SEARCH" value
+                    # set reduce_range to "SEARCHABLE_VALUES" value
                     # redundant since disable_search is false
-                    "reduce_range": "DEFAULT_SEARCH"
+                    "reduce_range": "SEARCHABLE_VALUES"
                     # user defined value for weight_type
                     "weight_type": "QUInt8"
                 },

--- a/docs/source/tutorials/configure_pass.rst
+++ b/docs/source/tutorials/configure_pass.rst
@@ -12,12 +12,12 @@ user provided, and/or search for other parameters).
 To fully configure a Pass, we require three things: :code:`type`, :code:`disable_search`, and :code:`config`.
 
 * :code:`type`: This is the type of the Pass. Check out :ref:`passes` for the full list of supported Passes.
-* :code:`disable_search`: This decides whether to use the default value (:code:`disable_search=True`) or the default search space,
+* :code:`disable_search`: This decides whether to use the default value (:code:`disable_search=True`) or the default searchable values,
   if any, (:code:`disable_search=False`) for the optional parameters. This is :code:`False` by default.
 * :code:`config`: This is a dictionary of the config parameters and values. It must contain all required parameters. For optional parameters
-  the default value or default search space (depending on whether :code:`disable_search` is :code:`True` or :code:`False`) can be
-  overridden by providing user defined values. You can also assign the value for a specific parameter as :code:`"DEFAULT"` to use the default
-  value or :code:`"SEARCHABLE_VALUES"` to use the default search values (if available).
+  the default value or default searchable values (dependending on whether :code:`disable_search` is :code:`True` or :code:`False`) can be
+  overridden by providing user defined values. You can also assign the value for a specific parameter as :code:`"DEFAULT_VALUE"` to use the default
+  value or :code:`"SEARCHABLE_VALUES"` to use the default searchable values (if available).
 
 Let's take the example of the :ref:`onnx_quantization` Pass:
 
@@ -32,8 +32,8 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
                 "config": {
                     "user_script": "./user_script.py",
                     "dataloader_func": "glue_calibration_reader",
-                    // set per_channel to "DEFAULT" value
-                    "per_channel": "DEFAULT",
+                    // set per_channel to "DEFAULT_VALUE"
+                    "per_channel": "DEFAULT_VALUE",
                     // set reduce_range to "SEARCHABLE_VALUES" value
                     // redundant since disable_search is false
                     "reduce_range": "SEARCHABLE_VALUES",
@@ -57,9 +57,9 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
                 config={
                     "user_script": "./user_script.py",
                     "dataloader_func": "glue_calibration_reader",
-                    # set per_channel to "DEFAULT" value
-                    "per_channel": "DEFAULT",
-                    # set reduce_range to "SEARCHABLE_VALUES" value
+                    # set per_channel to "DEFAULT_VALUE" value
+                    "per_channel": "DEFAULT_VALUE",
+                    # set reduce_range to "SEARCHABLE_VALUES"
                     # redundant since disable_search is false
                     "reduce_range": "SEARCHABLE_VALUES"
                     # user defined value for weight_type

--- a/docs/source/tutorials/how_to_add_pass.md
+++ b/docs/source/tutorials/how_to_add_pass.md
@@ -29,7 +29,7 @@ return `Dict[str, PassConfigParam]`.
             "quant_mode": PassConfigParam(
                 type_=str,
                 default="static",
-                default_search=Categorical(["dynamic", "static"]),
+                searchable_values=Categorical(["dynamic", "static"]),
                 description="""
                     Onnx Quantization mode. 'dynamic' for dynamic quantization,
                     'static' for static quantization.

--- a/docs/source/tutorials/how_to_add_pass.md
+++ b/docs/source/tutorials/how_to_add_pass.md
@@ -28,7 +28,7 @@ return `Dict[str, PassConfigParam]`.
         config = {
             "quant_mode": PassConfigParam(
                 type_=str,
-                default="static",
+                default_value="static",
                 searchable_values=Categorical(["dynamic", "static"]),
                 description="""
                     Onnx Quantization mode. 'dynamic' for dynamic quantization,

--- a/docs/source/tutorials/how_to_add_pass.md
+++ b/docs/source/tutorials/how_to_add_pass.md
@@ -15,6 +15,9 @@ from olive.passes import Pass
 
 class NewOptimizationTrick(Pass):
 
+    # set this to True if the pass has paremeters that are functions or objects and the user script is required
+    # to import the module containing the function or object
+    _requires_user_script: bool = False
 ```
 
 ## 2. Define configuration
@@ -22,19 +25,64 @@ class NewOptimizationTrick(Pass):
 Next, define the options used to configure this new technique by defining static method `_default_config`. The method should
 return `Dict[str, PassConfigParam]`.
 
+`PassConfigParam` is a dataclass that holds the information about the configuration option. The dataclass has the following fields:
+
+- `type_` : type of the parameter
+
+- `required` : whether the parameter is required
+
+- `is_object` : whether the parameter is an object/function. If so, this parameter accepts the object or a string with the
+    name of the object in the user script. The type must include `str`.
+
+- `is_path` : whether the parameter is a path. If so, this file/folder will be uploaded to the host system.
+
+- `description` : description of the parameter
+
+- `default_value`: default value for the parameter. This value is used as the default if `disable_search=False` or there are no searchable values.
+    Must be the same type as the parameter or a ConditionalDefault SearchParameter.
+
+- `searchable_values`: default searchable values for the parameter. This value is used as the default if `disable_search=True`.
+    Must be a Categorical or Conditional SearchParameter.
+
+### Example
 ```python
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
-        config = {
-            "quant_mode": PassConfigParam(
-                type_=str,
-                default_value="static",
-                searchable_values=Categorical(["dynamic", "static"]),
-                description="""
-                    Onnx Quantization mode. 'dynamic' for dynamic quantization,
-                    'static' for static quantization.
-                """,
-            )
+        return {
+            # required parameter
+            "param1": PassConfigParam(type_=int, required=True, description="param1 description"),
+            # optional parameter with default value
+            "param2": PassConfigParam(type_=int, default_value=1, description="param2 description"),
+            # optional parameter with default value and searchable values
+            "param3": PassConfigParam(
+                type_=int, default_value=1, searchable_values=Categorical([1, 2, 3]), description="param3 description"
+            ),
+            # optional parameter with `is_object` set to True
+            # the value of this parameter can be a string or a function that takes a string and returns the object,
+            # say a class ObjectClass
+            "param4": PassConfigParam(
+                type_=Union[str, Callable[[str], Pass]], is_object=True, description="param4 description"
+            ),
+            # optional parameter with default_value that depends on another parameter value
+            "param5": PassConfigParam(
+                type_=int,
+                default_value=ConditionalDefault(parents="param2", support={(1,): 2, (2,): 3}, default=4),
+                description="param5 description",
+            ),
+            # optional parameter with searchable_values that depends on other parameter values
+            "param6": PassConfigParam(
+                type_=int,
+                default_value=1,
+                searchable_values=Conditional(
+                    parents=("param2", "param3"),
+                    # invalid if (param2, param3) not in [(1, 1), (1, 2)]
+                    support={
+                        (1, 1): Categorical([1, 2, 3]),
+                        (1, 2): Categorical([4, 5, 6]),
+                    },
+                ),
+                description="param6 description",
+            ),
         }
 
 ```

--- a/docs/source/tutorials/passes/onnx.md
+++ b/docs/source/tutorials/passes/onnx.md
@@ -104,7 +104,7 @@ Please refer to [OnnxQuantization](onnx_quantization), [OnnxDynamicQuantization]
 [OnnxStaticQuantization](onnx_static_quantization) for more details about the passes and their config parameters.
 
 ### Example Configuration
-a. Tune the parameters of the OlivePass with pre-defined search space
+a. Tune the parameters of the OlivePass with pre-defined searchable values
 ```json
 {
     "type": "OnnxQuantization",
@@ -135,8 +135,8 @@ c. Use default values of the OlivePass (no tuning in this way)
 {
     "type": "OnnxQuantization",
     "config": {
-        // set per_channel to "DEFAULT" value.
-        "per_channel": "DEFAULT",
+        // set per_channel to "DEFAULT_VALUE"
+        "per_channel": "DEFAULT_VALUE",
         "user_script": "./user_script.py",
         "dataloader_func": "glue_calibration_reader",
     },

--- a/docs/source/tutorials/passes/onnx.md
+++ b/docs/source/tutorials/passes/onnx.md
@@ -120,9 +120,9 @@ b. Select parameters to tune
 {
     "type": "OnnxQuantization",
     "config": {
-        // select per_channel to tune with "DEFAULT_SEARCH".
+        // select per_channel to tune with "SEARCHABLE_VALUES".
         // other parameters will use the default value, not to be tuned.
-        "per_channel": "DEFAULT_SEARCH",
+        "per_channel": "SEARCHABLE_VALUES",
         "user_script": "./user_script.py",
         "dataloader_func": "glue_calibration_reader",
     },

--- a/examples/resnet_ptq_cpu/resnet_dynamic_config.json
+++ b/examples/resnet_ptq_cpu/resnet_dynamic_config.json
@@ -72,8 +72,8 @@
             "disable_search": true,
             "config": {
                 "weight_type": "QUInt8",
-                "per_channel": "DEFAULT_SEARCH",
-                "reduce_range": "DEFAULT_SEARCH"
+                "per_channel": "SEARCHABLE_VALUES",
+                "reduce_range": "SEARCHABLE_VALUES"
             },
             "clean_run_cache": false
         }

--- a/examples/resnet_ptq_cpu/resnet_static_config.json
+++ b/examples/resnet_ptq_cpu/resnet_static_config.json
@@ -74,8 +74,8 @@
                 "user_script": "user_script.py",
                 "data_dir": "data",
                 "dataloader_func": "resnet_calibration_reader",
-                "per_channel": "DEFAULT_SEARCH",
-                "reduce_range": "DEFAULT_SEARCH"
+                "per_channel": "SEARCHABLE_VALUES",
+                "reduce_range": "SEARCHABLE_VALUES"
             },
             "clean_run_cache": false
         }

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -122,7 +122,7 @@ class ConfigParam(ConfigBase):
 
     type_: Any
     required: bool = False
-    default: Any = None
+    default_value: Any = None
     is_object: bool = False
     description: str = None
 
@@ -182,7 +182,7 @@ def create_config_class(
             config[param] = (type_, ...)
             continue
 
-        config[param] = (Optional[type_], param_config.default)
+        config[param] = (Optional[type_], param_config.default_value)
 
     return create_model(class_name, **config, __base__=base, __validators__=validators)
 

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -29,11 +29,11 @@ class AccuracyBase(AutoConfigClass):
     def _default_config() -> Dict[str, ConfigParam]:
         return {
             "num_classes": ConfigParam(type_=int),
-            "threshold": ConfigParam(type_=float, default=0.5),
-            "average": ConfigParam(type_=str, default="micro"),
-            "ignore_index": ConfigParam(type_=list, default=None),
-            "top_k": ConfigParam(type_=int, default=None),
-            "mdmc_average": ConfigParam(type_=str, default="global"),
+            "threshold": ConfigParam(type_=float, default_value=0.5),
+            "average": ConfigParam(type_=str, default_value="micro"),
+            "ignore_index": ConfigParam(type_=list, default_value=None),
+            "top_k": ConfigParam(type_=int, default_value=None),
+            "mdmc_average": ConfigParam(type_=str, default_value="global"),
         }
 
     @abstractmethod
@@ -90,7 +90,7 @@ class AUC(AccuracyBase):
 
     @staticmethod
     def _default_config():
-        return {"reorder": ConfigParam(type_=bool, default=False)}
+        return {"reorder": ConfigParam(type_=bool, default_value=False)}
 
     def evaluate(self, preds, target):
         preds = np.array(preds).flatten()

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -18,7 +18,7 @@ _common_user_config = {
     "script_dir": ConfigParam(type_=Union[Path, str]),
     "user_script": ConfigParam(type_=Union[Path, str]),
     "data_dir": ConfigParam(type_=Union[Path, str]),
-    "batch_size": ConfigParam(type_=int, default=1),
+    "batch_size": ConfigParam(type_=int, default_value=1),
 }
 
 _common_user_config_validators = {}
@@ -27,7 +27,7 @@ _type_to_user_config = {
     "latency": {
         "dataloader_func": ConfigParam(type_=Union[Callable, str], required=True, is_object=True),
         "inference_settings": ConfigParam(type_=dict),
-        "io_bind": ConfigParam(type_=bool, default=False),
+        "io_bind": ConfigParam(type_=bool, default_value=False),
     },
     "accuracy": {
         "dataloader_func": ConfigParam(type_=Union[Callable, str], required=True, is_object=True),

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -100,13 +100,13 @@ class Pass(AutoConfigClass):
         """
         default_config = self.default_config()
         for key, value in config.items():
-            if value == PassParamDefault.DEFAULT:
-                config[key] = default_config[key].default
+            if value == PassParamDefault.DEFAULT_VALUE:
+                config[key] = default_config[key].default_value
             elif value == PassParamDefault.SEARCHABLE_VALUES:
                 value = default_config[key].searchable_values
                 if value is None:
                     logger.warning(f"Parameter {key} does not have searchable values. Using default value instead.")
-                    value = default_config[key].default
+                    value = default_config[key].default_value
                 config[key] = value
         return config
 
@@ -143,7 +143,7 @@ class Pass(AutoConfigClass):
             if isinstance(value, SearchParameter):
                 # resolve conditional parameters
                 # if categorical with single choice, use that choice directly
-                value = self._resolve_search_parameters(value, fixed_params)
+                value = self._resolve_search_parameter(value, fixed_params)
             if value == SpecialParamValue.INVALID:
                 # TODO: better error message, e.g. what the parent values were, how it was invalid
                 raise ValueError(
@@ -161,7 +161,7 @@ class Pass(AutoConfigClass):
 
         return fixed_params, search_space
 
-    def _resolve_search_parameters(self, param: SearchParameter, fixed_params: Dict[str, Any]) -> Any:
+    def _resolve_search_parameter(self, param: SearchParameter, fixed_params: Dict[str, Any]) -> Any:
         """
         Resolve a search parameter.
         """

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Type, Union
@@ -28,6 +29,8 @@ from olive.strategy.search_parameter import (
 )
 from olive.strategy.search_space import SearchSpace
 from olive.strategy.utils import cyclic_search_space, order_search_parameters
+
+logger = logging.getLogger(__name__)
 
 
 class Pass(AutoConfigClass):
@@ -99,10 +102,12 @@ class Pass(AutoConfigClass):
         for key, value in config.items():
             if value == PassParamDefault.DEFAULT:
                 config[key] = default_config[key].default
-            elif value == PassParamDefault.DEFAULT_SEARCH:
-                default_search = default_config[key].default_search
-                assert default_search is not None, f"Parameter {key} does not have a default search."
-                config[key] = default_search
+            elif value == PassParamDefault.SEARCHABLE_VALUES:
+                value = default_config[key].searchable_values
+                if value is None:
+                    logger.warning(f"Parameter {key} does not have searchable values. Using default value instead.")
+                    value = default_config[key].default
+                config[key] = value
         return config
 
     def _validate_user_script(self, config: Dict[str, Any], user_module_loader: UserModuleLoader) -> Dict[str, Any]:

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -91,6 +91,47 @@ class Pass(AutoConfigClass):
     def _default_config() -> Dict[str, PassConfigParam]:
         """
         Get the default configuration for the pass. Doesn't include user_script and script_dir.
+
+        Example:
+            return {
+                # required parameter
+                "param1": PassConfigParam(type_=int, required=True, description="param1 description"),
+                # optional parameter with default value
+                "param2": PassConfigParam(type_=int, default_value=1, description="param2 description"),
+                # optional parameter with default value and searchable values
+                "param3": PassConfigParam(
+                    type_=int,
+                    default_value=1,
+                    searchable_values=Categorical([1, 2, 3]),
+                    description="param3 description",
+                ),
+                # optional parameter with `is_object` set to True
+                # the value of this parameter can be a string or a function that takes a string and returns the object,
+                # say a class ObjectClass
+                "param4": PassConfigParam(
+                    type_=Union[str, Callable[[str], Pass]], is_object=True, description="param4 description"
+                ),
+                # optional parameter with default_value that depends on another parameter value
+                "param5": PassConfigParam(
+                    type_=int,
+                    default_value=ConditionalDefault(parents="param2", support={(1,): 2, (2,): 3}, default=4),
+                    description="param5 description",
+                ),
+                # optional parameter with searchable_values that depends on other parameter values
+                "param6": PassConfigParam(
+                    type_=int,
+                    default_value=1,
+                    searchable_values=Conditional(
+                        parents=("param2", "param3"),
+                        # invalid if (param2, param3) not in [(1, 1), (1, 2)]
+                        support={
+                            (1, 1): Categorical([1, 2, 3]),
+                            (1, 2): Categorical([4, 5, 6]),
+                        },
+                    ),
+                    description="param6 description",
+                ),
+            }
         """
         raise NotImplementedError()
 

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -35,7 +35,7 @@ class OnnxConversion(Pass):
             # required for if input_tensors_func is not provided
             "input_shapes": PassConfigParam(
                 type_=List[List[int]],
-                default=None,
+                default_value=None,
                 description=(
                     "List of input shapes. Must be provided if input_tensor_func is not provided. It is used to create"
                     " dummy inputs for the model during onnx export."
@@ -43,7 +43,7 @@ class OnnxConversion(Pass):
             ),
             "input_types": PassConfigParam(
                 type_=List[str],
-                default=None,
+                default_value=None,
                 description=(
                     "List of input types. If provided, must be the same length as input_shapes. Otherwise, defaults to"
                     " float32 for all inputs. Used with input_shapes to create dummy inputs for the model during onnx"
@@ -52,7 +52,7 @@ class OnnxConversion(Pass):
             ),
             "input_tensor_func": PassConfigParam(
                 type_=Union[Callable, str],
-                default=None,
+                default_value=None,
                 is_object=True,
                 description=(
                     "Function (no input) to create dummy inputs for the model. Can be a function (local use) or name of"
@@ -64,14 +64,14 @@ class OnnxConversion(Pass):
             "output_names": PassConfigParam(type_=List[str], required=True, description="List of output names."),
             "dynamic_axes": PassConfigParam(
                 type_=dict,
-                default=None,
+                default_value=None,
                 description=(
                     "Dynamic axes for the model. Refer to 'dynamic_axes' at"
                     " https://pytorch.org/docs/stable/onnx.html#torch.onnx.export for more details."
                 ),
             ),
             "target_opset": PassConfigParam(
-                type_=int, default=14, description="The version of the default (ai.onnx) opset to target."
+                type_=int, default_value=14, description="The version of the default (ai.onnx) opset to target."
             ),
         }
 

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import onnx
 from onnxconverter_common import float16
@@ -35,10 +35,10 @@ class OnnxFloatToFloat16(Pass):
                 type_=bool, default_value=False, description="Skips running onnx shape/type inference."
             ),
             "op_block_list": PassConfigParam(
-                type_=list[str], default_value=None, description="List of op types to leave as float32"
+                type_=List[str], default_value=None, description="List of op types to leave as float32"
             ),
             "node_block_list": PassConfigParam(
-                type_=list[str], default_value=None, description="List of node names to leave as float32"
+                type_=List[str], default_value=None, description="List of node names to leave as float32"
             ),
         }
 

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -23,22 +23,22 @@ class OnnxFloatToFloat16(Pass):
     def _default_config() -> Dict[str, PassConfigParam]:
         return {
             "min_positive_val": PassConfigParam(
-                type_=float, default=1e-7, description=("Constant values will be clipped against this value")
+                type_=float, default_value=1e-7, description="Constant values will be clipped against this value"
             ),
             "max_finite_val": PassConfigParam(
-                type_=float, default=1e4, description=("Constant values will be clipped against this value")
+                type_=float, default_value=1e4, description="Constant values will be clipped against this value"
             ),
             "keep_io_types": PassConfigParam(
-                type_=bool, default=False, description=("Whether model inputs/outputs should be left as float32")
+                type_=bool, default_value=False, description="Whether model inputs/outputs should be left as float32"
             ),
             "disable_shape_infer": PassConfigParam(
-                type_=bool, default=False, description=("Skips running onnx shape/type inference.")
+                type_=bool, default_value=False, description="Skips running onnx shape/type inference."
             ),
             "op_block_list": PassConfigParam(
-                type_=list[str], default=None, description=("List of op types to leave as float32")
+                type_=list[str], default_value=None, description="List of op types to leave as float32"
             ),
             "node_block_list": PassConfigParam(
-                type_=list[str], default=None, description=("List of node names to leave as float32")
+                type_=list[str], default_value=None, description="List of node names to leave as float32"
             ),
         }
 

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -224,34 +224,40 @@ class OrtPerfTuning(Pass):
                 description="Dataloader function to load data from given data_dir with given batch size.",
             ),
             "batch_size": PassConfigParam(type_=int, required=True, description="Batch size for inference."),
-            "device": PassConfigParam(type_=str, default="cpu", description="Device selected for tuning process."),
-            "cpu_cores": PassConfigParam(type_=int, default=None, description="CPU cores used for thread tuning."),
+            "device": PassConfigParam(
+                type_=str, default_value="cpu", description="Device selected for tuning process."
+            ),
+            "cpu_cores": PassConfigParam(
+                type_=int, default_value=None, description="CPU cores used for thread tuning."
+            ),
             "io_bind": PassConfigParam(
                 type_=Union[bool, List[bool]],
-                default=False,
+                default_value=False,
                 description="Whether enable IOBingding for ONNX Runimte infernece.",
             ),
             "providers_list": PassConfigParam(
-                type_=list, default=None, description="Execution providers framework list to execute the ONNX models."
+                type_=list,
+                default_value=None,
+                description="Execution providers framework list to execute the ONNX models.",
             ),
             "execution_mode_list": PassConfigParam(
-                type_=list, default=None, description="Parallelism list between operators."
+                type_=list, default_value=None, description="Parallelism list between operators."
             ),
             "opt_level_list": PassConfigParam(
-                type_=list, default=None, description="Optimization level list for ONNX model."
+                type_=list, default_value=None, description="Optimization level list for ONNX model."
             ),
             "trt_fp16_enable": PassConfigParam(
-                type_=bool, default=False, description="Whether enable FP16 mode for TensorRT execution provider."
+                type_=bool, default_value=False, description="Whether enable FP16 mode for TensorRT execution provider."
             ),
             "intra_thread_num_list": PassConfigParam(
-                type_=list, default=[None], description="List of intra thread number for test."
+                type_=list, default_value=[None], description="List of intra thread number for test."
             ),
             "inter_thread_num_list": PassConfigParam(
-                type_=list, default=[None], description="List of inter thread number for test."
+                type_=list, default_value=[None], description="List of inter thread number for test."
             ),
             "extra_session_config": PassConfigParam(
                 type_=Dict[str, Any],
-                default=None,
+                default_value=None,
                 description="Extra customized session options during tuning process.",
             ),
         }

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -25,7 +25,7 @@ _onnx_quantization_config = {
     "weight_type": PassConfigParam(
         type_=str,
         default="QInt8",
-        default_search=Categorical(["QInt8", "QUInt8"]),
+        searchable_values=Categorical(["QInt8", "QUInt8"]),
         description="""
             Data type for quantizing weights which is used both in dynamic
             and static quantization. 'QInt8' for signed 8-bit integer,
@@ -56,7 +56,7 @@ _onnx_quantization_config = {
     "per_channel": PassConfigParam(
         type_=bool,
         default=False,
-        default_search=Boolean(),
+        searchable_values=Boolean(),
         description="""
             Quantize weights per channel.
             Tips: When to use reduce_range and per-channel quantization:
@@ -66,7 +66,7 @@ _onnx_quantization_config = {
     "reduce_range": PassConfigParam(
         type_=bool,
         default=False,
-        default_search=Boolean(),
+        searchable_values=Boolean(),
         description="""
             Quantize weights with 7-bits. It may improve the accuracy for
             some models running on non-VNNI machine, especially for per-channel mode.
@@ -77,7 +77,7 @@ _onnx_quantization_config = {
     "optimize_model": PassConfigParam(
         type_=bool,
         default=False,
-        default_search=Boolean(),
+        searchable_values=Boolean(),
         description="""
             Deprecating Soon in ONNX! Optimize model before quantization. NOT recommended, optimization will
             change the computation graph, making debugging of quantization loss difficult.
@@ -94,7 +94,7 @@ _onnx_quantization_config = {
     "quant_preprocess": PassConfigParam(
         type_=bool,
         default=True,
-        default_search=Boolean(),
+        searchable_values=Boolean(),
         description="""
             Shape inference and model optimization, in preparation for quantization.
             https://onnxruntime.ai/docs/performance/quantization.html#pre-processing
@@ -134,7 +134,7 @@ _static_optional_config = {
     "calibrate_method": PassConfigParam(
         type_=str,
         default="MinMax",
-        default_search=Categorical(["MinMax", "Entropy", "Percentile"]),
+        searchable_values=Categorical(["MinMax", "Entropy", "Percentile"]),
         description="""
             Current calibration methods supported are MinMax and Entropy,
             Please use CalibrationMethod.MinMax or CalibrationMethod.Entropy as options.
@@ -143,7 +143,7 @@ _static_optional_config = {
     "quant_format": PassConfigParam(
         type_=str,
         default="QDQ",
-        default_search=Categorical(["QOperator", "QDQ"]),
+        searchable_values=Categorical(["QOperator", "QDQ"]),
         description="""
             QOperator format quantizes the model with quantized operators directly.
             QDQ format quantize the model by inserting QuantizeLinear/DeQuantizeLinear on the tensor.
@@ -152,7 +152,7 @@ _static_optional_config = {
     "activation_type": PassConfigParam(
         type_=str,
         default="QInt8",
-        default_search=Conditional(
+        searchable_values=Conditional(
             parents=("quant_format", "weight_type"),
             support={
                 ("QDQ", "QInt8"): Categorical(["QInt8"]),
@@ -187,7 +187,7 @@ class OnnxQuantization(Pass):
             "quant_mode": PassConfigParam(
                 type_=str,
                 default="static",
-                default_search=Categorical(["dynamic", "static"]),
+                searchable_values=Categorical(["dynamic", "static"]),
                 description="""
                     Onnx Quantization mode. 'dynamic' for dynamic quantization,
                     'static' for static quantization.
@@ -206,17 +206,18 @@ class OnnxQuantization(Pass):
                 parents=("quant_mode",),
                 support={("static",): value.default, ("dynamic",): ConditionalDefault.get_ignored_choice()},
             )
-            if isinstance(value.default_search, Categorical):
-                value.default_search = Conditional(
+            if isinstance(value.searchable_values, Categorical):
+                value.searchable_values = Conditional(
                     parents=("quant_mode",),
-                    support={("static",): value.default_search},
+                    support={("static",): value.searchable_values},
                     default=Conditional.get_ignored_choice(),
                 )
-            elif isinstance(value.default_search, Conditional):
-                value.default_search = Conditional(
-                    parents=("quant_mode",) + value.default_search.parents,
+            elif isinstance(value.searchable_values, Conditional):
+                value.searchable_values = Conditional(
+                    parents=("quant_mode",) + value.searchable_values.parents,
                     support={
-                        ("static",) + key: value.default_search.support[key] for key in value.default_search.support
+                        ("static",) + key: value.searchable_values.support[key]
+                        for key in value.searchable_values.support
                     },
                     default=Conditional.get_ignored_choice(),
                 )

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 _onnx_quantization_config = {
     "weight_type": PassConfigParam(
         type_=str,
-        default="QInt8",
+        default_value="QInt8",
         searchable_values=Categorical(["QInt8", "QUInt8"]),
         description="""
             Data type for quantizing weights which is used both in dynamic
@@ -34,28 +34,28 @@ _onnx_quantization_config = {
     ),
     "op_types_to_quantize": PassConfigParam(
         type_=list,
-        default=None,
+        default_value=None,
         description="""
             List of operator types to quantize. If None, all quantizable.
         """,
     ),
     "nodes_to_quantize": PassConfigParam(
         type_=list,
-        default=None,
+        default_value=None,
         description="""
             List of node names to quantize. If None, all quantizable.
         """,
     ),
     "nodes_to_exclude": PassConfigParam(
         type_=list,
-        default=None,
+        default_value=None,
         description="""
             List of node names to exclude from quantization. If None, all quantizable.
         """,
     ),
     "per_channel": PassConfigParam(
         type_=bool,
-        default=False,
+        default_value=False,
         searchable_values=Boolean(),
         description="""
             Quantize weights per channel.
@@ -65,7 +65,7 @@ _onnx_quantization_config = {
     ),
     "reduce_range": PassConfigParam(
         type_=bool,
-        default=False,
+        default_value=False,
         searchable_values=Boolean(),
         description="""
             Quantize weights with 7-bits. It may improve the accuracy for
@@ -76,7 +76,7 @@ _onnx_quantization_config = {
     ),
     "optimize_model": PassConfigParam(
         type_=bool,
-        default=False,
+        default_value=False,
         searchable_values=Boolean(),
         description="""
             Deprecating Soon in ONNX! Optimize model before quantization. NOT recommended, optimization will
@@ -86,14 +86,14 @@ _onnx_quantization_config = {
     # TODO: enable search if we support onnx external data format
     "use_external_data_format": PassConfigParam(
         type_=bool,
-        default=False,
+        default_value=False,
         description="""
             option used for large size (>2GB) model. Set to False by default.
         """,
     ),
     "quant_preprocess": PassConfigParam(
         type_=bool,
-        default=True,
+        default_value=True,
         searchable_values=Boolean(),
         description="""
             Shape inference and model optimization, in preparation for quantization.
@@ -114,7 +114,7 @@ _static_dataloader_config = {
     ),
     "batch_size": PassConfigParam(
         type_=int,
-        default=1,
+        default_value=1,
         description="""
             Batch size for calibration, required if quant_mode is 'static'.
         """,
@@ -133,7 +133,7 @@ _static_dataloader_config = {
 _static_optional_config = {
     "calibrate_method": PassConfigParam(
         type_=str,
-        default="MinMax",
+        default_value="MinMax",
         searchable_values=Categorical(["MinMax", "Entropy", "Percentile"]),
         description="""
             Current calibration methods supported are MinMax and Entropy,
@@ -142,7 +142,7 @@ _static_optional_config = {
     ),
     "quant_format": PassConfigParam(
         type_=str,
-        default="QDQ",
+        default_value="QDQ",
         searchable_values=Categorical(["QOperator", "QDQ"]),
         description="""
             QOperator format quantizes the model with quantized operators directly.
@@ -151,7 +151,7 @@ _static_optional_config = {
     ),
     "activation_type": PassConfigParam(
         type_=str,
-        default="QInt8",
+        default_value="QInt8",
         searchable_values=Conditional(
             parents=("quant_format", "weight_type"),
             support={
@@ -186,7 +186,7 @@ class OnnxQuantization(Pass):
         config = {
             "quant_mode": PassConfigParam(
                 type_=str,
-                default="static",
+                default_value="static",
                 searchable_values=Categorical(["dynamic", "static"]),
                 description="""
                     Onnx Quantization mode. 'dynamic' for dynamic quantization,
@@ -202,9 +202,9 @@ class OnnxQuantization(Pass):
         config.update(deepcopy(_static_dataloader_config))
         static_optional_config = deepcopy(_static_optional_config)
         for _, value in static_optional_config.items():
-            value.default = ConditionalDefault(
+            value.default_value = ConditionalDefault(
                 parents=("quant_mode",),
-                support={("static",): value.default, ("dynamic",): ConditionalDefault.get_ignored_choice()},
+                support={("static",): value.default_value, ("dynamic",): ConditionalDefault.get_ignored_choice()},
             )
             if isinstance(value.searchable_values, Categorical):
                 value.searchable_values = Conditional(
@@ -326,7 +326,9 @@ class OnnxDynamicQuantization(OnnxQuantization):
 
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
-        config = {"quant_mode": PassConfigParam(type_=str, default="dynamic", description="dynamic quantization mode")}
+        config = {
+            "quant_mode": PassConfigParam(type_=str, default_value="dynamic", description="dynamic quantization mode")
+        }
         # common quantization config
         config.update(deepcopy(_onnx_quantization_config))
         return config
@@ -339,7 +341,9 @@ class OnnxStaticQuantization(OnnxQuantization):
 
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
-        config = {"quant_mode": PassConfigParam(type_=str, default="static", description="static quantization mode")}
+        config = {
+            "quant_mode": PassConfigParam(type_=str, default_value="static", description="static quantization mode")
+        }
         # common quantization config
         config.update(deepcopy(_onnx_quantization_config))
         # static quantization specific config

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -27,34 +27,36 @@ class OrtTransformersOptimization(Pass):
                     "bert_tf (BERT exported by tf2onnx), bert_keras (BERT exported by keras2onnx)."
                 ),
             ),
-            "num_heads": PassConfigParam(type_=int, default=0, description="Number of attention heads."),
-            "hidden_size": PassConfigParam(type_=int, default=0, description="Number of hidden nodes."),
+            "num_heads": PassConfigParam(type_=int, default_value=0, description="Number of attention heads."),
+            "hidden_size": PassConfigParam(type_=int, default_value=0, description="Number of hidden nodes."),
             # TODO: Figure out what the expected type is
             "optimization_options": PassConfigParam(
-                type_=Any, default=None, description="Optimization options that turn on/off some fusions."
+                type_=Any, default_value=None, description="Optimization options that turn on/off some fusions."
             ),
             "opt_level": PassConfigParam(
                 type_=Any,
-                default=None,
+                default_value=None,
                 description=(
                     "Graph optimization level of Onnx Runtime: "
                     "0 - disable all (default), 1 - basic, 2 - extended, 99 - all."
                 ),
             ),
-            "use_gpu": PassConfigParam(type_=bool, default=False, description="Flag for GPU inference."),
+            "use_gpu": PassConfigParam(type_=bool, default_value=False, description="Flag for GPU inference."),
             "only_onnxruntime": PassConfigParam(
                 type_=bool,
-                default=False,
+                default_value=False,
                 description="Whether only use onnxruntime to optimize model, and no python fusion.",
             ),
             "float16": PassConfigParam(
-                type_=bool, default=False, description="Whether half-precision float will be used."
+                type_=bool, default_value=False, description="Whether half-precision float will be used."
             ),
             "input_int32": PassConfigParam(
-                type_=bool, default=False, description="Whether int32 tensors will be used as input."
+                type_=bool, default_value=False, description="Whether int32 tensors will be used as input."
             ),
             "use_external_data_format": PassConfigParam(
-                type_=bool, default=False, description="Whether use external data format to store large model (>2GB)"
+                type_=bool,
+                default_value=False,
+                description="Whether use external data format to store large model (>2GB)",
             ),
         }
 

--- a/olive/passes/openvino/conversion.py
+++ b/olive/passes/openvino/conversion.py
@@ -38,7 +38,7 @@ class OpenVINOConversion(Pass):
             ),
             "extra_config": PassConfigParam(
                 type_=Dict,
-                default=None,
+                default_value=None,
                 required=False,
                 description=(
                     "Extra configurations for OpenVINO model conversion. extra_config can be set by"

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -42,9 +42,9 @@ class OpenVINOQuantization(Pass):
             "data_dir": PassConfigParam(
                 type_=Union[Path, str],
                 is_path=True,
-                description=("Dataset path. 'data_dir' can be by a str or Pathlib.Path."),
+                description="Dataset path. 'data_dir' can be by a str or Pathlib.Path.",
             ),
-            "batch_size": PassConfigParam(type_=int, default=1, description=("Batch size for the dataloader.")),
+            "batch_size": PassConfigParam(type_=int, default_value=1, description="Batch size for the dataloader."),
             "metric_func": PassConfigParam(
                 type_=Union[Callable, str],
                 required=False,

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -18,7 +18,7 @@ class PassParamDefault(str, Enum):
     """
 
     DEFAULT = "DEFAULT"
-    DEFAULT_SEARCH = "DEFAULT_SEARCH"
+    SEARCHABLE_VALUES = "SEARCHABLE_VALUES"
 
 
 class PassConfigParam(ConfigParam):
@@ -26,7 +26,7 @@ class PassConfigParam(ConfigParam):
     Dataclass for pass configuration parameters.
     """
 
-    default_search: SearchParameter = None
+    searchable_values: SearchParameter = None
     is_path: bool = False
 
     def __repr__(self):
@@ -104,8 +104,8 @@ def create_config_class(
             continue
 
         type_ = Optional[Union[type_, SearchParameter, PassParamDefault]]
-        if not disable_search and param_config.default_search is not None:
-            config[param] = (type_, param_config.default_search)
+        if not disable_search and param_config.searchable_values is not None:
+            config[param] = (type_, param_config.searchable_values)
         else:
             config[param] = (type_, param_config.default)
 

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -17,7 +17,7 @@ class PassParamDefault(str, Enum):
     Default values for passes.
     """
 
-    DEFAULT = "DEFAULT"
+    DEFAULT_VALUE = "DEFAULT_VALUE"
     SEARCHABLE_VALUES = "SEARCHABLE_VALUES"
 
 
@@ -107,6 +107,6 @@ def create_config_class(
         if not disable_search and param_config.searchable_values is not None:
             config[param] = (type_, param_config.searchable_values)
         else:
-            config[param] = (type_, param_config.default)
+            config[param] = (type_, param_config.default_value)
 
     return create_model(f"{pass_type}Config", **config, __base__=PassConfigBase, __validators__=validators)

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -24,6 +24,19 @@ class PassParamDefault(str, Enum):
 class PassConfigParam(ConfigParam):
     """
     Dataclass for pass configuration parameters.
+
+    Parameters
+    ----------
+    type_ : type of the parameter
+    required : whether the parameter is required
+    is_object : whether the parameter is an object/function. If so, this parameter accepts the object or a string with
+        the name of the object/function in the user script. The type must include str.
+    is_path : whether the parameter is a path. If so, this file/folder will be uploaded to the host system.
+    description : description of the parameter
+    default_value: default value for the parameter. This value is used if search is disabled or there are no searchable
+        values. Must be the same type as the parameter or a ConditionalDefault SearchParameter.
+    searchable_values: default searchable values for the parameter. This value is used if search is enabled.
+        Must be a Categorical or Conditional SearchParameter.
     """
 
     searchable_values: SearchParameter = None

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -57,14 +57,16 @@ class QuantizationAwareTraining(Pass):
             ),
             "train_batch_size": PassConfigParam(type_=int, description="Batch size for training."),
             "num_epochs": PassConfigParam(type_=int, description="Maximum number of epochs for training."),
-            "num_steps": PassConfigParam(type_=int, default=-1, description="Maximum number of steps for training."),
+            "num_steps": PassConfigParam(
+                type_=int, default_value=-1, description="Maximum number of steps for training."
+            ),
             "do_validate": PassConfigParam(
                 type_=bool,
-                default=False,
+                default_value=False,
                 description="Whether perform one evaluation epoch over the validation set after training.",
             ),
             "modules_to_fuse": PassConfigParam(
-                type_=List[List[str]], default=None, description="List of list of module names to fuse."
+                type_=List[List[str]], default_value=None, description="List of list of module names to fuse."
             ),
             "input_shapes": PassConfigParam(
                 type_=List[List[int]],
@@ -73,12 +75,12 @@ class QuantizationAwareTraining(Pass):
             ),
             "input_types": PassConfigParam(
                 type_=List[str],
-                default=None,
+                default_value=None,
                 description="List ot input types. It is used to create dummy input for PyTorch model tracing.",
             ),
             "qconfig_func": PassConfigParam(
                 type_=Union[Callable, str],
-                default=None,
+                default_value=None,
                 is_object=True,
                 description=(
                     "Customized function to create a QConfig for QAT. Please refer to "
@@ -88,12 +90,12 @@ class QuantizationAwareTraining(Pass):
             "logger": PassConfigParam(
                 type_=Union[Logger, Iterable[Logger], Callable, bool],
                 required=False,
-                default=False,
+                default_value=False,
                 is_object=True,
                 description="Logger for training.",
             ),
             "gpus": PassConfigParam(type_=int, description="Number of GPUs to use."),
-            "seed": PassConfigParam(type_=int, default=None, description="Random seed for training."),
+            "seed": PassConfigParam(type_=int, default_value=None, description="Random seed for training."),
         }
 
     def _run_for_config(self, model: PyTorchModel, config: Dict[str, Any], output_model_path: str) -> PyTorchModel:

--- a/olive/passes/snpe/conversion.py
+++ b/olive/passes/snpe/conversion.py
@@ -60,7 +60,7 @@ class SNPEConversion(Pass):
             ),
             "input_types": PassConfigParam(
                 type_=List[Union[str, None]],
-                default=None,
+                default_value=None,
                 description=(
                     "List of input types. If not None, it must be a list of the same length as input_names. List"
                     " members can be None to use default value. Refer to olive.snpe.constants.InputType for valid"
@@ -69,7 +69,7 @@ class SNPEConversion(Pass):
             ),
             "input_layouts": PassConfigParam(
                 type_=List[Union[str, None]],
-                default=None,
+                default_value=None,
                 description=(
                     "List of input layouts. If not None, it must be a list of the same length as input_names. List"
                     " members can be None to use infered value. Refer to olive.snpe.constants.InputLayout for valid"
@@ -78,7 +78,7 @@ class SNPEConversion(Pass):
             ),
             "extra_args": PassConfigParam(
                 type_=str,
-                default=None,
+                default_value=None,
                 description=(
                     "Extra arguments to pass to snpe conversion tool. Refer to snpe-onnx-to-dlc and"
                     " snpe-tensorflow-to-dlc at https://developer.qualcomm.com/sites/default/files/docs/snpe/tools.html"

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -38,7 +38,7 @@ class SNPEQuantization(Pass):
             ),
             "use_enhanced_quantizer": PassConfigParam(
                 type_=bool,
-                default=False,
+                default_value=False,
                 searchable_values=Boolean(),
                 description=(
                     "Use the enhanced quantizer feature when quantizing the model. Uses an algorithm to determine"
@@ -48,16 +48,16 @@ class SNPEQuantization(Pass):
             ),
             "enable_htp": PassConfigParam(
                 type_=bool,
-                default=False,
+                default_value=False,
                 searchable_values=Boolean(),
                 description="Pack HTP information in quantized DLC.",
             ),
             "htp_socs": PassConfigParam(
-                type_=List[str], default=None, description="List of SoCs to generate HTP Offline cache for."
+                type_=List[str], default_value=None, description="List of SoCs to generate HTP Offline cache for."
             ),
             "extra_args": PassConfigParam(
                 type_=str,
-                default=None,
+                default_value=None,
                 description=(
                     "Extra arguments to pass to snpe conversion tool. Refer to"
                     " https://developer.qualcomm.com/sites/default/files/docs/snpe/tools.html#tools_snpe-dlc-quantize"

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -39,7 +39,7 @@ class SNPEQuantization(Pass):
             "use_enhanced_quantizer": PassConfigParam(
                 type_=bool,
                 default=False,
-                default_search=Boolean(),
+                searchable_values=Boolean(),
                 description=(
                     "Use the enhanced quantizer feature when quantizing the model. Uses an algorithm to determine"
                     " optimal range instead of min and max range of data.  It can be useful for quantizing models that"
@@ -49,7 +49,7 @@ class SNPEQuantization(Pass):
             "enable_htp": PassConfigParam(
                 type_=bool,
                 default=False,
-                default_search=Boolean(),
+                searchable_values=Boolean(),
                 description="Pack HTP information in quantized DLC.",
             ),
             "htp_socs": PassConfigParam(

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -32,10 +32,10 @@ class SNPEtoONNXConversion(Pass):
         return {
             "target_device": PassConfigParam(
                 type_=str,
-                default="cpu",
+                default_value="cpu",
                 description="Target device for the ONNX model. Refer to olive.snpe.SNPEDevice for valid values.",
             ),
-            "target_opset": PassConfigParam(type_=int, default=12, description="Target ONNX opset version."),
+            "target_opset": PassConfigParam(type_=int, default_value=12, description="Target ONNX opset version."),
         }
 
     @staticmethod

--- a/olive/strategy/search_algorithm/optuna_sampler.py
+++ b/olive/strategy/search_algorithm/optuna_sampler.py
@@ -25,8 +25,8 @@ class OptunaSearchAlgorithm(SearchAlgorithm):
     @staticmethod
     def _default_config() -> Dict[str, ConfigParam]:
         return {
-            "num_samples": ConfigParam(type_=int, default=1, description="Number of samples to suggest."),
-            "seed": ConfigParam(type_=int, default=1, description="Seed for the rng."),
+            "num_samples": ConfigParam(type_=int, default_value=1, description="Number of samples to suggest."),
+            "seed": ConfigParam(type_=int, default_value=1, description="Seed for the rng."),
         }
 
     def initialize(self):

--- a/olive/strategy/search_algorithm/random_sampler.py
+++ b/olive/strategy/search_algorithm/random_sampler.py
@@ -18,9 +18,9 @@ class RandomSearchAlgorithm(SearchAlgorithm):
     @staticmethod
     def _default_config() -> Dict[str, ConfigParam]:
         return {
-            "num_samples": ConfigParam(type_=int, default=1, description="Number of samples to suggest."),
-            "seed": ConfigParam(type_=int, default=1, description="Seed for the rng."),
-            "with_replacement": ConfigParam(type_=bool, default=False, description="Sample with replacement."),
+            "num_samples": ConfigParam(type_=int, default_value=1, description="Number of samples to suggest."),
+            "seed": ConfigParam(type_=int, default_value=1, description="Seed for the rng."),
+            "with_replacement": ConfigParam(type_=bool, default_value=False, description="Sample with replacement."),
         }
 
     def initialize(self):

--- a/olive/strategy/search_algorithm/search_algorithm.py
+++ b/olive/strategy/search_algorithm/search_algorithm.py
@@ -33,6 +33,8 @@ class SearchAlgorithm(AutoConfigClass):
     ):
         # search space
         self._search_space = SearchSpace(search_space)
+        if self._search_space.size() == 0:
+            raise ValueError("There are no valid points in the search space.")
 
         # objectives and directions
         objectives = objectives or []

--- a/olive/strategy/search_algorithm/tpe_sampler.py
+++ b/olive/strategy/search_algorithm/tpe_sampler.py
@@ -25,11 +25,11 @@ class TPESearchAlgorithm(OptunaSearchAlgorithm):
         return {
             **OptunaSearchAlgorithm._default_config(),
             "multivariate": ConfigParam(
-                type_=bool, default=True, description="Use multivariate TPE when suggesting parameters."
+                type_=bool, default_value=True, description="Use multivariate TPE when suggesting parameters."
             ),
             "group": ConfigParam(
                 type_=bool,
-                default=True,
+                default_value=True,
                 description=(
                     "If this and multivariate are True, the multivariate TPE with the group decomposed search space is"
                     " used when suggesting parameters. Refer to 'group' at"

--- a/olive/strategy/search_space.py
+++ b/olive/strategy/search_space.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from random import Random
 from typing import Any, Dict, List, Optional, Tuple
 
-from olive.strategy.search_parameter import Categorical, Conditional, SearchParameter
+from olive.strategy.search_parameter import Categorical, Conditional, SearchParameter, SpecialParamValue
 from olive.strategy.utils import order_search_parameters
 
 
@@ -63,6 +63,8 @@ class SearchSpace:
             elif isinstance(param, Categorical):
                 options = param.get_support()
             search_point[space_name][param_name] = self.rng.choice(options)
+            if search_point[space_name][param_name] == SpecialParamValue.INVALID:
+                return self.random_sample()
 
         return search_point
 
@@ -82,6 +84,8 @@ class SearchSpace:
         elif isinstance(param, Categorical):
             options = param.get_support()
         for option in options:
+            if option == SpecialParamValue.INVALID:
+                continue
             search_point[space_name][param_name] = option
             yield from self._iterate_util(full_iter_order, search_point, index + 1)
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -28,7 +28,7 @@ def automatically_insert_passes(config):
 
     # insert quantization
     q_config = {"type": "OnnxDynamicQuantization"}
-    q_config["config"] = {"per_channel": "DEFAULT_SEARCH", "reduce_range": "DEFAULT_SEARCH"}
+    q_config["config"] = {"per_channel": "SEARCHABLE_VALUES", "reduce_range": "SEARCHABLE_VALUES"}
     q_config["clean_run_cache"] = False
     new_passes["dynamic_quantization"] = q_config
 


### PR DESCRIPTION
This PR adds support for setting pass config default values that are conditional on other parameters. It introduces `ConditionalDefault` which is a special type of `Conditional` whose final choices are fixed values instead of `Categoricals`. 

Also adds some special parameter values called `IGNORED` and `INVALID` to better construct search spaces. A search point is invalid if any of the parameters get assigned as `SpecialParamValue.INVALID`. The search algorithms prune these search points during search.  

Renamed `default` -> `default_value` and `default_search` -> `searchable_values` in `PassConfigParam` to make their purposes clear. 
Added comments and documentation for search parameters and `_default_config`. 