### PR TITLE
Whisper: pin onnx to 1.13.1

### DIFF
--- a/examples/whisper/requirements.txt
+++ b/examples/whisper/requirements.txt
@@ -1,5 +1,5 @@
 coloredlogs
 flatbuffers
-onnx>=1.13.1
+onnx==1.13.1
 torch>=1.13.1
 transformers>=4.23.1


### PR DESCRIPTION
## Describe your changes
Onnx 1.14.0 was just released. However, the whisper example doesn't work it due to IR version mismatch between the components in the prepostprocessing step. So, pinning the onnx version in the whisper example requirements. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
