### PR TITLE
Retry test setup for example tests

### DIFF
--- a/examples/test_bert_ptq_cpu.py
+++ b/examples/test_bert_ptq_cpu.py
@@ -10,15 +10,11 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture()
-def example_dir():
-    return str(Path(__file__).resolve().parent / "bert_ptq_cpu")
-
-
-@pytest.fixture(autouse=True)
-def setup(example_dir):
+@pytest.fixture(scope="module", autouse=True)
+def setup():
     """setup any state specific to the execution of the given module."""
-    cur_dir = str(Path(__file__).resolve().parent)
+    cur_dir = Path(__file__).resolve().parent
+    example_dir = cur_dir / "bert_ptq_cpu"
     os.chdir(example_dir)
     yield
     os.chdir(cur_dir)

--- a/examples/test_resnet_ptq_cpu.py
+++ b/examples/test_resnet_ptq_cpu.py
@@ -8,22 +8,19 @@ from pathlib import Path
 
 import pytest
 
-from olive.common.utils import run_subprocess
+from olive.common.utils import retry_func, run_subprocess
 
 
-@pytest.fixture()
-def example_dir():
-    return str(Path(__file__).resolve().parent / "resnet_ptq_cpu")
-
-
-@pytest.fixture(autouse=True)
-def setup(example_dir):
+@pytest.fixture(scope="module", autouse=True)
+def setup():
     """setup any state specific to the execution of the given module."""
     cur_dir = Path(__file__).resolve().parent
+    example_dir = str(Path(__file__).resolve().parent / "resnet_ptq_cpu")
     os.chdir(example_dir)
 
-    # import prepare_model_data
-    run_subprocess("python prepare_model_data.py")
+    # prepare model and data
+    # retry since it fails randomly
+    retry_func(run_subprocess, kwargs={"cmd": "python prepare_model_data.py", "check": True})
 
     yield
     os.chdir(cur_dir)

--- a/examples/test_resnet_ptq_cpu.py
+++ b/examples/test_resnet_ptq_cpu.py
@@ -15,7 +15,7 @@ from olive.common.utils import retry_func, run_subprocess
 def setup():
     """setup any state specific to the execution of the given module."""
     cur_dir = Path(__file__).resolve().parent
-    example_dir = str(Path(__file__).resolve().parent / "resnet_ptq_cpu")
+    example_dir = cur_dir / "resnet_ptq_cpu"
     os.chdir(example_dir)
 
     # prepare model and data

--- a/examples/test_whisper.py
+++ b/examples/test_whisper.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from olive.common.utils import run_subprocess
+from olive.common.utils import retry_func, run_subprocess
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -19,11 +19,8 @@ def setup():
     os.chdir(example_dir)
 
     # prepare configs
-    try:
-        run_subprocess("python prepare_configs.py")
-    except Exception:
-        # for some reason the first time fails on windows
-        run_subprocess("python prepare_configs.py")
+    # retry since it fails randomly on windows
+    retry_func(run_subprocess, kwargs={"cmd": "python prepare_configs.py", "check": True})
 
     yield
     os.chdir(cur_dir)

--- a/examples/test_whisper.py
+++ b/examples/test_whisper.py
@@ -14,8 +14,8 @@ from olive.common.utils import retry_func, run_subprocess
 @pytest.fixture(scope="module", autouse=True)
 def setup():
     """setup any state specific to the execution of the given module."""
-    cur_dir = str(Path(__file__).resolve().parent)
-    example_dir = str(Path(__file__).resolve().parent / "whisper")
+    cur_dir = Path(__file__).resolve().parent
+    example_dir = cur_dir / "whisper"
     os.chdir(example_dir)
 
     # prepare configs


### PR DESCRIPTION
## Describe your changes
Sometimes, the example tests fail because the setups (preparing model, data, config, etc) fail randomly. Retry the test setups to catch such errors. 
Test fixtures are also updated to make them simpler and consistent across examples. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
