### PR TITLE
`dev` mode for `DockerSystem`

### DIFF
--- a/examples/bert_ptq_cpu/bert_config.json
+++ b/examples/bert_ptq_cpu/bert_config.json
@@ -36,7 +36,8 @@
                     "image_name": "olive-image",
                     "build_context_path": "docker",
                     "dockerfile": "Dockerfile"
-                }
+                },
+                "is_dev": true
             }
         }
     },

--- a/examples/test_bert_ptq_cpu.py
+++ b/examples/test_bert_ptq_cpu.py
@@ -53,6 +53,8 @@ def test_bert(search_algorithm, execution_order, system, olive_json):
 
     # set aml_system as dev
     olive_config["systems"]["aml_system"]["config"]["is_dev"] = True
+    # set docker_system as dev
+    olive_config["systems"]["docker_system"]["config"]["is_dev"] = True
 
     # update host and target
     olive_config["engine"]["host"] = system if system != "docker_system" else "local_system"

--- a/olive/systems/docker/dev_mount_cleanup.py
+++ b/olive/systems/docker/dev_mount_cleanup.py
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import argparse
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--dev_mount_path", type=str, help="path to dev mount")
+
+    args, _ = parser.parse_known_args()
+
+    for member in Path(args.dev_mount_path).iterdir():
+        if member.is_dir():
+            shutil.rmtree(member)
+        else:
+            member.unlink()

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -97,7 +97,6 @@ class DockerSystem(OliveSystem):
         eval_file_mount_path, eval_file_mount_str = docker_utils.create_eval_script_mount(container_root_path)
         volumes_list.append(eval_file_mount_str)
 
-        dev_mount_path = None
         if self.is_dev:
             dev_mount_path, dev_mount_str = docker_utils.create_dev_mount(tempdir, container_root_path)
             volumes_list.append(dev_mount_str)

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import json
 import logging
+import shutil
 from pathlib import Path
 from typing import List
 
@@ -97,6 +98,29 @@ def create_eval_script_mount(container_root_path: Path):
     current_dir = Path(__file__).resolve().parent
     eval_file_mount_str = f"{str(current_dir / 'eval.py')}:{eval_file_mount_path}"
     return eval_file_mount_path, eval_file_mount_str
+
+
+def create_dev_mount(tempdir: Path, container_root_path: Path):
+    logger.warning(
+        "This mode is only enabled for CI pipeline! "
+        + "It will overwrite the Olive package in docker container with latest code."
+    )
+    tempdir = Path(tempdir)
+
+    # copy the whole project folder to tempdir
+    project_folder = Path(__file__).resolve().parent.parent.parent
+    shutil.copytree(project_folder, tempdir / "olive", ignore=shutil.ignore_patterns("__pycache__"))
+
+    project_folder_mount_path = str(container_root_path / "olive")
+    project_folder_mount_str = f"{tempdir / 'olive'}:{project_folder_mount_path}"
+    return project_folder_mount_path, project_folder_mount_str
+
+
+def create_dev_cleanup_mount(container_root_path: Path):
+    mount_path = str(container_root_path / "dev_mount_cleanup.py")
+    current_dir = Path(__file__).resolve().parent
+    mount_str = f"{str(current_dir / 'dev_mount_cleanup.py')}:{mount_path}"
+    return mount_path, mount_str
 
 
 def create_output_mount(tempdir, docker_eval_output_path: str, container_root_path: Path):

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -23,6 +23,7 @@ class LocalTargetUserConfig(TargetUserConfig):
 
 class DockerTargetUserConfig(TargetUserConfig):
     local_docker_config: LocalDockerConfig
+    is_dev: bool = False
 
 
 class AzureMLTargetUserConfig(TargetUserConfig):

--- a/test/integ_test/evaluator/docker_eval/utils.py
+++ b/test/integ_test/evaluator/docker_eval/utils.py
@@ -129,4 +129,4 @@ def get_docker_target():
         build_context_path=str(current_dir / "dockerfile"),
         dockerfile="Dockerfile",
     )
-    return DockerSystem(local_docker_config=local_docker_config)
+    return DockerSystem(local_docker_config=local_docker_config, is_dev=True)

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -24,7 +24,7 @@ class TestDockerSystem:
         )
 
         # execute
-        docker_system = DockerSystem(docker_config)
+        docker_system = DockerSystem(docker_config, is_dev=True)
 
         # assert
         assert docker_system.image == mock_image
@@ -44,7 +44,7 @@ class TestDockerSystem:
         mock_docker_client.images.build = MagicMock()
 
         # execute
-        DockerSystem(docker_config)
+        DockerSystem(docker_config, is_dev=True)
 
         # assert
         mock_docker_client.images.build.called_once_with(
@@ -73,7 +73,7 @@ class TestDockerSystem:
         mock_docker_client.images.build = MagicMock()
 
         # execute
-        docker_system = DockerSystem(docker_config)
+        docker_system = DockerSystem(docker_config, is_dev=True)
 
         # assert
         mock_docker_client.images.build.called_once_with(
@@ -113,7 +113,7 @@ class TestDockerSystem:
         docker_config = LocalDockerConfig(
             image_name="image_name", build_context_path="build_context_path", dockerfile="dockerfile"
         )
-        docker_system = DockerSystem(docker_config)
+        docker_system = DockerSystem(docker_config, is_dev=True)
         container_root_path = Path("/olive/")
         eval_output_path = "eval_output"
         eval_output_name = "eval_res.json"

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -2,9 +2,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import tempfile
 from pathlib import Path
 from test.unit_test.utils import get_accuracy_metric, get_pytorch_model
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from olive.evaluator.metric import AccuracySubType
 from olive.systems.common import LocalDockerConfig
@@ -12,6 +15,10 @@ from olive.systems.docker.docker_system import DockerSystem
 
 
 class TestDockerSystem:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+
     @patch("olive.systems.docker.docker_system.docker.from_env")
     def test__init_image_exist(self, mock_from_env):
         # setup
@@ -61,7 +68,7 @@ class TestDockerSystem:
         # setup
         import docker
 
-        tempdir = "tempdir"
+        tempdir = self.tmp_dir.name
         mock_tempdir.return_value.__enter__.return_value = tempdir
         mock_docker_client = MagicMock()
         mock_from_env.return_value = mock_docker_client
@@ -106,7 +113,7 @@ class TestDockerSystem:
         # setup
         mock_docker_client = MagicMock()
         mock_from_env.return_value = mock_docker_client
-        tempdir = "tempdir"
+        tempdir = self.tmp_dir.name
         mock_tempdir.return_value.__enter__.return_value = tempdir
         olive_model = get_pytorch_model()
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)


### PR DESCRIPTION
## Describe your changes
Add `dev` mode for `DockerSystem` so that we don't need to keep updating the dockerfiles with dev branches. Works similar to `AzureMLSystem` dev mode where a copy of the project directory is mounted to the same directory as the evaluation script runner. 

It also cleans up the mounted directory since the evaluation call creates `__pycache__` which cannot be deleted automatically by the host due to docker running with higher privileges. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
