### PR TITLE
Auto remove unit test resulting files

### DIFF
--- a/olive/passes/pytorch/pytorch_lightning_utils.py
+++ b/olive/passes/pytorch/pytorch_lightning_utils.py
@@ -18,6 +18,7 @@ def create_trainer(
     val_check_interval=None,
     log_every_n_steps=50,
     precision=32,
+    default_root_dir=None,
     **kwargs,
 ):
     trainer = pl.Trainer(
@@ -28,6 +29,7 @@ def create_trainer(
         val_check_interval=val_check_interval,
         log_every_n_steps=log_every_n_steps,
         precision=precision,
+        default_root_dir=default_root_dir,
         **kwargs,
     )
 

--- a/olive/passes/pytorch/qat_utils.py
+++ b/olive/passes/pytorch/qat_utils.py
@@ -88,7 +88,11 @@ class QatTrainer:
                     kwargs["replace_sampler_ddp"] = False
 
             trainer = create_trainer(
-                max_epochs=self.config.num_epochs, max_steps=self.config.num_steps, logger=self.config.logger, **kwargs
+                max_epochs=self.config.num_epochs,
+                max_steps=self.config.num_steps,
+                logger=self.config.logger,
+                default_root_dir=self.config.checkpoint_path,
+                **kwargs
             )
 
             trainer.fit(ptl_module, datamodule=ptl_data_module)

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -86,6 +86,7 @@ class QuantizationAwareTraining(Pass):
             ),
             "gpus": PassConfigParam(type_=int, description="Number of GPUs to use."),
             "seed": PassConfigParam(type_=int, default_value=None, description="Random seed for training."),
+            "checkpoint_path": PassConfigParam(type_=str, description="Path to save checkpoints."),
         }
 
     def _run_for_config(self, model: PyTorchModel, config: Dict[str, Any], output_model_path: str) -> PyTorchModel:

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -86,7 +86,7 @@ class QuantizationAwareTraining(Pass):
             ),
             "gpus": PassConfigParam(type_=int, description="Number of GPUs to use."),
             "seed": PassConfigParam(type_=int, default_value=None, description="Random seed for training."),
-            "checkpoint_path": PassConfigParam(type_=str, description="Path to save checkpoints."),
+            "checkpoint_path": PassConfigParam(type_=str, default_value=None, description="Path to save checkpoints."),
         }
 
     def _run_for_config(self, model: PyTorchModel, config: Dict[str, Any], output_model_path: str) -> PyTorchModel:

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -2,7 +2,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 
 import mlflow
 import pandas as pd
@@ -14,7 +17,8 @@ from olive.model import PyTorchModel
 
 class TestPyTorchMLflowModel(unittest.TestCase):
     def setup(self):
-        self.model_path = "mlflow_test"
+        self.tempdir = Path(tempfile.TemporaryDirectory().name)
+        self.model_path = str(self.tempdir.resolve() / "mlflow_test")
         self.task = "text-classification"
         self.architecture = "distilbert-base-uncased-finetuned-sst-2-english"
         self.original_model = transformers.AutoModelForSequenceClassification.from_pretrained(self.architecture)
@@ -55,6 +59,7 @@ class TestPyTorchMLflowModel(unittest.TestCase):
         olive_predict_result = [olive_model.config.id2label[olive_result]]
 
         assert mlflow_predict_result == olive_predict_result
+        shutil.rmtree(self.tempdir)
 
 
 class TestPyTorchHFModel(unittest.TestCase):

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -17,8 +16,9 @@ from olive.model import PyTorchModel
 
 class TestPyTorchMLflowModel(unittest.TestCase):
     def setup(self):
-        self.tempdir = Path(tempfile.TemporaryDirectory().name)
-        self.model_path = str(self.tempdir.resolve() / "mlflow_test")
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root_dir = Path(self.tempdir.name)
+        self.model_path = str(self.root_dir.resolve() / "mlflow_test")
         self.task = "text-classification"
         self.architecture = "distilbert-base-uncased-finetuned-sst-2-english"
         self.original_model = transformers.AutoModelForSequenceClassification.from_pretrained(self.architecture)
@@ -59,7 +59,7 @@ class TestPyTorchMLflowModel(unittest.TestCase):
         olive_predict_result = [olive_model.config.id2label[olive_result]]
 
         assert mlflow_predict_result == olive_predict_result
-        shutil.rmtree(self.tempdir)
+        self.tempdir.cleanup()
 
 
 class TestPyTorchHFModel(unittest.TestCase):

--- a/test/unit_test/passes/pytorch/test_quantization_aware_training.py
+++ b/test/unit_test/passes/pytorch/test_quantization_aware_training.py
@@ -13,11 +13,16 @@ from olive.systems.local import LocalSystem
 
 def test_quantization_aware_training_pass_default():
     # setup
-    local_system = LocalSystem()
-    input_model = get_pytorch_model()
-    config = {"train_dataloader_func": create_dataloader}
-    p = create_pass_from_dict(QuantizationAwareTraining, config, disable_search=True)
+
     with tempfile.TemporaryDirectory() as tempdir:
+        local_system = LocalSystem()
+        input_model = get_pytorch_model()
+        config = {
+            "train_dataloader_func": create_dataloader,
+            "checkpoint_path": str(Path(tempdir) / "checkpoint"),
+        }
+
+        p = create_pass_from_dict(QuantizationAwareTraining, config, disable_search=True)
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute


### PR DESCRIPTION
## Describe your changes
When I run unit test locally, always generate many temp files in root folder. It often breaks my git track for changed files.

This PR is used to move those temp files into temp folder and remove them when test is done.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
