### PR TITLE
Register custom data config components using user script

### DIFF
--- a/examples/snpe/inception_snpe_qualcomm_npu/inception_config.json
+++ b/examples/snpe/inception_snpe_qualcomm_npu/inception_config.json
@@ -9,6 +9,12 @@
         "raw_data": {
             "name": "raw_data",
             "type": "RawDataContainer",
+            "user_script": "user_script.py",
+            "components": {
+                "post_process_data": {
+                    "type": "inception_post_process"
+                }
+            },
             "params_config": {
                 "data_dir": "data",
                 "input_names": ["input"],
@@ -29,8 +35,6 @@
                         {"name": "accuracy_score", "priority": 1}
                     ],
                     "user_config":{
-                        "user_script": "user_script.py",
-                        "post_processing_func": "post_process",
                         "inference_settings": {
                             "snpe": {
                                 "return_numpy_results": true

--- a/examples/snpe/inception_snpe_qualcomm_npu/user_script.py
+++ b/examples/snpe/inception_snpe_qualcomm_npu/user_script.py
@@ -2,8 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from olive.data.registry import Registry
 
 
-# TODO: Support registering custom components for data config
-def post_process(output):
+@Registry.register_post_process()
+def inception_post_process(output):
     return output["results"]["InceptionV3/Predictions/Reshape_1:0"].squeeze(1).argmax(axis=1)

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -3,9 +3,11 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-from typing import TYPE_CHECKING, Dict
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Union
 
 from olive.common.config_utils import ConfigBase
+from olive.common.user_module_loader import UserModuleLoader
 from olive.data.constants import DataComponentType, DefaultDataComponent, DefaultDataContainer
 from olive.data.registry import Registry
 
@@ -36,6 +38,10 @@ class DataConfig(ConfigBase):
     # used to store the params for each component
     params_config: Dict = None
 
+    # user script to define and register the components
+    user_script: Union[Path, str] = None
+    script_dir: Union[Path, str] = None
+
     # use to update default components
     # 1. update default_components_type from DataContainer or DefaultDataComponentCombos
     # 2. update default_components from default_components_type
@@ -46,6 +52,8 @@ class DataConfig(ConfigBase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        # call UserModuleLoader to load the user script once and register the components
+        UserModuleLoader(self.user_script, self.script_dir)
         self.update_components()
         self.fill_in_params()
 


### PR DESCRIPTION
## Describe your changes
Add `user_script` and `script_dir` to `DataConfig` and load the user script during initialization so that the custom components are registered. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
