### PR TITLE
dummy inputs to cpu & model to cpu before conversion

### DIFF
--- a/examples/test_bert_ptq_cpu.py
+++ b/examples/test_bert_ptq_cpu.py
@@ -35,6 +35,7 @@ def check_output(footprint):
 @pytest.mark.parametrize("system", ["local_system", "aml_system", "docker_system"])
 @pytest.mark.parametrize("olive_json", ["bert_config.json"])
 def test_bert(search_algorithm, execution_order, system, olive_json):
+    # TODO: add gpu e2e test
     if system == "docker_system" and platform.system() == "Windows":
         pytest.skip("Skip Linux containers on Windows host test case.")
 

--- a/examples/test_resnet_ptq_cpu.py
+++ b/examples/test_resnet_ptq_cpu.py
@@ -40,7 +40,7 @@ def check_output(footprint):
 @pytest.mark.parametrize("system", ["local_system", "aml_system"])
 @pytest.mark.parametrize("olive_json", ["resnet_config.json"])
 def test_resnet(search_algorithm, execution_order, system, olive_json):
-
+    # TODO: add gpu e2e test
     from olive.workflows import run as olive_run
 
     olive_config = None

--- a/olive/evaluator/evaluation.py
+++ b/olive/evaluator/evaluation.py
@@ -158,13 +158,10 @@ def evaluate_accuracy_pytorch(sess, dataloader, post_func, device):
     if device:
         sess.to(device)
     for input_data, labels in dataloader:
+        input_data = tensor_data_to_device(input_data, device)
         if isinstance(input_data, dict):
-            if device:
-                input_data = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in input_data.items()}
             result = sess(**input_data)
         else:
-            if device:
-                input_data = input_data.to(device)
             result = sess(input_data)
         if post_func:
             outputs = post_func(result)
@@ -176,7 +173,6 @@ def evaluate_accuracy_pytorch(sess, dataloader, post_func, device):
         #  ValueError: expected sequence of length 128 at dim 1 (got 3)
         preds.extend(outputs.tolist())
         targets.extend(labels.data.tolist())
-    sess.to(torch.device(Device.CPU))
     return preds, targets
 
 
@@ -255,9 +251,8 @@ def evaluate_latency_pytorch(sess, dataloader, device, warmup_num, repeat_test_n
     device = device_string_to_torch_device(device)
     if device:
         sess.to(device)
+        input_data = tensor_data_to_device(input_data, device)
     if isinstance(input_data, dict):
-        if device:
-            input_data = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in input_data.items()}
         for _ in range(warmup_num):
             sess(**input_data)
         for _ in range(repeat_test_num):
@@ -265,15 +260,12 @@ def evaluate_latency_pytorch(sess, dataloader, device, warmup_num, repeat_test_n
             sess(**input_data)
             latencies.append(time.perf_counter() - t)
     else:
-        if device:
-            input_data = input_data.to(device)
         for _ in range(warmup_num):
             sess(input_data)
         for _ in range(repeat_test_num):
             t = time.perf_counter()
             sess(input_data)
             latencies.append(time.perf_counter() - t)
-    sess.to(torch.device(Device.CPU))
     return latencies
 
 
@@ -316,6 +308,23 @@ def get_user_config(config: dict):
 def device_string_to_torch_device(device: Device):
     device = torch.device("cuda") if device == Device.GPU else torch.device(device)
     return device
+
+
+def tensor_data_to_device(data, device: torch.device):
+    if device is None:
+        return data
+    if isinstance(data, torch.Tensor):
+        return data.to(device)
+    if isinstance(data, dict):
+        return {k: tensor_data_to_device(v, device) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [tensor_data_to_device(v, device) for v in data]
+    elif isinstance(data, tuple):
+        return tuple(tensor_data_to_device(v, device) for v in data)
+    elif isinstance(data, set):
+        return set(tensor_data_to_device(v, device) for v in data)
+    else:
+        return data
 
 
 class DummyDataloader(Dataset):

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -120,9 +120,11 @@ class OnnxConversion(Pass):
     def _run_for_config(self, model: PyTorchModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
         pytorch_model = model.load_model()
         pytorch_model.eval()
+
+        # TODO: add e2e test for model on cpu but data on gpu; model on gpu but data on cpu
         # put pytorch_model and dummy_inputs at the same device
-        torch_device = pytorch_model.device
-        dummy_inputs = tensor_data_to_device(self._dummy_inputs, torch_device)
+        pytorch_model.to("cpu")
+        dummy_inputs = tensor_data_to_device(self._dummy_inputs, "cpu")
         if isinstance(pytorch_model, torch.jit.RecursiveScriptModule):
             pytorch_model = TraceModelWrapper(pytorch_model)
 


### PR DESCRIPTION
To avoid the case where user define the customized evaluation functions and forget to reset the device back to cpu.
Further fix for PR: https://github.com/microsoft/Olive/pull/177