### PR TITLE
Search Strategy: Sort models without goals if no model meets goals, Fix sorting bug

### DIFF
--- a/olive/strategy/search_results.py
+++ b/olive/strategy/search_results.py
@@ -98,10 +98,10 @@ class SearchResults:
         if not results:
             return None, None, None
 
-        # sort by objectives
-        results = np.array(results)
-        results *= np.array([self.obj_mul[obj] for obj in objectives])
-        # TODO lexsort default sort by the last column, will support sorting by multiple columns later
+        # sort by objectives, left most objective has highest priority
+        # flip the order of the objectives since np.lexsort prioritizes the last column
+        # negate the results since np.lexsort sorts in ascending order
+        results = -np.flip(np.array(results), 1)
         sorted_indices = np.lexsort(results.T)
         sorted_hashes = [search_point_hashes[i] for i in sorted_indices]
 
@@ -117,6 +117,8 @@ class SearchResults:
     ) -> Tuple[List[List[float]], List[str]]:
         """
         Return the results as a list of lists.
+
+        Values are multiplied by the objective multiplier so that higher is better for all objectives.
         """
         if objectives is None:
             objectives = self.objectives

--- a/olive/strategy/search_strategy.py
+++ b/olive/strategy/search_strategy.py
@@ -127,6 +127,14 @@ class SearchStrategy(ABC):
             sorted_model_ids, sorted_search_points, sorted_results = self._search_results[
                 tuple(self._active_spaces_group)
             ].sort_search_points(apply_goals=True)
+            if sorted_model_ids is None:
+                logger.warning(
+                    f"No models in this search group {self._active_spaces_group} met the goals. Sorting the models"
+                    " without applying goals..."
+                )
+                sorted_model_ids, sorted_search_points, sorted_results = self._search_results[
+                    tuple(self._active_spaces_group)
+                ].sort_search_points(apply_goals=False)
             # TODO: this is a hack to get the best search point for the current search space group
             #      it totally work for joint execution order, but not for pass-by-pass
             if sorted_search_points and sorted_results:
@@ -137,6 +145,14 @@ class SearchStrategy(ABC):
         if len(self._spaces_groups) == 0:
             self._active_spaces_group = None
             return None
+
+        if init_model_id is None and self._active_spaces_group is None:
+            raise ValueError("init_model_id must be provided for the first search group")
+        if init_model_id is None and self._active_spaces_group is not None:
+            raise ValueError(
+                f"The previous search group {self._active_spaces_group} has no output models that were created and"
+                " evaluated successfully. Cannot continue."
+            )
 
         self._active_spaces_group = self._spaces_groups.pop(0)
         self._searchers[tuple(self._active_spaces_group)] = self._create_searcher(self._active_spaces_group)


### PR DESCRIPTION
When chosing the best models, we apply goals to filter the models. However, in the pass-by-pass execution order, the intermediate models might not meet goals. This causes the search to crash like in the recent CI failures. 

In this PR, we instead warn the user about the goal not being met and sort the models without applying goals so that the search can proceed. 

Also, updated the model sorting logic to fix a mistake in the previous implementation. The comment above the new logic explains the steps used. 