### PR TITLE
packing onnxruntime fix

### DIFF
--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -111,8 +111,8 @@ def _package_onnxruntime_packages(tempdir, pf_footprint: Footprint):
     )
 
     installed_packages = pkg_resources.working_set
-    onnxruntime_pkg = [i for i in installed_packages if i.key == "onnxruntime"]
-    ort_nightly_pkg = [i for i in installed_packages if i.key == "ort-nightly"]
+    onnxruntime_pkg = [i for i in installed_packages if i.key.startswith("onnxruntime")]
+    ort_nightly_pkg = [i for i in installed_packages if i.key.startswith("ort-nightly")]
     is_nightly = True if ort_nightly_pkg else False
     is_stable = True if onnxruntime_pkg else False
 


### PR DESCRIPTION
## Describe your changes
When I installed onnxruntime-gpu locally, the olive package generation will fail to prepare onnxruntime. The ut failed as well.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
