### PR TITLE
Change `read_timeout` for `azure.ai.ml.MLClient`

### DIFF
--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -37,12 +37,13 @@ class AzureMLSystem(OliveSystem):
         aml_compute: str,
         aml_docker_config: Union[Dict[str, Any], AzureMLDockerConfig],
         instance_count: int = 1,
+        read_timeout: int = 60,
         is_dev: bool = False,
     ):
         super().__init__()
         self._assert_not_none(aml_docker_config)
         aml_docker_config = validate_config(aml_docker_config, AzureMLDockerConfig)
-        self.ml_client = MLClient.from_config(self._get_credentials(), path=aml_config_path)
+        self.ml_client = MLClient.from_config(self._get_credentials(), path=aml_config_path, read_timeout=read_timeout)
         self.compute = aml_compute
         self.environment = self._create_environment(aml_docker_config)
         self.instance_count = instance_count

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -31,6 +31,10 @@ class AzureMLTargetUserConfig(TargetUserConfig):
     aml_compute: str
     aml_docker_config: AzureMLDockerConfig
     instance_count: int = 1
+    # read timeout in seconds for HTTP requests, user can increase if they find the default value too small.
+    # The default value from azureml sdk is 3000 which is too large and cause the evaluations and pass runs to
+    # hang for a long time
+    read_timeout: int = 60
     is_dev: bool = False
 
 

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -33,7 +33,7 @@ class AzureMLTargetUserConfig(TargetUserConfig):
     instance_count: int = 1
     # read timeout in seconds for HTTP requests, user can increase if they find the default value too small.
     # The default value from azureml sdk is 3000 which is too large and cause the evaluations and pass runs to
-    # hang for a long time
+    # sometimes hang for a long time between retries of job stream and download steps.
     read_timeout: int = 60
     is_dev: bool = False
 


### PR DESCRIPTION
## Describe your changes
The default `read_timeout` value for `MLClient` is `3000` seconds. However, this value is too large and causes `AzureMLSystem` pass runs and model evaluations to hang for a long time during the job streaming and download steps when there are multiple jobs being created at the same time (like in the CI pipelines). We already have retries set up for this step, so it is better to reduce the read_timeout value for Olive. 

With this change the bert and resnet ci tests now only take ~50 minutes instead of ~2 hours it takes when the hanging happens. 

We also allow user to set their own default values if they find the connections are timing out even with retries. I don't expect this to be needed much but it is safer to allow the user to overwrite instead of hardcoding it to `60`. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
