### PR TITLE
bugfix for latency metrics config in perf tuning

### DIFF
--- a/examples/resnet_ptq_cpu/resnet_config.json
+++ b/examples/resnet_ptq_cpu/resnet_config.json
@@ -73,7 +73,18 @@
                 "user_script": "user_script.py",
                 "data_dir": "data",
                 "dataloader_func": "resnet_calibration_reader",
-                "weight_type": "QUInt8"
+                "weight_type": "QUInt8",
+                "activation_type": "QUInt8",
+                "quant_preprocess": true
+            }
+        },
+        "perf_tuning": {
+            "type": "OrtPerfTuning",
+            "config": {
+                "user_script": "user_script.py",
+                "dataloader_func": "create_dataloader",
+                "batch_size": 1,
+                "data_dir": "data"
             }
         }
     },

--- a/examples/resnet_ptq_cpu/user_script.py
+++ b/examples/resnet_ptq_cpu/user_script.py
@@ -46,16 +46,16 @@ class PytorchResNetDataset(Dataset):
         return input_data, label
 
 
-def create_dataloader(data_dir, batchsize):
+def create_dataloader(data_dir, batch_size):
     cifar10_dataset = CIFAR10DataSet(data_dir)
     _, val_set = torch.utils.data.random_split(cifar10_dataset.val_dataset, [49000, 1000])
-    benchmark_dataloader = DataLoader(PytorchResNetDataset(val_set), batch_size=batchsize, drop_last=True)
+    benchmark_dataloader = DataLoader(PytorchResNetDataset(val_set), batch_size=batch_size, drop_last=True)
     return benchmark_dataloader
 
 
 def post_process(output):
     # max_elements, max_indices = torch.max(input_tensor, dim)
-    # This is a two classes classifcation task, result is a 2D array [[ 1.1541, -0.6622],[[-0.2137,  0.0360]]]
+    # This is a two classes classification task, result is a 2D array [[ 1.1541, -0.6622],[[-0.2137,  0.0360]]]
     # the index of this array among dimension 1 will be [1, 0], which are labels of this task
     _, preds = torch.max(output, 1)
     return preds
@@ -77,7 +77,7 @@ def resnet_calibration_reader(data_dir, batch_size=16):
     return ResnetCalibrationDataReader(data_dir, batch_size=batch_size)
 
 
-# TODO: use these functions to demo custom evaluation fucntions once the new evaluator is ready
+# keep this to demo/test custom evaluation function
 def eval_accuracy(model: OliveModel, data_dir, batch_size, device):
     sess = model.prepare_session(inference_settings=None, device=device)
     dataloader = create_dataloader(data_dir, batch_size)

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -53,6 +53,12 @@ def get_user_config_class(metric_type: str):
     return create_config_class(f"{metric_type.title()}UserConfig", default_config, ConfigBase, validators)
 
 
+def get_properties_from_metric_type(metric_type):
+    user_config_class = get_user_config_class(metric_type)
+    # list(user_config_class.schema()["properties"].keys()) # will ignore dataloader_func
+    return list(user_config_class.__fields__)
+
+
 # TODO: automate latency metric config also we standardize accuracy metric config
 class LatencyMetricConfig(ConfigBase):
     warmup_num: int = WARMUP_NUM

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -55,7 +55,7 @@ def get_user_config_class(metric_type: str):
 
 def get_properties_from_metric_type(metric_type):
     user_config_class = get_user_config_class(metric_type)
-    # list(user_config_class.schema()["properties"].keys()) # will ignore dataloader_func
+    # avoid to use schema() to get the fields, because it will skip the ones with object type
     return list(user_config_class.__fields__)
 
 

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -44,8 +44,10 @@ def generate_tuning_combos(model, config):
 def tune_onnx_model(model, config):
     latency_user_config = {}
     # which should be the same as the config in the metric
+    config_dict = config.dict()
     for eval_config in get_properties_from_metric_type(MetricType.LATENCY):
-        latency_user_config[eval_config] = config.dict().get(eval_config)
+        if eval_config in config_dict:
+            latency_user_config[eval_config] = config_dict.get(eval_config)
     latency_metric = Metric(
         name="latency", type=MetricType.LATENCY, sub_type=LatencySubType.AVG, user_config=latency_user_config
     )

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Union
 
 from olive.evaluator.evaluation import evaluate_latency
 from olive.evaluator.metric import LatencySubType, Metric, MetricType
+from olive.evaluator.metric_config import get_properties_from_metric_type
 from olive.model import ONNXModel
 from olive.passes import Pass
 from olive.passes.pass_config import PassConfigParam
@@ -42,15 +43,8 @@ def generate_tuning_combos(model, config):
 
 def tune_onnx_model(model, config):
     latency_user_config = {}
-    for eval_config in [
-        "data_dir",
-        "dataloader_func",
-        "batch_size",
-        "input_names",
-        "input_shapes",
-        "input_types",
-        "device",
-    ]:
+    # which should be the same as the config in the metric
+    for eval_config in get_properties_from_metric_type(MetricType.LATENCY):
         latency_user_config[eval_config] = config.dict().get(eval_config)
     latency_metric = Metric(
         name="latency", type=MetricType.LATENCY, sub_type=LatencySubType.AVG, user_config=latency_user_config


### PR DESCRIPTION
1. When construct the latency metrics configs, it lost several configs like 'user_scirpts'. And the list is hard coded in perf-tuning which can crash again if we change the metrics schema in the future.
2. Enhance the e2e ResNet tests to make it cover the above failed case.
3. typos fix