### PR TITLE
Introduce CompositeOnnxModel

### DIFF
--- a/olive/model.py
+++ b/olive/model.py
@@ -78,7 +78,7 @@ class OliveModel(ABC):
         """
         raise NotImplementedError()
 
-    def set_compsite_parent(self, cp):
+    def set_composite_parent(self, cp):
         self.composite_parent = cp
 
     def get_composite_parent(self):

--- a/olive/model.py
+++ b/olive/model.py
@@ -616,3 +616,17 @@ class CompositeOnnxModel(OliveModel):
 
     def get_model_components(self):
         return self.model_components
+
+    def to_json(self, check_object: bool = False):
+        json_dict = {
+            "type": self.__class__.__name__,
+            "config": {
+                "name": self.name,
+                "version": self.version,
+            },
+        }
+        json_dict["config"]["components"] = []
+        for m in self.model_components:
+            json_dict["config"]["components"].append(m.to_json(check_object))
+
+        return serialize_to_json(json_dict, check_object)

--- a/olive/model.py
+++ b/olive/model.py
@@ -582,12 +582,14 @@ class DistributedOnnxModel(ONNXModelBase):
 
         return eps if eps else available_providers
 
+
 class CompositeOnnxModel(OliveModel):
     """
     CompositeOnnxModel represents multi component models. Whisper is an example composite
     model that has encoder and decoder components. CompositeOnnxModel is a collection of
     OnnxModels.
     """
+
     def __init__(
         self,
         model_components: List[str],
@@ -606,7 +608,6 @@ class CompositeOnnxModel(OliveModel):
             m.set_composite_parent(self)
 
     @property
-
     def load_model(self, rank: int = None):
         raise NotImplementedError()
 

--- a/olive/model.py
+++ b/olive/model.py
@@ -603,6 +603,16 @@ class CompositeOnnxModel(OliveModel):
             is_file=False,
             is_aml_model=False,
         )
+
+        if isinstance(model_components[0], dict):
+            assert all(
+                [m.get("type").lower() == "onnxmodel" for m in model_components]
+            ), "All components must be ONNXModel"
+            self.model_components = [ONNXModel(**m.get("config", {})) for m in model_components]
+        else:
+            assert all([isinstance(m, ONNXModel) for m in model_components]), "All components must be ONNXModel"
+            self.model_components = model_components
+
         self.model_components = model_components
         for m in self.model_components:
             m.set_composite_parent(self)

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -12,7 +12,7 @@ from pydantic import validator
 
 from olive.common.config_utils import ConfigBase, validate_config
 from olive.common.user_module_loader import UserModuleLoader
-from olive.model import DistributedOnnxModel, OliveModel
+from olive.model import CompositeOnnxModel, DistributedOnnxModel, OliveModel
 from olive.passes.pass_config import (
     PassConfigBase,
     PassConfigParam,
@@ -336,6 +336,11 @@ class Pass(ABC):
             return DistributedOnnxModel(
                 output_filepaths, model.name, version=model.version, inference_settings=model.inference_settings
             )
+        elif isinstance(model, CompositeOnnxModel):
+            components = []
+            for cidx, child in enumerate(model.get_model_components()):
+                components.append(self._run_for_config(child, config, str(f"{output_model_path}_{cidx}")))
+            return CompositeOnnxModel(components, model.name)
 
         return self._run_for_config(model, config, output_model_path)
 

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from olive.evaluator.evaluation import evaluate_accuracy, evaluate_custom_metric, evaluate_latency
 from olive.evaluator.metric import Metric, MetricType
-from olive.model import OliveModel
+from olive.model import CompositeOnnxModel, OliveModel
 from olive.passes.olive_pass import Pass
 from olive.systems.common import Device, SystemType
 from olive.systems.olive_system import OliveSystem
@@ -35,6 +35,10 @@ class LocalSystem(OliveSystem):
         """
         Evaluate the model
         """
+
+        if isinstance(model, CompositeOnnxModel):
+            raise NotImplementedError()
+
         metrics_res = {}
         for metric in metrics:
             if metric.type == MetricType.ACCURACY:


### PR DESCRIPTION
Introduce CompositeOnnxModel to represent models with encoder and decoder subcomponents as individual OnnxModels.

Separate PRs will introduce support for creating CompositeOnnxModel and converting CompositeOnnxModel into a OnnxModel