### PR TITLE
Set seed before training resnet model

### DIFF
--- a/examples/resnet_ptq_cpu/prepare_model_data.py
+++ b/examples/resnet_ptq_cpu/prepare_model_data.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import argparse
+import random
 import tarfile
 import urllib.request
 
@@ -35,6 +36,11 @@ def update_lr(optimizer, lr):
 
 
 def prepare_model(num_epochs=0, models_dir="models", data_dir="data"):
+    # seed everything to 0
+    random.seed(0)
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # Hyper-parameters

--- a/examples/test_resnet_ptq_cpu.py
+++ b/examples/test_resnet_ptq_cpu.py
@@ -2,14 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import importlib as imp
 import json
 import os
-import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
+
+from olive.common.utils import run_subprocess
 
 
 @pytest.fixture()
@@ -22,20 +21,12 @@ def setup(example_dir):
     """setup any state specific to the execution of the given module."""
     cur_dir = Path(__file__).resolve().parent
     os.chdir(example_dir)
-    sys.path.append(example_dir)
-    import prepare_model_data
 
-    # reload the module if there are multiple same name module.
-    imp.reload(prepare_model_data)
-
-    test_args = "prepare_model_data.py".split()
-
-    with patch.object(sys, "argv", test_args):
-        prepare_model_data.main()
+    # import prepare_model_data
+    run_subprocess("python prepare_model_data.py")
 
     yield
     os.chdir(cur_dir)
-    sys.path.remove(example_dir)
 
 
 def check_output(metrics):


### PR DESCRIPTION
The pytorch model for resnet example is trained in `prepare_model_data.py`. Because of randomness during training, the model is not the same between ci runs and causes inconsistent behavior. Set random seed before training so that the pytorch model is the not random. 