### PR TITLE
🐎Raise the failure in time after docker.container.run failed

### DIFF
--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -129,7 +129,7 @@ class ConfigListBase(ConfigBase):
 
 
 class ConfigDictBase(ConfigBase):
-    __root__: Dict[str, Any] = None
+    __root__: Dict[str, Any]
 
     def __iter__(self):
         return iter(self.__root__)

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -116,7 +116,7 @@ class ConfigBase(BaseModel):
 
 
 class ConfigListBase(ConfigBase):
-    __root__: List[Any] = None
+    __root__: List[Any]
 
     def __iter__(self):
         return iter(self.__root__)

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -576,7 +576,7 @@ class Engine:
         if goals:
             logger.debug(f"Resolving goals: {goals}")
 
-        baseline = MetricResult()
+        baseline = None
         for goal in goals.values():
             _evaluated = False
             for sub_goal in goal.values():

--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -160,7 +160,7 @@ class SubMetricResult(ConfigBase):
 
 
 class MetricResult(ConfigDictBase):
-    __root__: Dict[str, SubMetricResult] = None
+    __root__: Dict[str, SubMetricResult]
     delimiter: ClassVar[str] = "-"
 
     def get_value(self, metric_name, sub_type_name):

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -171,11 +171,11 @@ class DockerSystem(OliveSystem):
                     volumes=[dev_mount_str, clean_up_mount_str],
                 )
 
-        if docker.version_info[0] >= 3:
-            exit_code = exit_code["StatusCode"]
-
+        exit_code = exit_code["StatusCode"]
         if exit_code != 0:
-            raise RuntimeError(f"Container exited with code {exit_code}")
+            raise docker.errors.ContainerError(
+                container, exit_code, eval_command, self.image, "Docker container evaluation failed"
+            )
 
         metric_json = Path(output_local_path) / f"{eval_output_name}"
         return metric_json

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -170,6 +170,7 @@ class DockerSystem(OliveSystem):
                     command=f"python {clean_up_mount_path} --dev_mount_path {dev_mount_path}",
                     volumes=[dev_mount_str, clean_up_mount_str],
                 )
+                logger.debug("Dev mount cleaned up successfully")
 
         exit_code = exit_code["StatusCode"]
         if exit_code != 0:

--- a/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
+++ b/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import platform
-import tempfile
-from pathlib import Path
 from test.integ_test.evaluator.docker_eval.utils import (
     delete_directories,
     download_data,
@@ -18,7 +16,6 @@ from test.integ_test.evaluator.docker_eval.utils import (
     get_openvino_model,
     get_pytorch_model,
 )
-from unittest.mock import patch
 
 import pytest
 
@@ -59,17 +56,3 @@ class TestDockerEvaluation:
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res
-
-    @patch("olive.systems.docker.docker_system.docker_utils.create_evaluate_command")
-    def test_docker_run_failure(self, mock_create_evaluate_command):
-        docker_target = get_docker_target()
-        model_cls, model_config, metric, _ = self.EVALUATION_TEST_CASE[0]
-        # mock a non-existing command
-        with tempfile.TemporaryDirectory() as temp_dir:
-            eval_command = Path(temp_dir) / "non_existing_command.py"
-            with open(eval_command, "w") as f:
-                f.write("raise Exception('docker run with failure')")
-            mock_create_evaluate_command.return_value = f"python {str(eval_command)}"
-            olive_model = model_cls(**model_config)
-            with pytest.raises(RuntimeError, match=r"Container exited with code \d+"):
-                docker_target.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -88,34 +88,52 @@ class TestDockerSystem:
             tempdir, docker_system.BASE_DOCKERFILE, docker_config.image_name, docker_config.build_args
         )
 
-    @patch("olive.systems.docker.docker_system.copy.deepcopy")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_run_command")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_evaluate_command")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_output_mount")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_config_file")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_metric_volumes_list")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_model_mount")
-    @patch("olive.systems.docker.docker_system.docker_utils.create_eval_script_mount")
-    @patch("olive.systems.docker.docker_system.tempfile.TemporaryDirectory")
-    @patch("olive.systems.docker.docker_system.docker.from_env")
+    @pytest.fixture
+    def mock_docker_system_info(self):
+        self.mock_from_env = patch("olive.systems.docker.docker_system.docker.from_env").start()
+        self.mock_tempdir = patch("olive.systems.docker.docker_system.tempfile.TemporaryDirectory").start()
+        self.mock_create_eval_script_mount = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_eval_script_mount"
+        ).start()
+        self.mock_create_model_mount = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_model_mount"
+        ).start()
+        self.mock_create_metric_volumes_list = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_metric_volumes_list"
+        ).start()
+        self.mock_create_config_file = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_config_file"
+        ).start()
+        self.mock_create_output_mount = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_output_mount"
+        ).start()
+        self.mock_create_evaluate_command = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_evaluate_command"
+        ).start()
+        self.mock_create_run_command = patch(
+            "olive.systems.docker.docker_system.docker_utils.create_run_command"
+        ).start()
+        self.mock_copy = patch("olive.systems.docker.docker_system.copy.deepcopy").start()
+        yield
+        patch.stopall()
+
+    @pytest.mark.usefixtures("mock_docker_system_info")
+    @pytest.mark.parametrize("exit_code", [0, 1])
     def test_evaluate_model(
         self,
-        mock_from_env,
-        mock_tempdir,
-        mock_create_eval_script_mount,
-        mock_create_model_mount,
-        mock_create_metric_volumes_list,
-        mock_create_config_file,
-        mock_create_output_mount,
-        mock_create_evaluate_command,
-        mock_create_run_command,
-        mock_copy,
+        exit_code,
     ):
         # setup
+        import docker
+
         mock_docker_client = MagicMock()
-        mock_from_env.return_value = mock_docker_client
+        self.mock_from_env.return_value = mock_docker_client
+        if docker.version_info[0] < 3:
+            self.mock_from_env.return_value.containers.run.return_value.wait.return_value = exit_code
+        else:
+            self.mock_from_env.return_value.containers.run.return_value.wait.return_value = {"StatusCode": exit_code}
         tempdir = self.tmp_dir.name
-        mock_tempdir.return_value.__enter__.return_value = tempdir
+        self.mock_tempdir.return_value.__enter__.return_value = tempdir
         olive_model = get_pytorch_model()
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
         docker_config = LocalDockerConfig(
@@ -130,48 +148,52 @@ class TestDockerSystem:
 
         eval_file_mount_path = "eval_file_mount_path"
         eval_file_mount_str = "eval_file_mount_str"
-        mock_create_eval_script_mount.return_value = [eval_file_mount_path, eval_file_mount_str]
+        self.mock_create_eval_script_mount.return_value = [eval_file_mount_path, eval_file_mount_str]
 
         model_mount_path = "model_mount_path"
         model_mount_str_list = ["model_mount_str_list"]
-        mock_create_model_mount.return_value = [model_mount_path, model_mount_str_list]
+        self.mock_create_model_mount.return_value = [model_mount_path, model_mount_str_list]
 
         volumes_list = ["volumes_list"]
-        mock_create_metric_volumes_list.return_value = volumes_list
+        self.mock_create_metric_volumes_list.return_value = volumes_list
 
         config_mount_path = "config_mount_path"
         config_file_mount_str = "config_file_mount_str"
-        mock_create_config_file.return_value = [config_mount_path, config_file_mount_str]
+        self.mock_create_config_file.return_value = [config_mount_path, config_file_mount_str]
 
         output_local_path = Path(__file__).absolute().parent / "output_local_path"
         output_mount_path = "output_mount_path"
         output_mount_str = "output_mount_str"
-        mock_create_output_mount.return_value = [output_local_path, output_mount_path, output_mount_str]
+        self.mock_create_output_mount.return_value = [output_local_path, output_mount_path, output_mount_str]
 
         eval_command = "eval_command"
-        mock_create_evaluate_command.return_value = eval_command
+        self.mock_create_evaluate_command.return_value = eval_command
 
         run_command = {"key": "val"}
-        mock_create_run_command.return_value = run_command
+        self.mock_create_run_command.return_value = run_command
 
-        # execute
-        actual_res = docker_system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        if exit_code != 0:
+            with pytest.raises(RuntimeError, match=r"Container exited with code \d+"):
+                actual_res = docker_system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        else:
+            actual_res = docker_system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+            # assert
+            self.mock_create_eval_script_mount.called_once_with(container_root_path)
+            self.mock_create_model_mount.called_once_with(mock_copy, container_root_path)
+            vol_list = [eval_file_mount_str] + model_mount_str_list
+            self.mock_create_metric_volumes_list.called_once_with(mock_copy, container_root_path, vol_list)
+            self.mock_create_config_file.called_once_with(tempdir, mock_copy, mock_copy, container_root_path)
+            self.mock_create_output_mount.called_once_with(tempdir, eval_output_path, container_root_path)
+            self.mock_create_evaluate_command.called_once_with(
+                eval_file_mount_path, model_mount_path, config_mount_path, output_mount_path, eval_output_name
+            )
+            self.mock_create_run_command.called_once_with(docker_system.run_params)
+            volumes_list.append(config_file_mount_str)
+            volumes_list.append(output_mount_str)
+            mock_docker_client.containers.run.call_once_with(
+                docker_system.image, eval_command, volumes_list, **run_command
+            )
 
-        # assert
-        mock_create_eval_script_mount.called_once_with(container_root_path)
-        mock_create_model_mount.called_once_with(mock_copy, container_root_path)
-        vol_list = [eval_file_mount_str] + model_mount_str_list
-        mock_create_metric_volumes_list.called_once_with(mock_copy, container_root_path, vol_list)
-        mock_create_config_file.called_once_with(tempdir, mock_copy, mock_copy, container_root_path)
-        mock_create_output_mount.called_once_with(tempdir, eval_output_path, container_root_path)
-        mock_create_evaluate_command.called_once_with(
-            eval_file_mount_path, model_mount_path, config_mount_path, output_mount_path, eval_output_name
-        )
-        mock_create_run_command.called_once_with(docker_system.run_params)
-        volumes_list.append(config_file_mount_str)
-        volumes_list.append(output_mount_str)
-        mock_docker_client.containers.run.call_once_with(docker_system.image, eval_command, volumes_list, **run_command)
-
-        for sub_type in metric.sub_types:
-            joint_key = joint_metric_key(metric.name, sub_type.name)
-            assert actual_res[joint_key].value == 0.99618
+            for sub_type in metric.sub_types:
+                joint_key = joint_metric_key(metric.name, sub_type.name)
+                assert actual_res[joint_key].value == 0.99618


### PR DESCRIPTION
## Describe your changes
Sometimes, the CI pipeline failed with Connection error for docker tests, but the raised error is shown as None metric results. 
That is caused by:
docker.container.run failed, but olive continue run to get the empty results
MetricResult accept empty value which will put off the failure again.
![image](https://github.com/microsoft/Olive/assets/13343117/cd63feb0-db4c-4742-959a-7918b2423f20)

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
