### PR TITLE
Whisper: quantize embedding layer for smaller model, change default model to tiny 

### DIFF
--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -96,7 +96,7 @@ python prepare_whisper_configs.py [--model_name MODEL_NAME] [--no_audio_decoder]
 python prepare_whisper_configs.py --model_name openai/whisper-tiny.en
 ```
 
-`--model_name MODEL_NAME` is the name or path of the whisper model. The default value is `openai/whisper-base.en`.
+`--model_name MODEL_NAME` is the name or path of the whisper model. The default value is `openai/whisper-tiny.en`.
 
 `--no_audio_decoder` is optional. If not provided, will use audio decoder in the preprocessing ops.
 

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -24,7 +24,7 @@ SUPPORTED_WORKFLOWS = {
 
 def get_args(raw_args):
     parser = argparse.ArgumentParser(description="Prepare config file for Whisper")
-    parser.add_argument("--model_name", type=str, default="openai/whisper-base.en", help="Model name")
+    parser.add_argument("--model_name", type=str, default="openai/whisper-tiny.en", help="Model name")
     parser.add_argument(
         "--no_audio_decoder",
         action="store_true",

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -71,15 +71,12 @@
             "config": {
                 "per_channel": false,
                 "reduce_range": false,
-                "op_types_to_quantize": ["MatMul", "Gemm"],
+                "op_types_to_quantize": ["MatMul", "Gemm", "Gather"],
                 "MatMulConstBOnly": false
             }
         },
         "insert_beam_search" : {
-            "type" : "InsertBeamSearch",
-            "config": {
-                "save_as_external_data": true
-            }
+            "type" : "InsertBeamSearch"
         },
         "prepost": {
             "type": "AppendPrePostProcessingOps",


### PR DESCRIPTION
## Describe your changes
Update the dynamic quantization pass to add `Gather` to `op_types_to_quantize`. This reduces the model size from 121MB to 64MB for the tiny model. 

Change the default `model_name` in `prepare_configs.py` to `openai/whisper-tiny.en` .

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
