### PR TITLE
Pin mlflow-skinny to 2.3.2 

### DIFF
--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -14,8 +14,7 @@ psutil
 pytorch_lightning
 torchvision
 datasets
-# pip dependency resolver is stuck if we don't specify the version
-azureml-evaluate-mlflow==0.0.12
-# test breaks with newer version
-mlflow==2.3.2
+azureml-evaluate-mlflow
+mlflow
+mlflow-skinny==2.3.2
 evaluate

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -16,5 +16,7 @@ torchvision
 datasets
 azureml-evaluate-mlflow
 mlflow
+# newest version mlflow-skinny==2.4.0 is not compatible with the test
+# issue: https://github.com/mlflow/mlflow/issues/8629
 mlflow-skinny==2.3.2
 evaluate

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -14,6 +14,8 @@ psutil
 pytorch_lightning
 torchvision
 datasets
-azureml-evaluate-mlflow
-mlflow
+# pip dependency resolver is stuck if we don't specify the version
+azureml-evaluate-mlflow==0.0.12
+# test breaks with newer version
+mlflow==2.3.2
 evaluate


### PR DESCRIPTION
## Describe your changes
There are some changes in the latest mlflow version 2.4.0. https://github.com/mlflow/mlflow/issues/8629 
Our example installs `mlflow-1.28.0, azureml-evaluate-mlflow-0.0.2 azureml-mlflow-1.51.0` after depency resolution. So we need an older version of mlflow-skinny too. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
