### PR TITLE
Remove deepcopy before model conversion

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import copy
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Union
@@ -66,7 +65,6 @@ class OnnxConversion(Pass):
 
         # convert the model
         pytorch_model = model.load_model()
-        pytorch_model = copy.deepcopy(pytorch_model)
         pytorch_model.eval()
 
         # TODO: add e2e test for model on cpu but data on gpu; model on gpu but data on cpu


### PR DESCRIPTION
## Describe your changes
Remove the deepcopy of the pytorch model before conversion. This was added unintentionally after testing it during the whisper model debug. It breaks the stable diffusion example and is not needed. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
