### PR TITLE
Remove `enum-tools` from docs requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,6 @@ autodoc_pydantic
 azure-ai-ml>=0.1.0b6
 azure-identity
 docker
-enum-tools[sphinx]
 myst_parser
 onnxconverter_common
 psutil

--- a/docs/source/api/metric.rst
+++ b/docs/source/api/metric.rst
@@ -8,17 +8,23 @@ Metric
 
 MetricType
 ^^^^^^^^^^
-.. autoenum:: olive.evaluator.metric.MetricType
+.. autoclass:: olive.evaluator.metric.MetricType
+    :members:
+    :undoc-members:
 
 .. _accuracy_sub_type:
 AccuracySubType
 ^^^^^^^^^^^^^^^
-.. autoenum:: olive.evaluator.metric.AccuracySubType
+.. autoclass:: olive.evaluator.metric.AccuracySubType
+    :members:
+    :undoc-members:
 
 .. _latency_sub_type:
 LatencySubType
 ^^^^^^^^^^^^^^
-.. autoenum:: olive.evaluator.metric.LatencySubType
+.. autoclass:: olive.evaluator.metric.LatencySubType
+    :members:
+    :undoc-members:
 
 MetricGoal
 ^^^^^^^^^^

--- a/docs/source/api/systems.rst
+++ b/docs/source/api/systems.rst
@@ -11,7 +11,9 @@ Config
 SystemType
 ^^^^^^^^^^^
 
-.. autoenum:: olive.systems.common.SystemType
+.. autoclass:: olive.systems.common.SystemType
+    :members:
+    :undoc-members:
 
 .. _local_system_config:
 LocalTargetUserConfig
@@ -21,7 +23,9 @@ LocalTargetUserConfig
 
 **Device**
 
-.. autoenum:: olive.systems.common.Device
+.. autoclass:: olive.systems.common.Device
+    :members:
+    :undoc-members:
 
 .. _docker_system_config:
 DockerTargetUserConfig

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_tabs.tabs",
     # "nbsphinx",
-    "enum_tools.autoenum",
     "auto_config_doc",
     "sphinxcontrib.autodoc_pydantic",
     "sphinxcontrib.jquery",


### PR DESCRIPTION
`enum-tools` has GPL requirement which causes security compliance issue. So, removing it from docs requirement.