### PR TITLE
Rethrow ImportError, Fix example tests output check, Update bert and whisper requirements

### DIFF
--- a/examples/bert/conda.yaml
+++ b/examples/bert/conda.yaml
@@ -11,5 +11,4 @@ dependencies:
       - scipy
       - scikit-learn
       - transformers
-      - onnxconverter_common
       - git+https://github.com/microsoft/Olive.git

--- a/examples/bert/docker/Dockerfile
+++ b/examples/bert/docker/Dockerfile
@@ -5,7 +5,6 @@ RUN pip install onnxruntime \
             evaluate \
             scikit-learn \
             transformers \
-            onnxconverter_common \
             git+https://github.com/microsoft/Olive.git
 
 WORKDIR /olive

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -8,6 +8,7 @@ import os
 
 def check_search_output(footprints):
     """Check if the search output is valid."""
+    assert footprints, "footprints is empty. The search must have failed for all accelerator specs."
     for footprint in footprints.values():
         assert footprint.nodes
         for v in footprint.nodes.values():
@@ -15,6 +16,7 @@ def check_search_output(footprints):
 
 
 def check_no_search_output(outputs):
+    assert outputs, "outputs is empty. The run must have failed for all accelerator specs."
     for output in outputs.values():
         output_metrics = output["metrics"]
         for item in output_metrics.values():

--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -18,37 +18,9 @@ Outputs the final model and latency results.
 Refer to the instructions in the [examples README](../README.md) to clone the repository and install Olive.
 
 ### Pip requirements
-This example requires the latest code from onnxruntime-extensions which are not available in the stable releases yet.
-So, we will install the nightly version.
-
-On Linux:
-```bash
-# Install requirements
-python -m pip install -r requirements.txt
-# Install nightly version of onnxruntime-extensions
-python -m pip uninstall -y onnxruntime-extensions
-export OCOS_NO_OPENCV=1
-python -m pip install git+https://github.com/microsoft/onnxruntime-extensions.git
+Install the necessary python packages:
 ```
-
-On Windows (cmd):
-```cmd
-:: Install requirements
 python -m pip install -r requirements.txt
-:: Install nightly version of onnxruntime-extensions
-python -m pip uninstall -y onnxruntime-extensions
-python -m pip install onnxruntime-extensions==0.8.0.306180 ^
-    --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-```
-
-On Windows (PowerShell):
-```powershell
-# Install requirements
-python -m pip install -r requirements.txt
-# Install nightly version of onnxruntime-extensions
-python -m pip uninstall -y onnxruntime-extensions
-python -m pip install onnxruntime-extensions==0.8.0.306180 `
-    --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 ```
 
 ### Prepare workflow config json

--- a/examples/whisper/requirements.txt
+++ b/examples/whisper/requirements.txt
@@ -1,4 +1,5 @@
 onnx==1.13.1
 onnxruntime==1.15.0
+onnxruntime-extensions>=0.8.0
 torch>=1.13.1
 transformers>=4.23.1

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -46,7 +46,9 @@ def main(raw_args=None):
     config = json.load(open(args.config, "r"))
 
     # load output model json
-    output_model_json_path = Path(config["engine"]["output_dir"]) / f"{config['engine']['output_name']}_model.json"
+    output_model_json_path = (
+        Path(config["engine"]["output_dir"]) / f"{config['engine']['output_name']}_cpu-cpu_model.json"
+    )
     output_model_json = json.load(open(output_model_json_path, "r"))
 
     # load output model onnx
@@ -77,8 +79,9 @@ def main(raw_args=None):
         np.asarray([1.0], dtype=np.float32),
         np.zeros((1, N_MELS, N_FRAMES)).astype(np.int32),
     )
-    print(output_text)
+    return output_text[0]
 
 
 if __name__ == "__main__":
-    main()
+    output_text = main()
+    print(output_text)

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -28,6 +28,8 @@ from olive.systems.olive_system import OliveSystem
 
 logger = logging.getLogger(__name__)
 
+EXCEPTIONS_TO_RAISE = (AttributeError, ImportError, TypeError, ValueError)
+
 
 class Engine:
     """
@@ -312,7 +314,7 @@ class Engine:
                     outputs[accelerator_spec] = footprint
                     pf_footprints[accelerator_spec] = footprint
 
-            except (ValueError, TypeError, AttributeError):
+            except EXCEPTIONS_TO_RAISE:
                 raise
             except Exception as e:
                 logger.warning(f"Failed to run Olive on {accelerator_spec}: {e}", exc_info=True)
@@ -863,7 +865,7 @@ class Engine:
                 input_model = self._prepare_non_local_model(input_model)
             try:
                 output_model = host.run_pass(p, input_model, output_model_path, pass_search_point)
-            except (ValueError, TypeError, AttributeError):
+            except EXCEPTIONS_TO_RAISE:
                 # Don't catch these errors since most of time, it is caused by the user errors and need not retry.
                 raise
             except Exception:

--- a/scripts/test_examples.bat
+++ b/scripts/test_examples.bat
@@ -20,11 +20,6 @@ rem test samples
 call echo "Testing examples"
 call python -m pip install -r %ROOT_DIR%\\examples\\%EXAMPLE_FOLDER%\\requirements.txt || goto :error
 
-rem TODO: need to remove later
-if "%EXAMPLE%"=="whisper" (
-    call :whisper-setup || goto :error
-)
-
 call python -m pytest -v -s --log-cli-level=WARNING --junitxml=%ROOT_DIR%\\logs\\test_examples-TestOlive.xml^
  %ROOT_DIR%\\examples\\test\\test_%EXAMPLE_NAME%.py || goto :error
 
@@ -33,8 +28,3 @@ goto :EOF
 :error
 echo Failed with error #%errorlevel%.
 exit /b %errorlevel%
-
-:whisper-setup
-call echo "Installing custom packages for whisper"
-call python -m pip uninstall -y onnxruntime-extensions || goto :error
-call python -m pip install onnxruntime-extensions==0.8.0.306180 --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/  || goto :error

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -23,12 +23,4 @@ python -m pip install pytest
 echo "Testing examples"
 python -m pip install -r $ROOT_DIR/examples/$EXAMPLE_FOLDER/requirements.txt
 
-# TODO: need to remove later
-echo "Installing custom packages for whisper"
-if [[ "$EXAMPLE" == "whisper" ]]; then
-    python -m pip uninstall -y onnxruntime-extensions
-    export OCOS_NO_OPENCV=1
-    python -m pip install git+https://github.com/microsoft/onnxruntime-extensions.git
-fi
-
 python -m pytest -v -s --log-cli-level=WARNING --junitxml=$ROOT_DIR/logs/test_examples-TestOlive.xml $ROOT_DIR/examples/test/test_$EXAMPLE_NAME.py

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -7,7 +7,8 @@ set -eoux pipefail
 
 PIPELINE=$1
 ROOT_DIR=$2
-EXAMPLE=$3
+EXAMPLE_FOLDER=$3
+EXAMPLE_NAME=$4
 
 echo $PIPELINE
 if [[ "$PIPELINE" == "True" ]]; then


### PR DESCRIPTION
## Describe your changes
Add ImportError to list of exceptions to rethrow.  

Fix the output check for example tests. We need to check that `footprints` is not empty. Otherwise, we don't catch failed engine runs that just return empty footprints dict. 

Updated the docker and azureml requirements so that the tests are not broken anymore. 
Updated the whisper example requirement to use onnxruntime-extensions directly from pypi. Test is also updated to run `test_transcription` script also. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
