### PR TITLE
🐛 Remove weight/activation limitation on onnx quantization

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -288,10 +288,7 @@ class OnnxQuantization(Pass):
                 and config["activation_type"] == "QInt8"
                 and config["quant_format"] == "QOperator"
             ):
-                logger.info("QOperator is not supported for QInt8 activation and weight.")
-                return False
-            if config["weight_type"] != config["activation_type"]:
-                logger.info("Weight type and activation type must be the same.")
+                logger.info("S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general")
                 return False
             if config["EnableSubgraph"] is True:
                 logger.info("EnabaleSubgraph is not supported for static quantization.")


### PR DESCRIPTION
## Describe your changes
Remove weight/activation limitation on onnx quantization. Also test S8U8, worked for resnet static case.
https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
