### PR TITLE
Add option to save intermediate models in no-search, Fix snpe win target arch name

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -303,6 +303,10 @@ will be used.
 
 - `clean_run_cache: [Boolean]` This decides whether to clean the run cache of the pass before running the pass. This is `false` by default.
 
+- `output_name: str` In no-search mode (i.e., `search_strategy` is `null`), if `output_name` is provided, the output model of the pass will be
+saved to the engine's `output_dir` with the prefix of `output_name`. For the final pass, the engine's `output_name`, if provided, overrides the
+`output_name` of the pass.
+
 Please refer to [Configuring Pass](configuring_pass) for more details on `type`, `disable_search` and `config`.
 
 Please also find the detailed options from following table for each pass:

--- a/examples/snpe/vgg_snpe_qualcomm_npu/vgg_config.json
+++ b/examples/snpe/vgg_snpe_qualcomm_npu/vgg_config.json
@@ -26,20 +26,21 @@
                 "input_names": ["data"],
                 "input_shapes": [[1, 3, 224, 224]],
                 "output_names": ["vgg0_dense2_fwd"]
-            }
+            },
+            "output_name": "vgg_snpe"
         },
         "snpe_quantization": {
             "type": "SNPEQuantization",
             "config": {
                 "enable_htp": true,
                 "data_config": "raw_data"
-            }
+            },
+            "output_name": "vgg_snpe_quantized"
         }
     },
     "engine": {
         "search_strategy": false,
         "cache_dir": "cache",
-        "output_dir" : "outputs",
-        "output_name": "snpe_quantized"
+        "output_dir" : "outputs"
     }
 }

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -190,6 +190,7 @@ class Engine:
         host: OliveSystem = None,
         evaluator_config: OliveEvaluatorConfig = None,
         clean_run_cache: bool = False,
+        output_name: str = None,
     ):
         """Register a pass configuration so that it could be instantiated and executed later."""
         if name is not None:
@@ -211,6 +212,7 @@ class Engine:
             "host": host,
             "evaluator": evaluator_config,
             "clean_run_cache": clean_run_cache,
+            "output_name": output_name,
         }
 
     def register_pass(
@@ -219,6 +221,7 @@ class Engine:
         name: str = None,
         host: OliveSystem = None,
         evaluator_config: OliveEvaluatorConfig = None,
+        output_name: str = None,
     ):
         """
         Register a pass
@@ -237,11 +240,14 @@ class Engine:
 
         if self.no_search and len(p.search_space()) > 0:
             raise ValueError(f"Search strategy is None but pass {name} has search space")
+        if output_name and not self.no_search:
+            logger.debug(f"output_name {output_name} for pass {name} is ignored because search strategy is not None")
 
         self.passes[name] = {
             "pass": p,
             "host": host,
             "evaluator": evaluator_config,
+            "output_name": output_name,
         }
 
     def run(
@@ -340,7 +346,9 @@ class Engine:
             pass_cfg = config["config"]
             pass_cfg = pass_cls.generate_search_space(accelerator_spec, pass_cfg, config["disable_search"])
             p = pass_cls(accelerator_spec, pass_cfg, config["disable_search"])
-            self.register_pass(p, host=config["host"], evaluator_config=config["evaluator"])
+            self.register_pass(
+                p, host=config["host"], evaluator_config=config["evaluator"], output_name=config["output_name"]
+            )
 
         # list of passes starting from the first pass with non-empty search space
         # These passes will be added to the search space
@@ -393,21 +401,33 @@ class Engine:
             signal,
             model_ids,
         ) = self._run_passes(next_step["passes"], model, model_id, accelerator_spec)
-        model_id = model_ids[-1]
+        # names of the output models of the passes
+        pass_output_names = [self.passes[pass_name]["output_name"] for pass_name, _ in next_step["passes"]]
+        pass_output_names = [f"{name}_{accelerator_spec}" if name else None for name in pass_output_names]
 
-        prefix_output_name = f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}_"
-        # save the model to output_dir
-        output_model_name = f"{prefix_output_name}model"
-        output_model_json = cache_utils.save_model(
-            model_number=model_id,
-            output_dir=output_dir,
-            output_name=output_model_name,
-            overwrite=True,
-            cache_dir=self._config.cache_dir,
-        )
+        final_output_name = pass_output_names[-1]
+        if output_name:
+            # override the output name of the last pass
+            logger.debug("Engine output_name is provided. Will ignore output_name for final pass")
+            final_output_name = f"{output_name}_{accelerator_spec}"
+        elif not final_output_name:
+            # use the default output name
+            final_output_name = str(accelerator_spec)
+        pass_output_names[-1] = final_output_name
+
+        for pass_output_name, pass_output_model_id in zip(pass_output_names, model_ids):
+            if not pass_output_name:
+                continue
+            output_model_json = cache_utils.save_model(
+                model_number=pass_output_model_id,
+                output_dir=output_dir,
+                output_name=f"{pass_output_name}_model",
+                overwrite=True,
+                cache_dir=self._config.cache_dir,
+            )
 
         # save the evaluation results to output_dir
-        result_name = f"{prefix_output_name}metrics"
+        result_name = f"{final_output_name}_metrics"
         results_path = output_dir / f"{result_name}.json"
         if signal is not None:
             with open(results_path, "w") as f:

--- a/olive/snpe/configure.py
+++ b/olive/snpe/configure.py
@@ -8,7 +8,7 @@ from importlib import resources
 from pathlib import Path
 
 from olive.common.utils import run_subprocess
-from olive.snpe.utils.local import get_snpe_arm_win_arch_name, get_snpe_root, get_snpe_target_arch
+from olive.snpe.utils.local import get_snpe_root, get_snpe_target_arch, get_snpe_win_arch_name
 
 logger = logging.getLogger("olive.snpe.configure")
 
@@ -35,7 +35,7 @@ def eval():
         return
 
     snpe_root = get_snpe_root()
-    target_arch_name = get_snpe_arm_win_arch_name(snpe_root)
+    target_arch_name = get_snpe_win_arch_name(snpe_root, snpe_arch)
 
     logger.info(f"Configuring SNPE for {snpe_arch}...")
 

--- a/olive/snpe/tools/inference.py
+++ b/olive/snpe/tools/inference.py
@@ -236,17 +236,24 @@ def snpe_net_run(
         inferences_per_duration = 0 if inferences_per_duration is None else inferences_per_duration
         input_id = f"result_{result_idx}" if inferences_per_duration > 0 else input_ids[result_idx]
         for output_name, output_shape in zip(output_names, output_shapes):
-            raw_file = member / f"{output_name}{delimiter}0.raw"
-            if not raw_file.exists():
-                raw_file = member / f"{output_name}.raw"
-
+            # output names for dlcs converted from tensorflow models contain ":"
+            # try adding `:0` or `_0` to output file name in case original model was tensorflow and
+            # user provided original output names
+            output_file_name = f"{output_name}{delimiter}0.raw"
+            if not (member / output_file_name).exists():
+                # `:0` is already in the output name or source model was not tensorflow
+                output_file_name = f"{output_name}.raw"
+            if platform.system() == "Windows":
+                # replace ":" with "_" in the file name.
+                output_file_name = output_file_name.replace(":", "_")
+            raw_file = member / output_file_name
+            
             # copy the raw file to the workspace and rename it
             if output_dir is not None:
                 output_file = output_dir / f"{input_id}.{output_name}.raw"
                 if platform.system() == "Windows":
                     # replace ":" with "_" in the file name.
-                    # output names for dlcs converted from tensorflow models contain ":"
-                    output_file = output_file.replace(":", "_")
+                    output_file = output_dir / f"{input_id}.{output_name}.raw".replace(":", "_")
                 if len(output_names) == 1:
                     # no need to encode the output name in the file name
                     output_file = output_dir / f"{input_id}.raw"

--- a/olive/snpe/tools/inference.py
+++ b/olive/snpe/tools/inference.py
@@ -247,7 +247,7 @@ def snpe_net_run(
                 # replace ":" with "_" in the file name.
                 output_file_name = output_file_name.replace(":", "_")
             raw_file = member / output_file_name
-            
+
             # copy the raw file to the workspace and rename it
             if output_dir is not None:
                 output_file = output_dir / f"{input_id}.{output_name}.raw"

--- a/olive/snpe/utils/local.py
+++ b/olive/snpe/utils/local.py
@@ -50,21 +50,25 @@ def get_snpe_target_arch(fail_on_unsupported: bool = True) -> str:
     return snpe_target_arch
 
 
-def get_snpe_arm_win_arch_name(snpe_root: str) -> str:
+def get_snpe_win_arch_name(snpe_root: str, snpe_target_arch: str) -> str:
     """
     Get the SNPE ARM64-Windows architecture name from the SNPE root directory.
 
     snpe_root: The unzipped SNPE SDK directory
+    snpe_target_arch: The SNPE target architecture
     """
     if not Path(snpe_root).exists():
         raise FileNotFoundError(f"Path {snpe_root} does not exist")
 
-    arm_windows_archs = list(Path(snpe_root).glob("lib/aarch64-windows-*"))
+    prefix_map = {"x64-Windows": "x86_64-windows-", "ARM64-Windows": "aarch64-windows-"}
+    prefix = prefix_map[snpe_target_arch]
+
+    arm_windows_archs = list(Path(snpe_root).glob(f"lib/{prefix}*"))
     if len(arm_windows_archs) == 0:
-        raise FileNotFoundError(f"SNPE_ROOT {snpe_root} missing aarch64-windows-*")
+        raise FileNotFoundError(f"SNPE_ROOT {snpe_root} missing {prefix}*")
 
     arm_windows_arch = arm_windows_archs[0].name
-    logger.debug(f"SNPE ARM64-Windows arch name: {arm_windows_arch}")
+    logger.debug(f"SNPE {snpe_target_arch} arch name: {arm_windows_arch}")
 
     return arm_windows_arch
 
@@ -78,8 +82,8 @@ def get_snpe_env(dev: bool = False) -> dict:
     snpe_root = get_snpe_root()
     target_arch_mapping = {
         "x64-Linux": "x86_64-linux-clang",
-        "x64-Windows": "x86_64-windows-vc19",
-        "ARM64-Windows": get_snpe_arm_win_arch_name(snpe_root),
+        "x64-Windows": get_snpe_win_arch_name(snpe_root, "x64-Windows"),
+        "ARM64-Windows": get_snpe_win_arch_name(snpe_root, "ARM64-Windows"),
     }
     target_arch = get_snpe_target_arch()
     target_arch_name = target_arch_mapping[target_arch]

--- a/olive/snpe/utils/local.py
+++ b/olive/snpe/utils/local.py
@@ -80,13 +80,11 @@ def get_snpe_env(dev: bool = False) -> dict:
     dev: Whether to use the SNPE development environment. Only supported on x64-Linux
     """
     snpe_root = get_snpe_root()
-    target_arch_mapping = {
-        "x64-Linux": "x86_64-linux-clang",
-        "x64-Windows": get_snpe_win_arch_name(snpe_root, "x64-Windows"),
-        "ARM64-Windows": get_snpe_win_arch_name(snpe_root, "ARM64-Windows"),
-    }
     target_arch = get_snpe_target_arch()
-    target_arch_name = target_arch_mapping[target_arch]
+    if "Linux" in target_arch:
+        target_arch_name = "x86_64-linux-clang"
+    else:
+        target_arch_name = get_snpe_win_arch_name(snpe_root, target_arch)
 
     if dev and target_arch != "x64-Linux":
         raise ValueError("SNPE development environment is only supported on x64-Linux")

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -25,6 +25,7 @@ class RunPassConfig(FullPassConfig):
     host: SystemConfig = None
     evaluator: OliveEvaluatorConfig = None
     clean_run_cache: bool = False
+    output_name: str = None
 
 
 class RunEngineConfig(EngineConfig):

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -159,6 +159,7 @@ def run(config: Union[str, Path, dict], setup: bool = False):
                 host=host,
                 evaluator_config=pass_config.evaluator,
                 clean_run_cache=pass_config.clean_run_cache,
+                output_name=pass_config.output_name,
             )
 
         # run


### PR DESCRIPTION
## Describe your changes
Add `output_name` option to `PassRunConfig` so that output models from intermediate passes can also be saved in no-search mode. The engine's `output_name`, if provided, takes precedence over the final pass' `output_name`. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
