### PR TITLE
Always try save_as_external_data for `model_proto_to_file`, handle external data for quant preprocess

### DIFF
--- a/olive/cache.py
+++ b/olive/cache.py
@@ -58,22 +58,13 @@ def _delete_model(model_number: str, cache_dir: Union[str, Path] = ".olive-cache
     Deletes the model and all associated runs and evaluations.
     """
     model_cache_dir, run_cache_dir, evaluation_cache_dir = get_cache_sub_dirs(cache_dir)
-    model_jsons = list(model_cache_dir.glob(f"{model_number}_*.json"))
-    for model_json in model_jsons:
-        try:
-            model_data = json.load(open(model_json, "r"))
-            if model_data != {}:
-                model_file = Path(json.load(open(model_json, "r"))["model_path"])
-                model_file_number = model_file.stem.split("_")[0]
-                if model_file_number == model_number:
-                    if model_file.is_dir():
-                        shutil.rmtree(model_file, ignore_errors=True)
-                    elif model_file.is_file():
-                        model_file.unlink()
-        except Exception as e:
-            logger.exception(e)
-        finally:
-            model_json = model_json.unlink()
+    # delete all model files that start with model_number
+    model_files = list(model_cache_dir.glob(f"{model_number}_*"))
+    for model_file in model_files:
+        if model_file.is_dir():
+            shutil.rmtree(model_file, ignore_errors=True)
+        elif model_file.is_file():
+            model_file.unlink()
 
     evaluation_jsons = list(evaluation_cache_dir.glob(f"{model_number}_*.json"))
     for evaluation_json in evaluation_jsons:

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -123,9 +123,13 @@ class Engine:
         # we do this before cleaning pass run caches to ensure we don't reuse model numbers even if the model was
         # deleted from the cache
         self._new_model_number = 0
-        model_jsons = list(self._model_cache_path.glob("*_*.json"))
-        if len(model_jsons) > 0:
-            self._new_model_number = max([int(json_file.stem.split("_")[0]) for json_file in model_jsons]) + 1
+        # model jsons have the format <model_number>_<pass_type>-<source_model>-<pass_config_hash>.json
+        # model contents are stored in <model_number>_<pass_type>-<source_model>-<pass_config_hash> folder
+        # sometimes the folder is created with contents but the json is not created when the pass fails to run
+        # so we check for both when determining the new model number
+        model_files = list(self._model_cache_path.glob("*_*"))
+        if len(model_files) > 0:
+            self._new_model_number = max([int(model_file.stem.split("_")[0]) for model_file in model_files]) + 1
 
         # clean pass run cache if requested
         # removes all run cache for pass type and all children elements

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -415,8 +415,8 @@ class OnnxQuantization(Pass):
             quant_pre_process(input_model_path=model.model_path, output_model_path=output_model_path, auto_merge=True)
             has_external_data = False
         except Exception as e:
-            # TODO: try with `skip_optimization = False`
-            # the quantization preprocessing may fail if the model is too large
+            # TODO: try with `skip_optimization = True`
+            # quantization preprocessing will fail if the model is too large and `skip_optimization = False`
             # there are some problems with the path to where the external data is saved
             # need to find out why before enabling this
 

--- a/test/unit_test/test_cache.py
+++ b/test/unit_test/test_cache.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from olive.cache import clean_pass_run_cache, save_model
+from olive.cache import clean_pass_run_cache, create_cache, get_cache_sub_dirs, save_model
 
 
 class TestCache:
@@ -23,17 +23,17 @@ class TestCache:
         pass_type = "onnxconversion"
         cache_dir = Path("cache_dir")
         cache_dir.mkdir(parents=True, exist_ok=True)
+        create_cache(cache_dir)
+        model_cache_dir, run_cache_dir, evaluation_cache_dir = get_cache_sub_dirs(cache_dir)
 
         if model_path == "0_model_folder":
-            model_folder = cache_dir / model_path
+            model_folder = model_cache_dir / model_path
             model_folder.mkdir(parents=True, exist_ok=True)
             model_p = str(model_folder)
         else:
-            model_p = str(cache_dir / model_path)
+            model_p = str(model_cache_dir / model_path)
             open(str(cache_dir / model_path), "w")
 
-        run_cache_dir = cache_dir / "runs"
-        run_cache_dir.mkdir(parents=True, exist_ok=True)
         run_cache_file_path = str((run_cache_dir / f"{pass_type}-p(･◡･)p.json").resolve())
         with open(run_cache_file_path, "w") as run_cache_file:
             run_data = (
@@ -41,8 +41,6 @@ class TestCache:
             )
             run_cache_file.write(run_data)
 
-        model_cache_dir = cache_dir / "models"
-        model_cache_dir.mkdir(parents=True, exist_ok=True)
         model_cache_file_path = str((model_cache_dir / "0_p(･◡･)p.json").resolve())
         with open(model_cache_file_path, "w") as model_cache_file:
             model_data = f'{{"model_path": "{model_p}"}}'
@@ -50,8 +48,6 @@ class TestCache:
                 model_data = model_data.replace("\\", "//")
             model_cache_file.write(model_data)
 
-        evaluation_cache_dir = cache_dir / "evaluations"
-        evaluation_cache_dir.mkdir(parents=True, exist_ok=True)
         evaluation_cache_file_path = str((evaluation_cache_dir / "0_p(･◡･)p.json").resolve())
         open(evaluation_cache_file_path, "w")
 

--- a/test/unit_test/test_cache.py
+++ b/test/unit_test/test_cache.py
@@ -32,7 +32,7 @@ class TestCache:
             model_p = str(model_folder)
         else:
             model_p = str(model_cache_dir / model_path)
-            open(str(cache_dir / model_path), "w")
+            open(model_p, "w")
 
         run_cache_file_path = str((run_cache_dir / f"{pass_type}-p(･◡･)p.json").resolve())
         with open(run_cache_file_path, "w") as run_cache_file:
@@ -71,14 +71,16 @@ class TestCache:
         # setup
         cache_dir = Path("cache_dir")
         cache_dir.mkdir(parents=True, exist_ok=True)
+        create_cache(cache_dir)
+        model_cache_dir, _, _ = get_cache_sub_dirs(cache_dir)
 
         if model_path == "0_model_folder":
-            model_folder = cache_dir / model_path
+            model_folder = model_cache_dir / model_path
             model_folder.mkdir(parents=True, exist_ok=True)
             model_p = str(model_folder)
         else:
-            model_p = str(cache_dir / model_path)
-            open(str(cache_dir / model_path), "w")
+            model_p = str(model_cache_dir / model_path)
+            open(model_p, "w")
 
         # cache model to cache_dir
         model_id = "0"


### PR DESCRIPTION
## Describe your changes
When we try to save large onnx models (>2GB), we get a value error. However, the error message depends on the version of `onnx`. We previously tried to check the model byte size but there are cases when the byte size returned is negative. 
So, we always try again with `save_as_external_data=True` if the save failed without it. 
If this also fails, then raise original error. 

The `_quant_preprocess` method in onnx quantization pass doesn't handle cases where the quant preprocess fails but the original model has external data. In such cases, just copying the `.onnx` file is not enough. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
