### PR TITLE
Warn about parameters that are not part of config

### DIFF
--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -8,7 +8,7 @@ from typing import Dict, Union
 from pydantic import validator
 
 from olive.common.config_utils import ConfigBase
-from olive.engine import EngineConfig
+from olive.engine import Engine, EngineConfig
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.model import ModelConfig
 from olive.passes import FullPassConfig
@@ -25,6 +25,11 @@ class RunEngineConfig(EngineConfig):
     evaluation_only: bool = False
     output_dir: Union[Path, str] = None
     output_name: str = None
+
+    def create_engine(self):
+        config = self.dict()
+        del config["evaluation_only"], config["output_dir"], config["output_name"]
+        return Engine(config)
 
 
 class RunConfig(ConfigBase):

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -7,7 +7,6 @@ import logging
 from pathlib import Path
 from typing import Union
 
-from olive.engine import Engine
 from olive.workflows.run.config import RunConfig
 
 logger = logging.getLogger(__name__)
@@ -40,7 +39,7 @@ def automatically_insert_passes(config):
 
     new_config_dict["passes"] = new_passes
     new_config = RunConfig.parse_obj(new_config_dict)
-    new_engine = Engine(new_config.engine)
+    new_engine = new_config.engine.create_engine()
 
     return new_engine, new_config
 
@@ -56,7 +55,7 @@ def run(config: Union[str, Path, dict]):
     input_model = config.input_model.create_model()
 
     # engine
-    engine = Engine(config.engine.dict())
+    engine = config.engine.create_engine()
 
     if (config.passes is None or not config.passes) and (not config.engine.evaluation_only):
         # TODO enhance this logic for more passes templates


### PR DESCRIPTION
We use pydantic models for our config classes. By default, pydantic models ignore parameters that are not part of the config class. This is a desirable feature but we should warn the user if the config dict they provided has such parameters. 