### PR TITLE
pin mlflow to 2.2.1

### DIFF
--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -15,5 +15,5 @@ pytorch_lightning
 torchvision
 datasets
 azureml-evaluate-mlflow
-mlflow
+mlflow==2.3.2
 evaluate

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -15,5 +15,5 @@ pytorch_lightning
 torchvision
 datasets
 azureml-evaluate-mlflow
-mlflow==2.3.2
+mlflow==2.2.1
 evaluate


### PR DESCRIPTION
## Describe your changes
ci pipelines fail with mlflow 2.4.0. pin the version to 2.2.1 as a workaround. It is required by azureml-evaluate-mlflow package. 
![image](https://github.com/microsoft/Olive/assets/61653207/344f33af-5330-43eb-8480-7f55c1cd0c24)


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
