### PR TITLE
add whisper evaluation

### DIFF
--- a/examples/whisper/user_script.py
+++ b/examples/whisper/user_script.py
@@ -2,6 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from pathlib import Path
+
+import numpy as np
 from onnxruntime.transformers.models.whisper.whisper_decoder import WhisperDecoderInputs
 from onnxruntime.transformers.models.whisper.whisper_encoder_decoder_init import WhisperEncoderDecoderInitInputs
 
@@ -30,3 +33,54 @@ def decoder_dummy_inputs(model):
         use_int32_inputs=True,
     )
     return tuple(inputs.to_list())
+
+
+class WhisperDataset:
+    SAMPLE_RATE = 16000
+    N_FFT = 400
+    N_MELS = 80
+    HOP_LENGTH = 160
+    CHUNK_LENGTH = 30
+    N_SAMPLES = CHUNK_LENGTH * SAMPLE_RATE  # 480000 samples in a 30-second chunk
+    N_FRAMES = N_SAMPLES // HOP_LENGTH
+
+    def __init__(self, data_dir: str):
+        data_dir = Path(data_dir)
+        audio_files = list(data_dir.glob("*.mp3"))
+        audio_files.sort(key=lambda x: x.name)
+        assert len(audio_files) > 0, f"No audio files found in {data_dir}"
+
+        self.data = []
+        for audio_file in audio_files:
+            with open(audio_file, "rb") as _f:
+                audio_blob = np.asarray(list(_f.read()), dtype=np.uint8)
+            audio_blob = np.expand_dims(audio_blob, axis=0)  # add a batch_size
+            inputs = {
+                "audio_stream": audio_blob,
+                "max_length": np.asarray([200], dtype=np.int32),
+                "min_length": np.asarray([0], dtype=np.int32),
+                "num_beams": np.asarray([2], dtype=np.int32),
+                "num_return_sequences": np.asarray([1], dtype=np.int32),
+                "length_penalty": np.asarray([1.0], dtype=np.float32),
+                "repetition_penalty": np.asarray([1.0], dtype=np.float32),
+                "attention_mask": np.zeros((1, self.N_MELS, self.N_FRAMES)).astype(np.int32),
+            }
+            self.data.append(inputs)
+
+        self.labels = None
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        data = self.data[idx]
+        label = self.labels[idx] if self.labels is not None else -1
+        return data, label
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+
+
+def whisper_dataloader(data_dir, batch_size=None):
+    return WhisperDataset(data_dir=data_dir)

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -29,6 +29,23 @@
             "config": {"device": "<place_holder>"}
         }
     },
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "sub_type": "avg",
+                    "user_config": {
+                        "user_script": "user_script.py",
+                        "data_dir": "data",
+                        "dataloader_func": "whisper_dataloader"
+                    }
+                }
+            ],
+            "target": "local_system"
+        }
+    },
     "passes": {
         "conversion": {
             "type": "OnnxConversion",
@@ -79,6 +96,7 @@
     "engine": {
         "search_strategy": false,
         "host": "local_system",
+        "evaluator": "common_evaluator",
         "clean_cache": false,
         "cache_dir": "cache",
         "output_dir": "models",

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -2,13 +2,21 @@ from pathlib import Path
 from typing import Dict, Union
 
 
-def get_ort_inference_session(model_path: Union[Path, str], inference_settings: Dict[str, any]):
+def get_ort_inference_session(
+    model_path: Union[Path, str], inference_settings: Dict[str, any], use_ort_extensions: bool = False
+):
     """
     Get an ONNXRuntime inference session.
     """
     import onnxruntime as ort
 
     sess_options = ort.SessionOptions()
+    if use_ort_extensions:
+        # register custom ops for onnxruntime-extensions
+        from onnxruntime_extensions import get_library_path
+
+        sess_options.register_custom_ops_library(get_library_path())
+
     # execution provider
     execution_provider = inference_settings.get("execution_provider")
 

--- a/olive/evaluator/evaluation.py
+++ b/olive/evaluator/evaluation.py
@@ -344,7 +344,10 @@ def format_onnx_input(input_data, io_config):
     if not isinstance(input_data, dict):
         input_data = dict(zip(input_names, [input_data]))
     input_dict = {
-        k: np.ascontiguousarray(input_data[k].cpu().numpy(), dtype=name_to_type[k])
+        k: np.ascontiguousarray(
+            input_data[k].cpu().numpy() if isinstance(input_data[k], torch.Tensor) else input_data[k],
+            dtype=name_to_type[k],
+        )
         for k in input_data.keys()
         if k in input_names
     }

--- a/olive/passes/onnx/append_pre_post_processing_ops.py
+++ b/olive/passes/onnx/append_pre_post_processing_ops.py
@@ -84,4 +84,4 @@ class AppendPrePostProcessingOps(Pass):
             # TODO: Handle args pre and post here!
             pass
 
-        return ONNXModel(output_model_path, name=model.name)
+        return ONNXModel(output_model_path, name=model.name, use_ort_extensions=True)


### PR DESCRIPTION
## Describe your changes
Add dataloader for whisper example and evaluator. 

The model has onnxruntime-extensions ops, so this PR introduce an option in ONNXModel to use onnxruntime-extensions during creation of inference sessions. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
