### PR TITLE
Revert "Docs: Comment out broken link (#376)"

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -97,10 +97,7 @@ case insensitive.
         - `config: [str]`: The config of the model can be provided as well. Such as `WhisperConfig`. See
         [huggingface configurations](https://huggingface.co/docs/transformers/main_classes/configuration)
 
-        <!-- TODO: Add the following after the link comes back online.  -->
-        <!-- See [huggingface datasets](https://huggingface.co/docs/datasets/loading).  -->
-        - `dataset: [dict]`: If you want to use the huggingface dataset, you need to provide the dataset config.
-        Olive exposes the following configs (which will be extended in the future):
+        - `dataset: [dict]`: If you want to use the huggingface dataset, you need to provide the dataset config. See [huggingface datasets](https://huggingface.co/docs/datasets/loading). Olive exposes the following configs(which will be extended in the future):
             ```python
             "dataset": {
                 "model_name": "distilbert-base-uncased",  # the model name of the huggingface model, if not provided, it will use the model_name in hf_config


### PR DESCRIPTION
This reverts commit 25c91b9279b59ffaa43b587fe880b90b00b6fb8a.
The link is back online. 

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
