### PR TITLE
fix examples

### DIFF
--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -71,7 +71,12 @@
             "type": "OnnxQuantization"
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+                "input_shapes": [[1, 128], [1, 128], [1, 128]],
+                "input_types": ["int64", "int64", "int64"]
+            }
         }
     },
     "engine": {

--- a/examples/bert/bert_ptq_cpu_aml.json
+++ b/examples/bert/bert_ptq_cpu_aml.json
@@ -79,7 +79,12 @@
             "type": "OnnxQuantization"
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+                "input_shapes": [[1, 128], [1, 128], [1, 128]],
+                "input_types": ["int64", "int64", "int64"]
+            }
         }
     },
     "engine": {

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -9,7 +9,7 @@ import os
 def check_search_output(footprints):
     """Check if the search output is valid."""
     for footprint in footprints.values():
-        assert footprint.nodes is not None
+        assert footprint.nodes
         for v in footprint.nodes.values():
             assert all([metric_result.value > 0 for metric_result in v.metrics.value.values()])
 


### PR DESCRIPTION
## Describe your changes
input specs info is necessary for perf tuning pass if model io_config has dynamic axe.
The assertation is always true because `self.nodes = nodes or OrderedDict()`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
