### PR TITLE
Handle ONNX model with external data for AzureML systems

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -87,7 +87,10 @@ class OnnxConversion(Pass):
             "all_tensors_to_one_file": PassConfigParam(
                 type_=bool,
                 default_value=True,
-                description="If true, external data is written to a single file instead of one file per tensor.",
+                description=(
+                    "Effective only if save_as_external_data is True. If true, save all tensors to one external file"
+                    " specified by location. If false, save each tensor to a file named with the tensor name."
+                ),
             ),
         }
 

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -86,7 +86,7 @@ class OnnxConversion(Pass):
             ),
             "all_tensors_to_one_file": PassConfigParam(
                 type_=bool,
-                default_value=False,
+                default_value=True,
                 description="If true, external data is written to a single file instead of one file per tensor.",
             ),
         }
@@ -188,6 +188,7 @@ class OnnxConversion(Pass):
         # now we can move the files to the final location
         for path in tmp_dir_path.glob("*"):
             shutil.move(path, Path(output_model_path).parent / path.name)
+        tmp_dir.cleanup()
 
         is_file = not (has_external_data or config["save_as_external_data"])
         model = ONNXModel(output_model_path, model.name, is_file=is_file)

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -25,6 +25,8 @@ def parse_metric_args(raw_args):
 
 def create_metric(metric_config, metric_args):
     for key, value in vars(metric_args).items():
+        if key == "metric_config":
+            continue
         if value is not None:
             key = key.replace("metric_", "")
             metric_config["user_config"][key] = value

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -66,7 +66,7 @@ def main(raw_args=None):
             shutil.copy(old_path, new_path)
         else:
             new_path.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(old_path, new_path)
+            shutil.copytree(old_path, new_path, dirs_exist_ok=True)
         common_args.model_path = str(new_path)
 
     # pass specific args

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -20,7 +20,7 @@ from olive.common.config_utils import validate_config
 from olive.common.utils import retry_func
 from olive.constants import Framework
 from olive.evaluator.metric import Metric
-from olive.model import ModelConfig, OliveModel
+from olive.model import ModelConfig, OliveModel, ONNXModel
 from olive.passes.olive_pass import Pass
 from olive.systems.common import AzureMLDockerConfig, SystemType
 from olive.systems.olive_system import OliveSystem
@@ -308,10 +308,29 @@ class AzureMLSystem(OliveSystem):
             )
         elif model_json["config"]["model_path"] is not None:
             downloaded_model_path = pipeline_output_path / model_json["config"]["model_path"]
-            if Path(output_model_path).suffix != Path(downloaded_model_path).suffix:
-                output_model_path += Path(downloaded_model_path).suffix
-            # TODO: handle cases where output_model_path is a directory
-            shutil.copy(downloaded_model_path, output_model_path)
+            if model_json["type"].lower() == "onnxmodel":
+                # onnx model can have external data
+                output_model_path = ONNXModel.resolve_path(output_model_path)
+                if not model_json["config"]["is_file"]:
+                    # has external data
+                    # copy the .onnx file along with external data files
+                    shutil.copytree(downloaded_model_path.parent, Path(output_model_path).parent, dirs_exist_ok=True)
+                    # rename the .onnx file to the output_model_path, the downloaded model has "model.onnx" name
+                    (Path(output_model_path).parent / downloaded_model_path.name).rename(output_model_path)
+                else:
+                    # no external data
+                    # just copy over the .onnx file
+                    shutil.copy(downloaded_model_path, output_model_path)
+            else:
+                # handle other model types
+                if Path(output_model_path).suffix != Path(downloaded_model_path).suffix:
+                    output_model_path += Path(downloaded_model_path).suffix
+                if downloaded_model_path.is_file():
+                    # model is a file
+                    shutil.copy(downloaded_model_path, output_model_path)
+                else:
+                    # model is a directory
+                    shutil.copytree(downloaded_model_path, output_model_path, dirs_exist_ok=True)
             model_path = output_model_path
             model_json["config"]["is_aml_model"] = False
         model_json["config"]["model_path"] = model_path
@@ -355,7 +374,6 @@ class AzureMLSystem(OliveSystem):
         }
 
     def evaluate_model(self, model: OliveModel, metrics: List[Metric]) -> Dict[str, Any]:
-
         if model.framework == Framework.SNPE:
             raise NotImplementedError("SNPE model does not support azureml evaluation")
         if model.framework == Framework.OPENVINO:

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import argparse
 import json
+from pathlib import Path
 
 
 def parse_common_args(raw_args):
@@ -28,5 +29,7 @@ def get_model_config(common_args):
     for key, value in common_args.__dict__.items():
         if value and key in model_json["config"]:
             model_json["config"][key] = value
+    if model_json["type"].lower() == "onnxmodel" and not model_json["config"]["is_file"]:
+        model_json["config"]["model_path"] = str(Path(model_json["config"]["model_path"]) / "model.onnx")
 
     return model_json

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -106,12 +106,13 @@ class TestAzureMLSystem:
         # setup
         temp_model = tempfile.NamedTemporaryFile(dir=".", suffix=".onnx", prefix="model_0")
         model_json = {
+            "type": "onnxmodel",
             "config": {
                 "model_script": "model_script",
                 "script_dir": "script_dir",
                 "model_path": temp_model.name,
                 "is_file": True,
-            }
+            },
         }
         model_json["config"].update({"is_aml_model": is_aml_model})
         tem_dir = Path(".")

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -87,7 +87,7 @@ class TestAzureMLSystem:
         output_model_path = "output_model_path"
         output_folder = Path(__file__).absolute().parent / "output_pass"
         mock_tempdir.return_value.__enter__.return_value = output_folder
-        expected_model = ONNXModel(model_path=f"{output_model_path}.onnx", name="test_model")
+        expected_model = ONNXModel(model_path=ONNXModel.resolve_path(output_model_path), name="test_model")
 
         # execute
         actual_res = self.aml_system.run_pass(p, olive_model, output_model_path)


### PR DESCRIPTION
This PR adds support for ONNX models with external data for AzureML systems (both model evaluation and pass run). 

It also uses a temporary directory for onnx model conversion since the output model path or it's parent could be used by other processes if not provided carefully. 
`all_tensors_to_one_file` default value is now `True` like it is for `onnx.save_model`. This is beneficial since there is only one external data file. Also, for models with unsupported tensor names, the external data files have randomly generated names which is not ideal. 