### PR TITLE
Add `evaluation_only` option to run 

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -282,11 +282,15 @@ This is a dictionary that contains the information of the engine. The informatio
   If `search_strategy` is `true`, the search strategy will be the default search strategy. The default search strategy is `exhaustive` search
   algorithm with `joint` execution order.
 
+- `evaluation_only: [Boolean]` This decides whether to run the engine in evaluation only mode. In this mode, the engine will evaluate the input
+    model using the engine's evaluator and return the results. If the engine has no evaluator, it will raise an error. This is `false` by default.
+
 - `host: [str | Dict]` The host of the engine. It can be a string or a dictionary. If it is a string, it is the name of a system in `systems`.
     If it is a dictionary, it contains the system information. If not specified, it is the local system.
 
 - `evaluator: [str | Dict]` The evaluator of the engine. It can be a string or a dictionary. If it is a string, it is the name of an evaluator
-    in `evaluators`. If it is a dictionary, it contains the evaluator information.
+    in `evaluators`. If it is a dictionary, it contains the evaluator information. This evaluator will be used to evaluate the input model if
+    needed. It is also used to evaluate the output models of passes that don't have their own evaluators.
 
 - `cache_dir: [str]` The directory to store the cache of the engine. If not specified, the cache will be stored in the `.olive-cache` directory
     under the current working directory.

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -22,6 +22,7 @@ class RunPassConfig(FullPassConfig):
 
 
 class RunEngineConfig(EngineConfig):
+    evaluation_only: bool = False
     output_dir: Union[Path, str] = None
     output_name: str = None
 
@@ -42,6 +43,12 @@ class RunConfig(ConfigBase):
     def validate_engine(cls, v, values):
         v = _resolve_system(v, values, "host")
         return _resolve_evaluator(v, values)
+
+    @validator("engine")
+    def validate_evaluation_only(cls, v):
+        if v.evaluation_only and v.evaluator is None:
+            raise ValueError("Evaluation only requires evaluator")
+        return v
 
     @validator("passes", pre=True, each_item=True)
     def validate_pass_host(cls, v, values):

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -58,7 +58,7 @@ def run(config: Union[str, Path, dict]):
     # engine
     engine = Engine(config.engine.dict())
 
-    if config.passes is None or not config.passes:
+    if (config.passes is None or not config.passes) and (not config.engine.evaluation_only):
         # TODO enhance this logic for more passes templates
         engine, config = automatically_insert_passes(config)
     # passes
@@ -69,6 +69,8 @@ def run(config: Union[str, Path, dict]):
         engine.register(p, pass_name, host, evaluator, pass_config.clean_run_cache)
 
     # run
-    best_execution = engine.run(input_model, config.verbose, config.engine.output_dir, config.engine.output_name)
+    best_execution = engine.run(
+        input_model, config.verbose, config.engine.output_dir, config.engine.output_name, config.engine.evaluation_only
+    )
     logger.info(best_execution)
     return best_execution

--- a/test/unit_test/test_engine.py
+++ b/test/unit_test/test_engine.py
@@ -196,3 +196,39 @@ class TestEngine:
 
             # assert
             assert "Exception: test" in caplog.text
+
+    @patch("olive.engine.LocalSystem")
+    def test_run_evaluation_only(self, mock_local_system):
+        # setup
+        pytorch_model = get_pytorch_model()
+        p = get_onnxconversion_pass()
+        metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
+        evaluator = OliveEvaluator(metrics=[metric], target=mock_local_system)
+        options = {
+            "cache_dir": "./cache",
+            "clean_cache": True,
+            "search_strategy": None,
+            "clean_evaluation_cache": True,
+        }
+        engine = Engine(options, host=mock_local_system, evaluator=evaluator)
+        engine.register(p, clean_run_cache=True)
+        onnx_model = get_onnx_model()
+        mock_local_system.run_pass.return_value = onnx_model
+        mock_local_system.evaluate_model.return_value = {metric.name: 0.998}
+
+        # output model to output_dir
+        output_dir = Path("cache") / "output"
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+        expected_res = {metric.name: 0.998}
+
+        # execute
+        actual_res = engine.run(pytorch_model, output_dir=output_dir, evaluation_only=True)
+
+        assert expected_res == actual_res
+        result_json_path = Path(output_dir / "metrics.json")
+        assert result_json_path.is_file()
+        assert json.load(open(result_json_path, "r")) == actual_res
+
+        # clean up
+        shutil.rmtree(output_dir, ignore_errors=True)


### PR DESCRIPTION
This PR adds an `evaluation_only` boolean option to engine run and `olive.workflows.run`. When `True` the input model is evaluated, and the result is returned. 

## Test
Added `test_run_evaluation_only` to `test_engine`. 