### PR TITLE
Fix HF preprocessed label_cols

### DIFF
--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -58,5 +58,5 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwar
         remove_columns=dataset.column_names,
     )
     tokenized_datasets.set_format("torch", output_all_columns=True)
-    # label_cols is ["label"] since we added label_cols[0] as label to tokened_inputs
+    # label_cols is ["label"] since we added label_cols[0] as "label" to tokened_inputs
     return BaseDataset(tokenized_datasets, label_cols=["label"])

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -58,5 +58,5 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwar
         remove_columns=dataset.column_names,
     )
     tokenized_datasets.set_format("torch", output_all_columns=True)
-    # label_cols is ["label"] since we added label_cols[0] as "label" to tokened_inputs
+    # label_cols is ["label"] since we added label_cols[0] as "label" to tokenized_inputs
     return BaseDataset(tokenized_datasets, label_cols=["label"])

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -58,4 +58,5 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwar
         remove_columns=dataset.column_names,
     )
     tokenized_datasets.set_format("torch", output_all_columns=True)
-    return BaseDataset(tokenized_datasets, label_cols=label_cols)
+    # label_cols is ["label"] since we added label_cols[0] as label to tokened_inputs
+    return BaseDataset(tokenized_datasets, label_cols=["label"])


### PR DESCRIPTION
## Describe your changes
When preprocessing a huggingface dataset, `label_col[0]` is renamed to `"label"`. So pass `label_cols=["label"]` when instantiating BaseDataset. 

We didn't catch this bug before since the bert example original label col was also `"label"`. Refer to [this example](https://github.com/microsoft/Olive/blob/jambayk/dolly/examples/dolly/dolly_config.json) for a dataset with different label name. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
