### PR TITLE
reset model to cpu after evaluation on gpu

### DIFF
--- a/olive/evaluator/evaluation.py
+++ b/olive/evaluator/evaluation.py
@@ -176,6 +176,7 @@ def evaluate_accuracy_pytorch(sess, dataloader, post_func, device):
         #  ValueError: expected sequence of length 128 at dim 1 (got 3)
         preds.extend(outputs.tolist())
         targets.extend(labels.data.tolist())
+    sess.to(torch.device(Device.CPU))
     return preds, targets
 
 
@@ -272,6 +273,7 @@ def evaluate_latency_pytorch(sess, dataloader, device, warmup_num, repeat_test_n
             t = time.perf_counter()
             sess(input_data)
             latencies.append(time.perf_counter() - t)
+    sess.to(torch.device(Device.CPU))
     return latencies
 
 


### PR DESCRIPTION
When run Olive in gpu device, the evaluation will put the model in cuda, but forget to return back to cpu when evaluation is done. It caused conversion failed.

![image](https://user-images.githubusercontent.com/13343117/232491885-f0e5a048-30be-47dd-afaa-dd74a7e98320.png)
