### PR TITLE
Correct logger severity mapping

### DIFF
--- a/olive/__init__.py
+++ b/olive/__init__.py
@@ -24,4 +24,4 @@ def set_default_logger_severity(level):
     :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
     """
     # logging.DEBUG = 10, logging.INFO = 20, logging.WARNING = 30, logging.ERROR = 40, logging.CRITICAL = 50
-    _logger.setLevel((1 + level) * 10)
+    _logger.setLevel((level + 1) * 10)

--- a/olive/__init__.py
+++ b/olive/__init__.py
@@ -23,5 +23,12 @@ def set_default_logger_severity(level):
 
     :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
     """
-    # logging.DEBUG = 10, logging.INFO = 20, logging.WARNING = 30, logging.ERROR = 40, logging.CRITICAL = 50
-    _logger.setLevel((level + 1) * 10)
+    # mapping from level to logging level
+    level_map = {0: logging.DEBUG, 1: logging.INFO, 2: logging.WARNING, 3: logging.ERROR, 4: logging.CRITICAL}
+
+    # check if level is valid
+    if level not in level_map:
+        raise ValueError(f"Invalid level {level}, should be one of {list(level_map.keys())}")
+
+    # set logger level
+    _logger.setLevel(level_map[level])

--- a/olive/__init__.py
+++ b/olive/__init__.py
@@ -20,6 +20,8 @@ __version__ = "0.1.0"
 def set_default_logger_severity(level):
     """
     Set log level for olive package.
+
     :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
     """
-    _logger.setLevel(level * 10)
+    # logging.DEBUG = 10, logging.INFO = 20, logging.WARNING = 30, logging.ERROR = 40, logging.CRITICAL = 50
+    _logger.setLevel((1 + level) * 10)


### PR DESCRIPTION
## Describe your changes
`olive.set_default_logger_severity` takes int from 0-4 for severity level. The corresponding levels for `logging` are 10-50, not 0-40. Update the mapping for this. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
