### PR TITLE
Support data_config in OpenVINOQuantization quantization pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ settings.json
 models/
 logs/
 cache/
-.olive_cache/
+.olive-cache/
 olive_tmp_*/
 /olive-venv
 augmented_model.onnx

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -115,10 +115,9 @@ class OpenVINOQuantization(Pass):
 
         class _OVDataloader(DataLoader):
             def __init__(self, dataloader):
-                self.dataloader = dataloader
                 self.data = []
                 self.labels = []
-                for data, label in self.dataloader:
+                for data, label in dataloader:
                     if isinstance(data, dict):
                         data = {k: np.array(v) for k, v in data.items()}
                     elif isinstance(data, tuple):

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -5,8 +5,9 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
+import numpy as np
+
 from olive.cache import get_local_path
-from olive.common.user_module_loader import UserModuleLoader
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import OpenVINOModel
 from olive.passes import Pass
@@ -21,6 +22,7 @@ class OpenVINOQuantization(Pass):
     """
 
     _requires_user_script = True
+    _requires_data_config = True
 
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
@@ -78,11 +80,15 @@ class OpenVINOQuantization(Pass):
         # output model always has ov_model name stem
         model_name = "ov_model"
 
-        loader = UserModuleLoader(user_script=config["user_script"], script_dir=config["script_dir"])
-        data_loader = loader.call_object(
-            config["dataloader_func"], get_local_path(config["data_dir"]), config["batch_size"]
-        )
-        metric = loader.load_object(config["metric_func"])
+        if config["dataloader_func"]:
+            data_loader = self._user_module_loader.call_object(
+                config["dataloader_func"], get_local_path(config["data_dir"]), config["batch_size"]
+            )
+        elif self._data_config:
+            common_dataloader = self._data_config.to_data_container().create_dataloader()
+            data_loader = self._create_dataloader(common_dataloader)
+
+        metric = self._user_module_loader.load_object(config["metric_func"])
         engine = IEEngine(config=config["engine_config"], data_loader=data_loader, metric=metric)
         self.pipeline = create_pipeline(config["algorithms"], engine)
 
@@ -97,3 +103,38 @@ class OpenVINOQuantization(Pass):
         openvino_model = OpenVINOModel(model_path)
 
         return openvino_model
+
+    def _create_dataloader(self, common_dataloader):
+        """
+        Create an openvino.tools.pot.api.DataLoader instance from a common dataloader.
+        """
+        try:
+            from openvino.tools.pot.api import DataLoader
+        except ImportError:
+            raise ImportError("Please install olive-ai[openvino] to use OpenVINO pass")
+
+        class _OVDataloader(DataLoader):
+            def __init__(self, dataloader):
+                self.dataloader = dataloader
+                self.data = []
+                self.labels = []
+                for data, label in self.dataloader:
+                    if isinstance(data, dict):
+                        data = {k: np.array(v) for k, v in data.items()}
+                    elif isinstance(data, tuple):
+                        data = tuple(np.array(v) for v in data)
+                    else:
+                        data = np.array(data)
+                    self.data.append(data)
+                    self.labels.append(label)
+
+            def __len__(self):
+                return len(self.data)
+
+            def __getitem__(self, index):
+                if index >= len(self):
+                    raise IndexError
+
+                return self.data[index], self.labels[index]
+
+        return _OVDataloader(common_dataloader)

--- a/olive/snpe/data_loader.py
+++ b/olive/snpe/data_loader.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Tuple
 
 import numpy as np
+import torch
 
 import olive.snpe.utils.input_list as input_list_utils
 
@@ -299,6 +300,15 @@ class SNPECommonDataLoader(SNPEDataLoader):
         num_samples = len(self.config["dataloader"])
         sample_digits = len(str(num_samples))
         for i, (input_data, annotation) in enumerate(self.config["dataloader"]):
+            if isinstance(input_data, tuple):
+                input_data = dict(zip(input_specs.keys(), input_data))
+            elif isinstance(input_data, torch.Tensor) or isinstance(input_data, np.ndarray):
+                input_data = dict(zip(input_specs.keys(), [input_data]))
+            else:
+                assert isinstance(
+                    input_data, dict
+                ), f"Input data must be a tuple, torch.Tensor, np.ndarray, or dict. Got {type(input_data)}"
+
             input_file_name = f"{i}.bin".zfill(sample_digits + 4)
             input_order.append(input_file_name)
             for input_name, input_spec in input_specs.items():

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -5,10 +5,13 @@
 import tempfile
 from pathlib import Path
 
+import pytest
 import torch
 from torchvision import transforms
 from torchvision.datasets import CIFAR10
 
+from olive.data.config import DataConfig
+from olive.data.registry import Registry
 from olive.hardware import AcceleratorSpec
 from olive.model import PyTorchModel
 from olive.passes.olive_pass import create_pass_from_dict
@@ -17,7 +20,8 @@ from olive.passes.openvino.quantization import OpenVINOQuantization
 from olive.systems.local import LocalSystem
 
 
-def test_openvino_quantization():
+@pytest.mark.parametrize("data_source", ["dataloader_func", "data_config"])
+def test_openvino_quantization(data_source):
     # setup
     with tempfile.TemporaryDirectory() as tempdir:
         ov_model = get_openvino_model(tempdir)
@@ -26,8 +30,6 @@ def test_openvino_quantization():
         data_dir.mkdir(exist_ok=True)
         config = {
             "engine_config": {"device": "CPU"},
-            "dataloader_func": create_dataloader,
-            "data_dir": data_dir,
             "algorithms": [
                 {
                     "name": "DefaultQuantization",
@@ -35,6 +37,27 @@ def test_openvino_quantization():
                 }
             ],
         }
+        if data_source == "dataloader_func":
+            config.update(
+                {
+                    "dataloader_func": create_dataloader,
+                    "data_dir": data_dir,
+                }
+            )
+        elif data_source == "data_config":
+            config.update(
+                {
+                    "data_config": DataConfig(
+                        components={
+                            "load_dataset": {
+                                "name": "cifar10_dataset",
+                                "type": "cifar10_dataset",
+                                "params": {"data_dir": data_dir},
+                            }
+                        }
+                    )
+                }
+            )
         p = create_pass_from_dict(
             OpenVINOQuantization,
             config,
@@ -77,6 +100,14 @@ def get_openvino_model(tempdir):
     # execute
     openvino_model = local_system.run_pass(p, pytorch_model, output_folder)
     return openvino_model
+
+
+@Registry.register_dataset()
+def cifar10_dataset(data_dir):
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))]
+    )
+    return CIFAR10(root=data_dir, train=False, transform=transform, download=True)
 
 
 def create_dataloader(data_dir, batchsize):
@@ -127,8 +158,5 @@ def create_dataloader(data_dir, batchsize):
             return indexes, pictures, labels
 
     dataset_config = {"data_source": data_dir}
-    transform = transforms.Compose(
-        [transforms.ToTensor(), transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))]
-    )
-    dataset = CIFAR10(root=data_dir, train=False, transform=transform, download=True)
+    dataset = cifar10_dataset(data_dir)
     return CifarDataLoader(dataset_config, dataset)


### PR DESCRIPTION
## Describe your changes
Add support for `data_config` in `OpenVINOQuantization` pass. If data_config is given, the pass converts it into the correct `openvino.tools.pot.api.DataLoader` format.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
