### PR TITLE
Print `_exposed_extra_options_config` keys as list instead of set

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -138,8 +138,9 @@ _extra_options_config = {
         description=f"""
             Key value pair dictionary for `extra_options` in quantization. Please refer to
             https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/quantization/quantize.py
-            for details about the supported options. If an option is one of {set(_exposed_extra_options_config.keys())},
-            it will be overwritten by the corresponding config parameter value.
+            for details about the supported options. If an option is one of
+            {list(_exposed_extra_options_config.keys())}, it will be overwritten by the corresponding config parameter
+            value.
         """,
     ),
 }


### PR DESCRIPTION
`_exposed_extra_options_config` keys were printed as set before but the set does not have the keys in the same order every time. So, the doc gets updated everytime even though the keys are the same. 