### PR TITLE
Use same version for openvino in tests as extra

### DIFF
--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -6,8 +6,8 @@ docker
 neural-compressor
 onnxconverter_common
 onnxruntime-extensions
-openvino
-openvino-dev
+openvino==2022.3.0
+openvino-dev==2022.3.0
 pandas
 plotly
 psutil


### PR DESCRIPTION
## Describe your changes
The supported version for `openvino` extra is `2022.3.0` but the test requirement has no version requirement. There is a new release for openvino and one of the window's test fails. So set the same version in the test. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
