### PR TITLE
Pareto frontier: check for `<=` instead of `<`

### DIFF
--- a/olive/engine/__init__.py
+++ b/olive/engine/__init__.py
@@ -3,3 +3,4 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from olive.engine.engine import Engine, EngineConfig
+from olive.engine.footprint import Footprint

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -114,20 +114,29 @@ class Footprint:
         for k, v in self.nodes.items():
             # if current point's metrics is less than any other point's metrics, it is not pareto frontier
             cmp_flag = True and not self._is_empty_metric(v.metrics)
-            for _, _v in self.nodes.items():
+            for _k, _v in self.nodes.items():
+                if k == _k:
+                    # don't compare the point with itself
+                    continue
                 if not cmp_flag:
                     break
                 if not self._is_empty_metric(_v.metrics):
-                    _against_pareto_frontier_check = True
-                    # if all the metrics of current point is less than any other point's metrics,
-                    # it is not pareto frontier e.g. current point's metrics is [1, 2, 3],
+                    # if all the metrics of current point is less than or equal to any other point's metrics
+                    # (i.e., it is dominated by the other point), it is not pareto frontier
+                    # e.g. current point's metrics is [1, 2, 3],
                     # other point's metrics is [2, 3, 4], then current point is not pareto frontier
                     # but if current point's metrics is [3, 2, 3], other point's metrics is [2, 3, 4],
                     # then current point is pareto frontier
+                    # Note: equal points don't dominate one another
+                    equal = True  # two points are equal
+                    dominated = True  # current point is dominated by other point
                     for metric_name in v.metrics.value:
                         other_point_metrics = _v.metrics.value[metric_name] * _v.metrics.cmp_direction[metric_name]
                         current_point_metrics = v.metrics.value[metric_name] * v.metrics.cmp_direction[metric_name]
-                        _against_pareto_frontier_check &= current_point_metrics < other_point_metrics
+                        dominated &= current_point_metrics <= other_point_metrics
+                        equal &= current_point_metrics == other_point_metrics
+                    # point is not on pareto frontier if dominated and not equal
+                    _against_pareto_frontier_check = dominated and not equal
                     cmp_flag &= not _against_pareto_frontier_check
             self.nodes[k].is_pareto_frontier = cmp_flag
         self.is_marked_pareto_frontier = True


### PR DESCRIPTION
Currently, when checking if a point is dominated or not, we check if all values for current points are less than those for another points. However, this adds points to the pareto frontier that should not be present. For instance, points `[1,1]`, `[2,1]` are both present even though `[2,1]` is better. So we replace with `<=` and also check for equality.

Mathematically speaking, `<` might be more correct but it looks like `<=` is more used in practice. Optuna also does the same https://github.com/optuna/optuna/blob/master/optuna/study/_multi_objective.py#L72

Before 
![less_than](https://user-images.githubusercontent.com/94929125/231330191-c18aa818-978f-44fd-a82f-164c46a70abe.png)

After
![less_than_or_equal](https://user-images.githubusercontent.com/94929125/231330229-5b6af153-bfd3-45cf-9e66-55dda03fc036.png)

