### PR TITLE
Remove direct use of pass.default_config()

### DIFF
--- a/docs/source/exts/auto_config_doc/__init__.py
+++ b/docs/source/exts/auto_config_doc/__init__.py
@@ -40,6 +40,7 @@ class AutoConfigDirective(Directive):
             output_model_type = stringify_annotation(output_model_type).replace("olive.model.", "")
             lines += ["", f"**Output:** {stringify_annotation(output_model_type)}"]
 
+        # TODO: Use default accelerator spec for Passes when it is implemented
         default_config = auto_config_class.default_config()
         for key in default_config:
             param = default_config[key]

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -76,6 +76,7 @@ class Pass(ABC):
         for param, param_config in self._config_class._default_config.items():
             if param_config.is_path:
                 self.path_params.append((param, param_config.required))
+
         self._initialized = False
 
     @classmethod

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -72,12 +72,10 @@ class Pass(ABC):
                 self._fixed_params[k] = v
 
         # Params that are paths [(param_name, required)]
-        # TODO: replace the default_config with the instance?
         self.path_params = []
-        for param, param_config in self.default_config().items():
+        for param, param_config in self._config_class._default_config.items():
             if param_config.is_path:
                 self.path_params.append((param, param_config.required))
-
         self._initialized = False
 
     @classmethod
@@ -350,28 +348,13 @@ class Pass(ABC):
 class FullPassConfig(ConfigBase):
     type: str
     disable_search: bool = False
-    config: PassConfigBase = None
+    config: Dict[str, Any] = None
 
     @validator("type")
     def validate_type(cls, v):
         if v.lower() not in Pass.registry:
             raise ValueError(f"Unknown pass type {v}")
         return v
-
-    @validator("config", pre=True, always=True)
-    def validate_config(cls, v, values):
-        if "type" not in values:
-            raise ValueError("Invalid type")
-        if "disable_search" not in values:
-            raise ValueError("Invalid disable_search")
-
-        pass_type = values["type"].lower()
-        disable_search = values["disable_search"]
-        pass_cls = Pass.registry[pass_type]
-        # TODO: remove the default config call since it will accept hardware/EP info.
-        default_config = pass_cls.default_config()
-        config_class = pass_cls.get_config_class(default_config, disable_search)
-        return validate_config(v, PassConfigBase, config_class)
 
     def create_pass(self):
         pass_cls = Pass.registry[self.type.lower()]

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -122,4 +122,7 @@ def create_config_class(
         else:
             config[param] = (type_, param_config.default_value)
 
-    return create_model(f"{pass_type}Config", **config, __base__=PassConfigBase, __validators__=validators)
+    class PassConfigBaseDefaultConfig(PassConfigBase):
+        _default_config = default_config  # store default config as a class attribute, not included in json
+
+    return create_model(f"{pass_type}Config", **config, __base__=PassConfigBaseDefaultConfig, __validators__=validators)

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -28,6 +28,7 @@ def parse_pass_args(pass_type, raw_args):
 
     parser = argparse.ArgumentParser(f"{pass_type} pass args")
 
+    # TODO: get accelerator specs from args when it is implemented
     # parse pass args
     for param, param_config in pass_class.default_config().items():
         if param_config.is_path:


### PR DESCRIPTION
Since, we will be updating `pass.default_config` to take in the accelerator specs to generate the search space, it is not available inside the pass itself or before we know the accelerato specs. 

This PR removes such references by storing the instance of `default_config` that created the specific pass object as a private attribute of the `config_class`. 

Also added TODO for places where we have to update calls to `default_config` by providing the relevant accelerator specs. 