### PR TITLE
bugfix: perf_tuning batch size != latency.batch_size

### DIFF
--- a/examples/resnet_ptq_cpu/resnet_config.json
+++ b/examples/resnet_ptq_cpu/resnet_config.json
@@ -83,7 +83,7 @@
             "config": {
                 "user_script": "user_script.py",
                 "dataloader_func": "create_dataloader",
-                "batch_size": 1,
+                "batch_size": 16,
                 "data_dir": "data"
             }
         }

--- a/olive/evaluator/evaluation.py
+++ b/olive/evaluator/evaluation.py
@@ -70,6 +70,9 @@ def evaluate_latency(model: OliveModel, metric: Metric, device: Device = Device.
     sleep_num = metric.metric_config.sleep_num
 
     latencies = []
+    # user.config.inference_settings > model.inference_settings > default inference_settings
+    # when user.config.inference_settings is None, the model.inference_settings
+    # will be used in model.prepare_session(..)
     inference_settings = metric.user_config.inference_settings
     model_inference_settings = inference_settings.get(model.framework.lower()) if inference_settings else None
     sess = model.prepare_session(inference_settings=model_inference_settings, device=device)

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -56,11 +56,14 @@ def tune_onnx_model(model, config):
 
     tuning_results = []
     for tuning_combo in generate_tuning_combos(model, config):
-        logger.info("Run tuning for: {}".format(tuning_combo))
+        tuning_item = ["provider", "execution_mode", "ort_opt_level", "io_bind"]
+        logger.info("Run tuning for: {}".format(list(zip(tuning_item, tuning_combo))))
         if tuning_combo[0] == "CPUExecutionProvider" and tuning_combo[3]:
             continue
         tuning_results.extend(threads_num_tuning(model, latency_metric, config, tuning_combo))
-        logger.info("Current tuning results: {}".format(tuning_results[-1]["latency_ms"]))
+
+    for tuning_result in tuning_results:
+        logger.debug("Tuning result: {}".format(tuning_result["latency_ms"]))
 
     best_result = parse_tuning_result(*tuning_results, pretuning_inference_result)
     logger.info("Best result: {}".format(best_result))


### PR DESCRIPTION
1. Align the batch_size for olive examples, which inconsistency bring gap for perf_tuning metrics and olive evaluations. 

    - [ ] In the future PR, we should directly read batch_size from metrics config.

3. Refine perf-tuning's messy logger info.