### PR TITLE
fix pip install path

### DIFF
--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -102,7 +102,7 @@ def dependency_setup(config):
         try:
             __import__(package)
         except ImportError:
-            subprocess.check_call(["python -m pip", "install", "{}".format(package)])
+            subprocess.check_call(["python", "-m", "pip", "install", "{}".format(package)])
     if remote_packages:
         logger.info(
             "Please make sure the following packages are installed in {} environment: {}".format(

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -102,7 +102,7 @@ def dependency_setup(config):
         try:
             __import__(package)
         except ImportError:
-            subprocess.check_call(["pip", "install", "{}".format(package)])
+            subprocess.check_call(["python -m pip", "install", "{}".format(package)])
     if remote_packages:
         logger.info(
             "Please make sure the following packages are installed in {} environment: {}".format(


### PR DESCRIPTION
## Describe your changes
modify `pip install ` into `python -m pip install` in case the path to pip is not the same as the pip used by the current python environment.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
