### PR TITLE
use model io_config for perf tuning

### DIFF
--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -56,6 +56,14 @@ def tune_onnx_model(model, config):
     latency_user_config = {}
     # which should be the same as the config in the metric
     config_dict = config.dict()
+
+    # use model io_config if user does not specify input_names and input_shapes
+    if not config_dict.get("input_names") or not config_dict.get("input_shapes"):
+        io_config = model.get_io_config()
+        config_dict["input_names"] = io_config["input_names"]
+        config_dict["input_shapes"] = io_config["input_shapes"]
+        config_dict["input_types"] = io_config["input_types"]
+
     for eval_config in get_properties_from_metric_type(MetricType.LATENCY):
         if eval_config in config_dict:
             latency_user_config[eval_config] = config_dict.get(eval_config)

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -6,29 +6,18 @@ import tempfile
 from pathlib import Path
 from test.unit_test.utils import get_onnx_model
 
+import pytest
+
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OrtPerfTuning
 from olive.systems.local import LocalSystem
 
 
-def test_ort_perf_tuning_pass():
+@pytest.mark.parametrize("config", [{"input_names": ["input"], "input_shapes": [[1, 1]]}, {}])
+def test_ort_perf_tuning_pass(config):
     # setup
     local_system = LocalSystem()
     input_model = get_onnx_model()
-    config = {"input_names": ["input"], "input_shapes": [[1, 1]]}
-    p = create_pass_from_dict(OrtPerfTuning, config, disable_search=True)
-    with tempfile.TemporaryDirectory() as tempdir:
-        output_folder = str(Path(tempdir) / "onnx")
-
-        # execute
-        local_system.run_pass(p, input_model, output_folder)
-
-
-def test_ort_perf_tuning_pass_with_model_io_config():
-    # setup
-    local_system = LocalSystem()
-    input_model = get_onnx_model()
-    config = {}
     p = create_pass_from_dict(OrtPerfTuning, config, disable_search=True)
     with tempfile.TemporaryDirectory() as tempdir:
         output_folder = str(Path(tempdir) / "onnx")

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -22,3 +22,16 @@ def test_ort_perf_tuning_pass():
 
         # execute
         local_system.run_pass(p, input_model, output_folder)
+
+
+def test_ort_perf_tuning_pass_with_model_io_config():
+    # setup
+    local_system = LocalSystem()
+    input_model = get_onnx_model()
+    config = {}
+    p = create_pass_from_dict(OrtPerfTuning, config, disable_search=True)
+    with tempfile.TemporaryDirectory() as tempdir:
+        output_folder = str(Path(tempdir) / "onnx")
+
+        # execute
+        local_system.run_pass(p, input_model, output_folder)

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -44,10 +44,7 @@ def test_ort_perf_tuning_pass_with_dynamic_shapes(mock_get_io_config):
     with tempfile.TemporaryDirectory() as tempdir:
         output_folder = str(Path(tempdir) / "onnx")
 
-        try:
+        with pytest.raises(TypeError) as e:
             # execute
             local_system.run_pass(p, input_model, output_folder)
-            raise Exception()
-        except Exception as e:
-            assert isinstance(e, TypeError)
-            assert "ones() received an invalid combination of arguments" in str(e)
+            assert "ones() received an invalid combination of arguments" in str(e.value)


### PR DESCRIPTION
## Describe your changes
if user does not specify input_names and input_shapes for perf tuning, olive will use model io_config read from onnx model graph 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
