### PR TITLE
fix azureml-evaluate-mlflow version

### DIFF
--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -14,5 +14,5 @@ psutil
 pytorch_lightning
 torchvision
 datasets
-azureml-evaluate-mlflow
+azureml-evaluate-mlflow==0.0.6.post1
 mlflow


### PR DESCRIPTION
## Describe your changes
fix azureml-evaluate-mlflow version
azureml-evaluate-mlflow changed model_loader flavor name from `hftransformers` to `hftransformersv2` when updating to 0.8.0. Current ci test may fail when loading pytorch mlflow model. This is a workaround to make sure the test won't fail recently.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
