### PR TITLE
Change `default_to_search` -> `disable_search`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,11 +31,11 @@ Passes are the building blocks of an Olive workflow. Olive uses multiple Passes 
 The base class for Pass:
 ```python
 class Pass(ABC):
-    def __init__(self, config: Union[Dict[str, Any], BaseModel], default_to_search: Optional[bool] = False):
+    def __init__(self, config: Union[Dict[str, Any], BaseModel], disable_search: Optional[bool] = False):
         ...
 
     @classmethod
-    def get_config_class(cls, default_to_search: Optional[bool] = False) -> Type[BaseModel]:
+    def get_config_class(cls, disable_search: Optional[bool] = False) -> Type[BaseModel]:
         ...
 
     @staticmethod
@@ -45,9 +45,9 @@ class Pass(ABC):
 where `BaseModel` is a [pydantic model](https://docs.pydantic.dev/usage/models/)
 
 It is initialized using:
-- Config dictionary `{“param_name”: param_value}` and boolean `default_to_search`.
+- Config dictionary `{“param_name”: param_value}` and boolean `disable_search`.
 
-  If `default_to_search=True`, use default search parameters, if any, for parameters that are not specified
+  If `disable_search=False`, use default search parameters, if any, for parameters that are not specified
         in the config. Else use the default value.
 - Pydantic model which behaves like a dataclass with type validation. Each pass class has a class method `get_config_class` which returns the pass specific pydantic model that users can instantiate.
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -189,8 +189,9 @@ another dictionary that contains the information of the pass. The information of
 
 - `type: [str]` The type of the pass.
 
-- `default_to_search: [Boolean]` This decides whether to use the default value (`false`) or the default search space,
-  if any, (`true`) for the optional parameters. This is `false` by default.
+- `disable_search: [Boolean]` This decides whether to use the default value (`true`) or the default search space,
+  if any, (`false`) for the optional parameters. This is `false` by default and can be overridden if `search_strategy` under `engine` is
+  specified. Otherwise, it is always `true`.
 
 - `config: [Dict]` The configuration of the pass.
 
@@ -203,7 +204,7 @@ will be used.
 
 - `clean_run_cache: [Boolean]` This decides whether to clean the run cache of the pass before running the pass. This is `false` by default.
 
-Please refer to [Configuring Pass](configuring_pass) for more details on `type`, `default_to_search` and `config`.
+Please refer to [Configuring Pass](configuring_pass) for more details on `type`, `disable_search` and `config`.
 
 Please also find the detailed options from following table for each pass:
 
@@ -246,8 +247,7 @@ Please also find the detailed options from following table for each pass:
             "data_dir": "data",
             "dataloader_func": "resnet_calibration_reader",
             "weight_type": "QUInt8"
-        },
-        "default_to_search": true
+        }
     }
 }
 ```

--- a/docs/source/overview/quicktour.md
+++ b/docs/source/overview/quicktour.md
@@ -138,8 +138,7 @@ let us first convert the pytorch model to ONNX and quantize it.
         "data_dir": "data",
         "dataloader_func": "resnet_calibration_reader",
         "weight_type" : "QUInt8"
-    },
-    "default_to_search": true
+    }
 }
 ```
 
@@ -203,8 +202,7 @@ python -m olive.workflows.run --config config.json
                 "data_dir": "data",
                 "dataloader_func": "resnet_calibration_reader",
                 "weight_type" : "QUInt8"
-            },
-            "default_to_search": true
+            }
         }
     },
     "engine": {

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -117,7 +117,7 @@ quantization_config = {
     "weight_type" : "QUInt8"
 }
 # search over the values for the other config parameters
-quantization_pass = OnnxQuantization(quantization_config, default_to_search=True)
+quantization_pass = OnnxQuantization(quantization_config)
 engine.register(quantization_pass)
 ```
 

--- a/docs/source/tutorials/configure_pass.rst
+++ b/docs/source/tutorials/configure_pass.rst
@@ -9,13 +9,13 @@ When configuring a Pass, the user can chose to set the values of parameters to t
 (search for the best value from the possible options) or a combination of the two (fix some parameters to a certain value, default or
 user provided, and/or search for other parameters).
 
-To fully configure a Pass, we require three things: :code:`type`, :code:`default_to_search`, and :code:`config`.
+To fully configure a Pass, we require three things: :code:`type`, :code:`disable_search`, and :code:`config`.
 
 * :code:`type`: This is the type of the Pass. Check out :ref:`passes` for the full list of supported Passes.
-* :code:`default_to_search`: This decides whether to use the default value (:code:`default_to_search=False`) or the default search space,
-  if any, (:code:`default_to_search=True`) for the optional parameters. This is :code:`False` by default.
+* :code:`disable_search`: This decides whether to use the default value (:code:`disable_search=True`) or the default search space,
+  if any, (:code:`disable_search=False`) for the optional parameters. This is :code:`False` by default.
 * :code:`config`: This is a dictionary of the config parameters and values. It must contain all required parameters. For optional parameters
-  the default value or default search space (dependending on whether :code:`default_to_search` is :code:`False` or :code:`True`) can be
+  the default value or default search space (dependending on whether :code:`disable_search` is :code:`True` or :code:`False`) can be
   overridden by providing user defined values. You can also assign the value for a specific parameter as :code:`"DEFAULT"` to use the default
   value or :code:`"DEFAULT_SEARCH"` to use the default search values (if available).
 
@@ -28,14 +28,14 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
 
             {
                 "type": "OnnxQuantization",
-                "default_to_search": true,
+                "disable_search": false,
                 "config": {
                     "user_script": "./user_script.py",
                     "dataloader_func": "glue_calibration_reader",
                     // set per_channel to "DEFAULT" value
                     "per_channel": "DEFAULT",
                     // set reduce_range to "DEFAULT_SEARCH" value
-                    // redundant since default_to_search is true
+                    // redundant since disable_search is false
                     "reduce_range": "DEFAULT_SEARCH",
                     // user defined value for weight_type
                     "weight_type": "QUInt8"
@@ -60,10 +60,10 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
                     # set per_channel to "DEFAULT" value
                     "per_channel": "DEFAULT",
                     # set reduce_range to "DEFAULT_SEARCH" value
-                    # redundant since default_to_search is true
+                    # redundant since disable_search is false
                     "reduce_range": "DEFAULT_SEARCH"
                     # user defined value for weight_type
                     "weight_type": "QUInt8"
                 },
-                default_to_search=True
+                disable_search=False
             )

--- a/docs/source/tutorials/passes/onnx.md
+++ b/docs/source/tutorials/passes/onnx.md
@@ -111,8 +111,7 @@ a. Tune the parameters of the OlivePass with pre-defined search space
     "config": {
         "user_script": "./user_script.py",
         "dataloader_func": "glue_calibration_reader"
-    },
-    "default_to_search": true
+    }
 }
 ```
 
@@ -126,7 +125,8 @@ b. Select parameters to tune
         "per_channel": "DEFAULT_SEARCH",
         "user_script": "./user_script.py",
         "dataloader_func": "glue_calibration_reader",
-    }
+    },
+    "disable_search": true
 }
 ```
 
@@ -139,7 +139,8 @@ c. Use default values of the OlivePass (no tuning in this way)
         "per_channel": "DEFAULT",
         "user_script": "./user_script.py",
         "dataloader_func": "glue_calibration_reader",
-    }
+    },
+    "disable_search": true
 }
 ```
 
@@ -152,7 +153,8 @@ d. Specify parameters with user defined values
         "per_channel": true,
         "user_script": "./user_script.py",
         "dataloader_func": "glue_calibration_reader",
-    }
+    },
+    "disable_search": true
 }
 ```
 

--- a/examples/bert_ptq_cpu/bert_config.json
+++ b/examples/bert_ptq_cpu/bert_config.json
@@ -81,8 +81,7 @@
             "config": {
                 "user_script": "user_script.py",
                 "dataloader_func": "glue_calibration_reader"
-            },
-            "default_to_search": true
+            }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",

--- a/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu/bert.py
+++ b/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu/bert.py
@@ -111,7 +111,7 @@ def main():
         "input_shapes": [[1, 128], [1, 128], [1, 128]],
         "input_types": ["int64", "int64", "int64"],
     }
-    qat_pass = QuantizationAwareTraining(qat_config, default_to_search=False)
+    qat_pass = QuantizationAwareTraining(qat_config, disable_search=True)
     engine.register(qat_pass)
 
     # ------------------------------------------------------------------
@@ -124,12 +124,12 @@ def main():
         "output_names": ["output"],
         "target_opset": 17,
     }
-    onnx_conversion_pass = OnnxConversion(onnx_conversion_config, default_to_search=False)
+    onnx_conversion_pass = OnnxConversion(onnx_conversion_config, disable_search=True)
     engine.register(onnx_conversion_pass)
 
     # ------------------------------------------------------------------
     # Onnx model optimizer pass
-    onnx_model_optimizer_pass = OnnxModelOptimizer(config=None)
+    onnx_model_optimizer_pass = OnnxModelOptimizer()
     engine.register(onnx_model_optimizer_pass)
 
     # ------------------------------------------------------------------

--- a/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu/bert_config.json
+++ b/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu/bert_config.json
@@ -61,9 +61,7 @@
             }
         },
         "model_optimizer": {
-            "type": "ONNXModelOptimizer",
-            "config": {
-            }
+            "type": "ONNXModelOptimizer"
         },
         "transformers_optimization": {
             "type": "OrtTransformersOptimization",

--- a/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet.py
+++ b/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet.py
@@ -109,7 +109,7 @@ def main():
         "qconfig_func": "create_qat_config",
         "seed": 42,
     }
-    qat_pass = QuantizationAwareTraining(qat_config, default_to_search=False)
+    qat_pass = QuantizationAwareTraining(qat_config, disable_search=True)
     engine.register(qat_pass)
 
     # ------------------------------------------------------------------
@@ -122,7 +122,7 @@ def main():
         "dynamic_axes": {"input": {0: "batch_size"}, "output": {0: "batch_size"}},
         "target_opset": 17,
     }
-    onnx_conversion_pass = OnnxConversion(onnx_conversion_config, default_to_search=False)
+    onnx_conversion_pass = OnnxConversion(onnx_conversion_config, disable_search=True)
     engine.register(onnx_conversion_pass)
 
     # ------------------------------------------------------------------

--- a/examples/quantization_aware_training/resnet_qat_lightning_module_cpu/resnet.py
+++ b/examples/quantization_aware_training/resnet_qat_lightning_module_cpu/resnet.py
@@ -110,7 +110,7 @@ def main():
         "qconfig_func": "create_qat_config",
         "seed": 42,
     }
-    qat_pass = QuantizationAwareTraining(qat_config, default_to_search=False)
+    qat_pass = QuantizationAwareTraining(qat_config, disable_search=True)
     engine.register(qat_pass)
 
     # ------------------------------------------------------------------
@@ -123,7 +123,7 @@ def main():
         "dynamic_axes": {"input": {0: "batch_size"}, "output": {0: "batch_size"}},
         "target_opset": 17,
     }
-    onnx_conversion_pass = OnnxConversion(onnx_conversion_config, default_to_search=False)
+    onnx_conversion_pass = OnnxConversion(onnx_conversion_config, disable_search=True)
     engine.register(onnx_conversion_pass)
 
     # ------------------------------------------------------------------

--- a/examples/resnet_ptq_cpu/resnet_config.json
+++ b/examples/resnet_ptq_cpu/resnet_config.json
@@ -73,8 +73,7 @@
                 "data_dir": "data",
                 "dataloader_func": "resnet_calibration_reader",
                 "weight_type": "QUInt8"
-            },
-            "default_to_search": true
+            }
         }
     },
     "engine": {

--- a/examples/resnet_ptq_cpu/resnet_dynamic_config.json
+++ b/examples/resnet_ptq_cpu/resnet_dynamic_config.json
@@ -64,12 +64,12 @@
                 },
                 "target_opset": 13
             },
-            "default_to_search": true,
             "host": "local_system",
             "evaluator": "common_evaluator"
         },
         "onnx_dynamic_quantization": {
             "type": "OnnxDynamicQuantization",
+            "disable_search": true,
             "config": {
                 "weight_type": "QUInt8",
                 "per_channel": "DEFAULT_SEARCH",

--- a/examples/resnet_ptq_cpu/resnet_static_config.json
+++ b/examples/resnet_ptq_cpu/resnet_static_config.json
@@ -64,12 +64,12 @@
                 },
                 "target_opset": 13
             },
-            "default_to_search": true,
             "host": "local_system",
             "evaluator": "common_evaluator"
         },
         "onnx_static_quantization": {
             "type": "OnnxStaticQuantization",
+            "disable_search": true,
             "config": {
                 "user_script": "user_script.py",
                 "data_dir": "data",

--- a/examples/snpe/inception_snpe_qualcomm_npu/inception_dev.py
+++ b/examples/snpe/inception_snpe_qualcomm_npu/inception_dev.py
@@ -44,7 +44,8 @@ def main():
             "input_shapes": [[1, 299, 299, 3]],
             "output_names": ["InceptionV3/Predictions/Reshape_1"],
             "output_shapes": [[1, 1001]],
-        }
+        },
+        disable_search=True,
     )
     snpe_model = snpe_conversion.run(tensorflow_model, snpe_model_file)
     assert Path(snpe_model.model_path).is_file()
@@ -60,7 +61,8 @@ def main():
     snpe_quantized_model_file = str(models_dir / f"{name}_snpe_quantized.dlc")
     snpe_quantized_data_dir = str(data_dir)
     snpe_quantization = SNPEQuantization(
-        {"data_dir": snpe_quantized_data_dir, "dataloader_func": create_quant_dataloader, "enable_htp": True}
+        {"data_dir": snpe_quantized_data_dir, "dataloader_func": create_quant_dataloader, "enable_htp": True},
+        disable_search=True,
     )
     snpe_quantized_model = snpe_quantization.run(snpe_model, snpe_quantized_model_file)
     assert Path(snpe_quantized_model.model_path).is_file()
@@ -75,7 +77,7 @@ def main():
     print("Converting SNPE Quantized model to ONNX...")
     snpe_quantized_onnx_model_file = str(models_dir / f"{name}_snpe_quantized.onnx")
 
-    snpe_to_onnx_conversion = SNPEtoONNXConversion({"target_device": SNPEDevice.DSP})
+    snpe_to_onnx_conversion = SNPEtoONNXConversion({"target_device": SNPEDevice.DSP}, disable_search=True)
     snpe_quantized_onnx_model = snpe_to_onnx_conversion.run(snpe_quantized_model, snpe_quantized_onnx_model_file)
     assert Path(snpe_quantized_onnx_model.model_path).is_file()
 

--- a/examples/snpe/vgg_snpe_qualcomm_npu/vgg.py
+++ b/examples/snpe/vgg_snpe_qualcomm_npu/vgg.py
@@ -47,7 +47,8 @@ def main():
             "input_shapes": [[1, 3, 224, 224]],
             "output_names": ["vgg0_dense2_fwd"],
             "output_shapes": [[1, 1000]],
-        }
+        },
+        disable_search=True,
     )
     snpe_model = snpe_conversion.run(onnx_model, snpe_model_file)
     assert Path(snpe_model.model_path).is_file()
@@ -63,7 +64,7 @@ def main():
     snpe_quantized_model_file = str(models_dir / f"{name}_snpe_quantized.dlc")
 
     snpe_quantization = SNPEQuantization(
-        {"data_dir": str(data_dir), "dataloader_func": create_quant_dataloader, "enable_htp": True}
+        {"data_dir": str(data_dir), "dataloader_func": create_quant_dataloader, "enable_htp": True}, disable_search=True
     )
     snpe_quantized_model = snpe_quantization.run(snpe_model, snpe_quantized_model_file)
     assert Path(snpe_quantized_model.model_path).is_file()
@@ -78,7 +79,7 @@ def main():
     print("Converting SNPE Quantized model to ONNX...")
     snpe_quantized_onnx_model_file = str(models_dir / f"{name}_snpe_quantized.onnx")
 
-    snpe_to_onnx_conversion = SNPEtoONNXConversion({"target_device": SNPEDevice.DSP})
+    snpe_to_onnx_conversion = SNPEtoONNXConversion({"target_device": SNPEDevice.DSP}, disable_search=True)
     snpe_quantized_onnx_model = snpe_to_onnx_conversion.run(snpe_quantized_model, snpe_quantized_onnx_model_file)
     assert Path(snpe_quantized_onnx_model.model_path).is_file()
 

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -179,7 +179,7 @@ def create_config_class(
             config[param] = (type_, ...)
             continue
 
-        config[param] = (type_, param_config.default)
+        config[param] = (Optional[type_], param_config.default)
 
     return create_model(class_name, **config, __base__=base, __validators__=validators)
 

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -33,13 +33,14 @@ class Pass(AutoConfigClass):
     # True if pass configuration requires user script for non-local host support
     _requires_user_script: bool = False
 
-    def __init__(self, config: Union[Dict[str, Any], PassConfigBase] = None, disable_search: Optional[bool] = False):
+    def __init__(
+        self, config: Optional[Union[Dict[str, Any], PassConfigBase]] = None, disable_search: Optional[bool] = False
+    ):
         """
         Initialize the pass.
         disable_search: If False, use default search parameters, if any, for parameters that are not specified
         in the config. Only applies when the config is a dictionary.
         """
-        config = config or {}
         self._config_class = self.get_config_class(disable_search)
         self._config = validate_config(config, PassConfigBase, self._config_class)
         self._config = self._config.dict()

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -33,13 +33,14 @@ class Pass(AutoConfigClass):
     # True if pass configuration requires user script for non-local host support
     _requires_user_script: bool = False
 
-    def __init__(self, config: Union[Dict[str, Any], PassConfigBase], default_to_search: Optional[bool] = False):
+    def __init__(self, config: Union[Dict[str, Any], PassConfigBase] = None, disable_search: Optional[bool] = False):
         """
         Initialize the pass.
-        default_to_search: If True, use default search parameters, if any, for parameters that are not specified
+        disable_search: If False, use default search parameters, if any, for parameters that are not specified
         in the config. Only applies when the config is a dictionary.
         """
-        self._config_class = self.get_config_class(default_to_search)
+        config = config or {}
+        self._config_class = self.get_config_class(disable_search)
         self._config = validate_config(config, PassConfigBase, self._config_class)
         self._config = self._config.dict()
         self._config = self._resolve_defaults(self._config)
@@ -58,11 +59,11 @@ class Pass(AutoConfigClass):
         self._initialized = False
 
     @classmethod
-    def get_config_class(cls, default_to_search: Optional[bool] = False) -> Type[PassConfigBase]:
+    def get_config_class(cls, disable_search: Optional[bool] = False) -> Type[PassConfigBase]:
         """
         Get the configuration class for the pass.
         """
-        return create_config_class(cls.__name__, cls.default_config(), default_to_search, cls._validators())
+        return create_config_class(cls.__name__, cls.default_config(), disable_search, cls._validators())
 
     @classmethod
     def default_config(cls) -> Dict[str, PassConfigParam]:
@@ -210,13 +211,17 @@ class Pass(AutoConfigClass):
         """
         Convert the pass to json.
         """
-        return {"type": self.__class__.__name__, "config": self.serialize_config(self._config, check_objects)}
+        return {
+            "type": self.__class__.__name__,
+            "disable_search": True,
+            "config": self.serialize_config(self._config, check_objects),
+        }
 
 
 # TODO rename. We are using FullPassConfig since PassConfigBase already refers to inner config
 class FullPassConfig(ConfigBase):
     type: str
-    default_to_search: bool = False
+    disable_search: bool = False
     config: PassConfigBase = None
 
     @validator("type")
@@ -229,13 +234,13 @@ class FullPassConfig(ConfigBase):
     def validate_config(cls, v, values):
         if "type" not in values:
             raise ValueError("Invalid type")
-        if "default_to_search" not in values:
-            raise ValueError("Invalid default_to_search")
+        if "disable_search" not in values:
+            raise ValueError("Invalid disable_search")
 
         pass_type = values["type"].lower()
-        default_to_search = values["default_to_search"]
-        config_class = Pass.registry[pass_type].get_config_class(default_to_search)
+        disable_search = values["disable_search"]
+        config_class = Pass.registry[pass_type].get_config_class(disable_search)
         return validate_config(v, PassConfigBase, config_class)
 
     def create_pass(self):
-        return Pass.registry[self.type.lower()](self.config, self.default_to_search)
+        return Pass.registry[self.type.lower()](self.config, self.disable_search)

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -103,7 +103,7 @@ def create_config_class(
             config[param] = (type_, ...)
             continue
 
-        type_ = Union[type_, SearchParameter, PassParamDefault]
+        type_ = Optional[Union[type_, SearchParameter, PassParamDefault]]
         if not disable_search and param_config.default_search is not None:
             config[param] = (type_, param_config.default_search)
         else:

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -86,7 +86,7 @@ class PassConfigBase(ConfigBase):
 def create_config_class(
     pass_type: str,
     default_config: Dict[str, PassConfigParam],
-    default_to_search: Optional[bool] = True,
+    disable_search: Optional[bool] = False,
     validators: Dict[str, Callable] = None,
 ) -> Type[PassConfigBase]:
     """
@@ -104,7 +104,7 @@ def create_config_class(
             continue
 
         type_ = Union[type_, SearchParameter, PassParamDefault]
-        if default_to_search and param_config.default_search is not None:
+        if not disable_search and param_config.default_search is not None:
             config[param] = (type_, param_config.default_search)
         else:
             config[param] = (type_, param_config.default)

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -53,8 +53,8 @@ class RunConfig(ConfigBase):
         if "engine" not in values:
             raise ValueError("Invalid engine")
 
-        if values["engine"].search_strategy is None:
-            # disable search if search_strategy is None, user cannot override
+        if not values["engine"].search_strategy:
+            # disable search if search_strategy is None/False/{}, user cannot override
             disable_search = True
         else:
             # disable search if user explicitly set disable_search to True

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -44,9 +44,24 @@ class RunConfig(ConfigBase):
         return _resolve_evaluator(v, values)
 
     @validator("passes", pre=True, each_item=True)
-    def validate_pass_host(cls, v, values):
+    def validate_pass_host_evaluator(cls, v, values):
         v = _resolve_system(v, values, "host")
         return _resolve_evaluator(v, values)
+
+    @validator("passes", pre=True, each_item=True)
+    def validate_pass_search(cls, v, values):
+        if "engine" not in values:
+            raise ValueError("Invalid engine")
+
+        if values["engine"].search_strategy is None:
+            # disable search if search_strategy is None, user cannot override
+            disable_search = True
+        else:
+            # disable search if user explicitly set disable_search to True
+            disable_search = v.get("disable_search", False)
+
+        v["disable_search"] = disable_search
+        return v
 
 
 def _resolve_system(v, values, system_alias):

--- a/olive/workflows/snpe/convertquantize/convertquantize.py
+++ b/olive/workflows/snpe/convertquantize/convertquantize.py
@@ -54,7 +54,7 @@ def convertquantize(
     logger.info("Converting model to SNPE...")
     snpe_model_file = str(models_dir / f"{name}.dlc")
 
-    snpe_conversion = SNPEConversion({**config["io_config"], **config["convert_options"]})
+    snpe_conversion = SNPEConversion({**config["io_config"], **config["convert_options"]}, disable_search=True)
     snpe_model = snpe_conversion.run(model, snpe_model_file)
     assert Path(snpe_model.model_path).is_file()
     json.dump(snpe_model.io_config, open(str(models_dir / f"{name}.dlc_io_config.json"), "w"))
@@ -66,7 +66,8 @@ def convertquantize(
     dataloader_func = lambda data_dir: SNPEProcessedDataLoader(data_dir, input_list_file=input_list_file)  # noqa: E731
 
     snpe_quantization = SNPEQuantization(
-        {"data_dir": str(data_dir), "dataloader_func": dataloader_func, **config["quantize_options"]}
+        {"data_dir": str(data_dir), "dataloader_func": dataloader_func, **config["quantize_options"]},
+        disable_search=True,
     )
     snpe_quantized_model = snpe_quantization.run(snpe_model, snpe_quantized_model_file)
     assert Path(snpe_quantized_model.model_path).is_file()
@@ -82,7 +83,7 @@ def convertquantize(
     snpe_quantized_onnx_model_file = str(models_dir / f"{name}.quant.onnx")
 
     snpe_to_onnx_conversion = SNPEtoONNXConversion(
-        {"target_device": config["quantize_options"].get("target_device", SNPEDevice.CPU)}
+        {"target_device": config["quantize_options"].get("target_device", SNPEDevice.CPU)}, disable_search=True
     )
     snpe_quantized_onnx_model = snpe_to_onnx_conversion.run(snpe_quantized_model, snpe_quantized_onnx_model_file)
     assert Path(snpe_quantized_onnx_model.model_path).is_file()

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -45,7 +45,7 @@ def test_aml_model():
     }
     with tempfile.TemporaryDirectory() as tempdir:
         onnx_model_file = str(Path(tempdir) / "model.onnx")
-        onnx_conversion_pass = OnnxConversion(onnx_conversion_config, default_to_search=False)
+        onnx_conversion_pass = OnnxConversion(onnx_conversion_config, disable_search=True)
         onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model, onnx_model_file)
         assert Path(onnx_model.model_path).is_file()
 

--- a/test/unit_test/test_engine.py
+++ b/test/unit_test/test_engine.py
@@ -59,7 +59,7 @@ class TestEngine:
 
     def test_register_no_search(self):
         # setup
-        p = get_onnx_dynamic_quantization_pass(default_to_search=False)
+        p = get_onnx_dynamic_quantization_pass(disable_search=True)
         name = p.__class__.__name__
 
         options = {
@@ -76,7 +76,7 @@ class TestEngine:
 
     def test_register_no_search_fail(self):
         # setup
-        p = get_onnx_dynamic_quantization_pass(default_to_search=True)
+        p = get_onnx_dynamic_quantization_pass(disable_search=False)
         name = p.__class__.__name__
 
         options = {

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -109,6 +109,6 @@ def get_onnxconversion_pass():
     return p
 
 
-def get_onnx_dynamic_quantization_pass(default_to_search=False):
-    p = OnnxDynamicQuantization({}, default_to_search=default_to_search)
+def get_onnx_dynamic_quantization_pass(disable_search=False):
+    p = OnnxDynamicQuantization(disable_search=disable_search)
     return p


### PR DESCRIPTION
This PR changes `default_to_search` to `disable_search` to make the purpose of the parameter clear. When `disable_search` is `False`, the pass config parameters uses the searchable values (if any) while they use the default fixed values if `True`. The default value for `disable_search` is `False`. 

In `olive.workflows.run`, if there is a search strategy, the passes have `disable_search` as `False` unless the user explicitly sets it to `True`. If there search strategy is None, `disable_search` is always `True` and user cannot override it. 