### PR TITLE
Make Olive compatible with ORT 1.16.0 (nightly)

### DIFF
--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -38,8 +38,6 @@ python -m pip install librosa
 
 `--multiligual` is optional. If provided, the model produced will support multiple languages that are controlled using `decoder_input_ids` input.
 
-**Note:** Only supported in ONNXRuntime 1.16.0+ which is not released yet. Must be built from or after commit https://github.com/microsoft/onnxruntime/commit/4b69226fca914753844a3291818ce23ac2f00d8c.
-
 **Example of decoder_input_ids:**
 ```python
 import numpy as np
@@ -63,6 +61,14 @@ forced_decoder_ids = [config.decoder_start_token_id] + list(map(lambda token: to
 
 # decoder input ids
 decoder_input_ids = np.array([forced_decoder_ids], dtype=np.int32)
+```
+
+**Note:** `--multiligual` is only supported in ONNX Runtime 1.16.0+ which is not released yet. Must be built from or after commit https://github.com/microsoft/onnxruntime/commit/4b69226fca914753844a3291818ce23ac2f00d8c.
+
+Latest nightly build of ONNX Runtime can be installed using the following commands:
+```bash
+python -m pip uninstall -y onnxruntime
+python -m pip install ort-nightly --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 ```
 
 ## Run the config to optimize the model

--- a/examples/whisper/requirements.txt
+++ b/examples/whisper/requirements.txt
@@ -1,4 +1,4 @@
-onnx==1.13.1
+onnx==1.14.0
 onnxruntime>=1.15.0
 onnxruntime-extensions>=0.8.0
 torch>=1.13.1

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Union
 
 import onnx
+from packaging import version
 
 from olive.cache import get_local_path
 from olive.common.utils import hash_string
@@ -74,15 +75,6 @@ _onnx_quantization_config = {
             some models running on non-VNNI machine, especially for per-channel mode.
             Tips: When to use reduce_range and per-channel quantization:
             https://onnxruntime.ai/docs/performance/quantization.html#when-to-use-reduce-range-and-per-channel-quantization
-        """,
-    ),
-    "optimize_model": PassConfigParam(
-        type_=bool,
-        default_value=False,
-        searchable_values=Boolean(),
-        description="""
-            Deprecating Soon in ONNX! Optimize model before quantization. NOT recommended, optimization will
-            change the computation graph, making debugging of quantization loss difficult.
         """,
     ),
     "quant_preprocess": PassConfigParam(
@@ -297,6 +289,7 @@ class OnnxQuantization(Pass):
         return True
 
     def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+        from onnxruntime import __version__ as OrtVersion
         from onnxruntime.quantization import QuantFormat, QuantType, quantize_dynamic, quantize_static
         from onnxruntime.quantization.calibrate import CalibrationMethod
 
@@ -365,6 +358,12 @@ class OnnxQuantization(Pass):
         for key in to_delete:
             if key in run_config:
                 del run_config[key]
+
+        # for ORT version < 1.16.0, set optimize_model to False
+        # always set it to False since it is not recommended and is removed in ORT 1.16.0
+        # user needs to call pre-process to optimize the model, we already have pre-process option
+        if version.parse(OrtVersion) < version.parse("1.16.0"):
+            run_config["optimize_model"] = False
 
         # to be safe, run the quantizer with use_external_data_format set to `True` and
         # `model_output` to a temporary directory

--- a/olive/passes/onnx/vitis_ai/calibrate.py
+++ b/olive/passes/onnx/vitis_ai/calibrate.py
@@ -19,7 +19,7 @@ from onnxruntime.quantization.calibrate import (
     CalibrationDataReader,
     MinMaxCalibrater,
 )
-from onnxruntime.quantization.quant_utils import QuantType, clone_model_with_shape_infer
+from onnxruntime.quantization.quant_utils import QuantType
 
 from olive.passes.onnx.vitis_ai.quant_utils import PowerOfTwoMethod, quantize_data_pof2s
 
@@ -59,6 +59,10 @@ class PowOfTwoCalibrater(CalibraterBase):
         Make all quantization_candidates op type nodes as part of the graph output.
         :return: augmented ONNX model
         """
+        # not supported in ORT >= 1.16.0
+        # TODO: Update code to support different versions of ORT
+        from onnxruntime.quantization.quant_utils import clone_model_with_shape_infer
+
         model = clone_model_with_shape_infer(self.model)
 
         self.tensors_to_calibrate, value_infos = self.select_tensors_to_calibrate(model)
@@ -77,7 +81,6 @@ class PowOfTwoCalibrater(CalibraterBase):
         self.intermediate_outputs = []
 
     def collect_data(self, data_reader: CalibrationDataReader):
-
         while True:
             inputs = data_reader.get_next()
             if not inputs:
@@ -134,7 +137,6 @@ class PowOfTwoCollector(CalibrationDataCollector):
         )
 
     def collect(self, name_to_arr):
-
         self.name_to_arr = name_to_arr
 
         return
@@ -170,7 +172,6 @@ def create_calibrator_power_of_two(
     execution_providers=["CPUExecutionProvider"],
     extra_options={},
 ):
-
     calibrator = None
 
     # default settings for min-max algorithm

--- a/olive/passes/onnx/vitis_ai/quantize.py
+++ b/olive/passes/onnx/vitis_ai/quantize.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 
 from onnxruntime.quantization.calibrate import CalibrationDataReader, CalibrationMethod
-from onnxruntime.quantization.quant_utils import QuantFormat, QuantizationMode, QuantType, load_model
+from onnxruntime.quantization.quant_utils import QuantFormat, QuantizationMode, QuantType
 from onnxruntime.quantization.quantize import quantize_static as ort_quantize_static
 from onnxruntime.quantization.registry import QLinearOpsRegistry
 
@@ -165,6 +165,10 @@ def quantize_static(
 
     if not op_types_to_quantize or len(op_types_to_quantize) == 0:
         op_types_to_quantize = list(QLinearOpsRegistry.keys())
+
+    # not supported in ORT >= 1.16.0
+    # TODO: Update code to support different versions of ORT
+    from onnxruntime.quantization.quant_utils import load_model
 
     model = load_model(Path(model_input), optimize_model)
 


### PR DESCRIPTION
## Describe your changes
ORT main branch recently removed some functions in https://github.com/microsoft/onnxruntime/commit/89f8f20a61ceac0276c42d894c38400d86b175d0. 

For vitis ai code, the import of these functions is made lazy (only imported where needed). vitis ai code needs to be updated later to actually be compatible with ORT 1.16.0. Since this version of ORT is not released yet, it is not urgent. 

For onnx quantization passes, `optimize_model` config parameter is removed in ORT and we do the same. Using this option was already not recommended so I think it might be okay to remove it from Olive onnx quantization passes and always set it to `False` in older versions of ORT. As described in the code comments, we already have `quant_preprocess` which does the same optimization step as part of preprocessing. 
The commit above also says "This PR also remove the optimization from quantization. User needs to call pre-process to optimize the model". 

Whisper example requirements updated to `onnx==1.14.0` since the workflow fails for ORT nightly otherwise. ORT versions 1.15.0,1.15.1 are now compatible with onnx 1.14.0 because of https://github.com/microsoft/Olive/commit/a531f77b87738c0916e08d123da74f30532a5a26.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
