### PR TITLE
Use `data_config` for ort perf tuning

### DIFF
--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -71,12 +71,7 @@
             "type": "OnnxQuantization"
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning",
-            "config": {
-                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-                "input_shapes": [[1, 128], [1, 128], [1, 128]],
-                "input_types": ["int64", "int64", "int64"]
-            }
+            "type": "OrtPerfTuning"
         }
     },
     "engine": {

--- a/examples/bert/bert_ptq_cpu_aml.json
+++ b/examples/bert/bert_ptq_cpu_aml.json
@@ -79,12 +79,7 @@
             "type": "OnnxQuantization"
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning",
-            "config": {
-                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-                "input_shapes": [[1, 128], [1, 128], [1, 128]],
-                "input_types": ["int64", "int64", "int64"]
-            }
+            "type": "OrtPerfTuning"
         }
     },
     "engine": {

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -121,7 +121,7 @@ class Engine:
         if not_supported_ep:
             logger.warning(
                 f"The following execution provider is not supported: {','.join(not_supported_ep)}. "
-                "Please consider install the onnxruntime contains the appropriated execution providers. "
+                "Please consider installing an onnxruntime build that contains the relevant execution providers. "
             )
 
         # default evaluator

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -85,13 +85,16 @@ def tune_onnx_model(model, config):
         if eval_config in config_dict:
             latency_user_config[eval_config] = config_dict.get(eval_config)
     latency_sub_types = [{"name": LatencySubType.AVG}]
-    latency_metric = Metric(
-        name="latency",
-        type=MetricType.LATENCY,
-        sub_types=latency_sub_types,
-        user_config=latency_user_config,
-        data_config=config_dict.get("data_config"),
-    )
+    latency_metric_config = {
+        "name": "latency",
+        "type": MetricType.LATENCY,
+        "sub_types": latency_sub_types,
+        "user_config": latency_user_config,
+    }
+    if config_dict.get("data_config"):
+        # we have to do this condition since data_config cannot be None
+        latency_metric_config["data_config"] = config_dict.get("data_config")
+    latency_metric = Metric(**latency_metric_config)
 
     pretuning_inference_result = get_benchmark(model, latency_metric, config)
 


### PR DESCRIPTION
## Describe your changes
Use the provided `data_config` for perf tuning. We only infer model io config to create dummy data if the user doesn't provide input_names/input_shapes or data config. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
