### PR TITLE
Vitis ai

### DIFF
--- a/docs/source/tutorials/passes/onnx.md
+++ b/docs/source/tutorials/passes/onnx.md
@@ -134,7 +134,7 @@ Please refer to [IncQuantization](inc_quantization), [IncDynamicQuantization](in
 [IncStaticQuantization](inc_static_quantization) for more details about the passes and their config parameters.
 
 ### Quantize with AMD Vitis AI Quantizer
-Olive also integrates [AMD Vitis AI Quantizer](https://github.com/microsoft/Olive/blob/main/olive/passes/onnx/vitis_ai/quantizer.py) for quantization.
+Olive also integrates [AMD Vitis AI Quantizer](https://github.com/microsoft/Olive/blob/main/olive/passes/onnx/vitis_ai/quantize.py) for quantization.
 
 The Vitis™ AI development environment accelerates AI inference on AMD® hardware platforms. The Vitis AI quantizer can reduce the computing complexity by converting the 32-bit floating-point weights and activations to fixed-point like INT8. The fixed-point network model requires less memory bandwidth, thus providing faster speed and higher power efficiency than the floating-point model.
 Olive consolidates the Vitis™ AI quantization into a single pass called VitisAIQuantization which supports power-of-2 scale quantization methods and supports Vitis AI Execution Provider.

--- a/olive/passes/onnx/vitis_ai/quant_utils.py
+++ b/olive/passes/onnx/vitis_ai/quant_utils.py
@@ -7,7 +7,9 @@ from enum import Enum
 
 import numpy as np
 import onnx
+from onnxruntime import __version__ as OrtVersion
 from onnxruntime.quantization.quant_utils import get_qmin_qmax_for_qType, quantize_nparray
+from packaging import version
 
 
 class PowerOfTwoMethod(Enum):
@@ -352,3 +354,13 @@ def quantize_data_pof2s(data, qType, symmetric, reduce_range=False, method=Power
         rmax_mse = (qmax - zp_mse) * scale_mse
 
         return rmin_mse, rmax_mse, zp_mse, scale_mse, quantized_data_mse
+
+
+def is_ort_version_below_1_16():
+    """
+    This function checks whether the current version of ONNX Runtime (ORT) is below 1.16.0.
+
+    Returns:
+        True if the current ORT version is less than 1.16.0, False otherwise.
+    """
+    return version.parse(OrtVersion) < version.parse("1.16.0")


### PR DESCRIPTION
## Describe your changes
Update vitis_ai link in passes/onnx.md and make Vitis AI compatible with ORT 1.16.0 (nightly)
1. Stop using clone_model_with_shape_infer in ORT 1.16.
2. Set optimize_model=False by default.
3. Use load_model_with_shape_infer in ORT 1.16.
4. Convert string-type model_input to Path object.
5. Update some codes to be aligned with onnxruntime.quantization.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
https://github.com/microsoft/Olive/issues/382