### PR TITLE
Support external data in PyTorch-to-ONNX conversion pass

### DIFF
--- a/olive/model.py
+++ b/olive/model.py
@@ -139,7 +139,6 @@ class ONNXModel(OliveModel):
         )
         self.inference_settings = inference_settings
 
-
     @staticmethod
     def resolve_path(file_or_dir_path: str, model_filename: str = "model.onnx") -> str:
         """
@@ -150,7 +149,7 @@ class ONNXModel(OliveModel):
         returned. Examples:
 
         resolve_path("c:/foo/bar.onnx") -> c:/foo/bar.onnx
-        
+
         resolve_path("c:/foo/bar") -> c:/foo/bar/model.onnx
         """
         path = Path(file_or_dir_path)

--- a/olive/model.py
+++ b/olive/model.py
@@ -139,6 +139,28 @@ class ONNXModel(OliveModel):
         )
         self.inference_settings = inference_settings
 
+
+    @staticmethod
+    def resolve_path(file_or_dir_path: str, model_filename: str = "model.onnx") -> str:
+        """
+        The engine provides output paths to ONNX passes that do not contain .onnx
+        extension (these paths are generally locations in the cache). This function
+        will convert such paths to absolute file paths and also ensure the parent
+        directories exist. If the input path is already an ONNX file it is simply
+        returned. Examples:
+
+        resolve_path("c:/foo/bar.onnx") -> c:/foo/bar.onnx
+        
+        resolve_path("c:/foo/bar") -> c:/foo/bar/model.onnx
+        """
+        path = Path(file_or_dir_path)
+        if path.suffix != ".onnx":
+            path = path / model_filename
+            parent_dir = path.parent
+            if not parent_dir.exists():
+                parent_dir.mkdir(parents=True, exist_ok=True)
+        return str(path)
+
     def load_model(self) -> onnx.ModelProto:
         # HACK: ASSUME no external data
         return onnx.load(self.model_path)

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
+import onnx
 import torch
 
 from olive.model import ONNXModel, PyTorchModel
@@ -73,6 +74,17 @@ class OnnxConversion(Pass):
             "target_opset": PassConfigParam(
                 type_=int, default_value=14, description="The version of the default (ai.onnx) opset to target."
             ),
+            "save_as_external_data": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="Serializes tensor data to separate files instead of directly in the ONNX file."
+                " Large models (>2GB) may be forced to save external data regardless of the value of this parameter.",
+            ),
+            "all_tensors_to_one_file": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="If true, external data is written to a single file instead of one file per tensor.",
+            ),
         }
 
     def _initialize(self):
@@ -117,8 +129,13 @@ class OnnxConversion(Pass):
         if isinstance(pytorch_model, torch.jit.RecursiveScriptModule):
             pytorch_model = TraceModelWrapper(pytorch_model)
 
-        if Path(output_model_path).suffix != ".onnx":
-            output_model_path += ".onnx"
+        output_model_path = ONNXModel.resolve_path(output_model_path)
+
+        # When converting to ONNX, torch.onnx.export (1.11+) automatically saves tensor data as external data if the
+        # ONNX protobuf would exceed 2GB. With sufficiently large models, any tensor exceeding a size threshold will
+        # have its data stored in a separate file on disk in the same directory as the exported ONNX file. We track
+        # the files in the output directory to see if any external data has been emitted.
+        files_before_export = set(Path(output_model_path).parent.glob("*"))
 
         torch.onnx.export(
             pytorch_model,
@@ -131,6 +148,31 @@ class OnnxConversion(Pass):
             output_names=config["output_names"],
             dynamic_axes=self._dynamic_axes,
         )
+
+        files_after_export = set(Path(output_model_path).parent.glob("*"))
+        has_external_data = len(files_after_export) - len(files_before_export) > 1
+
+        # A second pass to serialize the model is required if either is true:
+        # - The user wants external data, but torch.onnx.export did not emit any external data
+        # - torch.onnx.export emits external data (as separate files) and the user wants it collated into a single file
+        if (config["save_as_external_data"] and not has_external_data) or (
+            has_external_data and config["all_tensors_to_one_file"]
+        ):
+            onnx_model = onnx.load(output_model_path)
+
+            # The model is loaded into memory, so it's safe to delete previously exported files.
+            for path in files_after_export - files_before_export:
+                path.unlink()
+
+            external_data_path = str(Path(output_model_path).name + ".data")
+            onnx.save_model(
+                onnx_model,
+                output_model_path,
+                save_as_external_data=True,
+                all_tensors_to_one_file=config["all_tensors_to_one_file"],
+                location=external_data_path,
+                convert_attribute=False,
+            )
 
         model = ONNXModel(output_model_path, model.name)
         return model

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -43,8 +43,7 @@ class OnnxFloatToFloat16(Pass):
         }
 
     def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
-        if Path(output_model_path).suffix != ".onnx":
-            output_model_path += ".onnx"
+        output_model_path = ONNXModel.resolve_path(output_model_path)
 
         config = self._config_class(**config)
 

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from pathlib import Path
 from typing import Any, Dict, List
 
 import onnx

--- a/olive/passes/onnx/model_optimizer.py
+++ b/olive/passes/onnx/model_optimizer.py
@@ -124,8 +124,7 @@ class OnnxModelOptimizer(Pass):
         return {}
 
     def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
-        if Path(output_model_path).suffix != ".onnx":
-            output_model_path += ".onnx"
+        output_model_path = ONNXModel.resolve_path(output_model_path)
 
         model_optimizer = ModelOptimizer(model.model_path, output_model_path)
         model_optimizer.optimize()

--- a/olive/passes/onnx/model_optimizer.py
+++ b/olive/passes/onnx/model_optimizer.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -255,9 +255,7 @@ class OnnxQuantization(Pass):
         run_config = deepcopy(config)
         is_static = run_config["quant_mode"] == "static"
 
-        # add onnx extension if not present
-        if Path(output_model_path).suffix != ".onnx":
-            output_model_path += ".onnx"
+        output_model_path = ONNXModel.resolve_path(output_model_path)
 
         # preprocess the model
         preprocessed_temp_model_path = Path(self.tmp_dir.name) / f"{Path(model.model_path).stem}_preprocessed.onnx"

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from copy import deepcopy
-from pathlib import Path
 from typing import Any, Dict
 
 from olive.model import ONNXModel

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -73,9 +73,7 @@ class OrtTransformersOptimization(Pass):
         if config["input_int32"]:
             optimizer.change_graph_inputs_to_int32()
 
-        # add onnx extension if not present
-        if Path(output_model_path).suffix != ".onnx":
-            output_model_path += ".onnx"
+        output_model_path = ONNXModel.resolve_path(output_model_path)
 
         optimizer.save_model_to_file(output_model_path, config["use_external_data_format"])
 

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from pathlib import Path
 from typing import Any, Callable, Dict
 
 from pydantic import validator

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -47,8 +47,7 @@ class SNPEtoONNXConversion(Pass):
     def _run_for_config(self, model: SNPEModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
         config = self._config_class(**config)
 
-        if Path(output_model_path).suffix != ".onnx":
-            output_model_path += ".onnx"
+        output_model_path = ONNXModel.resolve_path(output_model_path)
 
         dlc_to_onnx(model.model_path, config.dict(), output_model_path, **model.io_config)
         return ONNXModel(output_model_path, name=model.name)


### PR DESCRIPTION
Large models cannot be converted into a fully self-contained .onnx file (protobuf has a limit of 2GB), so the ONNX format allows tensor data to be stored as [external data](https://github.com/onnx/onnx/blob/main/docs/ExternalData.md) files on disk. The call to `torch.onnx.export` will write external data automatically when the graph and tensor data won't fit into a single .onnx file. This creates a problem for Olive, since output models are saved into a shared cache directory: the filenames of external data are based on the tensor names in the graph, so multiple passes on an ONNX model could collide and overwrite the data files.

Two potential solutions came to mind:
1. Have passes write ONNX files to subdirectories of the cache; the subdirectory has the .onnx file and potentially external data files.
2. Manually rename external data locations to have unique names (requires parsing and reserializing the converter-exported ONNX model).

Solution 1 is simpler and more efficient, since it avoids a second serialization pass in most cases, so this change implements the subdirectory solution.

Before:
```
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7.onnx
cache/models/feature.1.weights
cache/models/feature.2.weights
cache/models/feature.3.weights
```

After (with `all_tensors_to_one_file=false` - default):
```
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7/model.onnx
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7/feature.1.weights
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7/feature.2.weights
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7/feature.3.weights
...
```

After (with `all_tensors_to_one_file=true`):
```
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7/model.onnx
cache/models/0_OnnxConversion-aa8ca869c0b5de156f98cfbcf93442db-84db90deb08b43f8bd678c3a161134c7/model.onnx.data
```

Note that this change does _not_ mean external data automatically propagates across ONNX passes. For example, the `OnnxFloatToFloat16` pass will _not_ save its output model with external data if it consumes a model that was saved with external data. Further changes are required to any ONNX pass that serializes ONNX files to disk.