### PR TITLE
Add io_config, dummy_inputs_func and dynamic axes to PytorchModel

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -58,7 +58,16 @@ Please find the detailed config options from following table for each model type
         "model_path": null,
         "is_file": false,
         "model_loader": "load_pytorch_origin_model",
-        "model_script": "user_script.py"
+        "model_script": "user_script.py",
+        "io_config": {
+            "input_names": ["input"],
+            "input_shapes": [[1, 3, 32, 32]],
+            "output_names": ["output"]
+        },
+        "dynamic_axes": {
+            "input": {"0": "batch_size"},
+            "output": {"0": "batch_size"}
+        }
     }
 }
 ```
@@ -232,13 +241,6 @@ Please also find the detailed options from following table for each pass:
     "onnx_conversion": {
         "type": "OnnxConversion",
         "config": {
-            "input_names": ["input"],
-            "input_shapes": [[1, 3, 32, 32]],
-            "output_names": ["output"],
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
-            },
             "target_opset": 13
         }
     },

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -62,11 +62,11 @@ Please find the detailed config options from following table for each model type
         "io_config": {
             "input_names": ["input"],
             "input_shapes": [[1, 3, 32, 32]],
-            "output_names": ["output"]
-        },
-        "dynamic_axes": {
-            "input": {"0": "batch_size"},
-            "output": {"0": "batch_size"}
+            "output_names": ["output"],
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     }
 }

--- a/docs/source/overview/quicktour.md
+++ b/docs/source/overview/quicktour.md
@@ -55,11 +55,11 @@ You provide input model location and type. PyTorchModel, ONNXModel, OpenVINOMode
         "io_config": {
             "input_names": ["input"],
             "input_shapes": [[1, 3, 32, 32]],
-            "output_names": ["output"]
-        },
-        "dynamic_axes": {
-            "input": {"0": "batch_size"},
-            "output": {"0": "batch_size"}
+            "output_names": ["output"],
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     }
 }
@@ -167,11 +167,11 @@ python -m olive.workflows.run --config config.json
             "io_config": {
                 "input_names": ["input"],
                 "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"]
-            },
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
+                "output_names": ["output"],
+                "dynamic_axes": {
+                    "input": {"0": "batch_size"},
+                    "output": {"0": "batch_size"}
+                }
             }
         }
     },

--- a/docs/source/overview/quicktour.md
+++ b/docs/source/overview/quicktour.md
@@ -51,7 +51,16 @@ You provide input model location and type. PyTorchModel, ONNXModel, OpenVINOMode
     "type": "PyTorchModel",
     "config": {
         "model_path": "resnet.pt",
-        "is_file": true
+        "is_file": true,
+        "io_config": {
+            "input_names": ["input"],
+            "input_shapes": [[1, 3, 32, 32]],
+            "output_names": ["output"]
+        },
+        "dynamic_axes": {
+            "input": {"0": "batch_size"},
+            "output": {"0": "batch_size"}
+        }
     }
 }
 ```
@@ -122,13 +131,6 @@ let us first convert the pytorch model to ONNX and quantize it.
 "onnx_conversion": {
     "type": "OnnxConversion",
     "config": {
-        "input_names": ["input"],
-        "input_shapes": [[1, 3, 32, 32]],
-        "output_names": ["output"],
-        "dynamic_axes": {
-            "input": {"0": "batch_size"},
-            "output": {"0": "batch_size"}
-        },
         "target_opset": 13
     },
     "host": {"type": "LocalSystem"}
@@ -161,7 +163,16 @@ python -m olive.workflows.run --config config.json
         "type": "PyTorchModel",
         "config": {
             "model_path": "resnet.pt",
-            "is_file": true
+            "is_file": true,
+            "io_config": {
+                "input_names": ["input"],
+                "input_shapes": [[1, 3, 32, 32]],
+                "output_names": ["output"]
+            },
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     },
     "systems": {
@@ -189,13 +200,6 @@ python -m olive.workflows.run --config config.json
         "onnx_conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input"],
-                "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"],
-                "dynamic_axes": {
-                    "input": {"0": "batch_size"},
-                    "output": {"0": "batch_size"}
-                },
                 "target_opset": 13
             },
             "host": {"type": "LocalSystem"}

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -23,7 +23,16 @@ model can be loaded from file or using a model loader function. For a complete o
 ```python
 from olive.models import PytorchModel
 
-input_model = PyTorchModel(model_path="resnet.pt", is_file=True)
+input_model = PyTorchModel(
+    model_path="resnet.pt",
+    is_file=True,
+    io_config={
+        "input_names": ["input"],
+        "input_shapes": [[1, 3, 32, 32]],
+        "output_names": ["output"]
+    },
+    dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}}
+)
 ```
 
 ### Host and Target Systems
@@ -100,10 +109,6 @@ from olive.passes.olive_pass import create_pass_from_dict
 
 # Onnx conversion pass
 onnx_conversion_config = {
-    "input_names": ["input"],
-    "input_shapes": [[1, 3, 32, 32]],
-    "output_names": ["output"],
-    "dynamic_axes": {"input": {0: "batch_size"}, "output": {0: "batch_size"}},
     "target_opset": 13,
 }
 onnx_conversion_pass = create_pass_from_dict(OnnxConversion, onnx_conversion_config)

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -29,9 +29,9 @@ input_model = PyTorchModel(
     io_config={
         "input_names": ["input"],
         "input_shapes": [[1, 3, 32, 32]],
-        "output_names": ["output"]
-    },
-    dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}}
+        "output_names": ["output"],
+        "dynamic_axes": {"input": {0: "batch_size"}, "output": {0: "batch_size"}}
+    }
 )
 ```
 

--- a/docs/source/tutorials/passes/onnx.md
+++ b/docs/source/tutorials/passes/onnx.md
@@ -13,36 +13,14 @@ The user might not have a model ready in the ONNX format. `OnnxConversion` conve
 Please refer to [OnnxConversion](onnx_conversion) for more details about the pass and its config parameters.
 
 ### Example Configuration
-a. Provide input shapes
 ```json
  {
     "type": "OnnxConversion",
     "config": {
-        "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-        "input_shapes": [[1, 128], [1, 128], [1, 128]],
-        "input_types": ["int64", "int64", "int64"],
-        "output_names": ["output"],
         "target_opset": 13
     }
  }
 ```
-
-b. Provide custom input tensor function
-```json
-{
-    "type": "OnnxConversion",
-    "config": {
-        "user_script": "user_script.py",
-        "input_tensor_func": "create_input_tensors",
-        "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-        "output_names": ["output"],
-        "target_opset": 13
-    }
-}
-```
-
-Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/bert_ptq_cpu/user_script.py)
-for an example implementation of `"user_script.py"` and `"create_input_tensors"`.
 
 ## Model Optimizer
 `OnnxModelOptimizer` optimizes an ONNX model by fusing nodes. Fusing nodes involves merging multiple nodes in a model into a single node to

--- a/docs/source/tutorials/passes/pytorch.md
+++ b/docs/source/tutorials/passes/pytorch.md
@@ -19,8 +19,6 @@ a. Run QAT training with customized training loop.
 {
     "type": "QuantizationAwareTraining",
     "config":{
-        "input_shapes": [[1, 128], [1, 128], [1, 128]],
-        "input_types": ["int64", "int64", "int64"],
         "user_script": "user_script.py",
         "training_loop_func": "training_loop_func"
     }
@@ -35,7 +33,6 @@ b. Run QAT training with PyTorch Lightning.
 {
     "type": "QuantizationAwareTraining",
     "config":{
-        "input_shapes": [[1, 3, 32, 32]],
         "user_script": "user_script.py",
         "num_epochs": 5,
         "ptl_data_module": "PTLDataModule",
@@ -53,7 +50,6 @@ c. Run QAT training with default training loop.
 {
     "type": "QuantizationAwareTraining",
     "config":{
-        "input_shapes": [[1, 3, 32, 32]],
         "user_script": "user_script.py",
         "num_epochs": 5,
         "train_dataloader_func": "create_train_dataloader",

--- a/examples/bert_ptq_cpu/auto_bert_config.json
+++ b/examples/bert_ptq_cpu/auto_bert_config.json
@@ -6,7 +6,13 @@
             "model_path": null,
             "is_file": false,
             "model_loader": "load_pytorch_origin_model",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+                "input_shapes": [[1, 128], [1, 128], [1, 128]],
+                "input_types": ["int64", "int64", "int64"],
+                "output_names": ["output"]
+            }
         }
     },
     "systems": {
@@ -51,12 +57,6 @@
         "evaluator": "common_evaluator",
         "host": {"type": "LocalSystem"},
         "target": {"type": "LocalSystem"},
-        "cache_dir": "cache",
-        "model_io_config": {
-            "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-            "input_shapes": [[1, 128], [1, 128], [1, 128]],
-            "input_types": ["int64", "int64", "int64"],
-            "output_names": ["output"]
-        }
+        "cache_dir": "cache"
     }
 }

--- a/examples/bert_ptq_cpu/bert_config.json
+++ b/examples/bert_ptq_cpu/bert_config.json
@@ -6,7 +6,13 @@
             "model_path": null,
             "is_file": false,
             "model_loader": "load_pytorch_origin_model",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config" : {
+                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+                "input_shapes": [[1, 128], [1, 128], [1, 128]],
+                "input_types": ["int64", "int64", "int64"],
+                "output_names": ["output"]
+            }
         }
     },
     "systems": {
@@ -67,10 +73,6 @@
         "conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-                "input_shapes": [[1, 128], [1, 128], [1, 128]],
-                "input_types": ["int64", "int64", "int64"],
-                "output_names": ["output"],
                 "target_opset": 13
             }
         },

--- a/examples/bert_ptq_cpu/docker/Dockerfile
+++ b/examples/bert_ptq_cpu/docker/Dockerfile
@@ -6,6 +6,6 @@ RUN pip install azure-ai-ml \
             datasets \
             transformers \
             onnxconverter_common \
-            git+https://github.com/microsoft/Olive.git@myguo/model_type
+            git+https://github.com/microsoft/Olive.git@jambayk/model-info
 
 WORKDIR /olive

--- a/examples/bert_ptq_cpu/user_script.py
+++ b/examples/bert_ptq_cpu/user_script.py
@@ -13,7 +13,7 @@ from transformers import AutoModelForSequenceClassification, AutoTokenizer
 disable_progress_bar()
 
 
-def create_input_tensors():
+def create_input_tensors(model):
     return {
         "input_ids": torch.ones(1, 128, dtype=torch.int64),
         "attention_mask": torch.ones(1, 128, dtype=torch.int64),

--- a/examples/directml/squeezenet/squeezenet_config.json
+++ b/examples/directml/squeezenet/squeezenet_config.json
@@ -6,7 +6,12 @@
             "model_path": null,
             "is_file": false,
             "model_loader": "load_pytorch_origin_model",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": [ "input_image" ],
+                "input_shapes": [ [ 1, 3, 224, 224 ] ],
+                "output_names": [ "output" ]
+            }
         }
     },
     "systems": {
@@ -38,9 +43,6 @@
         "torch_to_onnx": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": [ "input_image" ],
-                "input_shapes": [ [ 1, 3, 224, 224 ] ],
-                "output_names": [ "output" ],
                 "target_opset": 13
             }
         },

--- a/examples/directml/stable_diffusion/config_safety_checker.json
+++ b/examples/directml/stable_diffusion/config_safety_checker.json
@@ -9,13 +9,13 @@
             "model_script": "user_script.py",
             "io_config": {
                 "input_names": [ "clip_input", "images" ],
-                "output_names": [ "out_images", "has_nsfw_concepts" ]
+                "output_names": [ "out_images", "has_nsfw_concepts" ],
+                "dynamic_axes": {
+                    "clip_input": { "0": "batch", "1": "channels", "2": "height", "3": "width" },
+                    "images": { "0": "batch", "1": "height", "2": "width", "3": "channels" }
+                }
             },
-            "dummy_inputs_func": "safety_checker_conversion_inputs",
-            "dynamic_axes": {
-                "clip_input": { "0": "batch", "1": "channels", "2": "height", "3": "width" },
-                "images": { "0": "batch", "1": "height", "2": "width", "3": "channels" }
-            }
+            "dummy_inputs_func": "safety_checker_conversion_inputs"
         }
     },
     "systems": {

--- a/examples/directml/stable_diffusion/config_safety_checker.json
+++ b/examples/directml/stable_diffusion/config_safety_checker.json
@@ -6,7 +6,16 @@
             "model_path": "runwayml/stable-diffusion-v1-5",
             "is_file": false,
             "model_loader": "safety_checker_load",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": [ "clip_input", "images" ],
+                "output_names": [ "out_images", "has_nsfw_concepts" ]
+            },
+            "dummy_inputs_func": "safety_checker_conversion_inputs",
+            "dynamic_axes": {
+                "clip_input": { "0": "batch", "1": "channels", "2": "height", "3": "width" },
+                "images": { "0": "batch", "1": "height", "2": "width", "3": "channels" }
+            }
         }
     },
     "systems": {
@@ -38,14 +47,6 @@
         "convert": {
             "type": "OnnxConversion",
             "config": {
-                "user_script": "user_script.py",
-                "input_names": [ "clip_input", "images" ],
-                "input_tensor_func": "safety_checker_conversion_inputs",
-                "output_names": [ "out_images", "has_nsfw_concepts" ],
-                "dynamic_axes": {
-                    "clip_input": { "0": "batch", "1": "channels", "2": "height", "3": "width" },
-                    "images": { "0": "batch", "1": "height", "2": "width", "3": "channels" }
-                },
                 "target_opset": 14
             }
         },

--- a/examples/directml/stable_diffusion/config_text_encoder.json
+++ b/examples/directml/stable_diffusion/config_text_encoder.json
@@ -9,10 +9,10 @@
             "model_script": "user_script.py",
             "io_config": {
                 "input_names": [ "input_ids" ],
-                "output_names": [ "last_hidden_state", "pooler_output" ]
+                "output_names": [ "last_hidden_state", "pooler_output" ],
+                "dynamic_axes": { "input_ids": { "0": "batch", "1": "sequence" } }
             },
-            "dummy_inputs_func": "text_encoder_conversion_inputs",
-            "dynamic_axes": { "input_ids": { "0": "batch", "1": "sequence" } }
+            "dummy_inputs_func": "text_encoder_conversion_inputs"
         }
     },
     "systems": {

--- a/examples/directml/stable_diffusion/config_text_encoder.json
+++ b/examples/directml/stable_diffusion/config_text_encoder.json
@@ -6,7 +6,13 @@
             "model_path": "runwayml/stable-diffusion-v1-5",
             "is_file": false,
             "model_loader": "text_encoder_load",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": [ "input_ids" ],
+                "output_names": [ "last_hidden_state", "pooler_output" ]
+            },
+            "dummy_inputs_func": "text_encoder_conversion_inputs",
+            "dynamic_axes": { "input_ids": { "0": "batch", "1": "sequence" } }
         }
     },
     "systems": {
@@ -38,11 +44,6 @@
         "convert": {
             "type": "OnnxConversion",
             "config": {
-                "user_script": "user_script.py",
-                "input_names": [ "input_ids" ],
-                "input_tensor_func": "text_encoder_conversion_inputs",
-                "output_names": [ "last_hidden_state", "pooler_output" ],
-                "dynamic_axes": { "input_ids": { "0": "batch", "1": "sequence" } },
                 "target_opset": 14
             }
         },

--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -9,14 +9,14 @@
             "model_script": "user_script.py",
             "io_config": {
                 "input_names": [ "sample", "timestep", "encoder_hidden_states", "return_dict" ],
-                "output_names": [ "out_sample" ]
+                "output_names": [ "out_sample" ],
+                "dynamic_axes": {
+                    "sample": {"0": "batch", "1": "channels", "2": "height", "3": "width"},
+                    "timestep": {"0": "batch"},
+                    "encoder_hidden_states": {"0": "batch", "1": "sequence"}
+                }
             },
-            "dummy_inputs_func": "unet_conversion_inputs",
-            "dynamic_axes": {
-                "sample": {"0": "batch", "1": "channels", "2": "height", "3": "width"},
-                "timestep": {"0": "batch"},
-                "encoder_hidden_states": {"0": "batch", "1": "sequence"}
-            }
+            "dummy_inputs_func": "unet_conversion_inputs"
         }
     },
     "systems": {

--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -6,7 +6,17 @@
             "model_path": "runwayml/stable-diffusion-v1-5",
             "is_file": false,
             "model_loader": "unet_load",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": [ "sample", "timestep", "encoder_hidden_states", "return_dict" ],
+                "output_names": [ "out_sample" ]
+            },
+            "dummy_inputs_func": "unet_conversion_inputs",
+            "dynamic_axes": {
+                "sample": {"0": "batch", "1": "channels", "2": "height", "3": "width"},
+                "timestep": {"0": "batch"},
+                "encoder_hidden_states": {"0": "batch", "1": "sequence"}
+            }
         }
     },
     "systems": {
@@ -38,15 +48,6 @@
         "convert": {
             "type": "OnnxConversion",
             "config": {
-                "user_script": "user_script.py",
-                "input_names": [ "sample", "timestep", "encoder_hidden_states", "return_dict" ],
-                "input_tensor_func": "unet_conversion_inputs",
-                "output_names": [ "out_sample" ],
-                "dynamic_axes": {
-                    "sample": {"0": "batch", "1": "channels", "2": "height", "3": "width"},
-                    "timestep": {"0": "batch"},
-                    "encoder_hidden_states": {"0": "batch", "1": "sequence"}
-                },
                 "target_opset": 14,
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true,

--- a/examples/directml/stable_diffusion/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion/config_vae_decoder.json
@@ -9,10 +9,10 @@
             "model_script": "user_script.py",
             "io_config": {
                 "input_names": [ "latent_sample", "return_dict" ],
-                "output_names": [ "sample" ]
+                "output_names": [ "sample" ],
+                "dynamic_axes": { "latent_sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } }
             },
-            "dummy_inputs_func": "vae_decoder_conversion_inputs",
-            "dynamic_axes": { "latent_sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } }
+            "dummy_inputs_func": "vae_decoder_conversion_inputs"
         }
     },
     "systems": {

--- a/examples/directml/stable_diffusion/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion/config_vae_decoder.json
@@ -6,7 +6,13 @@
             "model_path": "runwayml/stable-diffusion-v1-5",
             "is_file": false,
             "model_loader": "vae_decoder_load",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": [ "latent_sample", "return_dict" ],
+                "output_names": [ "sample" ]
+            },
+            "dummy_inputs_func": "vae_decoder_conversion_inputs",
+            "dynamic_axes": { "latent_sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } }
         }
     },
     "systems": {
@@ -38,11 +44,6 @@
         "convert": {
             "type": "OnnxConversion",
             "config": {
-                "user_script": "user_script.py",
-                "input_names": [ "latent_sample", "return_dict" ],
-                "input_tensor_func": "vae_decoder_conversion_inputs",
-                "output_names": [ "sample" ],
-                "dynamic_axes": { "latent_sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } },
                 "target_opset": 14
             }
         },

--- a/examples/directml/stable_diffusion/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion/config_vae_encoder.json
@@ -6,7 +6,13 @@
             "model_path": "runwayml/stable-diffusion-v1-5",
             "is_file": false,
             "model_loader": "vae_encoder_load",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": [ "sample", "return_dict" ],
+                "output_names": [ "latent_sample" ]
+            },
+            "dummy_inputs_func": "vae_encoder_conversion_inputs",
+            "dynamic_axes": { "sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } }
         }
     },
     "systems": {
@@ -38,11 +44,6 @@
         "convert": {
             "type": "OnnxConversion",
             "config": {
-                "user_script": "user_script.py",
-                "input_names": [ "sample", "return_dict" ],
-                "input_tensor_func": "vae_encoder_conversion_inputs",
-                "output_names": [ "latent_sample" ],
-                "dynamic_axes": { "sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } },
                 "target_opset": 14
             }
         },

--- a/examples/directml/stable_diffusion/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion/config_vae_encoder.json
@@ -9,10 +9,10 @@
             "model_script": "user_script.py",
             "io_config": {
                 "input_names": [ "sample", "return_dict" ],
-                "output_names": [ "latent_sample" ]
+                "output_names": [ "latent_sample" ],
+                "dynamic_axes": { "sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } }
             },
-            "dummy_inputs_func": "vae_encoder_conversion_inputs",
-            "dynamic_axes": { "sample": { "0": "batch", "1": "channels", "2": "height", "3": "width" } }
+            "dummy_inputs_func": "vae_encoder_conversion_inputs"
         }
     },
     "systems": {

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -139,7 +139,7 @@ def safety_checker_load(model_name):
     return model
 
 
-def safety_checker_conversion_inputs():
+def safety_checker_conversion_inputs(model):
     return tuple(safety_checker_inputs(1, torch.float32).values())
 
 

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -34,7 +34,7 @@ def text_encoder_load(model_name):
     return model
 
 
-def text_encoder_conversion_inputs():
+def text_encoder_conversion_inputs(model):
     return text_encoder_inputs(1, torch.int32)
 
 
@@ -61,7 +61,7 @@ def unet_load(model_name):
     return model
 
 
-def unet_conversion_inputs():
+def unet_conversion_inputs(model):
     return tuple(unet_inputs(1, torch.float32).values())
 
 
@@ -87,7 +87,7 @@ def vae_encoder_load(model_name):
     return model
 
 
-def vae_encoder_conversion_inputs():
+def vae_encoder_conversion_inputs(model):
     return tuple(vae_encoder_inputs(1, torch.float32).values())
 
 
@@ -113,7 +113,7 @@ def vae_decoder_load(model_name):
     return model
 
 
-def vae_decoder_conversion_inputs():
+def vae_decoder_conversion_inputs(model):
     return tuple(vae_decoder_inputs(1, torch.float32).values())
 
 

--- a/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu/bert_config.json
+++ b/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu/bert_config.json
@@ -6,7 +6,13 @@
             "model_path": null,
             "is_file": false,
             "model_loader": "load_pytorch_origin_model",
-            "model_script": "user_script.py"
+            "model_script": "user_script.py",
+            "io_config": {
+                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+                "input_shapes": [[1, 128], [1, 128], [1, 128]],
+                "input_types": ["int64", "int64", "int64"],
+                "output_names": ["output"]
+            }
         }
     },
     "systems": {
@@ -46,8 +52,6 @@
         "quantization_aware_training":{
             "type": "QuantizationAwareTraining",
             "config":{
-                "input_shapes": [[1, 128], [1, 128], [1, 128]],
-                "input_types": ["int64", "int64", "int64"],
                 "user_script": "user_script.py",
                 "training_loop_func": "training_loop_func"
             }
@@ -55,10 +59,6 @@
         "conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-                "input_shapes": [[1, 128], [1, 128], [1, 128]],
-                "input_types": ["int64", "int64", "int64"],
-                "output_names": ["output"],
                 "target_opset": 17
             }
         },

--- a/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet_config.json
+++ b/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet_config.json
@@ -64,7 +64,6 @@
         "conversion": {
             "type": "OnnxConversion",
             "config": {
-
                 "target_opset": 17
             }
         },

--- a/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet_config.json
+++ b/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet_config.json
@@ -4,7 +4,16 @@
         "type": "PyTorchModel",
         "config": {
             "model_path": "models/resnet_trained_for_cifar10.pt",
-            "is_file": true
+            "is_file": true,
+            "io_config": {
+                "input_names": ["input"],
+                "input_shapes": [[1, 3, 32, 32]],
+                "output_names": ["output"]
+            },
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     },
     "systems": {
@@ -44,7 +53,6 @@
         "quantization_aware_training":{
             "type": "QuantizationAwareTraining",
             "config":{
-                "input_shapes": [[1, 3, 32, 32]],
                 "user_script": "user_script.py",
                 "num_epochs": 1,
                 "train_dataloader_func": "create_train_dataloader",
@@ -56,13 +64,7 @@
         "conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input"],
-                "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"],
-                "dynamic_axes": {
-                    "input": {"0": "batch_size"},
-                    "output": {"0": "batch_size"}
-                },
+
                 "target_opset": 17
             }
         },

--- a/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet_config.json
+++ b/examples/quantization_aware_training/resnet_qat_default_train_loop_cpu/resnet_config.json
@@ -8,11 +8,11 @@
             "io_config": {
                 "input_names": ["input"],
                 "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"]
-            },
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
+                "output_names": ["output"],
+                "dynamic_axes": {
+                    "input": {"0": "batch_size"},
+                    "output": {"0": "batch_size"}
+                }
             }
         }
     },

--- a/examples/quantization_aware_training/resnet_qat_lightning_module_cpu/resnet_config.json
+++ b/examples/quantization_aware_training/resnet_qat_lightning_module_cpu/resnet_config.json
@@ -4,7 +4,16 @@
         "type": "PyTorchModel",
         "config": {
             "model_path": "models/resnet_trained_for_cifar10.pt",
-            "is_file": true
+            "is_file": true,
+            "io_config": {
+                "input_names": ["input"],
+                "input_shapes": [[1, 3, 32, 32]],
+                "output_names": ["output"]
+            },
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     },
     "systems": {
@@ -44,7 +53,6 @@
         "quantization_aware_training":{
             "type": "QuantizationAwareTraining",
             "config":{
-                "input_shapes": [[1, 3, 32, 32]],
                 "user_script": "user_script.py",
                 "num_epochs": 10,
                 "ptl_data_module": "PTLDataModule",
@@ -57,13 +65,6 @@
         "conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input"],
-                "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"],
-                "dynamic_axes": {
-                    "input": {"0": "batch_size"},
-                    "output": {"0": "batch_size"}
-                },
                 "target_opset": 17
             }
         },

--- a/examples/quantization_aware_training/resnet_qat_lightning_module_cpu/resnet_config.json
+++ b/examples/quantization_aware_training/resnet_qat_lightning_module_cpu/resnet_config.json
@@ -8,11 +8,11 @@
             "io_config": {
                 "input_names": ["input"],
                 "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"]
-            },
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
+                "output_names": ["output"],
+                "dynamic_axes": {
+                    "input": {"0": "batch_size"},
+                    "output": {"0": "batch_size"}
+                }
             }
         }
     },

--- a/examples/resnet_ptq_cpu/resnet_config.json
+++ b/examples/resnet_ptq_cpu/resnet_config.json
@@ -4,7 +4,16 @@
         "type": "PyTorchModel",
         "config": {
             "model_path": "models/resnet_trained_for_cifar10.pt",
-            "is_file": true
+            "is_file": true,
+            "io_config": {
+                "input_names": ["input"],
+                "input_shapes": [[1, 3, 32, 32]],
+                "output_names": ["output"]
+            },
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     },
     "systems": {
@@ -58,13 +67,6 @@
         "onnx_conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input"],
-                "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"],
-                "dynamic_axes": {
-                    "input": {"0": "batch_size"},
-                    "output": {"0": "batch_size"}
-                },
                 "target_opset": 13
             }
         },

--- a/examples/resnet_ptq_cpu/resnet_config.json
+++ b/examples/resnet_ptq_cpu/resnet_config.json
@@ -8,11 +8,11 @@
             "io_config": {
                 "input_names": ["input"],
                 "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"]
-            },
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
+                "output_names": ["output"],
+                "dynamic_axes": {
+                    "input": {"0": "batch_size"},
+                    "output": {"0": "batch_size"}
+                }
             }
         }
     },

--- a/examples/resnet_ptq_cpu/resnet_dynamic_config.json
+++ b/examples/resnet_ptq_cpu/resnet_dynamic_config.json
@@ -8,11 +8,11 @@
             "io_config": {
                 "input_names": ["input"],
                 "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"]
-            },
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
+                "output_names": ["output"],
+                "dynamic_axes": {
+                    "input": {"0": "batch_size"},
+                    "output": {"0": "batch_size"}
+                }
             }
         }
     },

--- a/examples/resnet_ptq_cpu/resnet_dynamic_config.json
+++ b/examples/resnet_ptq_cpu/resnet_dynamic_config.json
@@ -4,7 +4,16 @@
         "type": "PyTorchModel",
         "config": {
             "model_path": "models/resnet_trained_for_cifar10.pt",
-            "is_file": true
+            "is_file": true,
+            "io_config": {
+                "input_names": ["input"],
+                "input_shapes": [[1, 3, 32, 32]],
+                "output_names": ["output"]
+            },
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     },
     "systems": {
@@ -57,13 +66,6 @@
         "onnx_conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input"],
-                "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"],
-                "dynamic_axes": {
-                    "input": {"0": "batch_size"},
-                    "output": {"0": "batch_size"}
-                },
                 "target_opset": 13
             },
             "host": "local_system",

--- a/examples/resnet_ptq_cpu/resnet_static_config.json
+++ b/examples/resnet_ptq_cpu/resnet_static_config.json
@@ -8,11 +8,11 @@
             "io_config": {
                 "input_names": ["input"],
                 "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"]
-            },
-            "dynamic_axes": {
-                "input": {"0": "batch_size"},
-                "output": {"0": "batch_size"}
+                "output_names": ["output"],
+                "dynamic_axes": {
+                    "input": {"0": "batch_size"},
+                    "output": {"0": "batch_size"}
+                }
             }
         }
     },

--- a/examples/resnet_ptq_cpu/resnet_static_config.json
+++ b/examples/resnet_ptq_cpu/resnet_static_config.json
@@ -4,7 +4,16 @@
         "type": "PyTorchModel",
         "config": {
             "model_path": "models/resnet_trained_for_cifar10.pt",
-            "is_file": true
+            "is_file": true,
+            "io_config": {
+                "input_names": ["input"],
+                "input_shapes": [[1, 3, 32, 32]],
+                "output_names": ["output"]
+            },
+            "dynamic_axes": {
+                "input": {"0": "batch_size"},
+                "output": {"0": "batch_size"}
+            }
         }
     },
     "systems": {
@@ -57,13 +66,6 @@
         "onnx_conversion": {
             "type": "OnnxConversion",
             "config": {
-                "input_names": ["input"],
-                "input_shapes": [[1, 3, 32, 32]],
-                "output_names": ["output"],
-                "dynamic_axes": {
-                    "input": {"0": "batch_size"},
-                    "output": {"0": "batch_size"}
-                },
                 "target_opset": 13
             },
             "host": "local_system",

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -34,7 +34,6 @@ class EngineConfig(ConfigBase):
     search_strategy: Union[SearchStrategyConfig, bool] = None
     host: SystemConfig = None
     target: SystemConfig = None
-    model_io_config: Dict[str, List] = None
     evaluator: OliveEvaluatorConfig = None
     packaging_config: PackagingConfig = None
     cache_dir: Union[Path, str] = ".olive-cache"

--- a/olive/model.py
+++ b/olive/model.py
@@ -349,7 +349,7 @@ class PyTorchModel(OliveModel):
         model_script: Union[str, Path] = None,
         script_dir: Union[str, Path] = None,
         io_config: Union[Dict[str, Any], IOConfig] = None,
-        dummy_input_func: Union[str, Callable] = None,
+        dummy_inputs_func: Union[str, Callable] = None,
         dynamic_axes: Dict[str, Dict[int, str]] = None,
     ):
         if not (
@@ -378,7 +378,7 @@ class PyTorchModel(OliveModel):
 
         # io config for conversion to onnx
         self.io_config = validate_config(io_config, IOConfig) if io_config else None
-        self.dummy_inputs_func = dummy_input_func
+        self.dummy_inputs_func = dummy_inputs_func
 
         # dynamic axes for conversion to onnx
         self.dynamic_axes = dynamic_axes
@@ -418,11 +418,11 @@ class PyTorchModel(OliveModel):
 
         assert self.dummy_inputs_func or (
             self.io_config and self.io_config.input_shapes
-        ), "dummy_input_func or io_config.input_shapes must be provided to get dummy input"
+        ), "dummy_input_funcs or io_config.input_shapes must be provided to get dummy input"
 
         if self.dummy_inputs_func is not None:
             user_module_loader = UserModuleLoader(self.model_script, self.script_dir)
-            self.dummy_inputs = user_module_loader.call_object(self.dummy_inputs_func, self)
+            dummy_inputs = user_module_loader.call_object(self.dummy_inputs_func, self)
         else:
             str_to_type = {
                 "float32": torch.float32,
@@ -450,7 +450,7 @@ class PyTorchModel(OliveModel):
                 "model_script": Path(self.model_script) if self.model_script else None,
                 "script_dir": Path(self.script_dir) if self.script_dir else None,
                 "io_config": self.io_config,
-                "dummy_input_func": self.dummy_inputs_func,
+                "dummy_input_funcs": self.dummy_inputs_func,
                 "dynamic_axes": self.dynamic_axes,
             }
         )

--- a/olive/model.py
+++ b/olive/model.py
@@ -418,7 +418,7 @@ class PyTorchModel(OliveModel):
 
         assert self.dummy_inputs_func or (
             self.io_config and self.io_config.input_shapes
-        ), "dummy_input_funcs or io_config.input_shapes must be provided to get dummy input"
+        ), "dummy_inputs_func or io_config.input_shapes must be provided to get dummy input"
 
         if self.dummy_inputs_func is not None:
             user_module_loader = UserModuleLoader(self.model_script, self.script_dir)
@@ -450,7 +450,7 @@ class PyTorchModel(OliveModel):
                 "model_script": Path(self.model_script) if self.model_script else None,
                 "script_dir": Path(self.script_dir) if self.script_dir else None,
                 "io_config": self.io_config,
-                "dummy_input_funcs": self.dummy_inputs_func,
+                "dummy_inputs_func": self.dummy_inputs_func,
                 "dynamic_axes": self.dynamic_axes,
             }
         )

--- a/olive/model.py
+++ b/olive/model.py
@@ -520,6 +520,7 @@ class DistributedOnnxModel(ONNXModelBase):
             version=version,
             is_file=False,
             is_aml_model=False,
+            inference_settings=inference_settings,
         )
         self.model_filepaths = model_filepaths
 
@@ -561,7 +562,7 @@ class DistributedOnnxModel(ONNXModelBase):
         return ["CUDAExecutionProvider", "CPUExecutionProvider"]
 
     @staticmethod
-    def get_execution_providers(self, device: Device):
+    def get_execution_providers(device: Device):
         import onnxruntime as ort
 
         available_providers = ort.get_available_providers()
@@ -574,3 +575,15 @@ class DistributedOnnxModel(ONNXModelBase):
                     eps.append(ep)
 
         return eps if eps else available_providers
+
+    def to_json(self, check_object: bool = False):
+        config = {
+            "type": self.__class__.__name__,
+            "config": {
+                "model_filepaths": self.model_filepaths,
+                "name": self.name,
+                "version": self.version,
+                "inference_settings": self.inference_settings,
+            },
+        }
+        return serialize_to_json(config, check_object=check_object)

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -46,13 +46,11 @@ class OnnxConversion(Pass):
         # get dummy inputs
         dummy_inputs = model.get_dummy_inputs()
 
-        # get input and output names
+        # get input and output names, and dynamic axes
         assert model.io_config, "Model IO config is not set."
         input_names = model.io_config.input_names
         output_names = model.io_config.output_names
-
-        # get dynamic axes
-        dynamic_axes = model.dynamic_axes
+        dynamic_axes = model.io_config.dynamic_axes
 
         # convert the model
         pytorch_model = model.load_model()

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import tempfile
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Dict
 
 import onnx
 import torch
@@ -35,45 +35,6 @@ class OnnxConversion(Pass):
     @staticmethod
     def _default_config() -> Dict[str, PassConfigParam]:
         config = {
-            "input_names": PassConfigParam(type_=List[str], required=True, description="List of input names."),
-            # required for if input_tensors_func is not provided
-            "input_shapes": PassConfigParam(
-                type_=List[List[int]],
-                default_value=None,
-                description=(
-                    "List of input shapes. Must be provided if input_tensor_func is not provided. It is used to create"
-                    " dummy inputs for the model during onnx export."
-                ),
-            ),
-            "input_types": PassConfigParam(
-                type_=List[str],
-                default_value=None,
-                description=(
-                    "List of input types. If provided, must be the same length as input_shapes. Otherwise, defaults to"
-                    " float32 for all inputs. Used with input_shapes to create dummy inputs for the model during onnx"
-                    " export."
-                ),
-            ),
-            "input_tensor_func": PassConfigParam(
-                type_=Union[Callable, str],
-                default_value=None,
-                is_object=True,
-                description=(
-                    "Function (no input) to create dummy inputs for the model. Can be a function (local use) or name of"
-                    " a function to be imported from user script. If provided, input_shapes and input_types will be"
-                    " ignored. Refer to 'args' at https://pytorch.org/docs/stable/onnx.html#torch.onnx.export for more"
-                    " details."
-                ),
-            ),
-            "output_names": PassConfigParam(type_=List[str], required=True, description="List of output names."),
-            "dynamic_axes": PassConfigParam(
-                type_=dict,
-                default_value=None,
-                description=(
-                    "Dynamic axes for the model. Refer to 'dynamic_axes' at"
-                    " https://pytorch.org/docs/stable/onnx.html#torch.onnx.export for more details."
-                ),
-            ),
             "target_opset": PassConfigParam(
                 type_=int, default_value=14, description="The version of the default (ai.onnx) opset to target."
             ),
@@ -81,50 +42,26 @@ class OnnxConversion(Pass):
         config.update(get_external_data_config())
         return config
 
-    def _initialize(self):
-        # input shapes
-        self._fixed_params["input_shapes"] = self._fixed_params["input_shapes"] or []
-
-        # input types
-        str_to_type = {"float32": torch.float32, "float16": torch.float16, "int32": torch.int32, "int64": torch.int64}
-        input_types = []
-        if self._fixed_params["input_types"] is not None:
-            for input_type in self._fixed_params["input_types"]:
-                input_types.append(str_to_type[input_type])
-        else:
-            input_types = [str_to_type["float32"] for _ in self._fixed_params["input_shapes"]]
-
-        assert not (
-            self._fixed_params["input_tensor_func"] and self._fixed_params["input_shapes"]
-        ), "Either input_tensor_func or input_shapes must be provided."
-
-        # dummy inputs
-        self._dummy_inputs = []
-        if self._fixed_params["input_tensor_func"] is not None:
-            self._dummy_inputs = self._user_module_loader.call_object(self._fixed_params["input_tensor_func"])
-        else:
-            for input_shape, input_type in zip(self._fixed_params["input_shapes"], input_types):
-                self._dummy_inputs.append(torch.zeros(input_shape, dtype=input_type))
-            self._dummy_inputs = tuple(self._dummy_inputs) if len(self._dummy_inputs) > 1 else self._dummy_inputs[0]
-
-        # dynamic axes
-        self._dynamic_axes = {}
-        if self._fixed_params["dynamic_axes"] is not None:
-            for name in self._fixed_params["dynamic_axes"]:
-                self._dynamic_axes[name] = {
-                    int(key): value for key, value in self._fixed_params["dynamic_axes"][name].items()
-                }
-        else:
-            self._dynamic_axes = None
-
     def _run_for_config(self, model: PyTorchModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+        # get dummy inputs
+        dummy_inputs = model.get_dummy_inputs()
+
+        # get input and output names
+        assert model.io_config, "Model IO config is not set."
+        input_names = model.io_config.input_names
+        output_names = model.io_config.output_names
+
+        # get dynamic axes
+        dynamic_axes = model.dynamic_axes
+
+        # convert the model
         pytorch_model = model.load_model()
         pytorch_model.eval()
 
         # TODO: add e2e test for model on cpu but data on gpu; model on gpu but data on cpu
         # put pytorch_model and dummy_inputs at the same device
         pytorch_model.to("cpu")
-        dummy_inputs = tensor_data_to_device(self._dummy_inputs, "cpu")
+        dummy_inputs = tensor_data_to_device(dummy_inputs, "cpu")
         if isinstance(pytorch_model, torch.jit.RecursiveScriptModule):
             pytorch_model = TraceModelWrapper(pytorch_model)
 
@@ -143,9 +80,9 @@ class OnnxConversion(Pass):
             tmp_model_path,
             export_params=True,
             opset_version=config["target_opset"],
-            input_names=config["input_names"],
-            output_names=config["output_names"],
-            dynamic_axes=self._dynamic_axes,
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
         )
 
         # load the model

--- a/olive/passes/pytorch/qat_utils.py
+++ b/olive/passes/pytorch/qat_utils.py
@@ -110,11 +110,11 @@ class QatTrainer:
         if is_master_proc():
             torch.jit.save(traced_model_converted, self.output_model_path)
         barrier()
-        # preserve the io_config, dummy_input_func, dynamic_axes, model_script, script_dir
+        # preserve the io_config, dummy_inputs_func, dynamic_axes, model_script, script_dir
         # from the original model
         original_config = self.model.to_json()["config"]
-        to_keep = ["io_config", "dummy_input_func", "dynamic_axes"]
-        if isinstance(original_config["dummy_input_func"], str):
+        to_keep = ["io_config", "dummy_inputs_func", "dynamic_axes"]
+        if isinstance(original_config["dummy_inputs_func"], str):
             to_keep += ["model_script", "script_dir"]
         config_to_keep = {k: original_config[k] for k in to_keep}
         # TODO: Add PyTorch model type flag

--- a/olive/passes/pytorch/qat_utils.py
+++ b/olive/passes/pytorch/qat_utils.py
@@ -110,10 +110,10 @@ class QatTrainer:
         if is_master_proc():
             torch.jit.save(traced_model_converted, self.output_model_path)
         barrier()
-        # preserve the io_config, dummy_inputs_func, dynamic_axes, model_script, script_dir
+        # preserve the io_config, dummy_inputs_func, model_script, script_dir
         # from the original model
         original_config = self.model.to_json()["config"]
-        to_keep = ["io_config", "dummy_inputs_func", "dynamic_axes"]
+        to_keep = ["io_config", "dummy_inputs_func"]
         if isinstance(original_config["dummy_inputs_func"], str):
             to_keep += ["model_script", "script_dir"]
         config_to_keep = {k: original_config[k] for k in to_keep}

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -68,16 +68,6 @@ class QuantizationAwareTraining(Pass):
             "modules_to_fuse": PassConfigParam(
                 type_=List[List[str]], default_value=None, description="List of list of module names to fuse."
             ),
-            "input_shapes": PassConfigParam(
-                type_=List[List[int]],
-                required=True,
-                description="List ot input shapes. It is used to create dummy input for PyTorch model tracing.",
-            ),
-            "input_types": PassConfigParam(
-                type_=List[str],
-                default_value=None,
-                description="List ot input types. It is used to create dummy input for PyTorch model tracing.",
-            ),
             "qconfig_func": PassConfigParam(
                 type_=Union[Callable, str],
                 default_value=None,

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -21,11 +21,10 @@ def automatically_insert_passes(config):
 
     # insert onnx converter
     oc_config = {"type": "OnnxConversion"}
-    oc_config["config"] = config.engine.model_io_config
     new_passes["conversion"] = oc_config
 
     # insert transformer opt
-    to_config = {"type": "OnnxTransformersOptimization"}
+    to_config = {"type": "OrtTransformersOptimization"}
     to_config["config"] = {"model_type": "bert"}
     new_passes["transformers_optimization"] = to_config
 
@@ -77,10 +76,8 @@ def dependency_setup(config):
             remote_packages.extend(DEPENDENCY_MAPPING["pass"].get(pass_config.type, []))
         if pass_config.type in ["SNPEConversion", "SNPEQuantization", "SNPEtoONNXConversion"]:
             logger.info(
-                "Please refer to https://microsoft.github.io/Olive/tutorials/passes/snpe.html \
-                to install SNPE Prerequisites for pass {}".format(
-                    pass_config.type
-                )
+                "Please refer to https://microsoft.github.io/Olive/tutorials/passes/snpe.html                 to"
+                " install SNPE Prerequisites for pass {}".format(pass_config.type)
             )
 
     # add dependencies for engine
@@ -96,7 +93,7 @@ def dependency_setup(config):
     for package in set(local_packages):
         try:
             __import__(package)
-        except (ImportError):
+        except ImportError:
             subprocess.check_call(["pip", "install", "{}".format(package)])
     if remote_packages:
         logger.info(

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -14,7 +14,6 @@ from olive.systems.azureml import AzureMLDockerConfig, AzureMLSystem
 
 
 def test_aml_model():
-
     # ------------------------------------------------------------------
     # Azure ML System
     aml_compute = "cpu-cluster"
@@ -32,16 +31,23 @@ def test_aml_model():
 
     # ------------------------------------------------------------------
     # Input model
-    pytorch_model = PyTorchModel(name="bert_glue", is_file=True, is_aml_model=True, version=10)
+    pytorch_model = PyTorchModel(
+        name="bert_glue",
+        is_file=True,
+        is_aml_model=True,
+        version=10,
+        io_config={
+            "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+            "input_shapes": [[1, 128], [1, 128], [1, 128]],
+            "input_types": ["int64", "int64", "int64"],
+            "output_names": ["output"],
+        },
+    )
 
     # ------------------------------------------------------------------
     # Onnx conversion pass
     # config can be a dictionary
     onnx_conversion_config = {
-        "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-        "input_shapes": [[1, 128], [1, 128], [1, 128]],
-        "input_types": ["int64", "int64", "int64"],
-        "output_names": ["output"],
         "target_opset": 13,
     }
     with tempfile.TemporaryDirectory() as tempdir:

--- a/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
+++ b/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
@@ -11,6 +11,6 @@ RUN pip install onnxruntime \
             openvino \
             openvino-dev \
             onnxconverter_common \
-            git+https://github.com/microsoft/Olive.git@myguo/model_type
+            git+https://github.com/microsoft/Olive.git@jambayk/model-info
 
 WORKDIR /olive

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -79,10 +79,7 @@ class TestAzureMLSystem:
     @patch("olive.systems.azureml.aml_system.tempfile.TemporaryDirectory")
     def test_run_pass(self, mock_tempdir, mock_create_pipeline, mock_retry_func, mock_copy):
         # setup
-        onnx_conversion_config = {
-            "input_names": ["input"],
-            "output_names": ["output"],
-        }
+        onnx_conversion_config = {}
         p = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
         olive_model = get_pytorch_model()
         output_model_path = "output_model_path"

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -58,7 +58,11 @@ def pytorch_model_loader(model_path):
 
 
 def get_pytorch_model():
-    return PyTorchModel(model_loader=pytorch_model_loader, model_path=None)
+    return PyTorchModel(
+        model_loader=pytorch_model_loader,
+        model_path=None,
+        io_config={"input_names": ["input"], "output_names": ["output"]},
+    )
 
 
 def get_pytorch_model_dummy_input():
@@ -125,10 +129,7 @@ def get_latency_metric(lat_subtype):
 
 
 def get_onnxconversion_pass(ignore_pass_config=True):
-    onnx_conversion_config = {
-        "input_names": ["input"],
-        "output_names": ["output"],
-    }
+    onnx_conversion_config = {}
     p = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
     if ignore_pass_config:
         return p


### PR DESCRIPTION
Currently, model specific information such as `input_names`, `input_shapes`, etc. are provided as config parameters for passes like `ONNXConversion`. We want to support composite models which are made of multiple models. For such cases, we cannot provide the io information to a pass for all at once. 

So, we make the io information optional init parameters of PytorchModel. The passes will in turn get them from the model itself. This also makes more sense conceptually since these are attributes of the model and not the pass. 

We will make similar changes to the ONNXModel and onnx related passes in the future. Any model specific information should be part of the model and not the pass config. 