### PR TITLE
Whisper: Fix WhisperConfig init, Remove encoder_attention_mask

### DIFF
--- a/examples/whisper/code/user_script.py
+++ b/examples/whisper/code/user_script.py
@@ -38,13 +38,13 @@ def get_encdec_io_config():
         use_int32_inputs=True,
     )
 
-    out = model(inputs.encoder_input_ids, inputs.encoder_attention_mask, inputs.decoder_input_ids)
+    out = model(inputs.encoder_input_ids, inputs.decoder_input_ids)
     present = out[2]
     present_names = PastKeyValuesHelper.get_input_names(present, encoder=True)
 
     output_names = ["logits", "encoder_hidden_states", *present_names]
 
-    input_names = ["encoder_input_ids", "encoder_attention_mask"]
+    input_names = ["encoder_input_ids"]
 
     # ONNX exporter might mark dimension like 'Transposepresent_value_self_1_dim_2' in shape inference.
     # We use a workaround here: first use dim_param "1" for sequence_length, and later change to dim_value.
@@ -54,7 +54,6 @@ def get_encdec_io_config():
     head_size = str(model.config.d_model // model.config.encoder_attention_heads)
     dynamic_axes = {
         "encoder_input_ids": {0: "batch_size", 1: "encode_sequence_length"},
-        "encoder_attention_mask": {0: "batch_size", 1: "encode_sequence_length"},
         "encoder_hidden_states": {
             0: "batch_size",
             1: "encode_sequence_length",
@@ -111,12 +110,10 @@ def get_dec_io_config():
     output_names = ["logits", *output_present_names]
 
     input_names = ["input_ids"]
-    input_names.append("encoder_attention_mask")
     input_names.extend(input_past_names)
 
     dynamic_axes = {
         "input_ids": {0: "batch_size"},
-        "encoder_attention_mask": {0: "batch_size", 1: "encode_sequence_length"},
         "encoder_hidden_states": {0: "batch_size", 1: "encode_sequence_length / 2"},
         "logits": {0: "batch_size", 1: "sequence_length"},
     }

--- a/examples/whisper/code/whisper_decoder.py
+++ b/examples/whisper/code/whisper_decoder.py
@@ -7,7 +7,6 @@ from typing import List, Union
 import torch
 from past_helper import PastKeyValuesHelper  # noqa: E402
 from transformers import WhisperConfig, file_utils
-from whisper_encoder import WhisperEncoderInputs
 
 
 class WhisperDecoderInit(torch.nn.Module):
@@ -33,7 +32,6 @@ class WhisperDecoderInit(torch.nn.Module):
     def forward(
         self,
         decoder_input_ids: torch.Tensor,
-        encoder_attention_mask: torch.Tensor,
         encoder_hidden_states: torch.FloatTensor,
     ):
         encoder_outputs = file_utils.ModelOutput()
@@ -45,7 +43,6 @@ class WhisperDecoderInit(torch.nn.Module):
             None,
             encoder_outputs=encoder_outputs,
             decoder_input_ids=decoder_input_ids,
-            head_mask=encoder_attention_mask,
             past_key_values=None,
             use_cache=True,
             return_dict=True,
@@ -63,7 +60,7 @@ class WhisperDecoder(torch.nn.Module):
         self.lm_head = lm_head
         self.config = config
 
-    def forward(self, decoder_input_ids, encoder_attention_mask, *past):
+    def forward(self, decoder_input_ids, *past):
         encoder_outputs = file_utils.ModelOutput()
         dummy_encoder_hidden_states = torch.randn((decoder_input_ids.shape[0], 3000, int(self.config.d_model)))
         encoder_outputs["last_hidden_state"] = dummy_encoder_hidden_states
@@ -78,7 +75,6 @@ class WhisperDecoder(torch.nn.Module):
             None,
             encoder_outputs=encoder_outputs,
             decoder_input_ids=decoder_input_ids,
-            # decoder_attention_mask=encoder_attention_mask,
             past_key_values=past_key_values,
             use_cache=True,
             return_dict=True,
@@ -92,11 +88,9 @@ class WhisperDecoderInputs:
     def __init__(
         self,
         decoder_input_ids,
-        encoder_attention_mask=None,
         past_key_values=None,
     ):
         self.decoder_input_ids: torch.LongTensor = decoder_input_ids
-        self.encoder_attention_mask: torch.LongTensor = encoder_attention_mask
         self.past_key_values: Union[List[torch.FloatTensor], List[torch.HalfTensor], None] = past_key_values
 
     @staticmethod
@@ -140,14 +134,6 @@ class WhisperDecoderInputs:
             device=device,
         )
 
-        encoder_inputs = WhisperEncoderInputs.create_dummy(
-            batch_size,
-            encode_sequence_length,
-            vocab_size,
-            device,
-            use_int32_inputs=use_int32_inputs,
-        )
-
         float_type = torch.float16 if float16 else torch.float32
 
         if past_decode_sequence_length > 0:
@@ -173,16 +159,10 @@ class WhisperDecoderInputs:
         else:
             past = None
 
-        encoder_attention_mask = torch.zeros(
-            (encoder_inputs.input_ids.shape[0], 1, encoder_inputs.input_ids.shape[1], encoder_inputs.input_ids.shape[1])
-        ).type(torch.int8)
-        return WhisperDecoderInputs(decoder_input_ids, encoder_attention_mask, past)
+        return WhisperDecoderInputs(decoder_input_ids, past)
 
     def to_list(self) -> List:
-        input_list = [
-            self.decoder_input_ids,
-            self.encoder_attention_mask,
-        ]
+        input_list = [self.decoder_input_ids]
         if self.past_key_values:
             input_list.extend(self.past_key_values)
         return input_list
@@ -191,6 +171,5 @@ class WhisperDecoderInputs:
         past = [p.to(dtype=torch.float32) for p in self.past_key_values] if self.past_key_values else None
         return WhisperDecoderInputs(
             self.decoder_input_ids.clone(),
-            self.encoder_attention_mask.clone(),
             past,
         )

--- a/examples/whisper/code/whisper_encoder.py
+++ b/examples/whisper/code/whisper_encoder.py
@@ -16,12 +16,12 @@ class WhisperEncoder(torch.nn.Module):
         self.encoder = encoder
         self.config = config
 
-    def forward(self, input_features, attention_mask):
+    def forward(self, input_features):
         return self.encoder.model.encoder(input_features)[0]
 
 
 class WhisperEncoderInputs:
-    def __init__(self, input_features, attention_mask):
+    def __init__(self, input_features):
         self.input_ids: torch.LongTensor = input_features
         # HF Whisper model doesn't support Attention Mask functionality
 
@@ -40,14 +40,12 @@ class WhisperEncoderInputs:
         Returns:
             WhisperEncoderInputs: dummy inputs for encoder
         """
-        dtype = torch.float32
 
         input_features = torch.randn(
             size=(batch_size, feature_size, sequence_length),
             device=device,
         )
-        attention_mask = torch.ones([batch_size, feature_size, sequence_length], dtype=dtype, device=device)
-        return WhisperEncoderInputs(input_features, attention_mask)
+        return WhisperEncoderInputs(input_features)
 
     def to_list(self) -> List:
         if self.input_features is None:

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -35,7 +35,7 @@ def main(raw_args=None):
     # load template
     template_json = json.load(open("whisper_template.json", "r"))
 
-    whisper_config = WhisperConfig(template_json["input_model"]["config"]["hf_config"]["model_name"])
+    whisper_config = WhisperConfig.from_pretrained(template_json["input_model"]["config"]["hf_config"]["model_name"])
 
     # set dataloader
     template_json["evaluators"]["common_evaluator"]["metrics"][0]["user_config"]["dataloader_func"] = (

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -133,6 +133,7 @@ def model_proto_to_olive_model(
     :param external_data_config: The external data configuration. Must be a dictionary with keys
         "save_as_external_data", "all_tensors_to_one_file", and "external_data_name".
     :param name: The name of the model.
+    :check_model: If True, run onnx.checker.check_model on the model before returning.
 
     :return: The ONNXModel.
     """

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -120,7 +120,10 @@ def model_proto_to_file(
 
 
 def model_proto_to_olive_model(
-    model_proto: onnx.ModelProto, output_model_path: Union[str, Path], external_data_config: dict
+    model_proto: onnx.ModelProto,
+    output_model_path: Union[str, Path],
+    external_data_config: dict,
+    check_model: bool = False,
 ) -> ONNXModel:
     """
     Save the ONNX model to the specified path and return the ONNXModel.
@@ -148,4 +151,9 @@ def model_proto_to_olive_model(
         model_path = LocalFile({"path": output_model_path})
         onnx_file_name = None
 
-    return ONNXModel(model_path=model_path, onnx_file_name=onnx_file_name)
+    olive_model = ONNXModel(model_path=model_path, onnx_file_name=onnx_file_name)
+
+    if check_model:
+        onnx.checker.check_model(olive_model.model_path)
+
+    return olive_model

--- a/olive/passes/onnx/insert_beam_search.py
+++ b/olive/passes/onnx/insert_beam_search.py
@@ -160,5 +160,4 @@ class InsertBeamSearch(Pass):
 
         # save the model to the output path and return the model
         output_model_path = ONNXModel.resolve_path(output_model_path)
-
         return model_proto_to_olive_model(combined_model, output_model_path, config, True)

--- a/olive/passes/onnx/insert_beam_search.py
+++ b/olive/passes/onnx/insert_beam_search.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 from typing import Any, Dict
 
 from onnx import ModelProto, TensorProto, helper
@@ -12,6 +13,8 @@ from olive.model import CompositeOnnxModel, OliveModel, ONNXModel
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.pass_config import PassConfigParam
+
+logger = logging.getLogger(__name__)
 
 
 class InsertBeamSearch(Pass):
@@ -111,7 +114,16 @@ class InsertBeamSearch(Pass):
         ]
 
         beam_graph = helper.make_graph([node], "beam-search-test", graph_inputs, graph_outputs, initializers)
-        beam_model = helper.make_model(beam_graph, producer_name="pytorch", opset_imports=opset_import)
+        assert model_A.ir_version == model_B.ir_version
+        logger.debug(f"Using IR version {model_A.ir_version} for chained model")
+
+        # Set IR version of chained model to IR version of subgraphs in order to generate a working E2E model
+        beam_model = helper.make_model_gen_version(
+            beam_graph,
+            producer_name="Olive",
+            opset_imports=opset_import,
+            ir_version=model_A.ir_version,
+        )
 
         return beam_model
 
@@ -148,4 +160,5 @@ class InsertBeamSearch(Pass):
 
         # save the model to the output path and return the model
         output_model_path = ONNXModel.resolve_path(output_model_path)
-        return model_proto_to_olive_model(combined_model, output_model_path, config)
+
+        return model_proto_to_olive_model(combined_model, output_model_path, config, True)


### PR DESCRIPTION
## Describe your changes
Fix `prepare_whisper_configs.py` to create the correct `WhisperConfig` object. It was not picking up the correct model and made the fp32 configs incorrect. 

Also port over the changes from https://github.com/microsoft/onnxruntime/pull/15880 that removes the unnecessary `encoder_attention_mask` inputs for whisper components. 

Added an option in `model_proto_to_olive_model` to check the onnx model. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
