### PR TITLE
Aml_client.models.download -> aml fsspec.download

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -198,9 +198,7 @@ information of the evaluator contains following items:
 
         - `script_dir: [str]` The directory that contains dependencies for the user script.
 
-        - `data_dir: [str]` [!Deprecated Soon] he directory that contains the data for the metric evaluation.
-
-        - `data_path: [ResourcePath]` The path to the data for the metric evaluation which can be a local file, local folder, or data hosted on AML Datastore.
+        - `data_dir: [str]` The directory that contains the data for the metric evaluation.
 
         - `batch_size: [int]` The batch size for the metric evaluation.
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -36,7 +36,7 @@ The default value is 3. User can increase if there are network issues and the op
 ### Example
 ```json
 "azureml_client": {
-   "subscription_id": "<subscription_id>",
+    "subscription_id": "<subscription_id>",
     "resource_group": "<resource_group>",
     "workspace_name": "<workspace_name>",
     "read_timeout" : 4000,
@@ -198,7 +198,9 @@ information of the evaluator contains following items:
 
         - `script_dir: [str]` The directory that contains dependencies for the user script.
 
-        - `data_dir: [str]` The directory that contains the data for the metric evaluation.
+        - `data_dir: [str]` [!Deprecated Soon] he directory that contains the data for the metric evaluation.
+
+        - `data_path: [ResourcePath]` The path to the data for the metric evaluation which can be a local file, local folder, or data hosted on AML Datastore.
 
         - `batch_size: [int]` The batch size for the metric evaluation.
 

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Union
 from pydantic import validator
 
 from olive.common.config_utils import ConfigBase, ConfigParam, create_config_class
+from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 WARMUP_NUM = 10
 REPEAT_TEST_NUM = 20
@@ -18,6 +19,7 @@ _common_user_config = {
     "script_dir": ConfigParam(type_=Union[Path, str]),
     "user_script": ConfigParam(type_=Union[Path, str]),
     "data_dir": ConfigParam(type_=Union[Path, str]),
+    "data_path": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS),
     "batch_size": ConfigParam(type_=int, default_value=1),
     "input_names": ConfigParam(type_=List),
     "input_shapes": ConfigParam(type_=List),

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -8,7 +8,6 @@ from typing import Callable, List, Union
 from pydantic import validator
 
 from olive.common.config_utils import ConfigBase, ConfigParam, create_config_class
-from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 WARMUP_NUM = 10
 REPEAT_TEST_NUM = 20
@@ -19,7 +18,6 @@ _common_user_config = {
     "script_dir": ConfigParam(type_=Union[Path, str]),
     "user_script": ConfigParam(type_=Union[Path, str]),
     "data_dir": ConfigParam(type_=Union[Path, str]),
-    "data_path": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS),
     "batch_size": ConfigParam(type_=int, default_value=1),
     "input_names": ConfigParam(type_=List),
     "input_shapes": ConfigParam(type_=List),

--- a/olive/model.py
+++ b/olive/model.py
@@ -32,7 +32,13 @@ from olive.hf_utils import (
     load_huggingface_model_from_model_class,
     load_huggingface_model_from_task,
 )
-from olive.resource_path import ResourcePath, ResourcePathConfig, ResourceType, create_resource_path
+from olive.resource_path import (
+    OLIVE_RESOURCE_ANNOTATIONS,
+    ResourcePath,
+    ResourcePathConfig,
+    ResourceType,
+    create_resource_path,
+)
 from olive.snpe import SNPEDevice, SNPEInferenceSession, SNPESessionOptions
 from olive.snpe.tools.dev import get_dlc_metrics
 
@@ -56,7 +62,7 @@ class OliveModel(ABC):
         self,
         framework: Framework,
         model_file_format: ModelFileFormat,
-        model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]] = None,
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
     ):
         self.framework = framework
         self.model_file_format = model_file_format
@@ -259,7 +265,7 @@ class ONNXModelBase(OliveModel):
 
     def __init__(
         self,
-        model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]] = None,
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         inference_settings: Optional[dict] = None,
         use_ort_extensions: bool = False,
     ):
@@ -300,7 +306,7 @@ class ONNXModelBase(OliveModel):
 class ONNXModel(ONNXModelBase):
     def __init__(
         self,
-        model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]] = None,
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         onnx_file_name: Optional[str] = None,
         inference_settings: Optional[dict] = None,
         use_ort_extensions: bool = False,
@@ -539,7 +545,7 @@ class ONNXModel(ONNXModelBase):
 class PyTorchModel(OliveModel):
     def __init__(
         self,
-        model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]] = None,
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         model_file_format: ModelFileFormat = ModelFileFormat.PYTORCH_ENTIRE_MODEL,
         model_loader: Union[str, Callable] = None,
         model_script: Union[str, Path] = None,
@@ -725,9 +731,7 @@ class PyTorchModel(OliveModel):
 
 
 class OptimumModel(OliveModel):
-    def __init__(
-        self, model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]], model_components: List[str]
-    ):
+    def __init__(self, model_path: OLIVE_RESOURCE_ANNOTATIONS, model_components: List[str]):
         super().__init__(
             framework=Framework.PYTORCH,
             model_file_format=ModelFileFormat.OPTIMUM,
@@ -754,7 +758,7 @@ class SNPEModel(OliveModel):
         input_shapes: List[List[int]],
         output_names: List[str],
         output_shapes: List[List[int]],
-        model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]] = None,
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
     ):
         super().__init__(framework=Framework.SNPE, model_file_format=ModelFileFormat.SNPE_DLC, model_path=model_path)
         self.io_config = {
@@ -792,7 +796,7 @@ class SNPEModel(OliveModel):
 class TensorFlowModel(OliveModel):
     def __init__(
         self,
-        model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]] = None,
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         model_file_format: ModelFileFormat = ModelFileFormat.TENSORFLOW_SAVED_MODEL,
     ):
         super().__init__(model_path=model_path, framework=Framework.TENSORFLOW, model_file_format=model_file_format)
@@ -811,7 +815,7 @@ class TensorFlowModel(OliveModel):
 
 
 class OpenVINOModel(OliveModel):
-    def __init__(self, model_path: Optional[Union[Path, str, ResourcePath, ResourcePathConfig]]):
+    def __init__(self, model_path: OLIVE_RESOURCE_ANNOTATIONS):
         super().__init__(
             model_path=model_path, framework=Framework.OPENVINO, model_file_format=ModelFileFormat.OPENVINO_IR
         )

--- a/test/integ_test/aml_resource_path/test_aml_resource_path.py
+++ b/test/integ_test/aml_resource_path/test_aml_resource_path.py
@@ -25,7 +25,7 @@ class TestAMLResourcePath:
                 "config": {"azureml_client": workspace_config, "name": "olive_model", "version": 1},
             },
             ResourceType.AzureMLDatastore: {
-                "type": ResourceType.AzureMLDatastore,
+                "type": ResourceType.AzureMLModelDatastore,
                 "config": {
                     "azureml_client": workspace_config,
                     "datastore_name": "workspaceblobstore",


### PR DESCRIPTION
## Describe your changes
1. Replace the `aml_client.models.dwonload` with azureml fsspec for Datastore resource download
2. Add the interface to let user directly input datastore url without aml client preparation.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
