### PR TITLE
Support external data for all onnx passes

### DIFF
--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -48,6 +48,7 @@
                     "encoder_hidden_states": {"0": "batch", "1": "sequence"}
                 },
                 "target_opset": 14,
+                "save_as_external_data": true,
                 "all_tensors_to_one_file": true,
                 "external_data_name": "weights.pb"
             }

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -78,16 +78,15 @@ def model_proto_to_file(
         try:
             # save model
             onnx.save_model(model, str(output_path))
-        except ValueError as e:
+        except ValueError:
             # model is too large to save as a single file
-            if "Please use save_as_external_data to save tensors separately from the model file." in str(e):
+            if model.ByteSize() >= onnx.checker.MAXIMUM_PROTOBUF:
                 logger.warning(
                     "Model is too large to save as a single file but 'save_as_external_data' is False. Saving tensors"
                     " as external data regardless."
                 )
                 return model_proto_to_file(model, output_path, True, all_tensors_to_one_file, external_data_name)
-            else:
-                raise e
+            raise
         return False
 
     # location for external data

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -29,7 +29,7 @@ def get_external_data_config():
             default_value=True,
             description=(
                 "Effective only if save_as_external_data is True. If true, save all tensors to one external file"
-                " specified by location. If false, save each tensor to a file named with the tensor name."
+                " specified by 'external_data_name'. If false, save each tensor to a file named with the tensor name."
             ),
         ),
         "external_data_name": PassConfigParam(
@@ -57,8 +57,9 @@ def model_proto_to_file(
     :param output_path: The path to save the ONNX model to.
     :param save_as_external_data: If True, save tensor data to separate files instead of directly in the ONNX file.
         Large models (>2GB) may be forced to save external data regardless of the value of this parameter.
-    :param all_tensors_to_one_file: Effective only if save_as_external_data is True. If true, save all tensors to one
-        external file specified by location. If false, save each tensor to a file named with the tensor name.
+    :param all_tensors_to_one_file: Effective only if save_as_external_data is True. If True, save all tensors to one
+        external file specified by 'external_data_name'. If False, save each tensor to a file named with the tensor
+        name.
     :param external_data_name: Effective only if all_tensors_to_one_file is True and save_as_external_data is True.
         If not specified, the external data file will be named with <model_path_name>.data
 

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -1,0 +1,141 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import onnx
+
+from olive.model import ONNXModel
+from olive.passes.pass_config import PassConfigParam
+
+logger = logging.getLogger(__name__)
+
+
+def get_external_data_config():
+    return {
+        "save_as_external_data": PassConfigParam(
+            type_=bool,
+            default_value=False,
+            description=(
+                "Serializes tensor data to separate files instead of directly in the ONNX file. Large models (>2GB)"
+                " may be forced to save external data regardless of the value of this parameter."
+            ),
+        ),
+        "all_tensors_to_one_file": PassConfigParam(
+            type_=bool,
+            default_value=True,
+            description=(
+                "Effective only if save_as_external_data is True. If true, save all tensors to one external file"
+                " specified by location. If false, save each tensor to a file named with the tensor name."
+            ),
+        ),
+        "external_data_name": PassConfigParam(
+            type_=str,
+            default_value=None,
+            description=(
+                "Effective only if all_tensors_to_one_file is True and save_as_external_data is True. If not specified,"
+                " the external data file will be named with <model_path_name>.data"
+            ),
+        ),
+    }
+
+
+def model_proto_to_file(
+    model: onnx.ModelProto,
+    output_path: Union[str, Path],
+    save_as_external_data: Optional[bool] = False,
+    all_tensors_to_one_file: Optional[bool] = True,
+    external_data_name: Optional[Union[str, Path]] = None,
+) -> bool:
+    """
+    Save the ONNX model to the specified path.
+
+    :param model: The ONNX model to save.
+    :param output_path: The path to save the ONNX model to.
+    :param save_as_external_data: If True, save tensor data to separate files instead of directly in the ONNX file.
+        Large models (>2GB) may be forced to save external data regardless of the value of this parameter.
+    :param all_tensors_to_one_file: Effective only if save_as_external_data is True. If true, save all tensors to one
+        external file specified by location. If false, save each tensor to a file named with the tensor name.
+    :param external_data_name: Effective only if all_tensors_to_one_file is True and save_as_external_data is True.
+        If not specified, the external data file will be named with <model_path_name>.data
+
+    :return: True if the model has external data, False otherwise.
+    """
+    output_path = Path(output_path)
+    if output_path.exists():
+        logger.info(f"Deleting existing onnx file: {output_path}")
+        output_path.unlink()
+
+    # parent directory of .onnx file
+    output_dir = output_path.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not save_as_external_data:
+        try:
+            # save model
+            onnx.save_model(model, str(output_path))
+        except ValueError as e:
+            # model is too large to save as a single file
+            if "Please use save_as_external_data to save tensors separately from the model file." in str(e):
+                logger.warning(
+                    "Model is too large to save as a single file but 'save_as_external_data' is False. Saving tensors"
+                    " as external data regardless."
+                )
+                return model_proto_to_file(model, output_path, True, all_tensors_to_one_file, external_data_name)
+            else:
+                raise e
+        return False
+
+    # location for external data
+    external_data_path = output_dir / (external_data_name if external_data_name else f"{output_path.name}.data")
+    location = external_data_path.name if all_tensors_to_one_file else None
+
+    if all_tensors_to_one_file:
+        if external_data_path.exists():
+            # Delete the external data file. Otherwise, data will be appended to existing file.
+            logger.info(f"Deleting existing external data file: {external_data_path}")
+            external_data_path.unlink()
+    else:
+        if any(output_dir.iterdir()):
+            raise RuntimeError(f"Output directory ({output_dir}) for external data is not empty.")
+
+    # save model
+    onnx.save_model(
+        model,
+        str(output_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=all_tensors_to_one_file,
+        location=location,
+    )
+    return True
+
+
+def model_proto_to_olive_model(
+    model_proto: onnx.ModelProto,
+    output_model_path: Union[str, Path],
+    external_data_config: dict,
+    name: Optional[str] = None,
+) -> ONNXModel:
+    """
+    Save the ONNX model to the specified path and return the ONNXModel.
+
+    :param model_proto: The ONNX model to save.
+    :param output_model_path: The path to save the ONNX model to.
+    :param external_data_config: The external data configuration. Must be a dictionary with keys
+        "save_as_external_data", "all_tensors_to_one_file", and "external_data_name".
+    :param name: The name of the model.
+
+    :return: The ONNXModel.
+    """
+    has_external_data = model_proto_to_file(
+        model_proto,
+        output_model_path,
+        save_as_external_data=external_data_config["save_as_external_data"],
+        all_tensors_to_one_file=external_data_config["all_tensors_to_one_file"],
+        external_data_name=external_data_config["external_data_name"],
+    )
+
+    return ONNXModel(model_path=output_model_path, name=name, is_file=not has_external_data)

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
@@ -12,6 +11,7 @@ import torch
 
 from olive.model import ONNXModel, PyTorchModel
 from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.pass_config import PassConfigParam
 
 
@@ -33,7 +33,7 @@ class OnnxConversion(Pass):
 
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
-        return {
+        config = {
             "input_names": PassConfigParam(type_=List[str], required=True, description="List of input names."),
             # required for if input_tensors_func is not provided
             "input_shapes": PassConfigParam(
@@ -76,28 +76,9 @@ class OnnxConversion(Pass):
             "target_opset": PassConfigParam(
                 type_=int, default_value=14, description="The version of the default (ai.onnx) opset to target."
             ),
-            "save_as_external_data": PassConfigParam(
-                type_=bool,
-                default_value=False,
-                description=(
-                    "Serializes tensor data to separate files instead of directly in the ONNX file. Large models (>2GB)"
-                    " may be forced to save external data regardless of the value of this parameter."
-                ),
-            ),
-            "all_tensors_to_one_file": PassConfigParam(
-                type_=bool,
-                default_value=True,
-                description=(
-                    "Effective only if save_as_external_data is True. If true, save all tensors to one external file"
-                    " specified by location. If false, save each tensor to a file named with the tensor name."
-                ),
-            ),
-            "external_data_name": PassConfigParam(
-                type_=str,
-                default_value=None,
-                description=("Effective only if all_tensors_to_one_file is True and save_as_external_data is True."),
-            ),
         }
+        config.update(get_external_data_config())
+        return config
 
     def _initialize(self):
         # input shapes
@@ -146,19 +127,12 @@ class OnnxConversion(Pass):
         # there might be multiple files created during export, so we need to track the dir
         # if there are other processes writing to the same dir, we might end up deleting files created by
         # other processes
-        tmp_dir = tempfile.TemporaryDirectory(dir=Path.cwd(), prefix="olive_tmp")
+        tmp_dir = tempfile.TemporaryDirectory(prefix="olive_tmp")
         tmp_dir_path = Path(tmp_dir.name)
         tmp_model_path = str(tmp_dir_path / Path(output_model_path).name)
 
-        # When converting to ONNX, torch.onnx.export (1.11+) automatically saves tensor data as external data if the
-        # ONNX protobuf would exceed 2GB. With sufficiently large models, any tensor exceeding a size threshold will
-        # have its data stored in a separate file on disk in the same directory as the exported ONNX file. We track
-        # the files in the output directory to see if any external data has been emitted.
-        files_before_export = set(tmp_dir_path.glob("*"))
-
         torch.onnx.export(
             pytorch_model,
-            # TODO: support custom input tensor. Will implement once we decide how to handle non-hashable config params
             self._dummy_inputs,
             tmp_model_path,
             export_params=True,
@@ -168,39 +142,10 @@ class OnnxConversion(Pass):
             dynamic_axes=self._dynamic_axes,
         )
 
-        files_after_export = set(tmp_dir_path.glob("*"))
-        has_external_data = len(files_after_export) - len(files_before_export) > 1
-
-        # A second pass to serialize the model is required if either is true:
-        # - The user wants external data, but torch.onnx.export did not emit any external data
-        # - torch.onnx.export emits external data (as separate files) and the user wants it collated into a single file
-        if (config["save_as_external_data"] and not has_external_data) or (
-            has_external_data and config["all_tensors_to_one_file"]
-        ):
-            onnx_model = onnx.load(tmp_model_path)
-
-            # The model is loaded into memory, so it's safe to delete previously exported files.
-            for path in files_after_export - files_before_export:
-                path.unlink()
-
-            external_data_path = config["external_data_name"]
-            if external_data_path is None:
-                external_data_path = str(Path(tmp_model_path).name + ".data")
-
-            onnx.save_model(
-                onnx_model,
-                tmp_model_path,
-                save_as_external_data=True,
-                all_tensors_to_one_file=config["all_tensors_to_one_file"],
-                location=external_data_path,
-                convert_attribute=False,
-            )
-
-        # now we can move the files to the final location
-        for path in tmp_dir_path.glob("*"):
-            shutil.move(path, Path(output_model_path).parent / path.name)
+        # load the model
+        onnx_model = onnx.load(tmp_model_path)
+        # the model is loaded into memory, so it's safe to delete previously exported file(s)
         tmp_dir.cleanup()
 
-        is_file = not (has_external_data or config["save_as_external_data"])
-        model = ONNXModel(output_model_path, model.name, is_file=is_file)
-        return model
+        # save the model to the output path and return the model
+        return model_proto_to_olive_model(onnx_model, output_model_path, config, model.name)

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -9,6 +9,7 @@ from onnxconverter_common import float16
 
 from olive.model import ONNXModel
 from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.pass_config import PassConfigParam
 
 
@@ -20,7 +21,7 @@ class OnnxFloatToFloat16(Pass):
 
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
-        return {
+        config = {
             "min_positive_val": PassConfigParam(
                 type_=float, default_value=1e-7, description="Constant values will be clipped against this value"
             ),
@@ -40,6 +41,8 @@ class OnnxFloatToFloat16(Pass):
                 type_=List[str], default_value=None, description="List of node names to leave as float32"
             ),
         }
+        config.update(get_external_data_config())
+        return config
 
     def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
         output_model_path = ONNXModel.resolve_path(output_model_path)
@@ -56,6 +59,6 @@ class OnnxFloatToFloat16(Pass):
             op_block_list=config.op_block_list,
             node_block_list=config.node_block_list,
         )
-        onnx.save(model_fp16, output_model_path)
 
-        return ONNXModel(output_model_path, model.name)
+        # save the model to the output path and return the model
+        return model_proto_to_olive_model(model_fp16, output_model_path, config.dict(), model.name)

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -85,14 +85,6 @@ _onnx_quantization_config = {
             change the computation graph, making debugging of quantization loss difficult.
         """,
     ),
-    # TODO: enable search if we support onnx external data format
-    "use_external_data_format": PassConfigParam(
-        type_=bool,
-        default_value=False,
-        description="""
-            option used for large size (>2GB) model. Set to False by default.
-        """,
-    ),
     "quant_preprocess": PassConfigParam(
         type_=bool,
         default_value=True,
@@ -126,7 +118,7 @@ _exposed_extra_options_config = {
             quantized output. Also the True behavior could be disabled per node using the nodes_to_exclude.
         """,
     ),
-    "MatMulConstBOnly ": PassConfigParam(
+    "MatMulConstBOnly": PassConfigParam(
         type_=bool,
         default_value=ConditionalDefault(parents=("quant_mode",), support={("dynamic",): True, ("static",): False}),
         description="If enabled, only MatMul with const B will be quantized.",

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -9,12 +9,14 @@ from pathlib import Path
 from shutil import copyfile
 from typing import Any, Callable, Dict, Union
 
+import onnx
 from onnxruntime.quantization import QuantFormat, QuantType, quantize_dynamic, quantize_static
 from onnxruntime.quantization.calibrate import CalibrationMethod
 from onnxruntime.quantization.preprocess import quant_pre_process
 
 from olive.model import ONNXModel
 from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.pass_config import PassConfigParam
 from olive.strategy.search_parameter import Boolean, Categorical, Conditional, ConditionalDefault
 
@@ -280,6 +282,9 @@ class OnnxQuantization(Pass):
         # exposed extra options config
         config.update(deepcopy(_exposed_extra_options_config))
         config.update(deepcopy(_extra_options_config))
+
+        # external data config
+        config.update(get_external_data_config())
         return config
 
     def validate_search_point(self, search_point: Dict[str, Any]) -> bool:
@@ -330,10 +335,11 @@ class OnnxQuantization(Pass):
                 model = self._quant_preprocess(model, preprocessed_temp_model_path)
             else:
                 logger.info("Already processed model for quantization, skipping preprocessing")
-                model = ONNXModel(preprocessed_temp_model_path)
+                model = ONNXModel(preprocessed_temp_model_path, model.name)
 
         # keys not needed for quantization
         to_delete = ["quant_mode", "script_dir", "user_script", "quant_preprocess"]
+        to_delete += list(get_external_data_config().keys())
 
         # update string values to enum values
         if is_static:
@@ -361,6 +367,15 @@ class OnnxQuantization(Pass):
             if key in run_config:
                 del run_config[key]
 
+        # to be safe, run the quantizer with use_external_data_format set to `True` and
+        # `model_output` to a temporary directory
+        # reload the model and save to output_model_path using the external data config
+        # TODO: don't default to use_external_data_format=True if the loading and saving model makes
+        # the pass inefficient
+        tmp_dir = tempfile.TemporaryDirectory(prefix="olive_tmp")
+        tmp_dir_path = Path(tmp_dir.name)
+        tmp_model_path = str(tmp_dir_path / Path(output_model_path).name)
+
         if is_static:
             # get the dataloader
             dataloader = self._user_module_loader.call_object(
@@ -368,14 +383,23 @@ class OnnxQuantization(Pass):
             )
             quantize_static(
                 model_input=model.model_path,
-                model_output=output_model_path,
+                model_output=tmp_model_path,
                 calibration_data_reader=dataloader,
+                use_external_data_format=True,
                 **run_config,
             )
         else:
-            quantize_dynamic(model_input=model.model_path, model_output=output_model_path, **run_config)
+            quantize_dynamic(
+                model_input=model.model_path, model_output=tmp_model_path, use_external_data_format=True, **run_config
+            )
 
-        return ONNXModel(output_model_path, model.name)
+        # load the model
+        onnx_model = onnx.load(tmp_model_path)
+        # the model is loaded into memory, so it's safe to delete previously exported files
+        tmp_dir.cleanup()
+
+        # save the model to the output path and return the model
+        return model_proto_to_olive_model(onnx_model, output_model_path, config, model.name)
 
     def _quant_preprocess(self, model: ONNXModel, output_model_path: str) -> ONNXModel:
         try:
@@ -384,7 +408,7 @@ class OnnxQuantization(Pass):
             logger.warning(f"failed to run quantization preprocessing with error of {e}")
             copyfile(model.model_path, output_model_path)
 
-        return ONNXModel(output_model_path)
+        return ONNXModel(output_model_path, model.name)
 
 
 class OnnxDynamicQuantization(OnnxQuantization):
@@ -402,6 +426,8 @@ class OnnxDynamicQuantization(OnnxQuantization):
         # exposed extra options config
         config.update(deepcopy(_exposed_extra_options_config))
         config.update(deepcopy(_extra_options_config))
+        # external data config
+        config.update(get_external_data_config())
         return config
 
 
@@ -423,4 +449,6 @@ class OnnxStaticQuantization(OnnxQuantization):
         # exposed extra options config
         config.update(deepcopy(_exposed_extra_options_config))
         config.update(deepcopy(_extra_options_config))
+        # external data config
+        config.update(get_external_data_config())
         return config

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -8,6 +8,7 @@ from pydantic import validator
 
 from olive.model import ONNXModel, SNPEModel
 from olive.passes.olive_pass import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.pass_config import PassConfigParam
 from olive.snpe import SNPEDevice
 from olive.snpe.tools.dev import dlc_to_onnx
@@ -28,7 +29,7 @@ class SNPEtoONNXConversion(Pass):
 
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
-        return {
+        config = {
             "target_device": PassConfigParam(
                 type_=str,
                 default_value="cpu",
@@ -36,6 +37,8 @@ class SNPEtoONNXConversion(Pass):
             ),
             "target_opset": PassConfigParam(type_=int, default_value=12, description="Target ONNX opset version."),
         }
+        config.update(get_external_data_config())
+        return config
 
     @staticmethod
     def _validators() -> Dict[str, Callable]:
@@ -48,5 +51,8 @@ class SNPEtoONNXConversion(Pass):
 
         output_model_path = ONNXModel.resolve_path(output_model_path)
 
-        dlc_to_onnx(model.model_path, config.dict(), output_model_path, **model.io_config)
-        return ONNXModel(output_model_path, name=model.name)
+        # create a onnx model that wraps the dlc binary in a node
+        onnx_model = dlc_to_onnx(model.model_path, config.dict(), **model.io_config)
+
+        # save the model to the output path and return the model
+        return model_proto_to_olive_model(onnx_model, output_model_path, config.dict(), model.name)

--- a/olive/snpe/tools/dev.py
+++ b/olive/snpe/tools/dev.py
@@ -216,15 +216,22 @@ def quantize_dlc(dlc_path: str, input_list: str, config: dict, output_file: str)
         raise Exception(stderr)
 
 
-def dlc_to_onnx(dlc_path, config, output_file, input_names, input_shapes, output_names, output_shapes):
+def dlc_to_onnx(
+    dlc_path: str,
+    config: dict,
+    input_names: List[str],
+    input_shapes: List[List[int]],
+    output_names: List[str],
+    output_shapes: List[List[int]],
+) -> onnx.ModelProto:
     """
     Convert a SNPE DLC to ONNX. The DLC is wrapped in a ONNX model for use with onnxruntime SNPE EP.
+    Returns an ONNX ModelProto.
 
     dlc_path: path to the DLC file.
     config: Config dict with the following keys:
         target_device: str = target device for the ONNX-wrapped SNPE model.
         target_opset: int = target ONNX opset for the ONNX-wrapped SNPE model.
-    output_file: path to the output ONNX file.
     input_names: List[str] = list of input names.
     input_shapes: List[List[int]] = list of input shapes.
     output_names: List[str] = list of output names.
@@ -273,5 +280,4 @@ def dlc_to_onnx(dlc_path, config, output_file, input_names, input_shapes, output
     op.version = config["target_opset"]
     model_def = helper.make_model(graph_def, producer_name="Olive", opset_imports=[op])
 
-    # Save the model
-    onnx.save(model_def, output_file)
+    return model_def


### PR DESCRIPTION
Due the limit of protobuf, large onnx models (>2GB) cannot be saved to a single onnx file. The tensors must be saved to an external data file. Our onnx related passes do not handle this case. 

This PR adds options for user to specify whether to save as external data or not. If the model is too large, we override the user's configuration and save as external data regardless. A warning is also generated to inform the user of this. This ensures that the pass doesn't fail when saving the onnx model to file.  

The model save logic is based on a similar implementation by onnxruntime https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/onnx_model.py#L947 but with more control on the name of the external data file. 