### PR TITLE
Models with required model_path and resource type check. DistributedONNXModel resource

### DIFF
--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -81,6 +81,8 @@ def create_onnx_model_file():
 
 
 def get_onnx_model():
+    if not os.path.exists(ONNX_MODEL_PATH):
+        create_onnx_model_file()
     return ONNXModel(model_path=str(ONNX_MODEL_PATH))
 
 


### PR DESCRIPTION
## Describe your changes
The `__init__` signatures of some olive models are updated to make `model_path` required. Also added some checks for supported model resource types. 

DistributedONNXModel has been updated to refactor how the model file paths are specified. In order to make uploading/mounting distributed onnx models to docker or aml systems, the parent directory is specified using `model_path`. The rank files are specified using `model_file_names` which are strings for file name/path relative to `model_path`. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
