### PR TITLE
Whisper: update pre/post-processing script to latest ort-extensions

### DIFF
--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -47,7 +47,7 @@ python -m pip install git+https://github.com/microsoft/Olive
 python -m pip install -r requirements.txt
 :: Install nightly versions of onnxruntime and onnxruntime-extensions
 python -m pip uninstall -y onnxruntime onnxruntime-extensions
-python -m pip install ort-nightly==1.15.0.dev20230429003 onnxruntime-extensions==0.8.0.303816 ^
+python -m pip install ort-nightly==1.15.0.dev20230429003 onnxruntime-extensions==0.8.0.306180 ^
     --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 ```
 
@@ -62,7 +62,7 @@ python -m pip install git+https://github.com/microsoft/Olive
 python -m pip install -r requirements.txt
 # Install nightly versions of onnxruntime and onnxruntime-extensions
 python -m pip uninstall -y onnxruntime onnxruntime-extensions
-python -m pip install ort-nightly==1.15.0.dev20230429003 onnxruntime-extensions==0.8.0.303816 `
+python -m pip install ort-nightly==1.15.0.dev20230429003 onnxruntime-extensions==0.8.0.306180 `
     --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 ```
 **Note:** You can also use a python virtual environment instead of conda.

--- a/scripts/test_examples.bat
+++ b/scripts/test_examples.bat
@@ -36,4 +36,4 @@ exit /b %errorlevel%
 :whisper-setup
 call echo "Installing custom packages for whisper"
 call python -m pip uninstall -y onnxruntime onnxruntime-extensions || goto :error
-call python -m pip install ort-nightly==1.15.0.dev20230429003 onnxruntime-extensions==0.8.0.303816 --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/  || goto :error
+call python -m pip install ort-nightly==1.15.0.dev20230429003 onnxruntime-extensions==0.8.0.306180 --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/  || goto :error


### PR DESCRIPTION
## Describe your changes
Add recent ort-extensions downsampling support for whisper audio preprocessing. Some other changes to whisper prepostprocessing tools to align with the latest whisper_e2e example script. The pass also now uses external data config to save the model to the desired path correctly and keep track of external data if any. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
