### PR TITLE
Bert example bugfix for f1_score

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -197,7 +197,7 @@ information of the evaluator contains following items:
                 "type": "accuracy",
                 "sub_types": [
                     {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                    {"name": "f1_score"},
+                    {"name": "f1_score", "metric_config": {"task": "binary"}},
                     {"name": "auc", "metric_config": {"reorder": true}}
                 ],
                 "user_config":{

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -197,7 +197,7 @@ information of the evaluator contains following items:
                 "type": "accuracy",
                 "sub_types": [
                     {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                    {"name": "f1_score", "metric_config": {"task": "binary"}},
+                    {"name": "f1_score", "metric_config": {"multiclass": false}},
                     {"name": "auc", "metric_config": {"reorder": true}}
                 ],
                 "user_config":{

--- a/docs/source/tutorials/configure_metrics.rst
+++ b/docs/source/tutorials/configure_metrics.rst
@@ -19,7 +19,7 @@ Accuracy Metric
                 "type": "accuracy",
                 "sub_types": [
                     {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                    {"name": "f1_score"},
+                    {"name": "f1_score", "metric_config": {"task": "binary"}},
                     {"name": "auc", "metric_config": {"reorder": true}}
                 ],
                 "user_config": {
@@ -177,7 +177,7 @@ If you have multiple metrics to evaluate, you can configure them in the followin
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score"},
+                        {"name": "f1_score", "metric_config": {"task": "binary"}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/docs/source/tutorials/configure_metrics.rst
+++ b/docs/source/tutorials/configure_metrics.rst
@@ -19,7 +19,7 @@ Accuracy Metric
                 "type": "accuracy",
                 "sub_types": [
                     {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                    {"name": "f1_score", "metric_config": {"task": "binary"}},
+                    {"name": "f1_score", "metric_config": {"multiclass": false}},
                     {"name": "auc", "metric_config": {"reorder": true}}
                 ],
                 "user_config": {
@@ -177,7 +177,7 @@ If you have multiple metrics to evaluate, you can configure them in the followin
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score", "metric_config": {"task": "binary"}},
+                        {"name": "f1_score", "metric_config": {"multiclass": false}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/docs/source/tutorials/how_to_write_userscript.md
+++ b/docs/source/tutorials/how_to_write_userscript.md
@@ -52,7 +52,7 @@ Use `my_script.py` with Olive workflow configuration json file(sub_types name sh
         "type": "accuracy",
         "sub_types": [
             {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-            {"name": "f1_score", "metric_config": {"task": "binary"}},
+            {"name": "f1_score", "metric_config": {"multiclass": false}},
             {"name": "auc", "metric_config": {"reorder": true}}
         ],
         "user_config":{
@@ -104,7 +104,7 @@ Use `script_dir` and `my_script.py` with Olive workflow configuration json file:
         "type": "accuracy",
         "sub_types": [
             {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-            {"name": "f1_score", "metric_config": {"task": "binary"}},
+            {"name": "f1_score", "metric_config": {"multiclass": false}},
             {"name": "auc", "metric_config": {"reorder": true}}
         ]
         "user_config":{

--- a/docs/source/tutorials/how_to_write_userscript.md
+++ b/docs/source/tutorials/how_to_write_userscript.md
@@ -52,7 +52,7 @@ Use `my_script.py` with Olive workflow configuration json file(sub_types name sh
         "type": "accuracy",
         "sub_types": [
             {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-            {"name": "f1_score"},
+            {"name": "f1_score", "metric_config": {"task": "binary"}},
             {"name": "auc", "metric_config": {"reorder": true}}
         ],
         "user_config":{
@@ -104,7 +104,7 @@ Use `script_dir` and `my_script.py` with Olive workflow configuration json file:
         "type": "accuracy",
         "sub_types": [
             {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-            {"name": "f1_score"},
+            {"name": "f1_score", "metric_config": {"task": "binary"}},
             {"name": "auc", "metric_config": {"reorder": true}}
         ]
         "user_config":{

--- a/examples/bert_ptq_cpu/bert_config.json
+++ b/examples/bert_ptq_cpu/bert_config.json
@@ -71,7 +71,7 @@
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score"},
+                        {"name": "f1_score", "metric_config": {"task": "binary"}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/examples/bert_ptq_cpu/bert_config.json
+++ b/examples/bert_ptq_cpu/bert_config.json
@@ -71,7 +71,7 @@
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score", "metric_config": {"task": "binary"}},
+                        {"name": "f1_score", "metric_config": {"multiclass": false}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -87,7 +87,7 @@ class Footprint:
             is_goals_met = []
             for metric_name in v.metrics.value:
                 if metric_name not in self.objective_dict:
-                    logger.debug("There is no goal set for metric: {metric_name}.")
+                    logger.debug(f"There is no goal set for metric: {metric_name}.")
                     continue
                 higher_is_better = self.objective_dict[metric_name]["higher_is_better"]
                 cmp_direction = 1 if higher_is_better else -1

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -34,6 +34,7 @@ class AccuracyBase(AutoConfigClass):
             "ignore_index": ConfigParam(type_=list, default_value=None),
             "top_k": ConfigParam(type_=int, default_value=None),
             "mdmc_average": ConfigParam(type_=str, default_value="global"),
+            "task": ConfigParam(type_=str, default_value=None),
         }
 
     @abstractmethod

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -34,7 +34,7 @@ class AccuracyBase(AutoConfigClass):
             "ignore_index": ConfigParam(type_=list, default_value=None),
             "top_k": ConfigParam(type_=int, default_value=None),
             "mdmc_average": ConfigParam(type_=str, default_value="global"),
-            "task": ConfigParam(type_=str, default_value=None),
+            "multiclass": ConfigParam(type_=bool, default_value=None),
         }
 
     @abstractmethod

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -37,7 +37,7 @@ class AccuracyBase(AutoConfigClass):
         super().__init__(config)
 
     @classmethod
-    def metric_config_from_torch_metrics(cls):
+    def _metric_config_from_torch_metrics(cls):
         metric_module = cls.metric_cls_map[cls.name]
         params = signature(metric_module).parameters
         # if the metrics is calculated by torchmetrics.functional, we should filter the label data out
@@ -59,7 +59,7 @@ class AccuracyBase(AutoConfigClass):
 
     @classmethod
     def _default_config(cls) -> Dict[str, ConfigParam]:
-        return cls.metric_config_from_torch_metrics()
+        return cls._metric_config_from_torch_metrics()
 
     @abstractmethod
     def measure(self, preds, target):

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -100,8 +100,15 @@ def create_fixed_dataloader(datadir, batchsize):
 
 def get_accuracy_metric(*acc_subtype, random_dataloader=True, user_config=None, backend="torch_metrics"):
     accuracy_metric_config = {"dataloader_func": create_dataloader if random_dataloader else create_fixed_dataloader}
-    sub_types = [{"name": sub, "metric_config": {"mdmc_average": "global"},
-                  "goal": MetricGoal(type="threshold", value=0.99)} for sub in acc_subtype]
+    accuracy_score_metric_config = {"mdmc_average": "global"}
+    sub_types = [
+        {
+            "name": sub,
+            "metric_config": accuracy_score_metric_config if sub == "accuracy_score" else {},
+            "goal": MetricGoal(type="threshold", value=0.99),
+        }
+        for sub in acc_subtype
+    ]
     sub_types[0]["priority"] = 1
     accuracy_metric = Metric(
         name="accuracy",

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -100,7 +100,8 @@ def create_fixed_dataloader(datadir, batchsize):
 
 def get_accuracy_metric(*acc_subtype, random_dataloader=True, user_config=None):
     accuracy_metric_config = {"dataloader_func": create_dataloader if random_dataloader else create_fixed_dataloader}
-    sub_types = [{"name": sub, "goal": MetricGoal(type="threshold", value=0.99)} for sub in acc_subtype]
+    sub_types = [{"name": sub, "metric_config": {"mdmc_average": "global"},
+                  "goal": MetricGoal(type="threshold", value=0.99)} for sub in acc_subtype]
     sub_types[0]["priority"] = 1
     accuracy_metric = Metric(
         name="accuracy",

--- a/test/unit_test/workflows/mock_data/only_transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/only_transformer_dataset.json
@@ -63,7 +63,7 @@
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score"},
+                        {"name": "f1_score", "metric_config": {"task": "binary"}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/test/unit_test/workflows/mock_data/only_transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/only_transformer_dataset.json
@@ -63,7 +63,7 @@
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score", "metric_config": {"task": "binary"}},
+                        {"name": "f1_score", "metric_config": {"multiclass": false}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/test/unit_test/workflows/mock_data/transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/transformer_dataset.json
@@ -38,7 +38,7 @@
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score"},
+                        {"name": "f1_score", "metric_config": {"task": "binary"}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },

--- a/test/unit_test/workflows/mock_data/transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/transformer_dataset.json
@@ -38,7 +38,7 @@
                     "type": "accuracy",
                     "sub_types": [
                         {"name": "accuracy_score", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
-                        {"name": "f1_score", "metric_config": {"task": "binary"}},
+                        {"name": "f1_score", "metric_config": {"multiclass": false}},
                         {"name": "auc", "metric_config": {"reorder": true}}
                     ]
                 },


### PR DESCRIPTION
## Describe your changes
For bert example, when we apply `f1_score`, olive got the unmatched number with official report as the `task` is not assigned to `binary` for bert-mnli task.

https://huggingface.co/Intel/bert-base-uncased-mrpc

![image](https://github.com/microsoft/Olive/assets/13343117/d964909f-3687-4941-bed0-47485002dd64)

This PR added the `task` parameters into accuracy base class which can help get correct numbers.

![image](https://github.com/microsoft/Olive/assets/13343117/f98e47e4-8fbd-4d25-90bb-3083a947237e)



## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`

## (Optional) Issue link
