### PR TITLE
MoE Experts Distributor

### DIFF
--- a/examples/switch/README.md
+++ b/examples/switch/README.md
@@ -1,0 +1,32 @@
+# Experts distributor for MoE models (using ORT MoE implementation)
+This folder contains a sample use case of Olive to distribute experts across multiple onnx graphs for use with distributed inferencing with MoE models.
+
+## Prerequisites
+### Clone the repository and install Olive
+
+Refer to the instructions in the [examples README](../README.md) to clone the repository and install Olive.
+
+**Important:** To run the example, you would need a custom onnxruntime build with support for cuda, nccl & mpi.
+
+### Pip requirements
+Install the necessary python packages:
+```
+python -m pip install -r requirements.txt
+```
+
+## Run the config to distribute the model
+```bash
+python -m olive.workflows.run --config examples/switch/config.json --setup
+```
+
+## Test the generated models
+```bash
+python examples/switch/inference.py --filename-pattern {base_model_name}{{:02d}}.onnx --world-size {gpu count}
+
+```
+
+## To compare the results of non-distributed model to the distributed one
+```bash
+python examples/switch/inference.py --filepath {base_model_name}.onnx --filename-pattern {base_model_name}_{{:02d}}.onnx --world-size {gpu count} --compare
+
+```

--- a/examples/switch/config.json
+++ b/examples/switch/config.json
@@ -1,0 +1,31 @@
+{
+    "verbose": true,
+    "input_model":{
+        "type": "OnnxModel",
+        "config": {
+            "model_path": "model_4n_2l_8e.onnx"
+        }
+    },
+    "passes": {
+        "distribute": {
+            "type": "MoEExpertsDistributor",
+            "config": {
+                "world_size": 2
+            }
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "config": {
+                "accelerators": ["gpu"]
+            }
+        }
+    },
+    "engine": {
+        "host": "local_system",
+        "clean_cache": true,
+        "cache_dir": "cache",
+        "output_dir": "models"
+    }
+}

--- a/examples/switch/inference.py
+++ b/examples/switch/inference.py
@@ -1,0 +1,134 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import argparse
+import os
+import pprint
+import sys
+
+import numpy
+import onnxruntime
+
+
+def _run_non_distributed(filepath):
+    session = onnxruntime.InferenceSession(filepath, providers=["CPUExecutionProvider", "CUDAExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    data = numpy.full((40, 40), 2, dtype=numpy.int64)
+    output = session.run(None, {input_name: data})[0]
+
+    return output
+
+
+def _mpipool_worker(args):
+    local_rank, world_size, filepath = args
+
+    os.environ["OMPI_COMM_WORLD_RANK"] = str(local_rank)
+    os.environ["OMPI_COMM_WORLD_SIZE"] = str(world_size)
+
+    from mpi4py import MPI
+
+    local_rank = MPI.COMM_WORLD.Get_rank()
+    MPI.COMM_WORLD.barrier()
+
+    print(f"rank: {local_rank}, filepath: {filepath}")
+
+    session = onnxruntime.InferenceSession(
+        filepath,
+        providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+        provider_options=[{"device_id": str(local_rank)}, {}],
+    )
+    input_name = session.get_inputs()[0].name
+    data = numpy.full((40, 40), 2, dtype=numpy.int64)
+    output = session.run(None, {input_name: data})[0]
+
+    return output
+
+
+def _run_using_mpipool(filepath, world_size):
+    from mpi4py.futures import MPIPoolExecutor
+    from mpi4py.MPI import COMM_WORLD
+
+    args = [(rank, world_size, filepath.format(rank)) for rank in range(world_size)]
+    with MPIPoolExecutor(max_workers=world_size) as executor:
+        outputs = executor.map(_mpipool_worker, args)
+        executor.shutdown()
+
+    COMM_WORLD.barrier()
+
+    return list(outputs)
+
+
+def _main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--filepath", dest="filepath", type=str, help="Onnx model file to load for non-distributed run")
+    parser.add_argument(
+        "--filename-pattern",
+        dest="filename_pattern",
+        type=str,
+        help="Onnx model file name pattern to use for distributed run",
+    )
+    parser.add_argument("--world-size", dest="world_size", type=int, help="World size for distributed run")
+    parser.add_argument(
+        "--compare",
+        dest="compare",
+        action="store_true",
+        default=False,
+        help="Compare results from distributed session to non-distributed session",
+    )
+    parser.add_argument("--debug", action="store_true", default=False, help="Enable debug output")
+    args = parser.parse_args()
+
+    distributed_session_outputs = None
+    if args.filename_pattern and (args.world_size > 1):
+        distributed_session_outputs = _run_using_mpipool(args.filename_pattern, args.world_size)
+
+    # For some unidentified reason, running a non-distributed session before a distributed one doesn't work.
+    # The distributed session fails on MPI initialization.
+    non_distributed_session_outputs = None
+    if args.filepath:
+        non_distributed_session_outputs = _run_non_distributed(args.filepath)
+
+    if args.debug:
+        pprint.pprint(
+            {
+                "non_distributed_session_outputs": non_distributed_session_outputs,
+                "distributed_session_outputs": distributed_session_outputs,
+            }
+        )
+
+    if args.compare and (non_distributed_session_outputs is not None) and (distributed_session_outputs is not None):
+        atol = 1e-04
+        results = {}
+        for i in range(args.world_size):
+            results[f"nondist vs. dist_{i:02d}"] = numpy.allclose(
+                non_distributed_session_outputs, distributed_session_outputs[i], atol=atol
+            )
+
+            if i > 0:
+                results[f"dist_00 vs. dist_{i:02d}"] = numpy.allclose(
+                    distributed_session_outputs[0], distributed_session_outputs[i], atol=atol
+                )
+
+        pprint.pprint(results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())
+
+
+# python3 inference.py \
+#   --filepath model_4n_2l_8e.onnx
+#
+# python3 inference.py \
+#   --filename-pattern model_4n_2l_8e_{:02d}.onnx \
+#   --world-size 2
+#
+# python3 inference.py \
+#   --filepath model_4n_2l_8e.onnx \
+#   --filename-pattern model_4n_2l_8e_{:02d}.onnx \
+#   --world-size 2
+#   --compare

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -187,8 +187,8 @@ def save_model(
     with model_jsons[0].open("r") as f:
         model_json = serialize_to_json(json.load(f))
 
-    if model_json["type"].lower() == "compositeonnxmodel":
-        logger.warning("Saving composite ONNX models is not supported yet.")
+    if model_json["type"].lower() in ["compositeonnxmodel", "distributedonnxmodel"]:
+        logger.warning(f"Saving models of type '{model_json['type']}' is not supported yet.")
         return
 
     model_path = model_json["config"]["model_path"]

--- a/olive/passes/onnx/__init__.py
+++ b/olive/passes/onnx/__init__.py
@@ -9,6 +9,7 @@ from olive.passes.onnx.inc_quantization import IncDynamicQuantization, IncQuanti
 from olive.passes.onnx.insert_beam_search import InsertBeamSearch
 from olive.passes.onnx.mixed_precision import OrtMixedPrecision
 from olive.passes.onnx.model_optimizer import OnnxModelOptimizer
+from olive.passes.onnx.moe_experts_distributor import MoEExpertsDistributor
 from olive.passes.onnx.optimum_conversion import OptimumConversion
 from olive.passes.onnx.optimum_merging import OptimumMerging
 from olive.passes.onnx.perf_tuning import OrtPerfTuning
@@ -25,6 +26,7 @@ __all__ = [
     "IncDynamicQuantization",
     "IncQuantization",
     "IncStaticQuantization",
+    "MoEExpertsDistributor",
     "OrtPerfTuning",
     "OrtTransformersOptimization",
     "OnnxModelOptimizer",

--- a/olive/passes/onnx/moe_experts_distributor.py
+++ b/olive/passes/onnx/moe_experts_distributor.py
@@ -1,0 +1,275 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import json
+import pprint
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+import numpy
+import onnx
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message
+from onnxruntime.transformers.onnx_model import OnnxModel
+from pydantic import validator
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import DistributedOnnxModel, ONNXModel
+from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config
+from olive.passes.pass_config import PassConfigParam
+
+_domain = "com.microsoft"
+_json_separators = (",", ": ")
+_expert_pattern = [
+    "Slice",  # 14
+    "Concat",  # 13
+    "MatMul",  # 12
+    "Cast",  # 11
+    "Relu",  # 10
+    "MatMul",  # 9
+    "Cast",  # 8
+    "Slice",  # 7
+    "Mul",  # 6
+    "Div",  # 5
+    "Add",  # 4
+    "Gather",  # 3
+    "Shape",  # 2
+    "Reshape",  # 1
+    "Reshape",  # 0
+]
+
+
+def _dump_graph(node: Message, filepath: str):
+    with open(filepath, "wt") as strm:
+        json.dump(MessageToDict(node), fp=strm, indent=2, sort_keys=True, separators=_json_separators)
+        strm.flush()
+
+
+def _iterate_experts(model: OnnxModel, producers: Dict[str, Message]):
+    for node in model.get_nodes_by_op_type(_expert_pattern[0]):
+        path = model.match_parent_path(node, _expert_pattern[1:], output_name_to_node=producers)
+        if path:
+            path.reverse()
+            path.append(node)
+            yield path
+
+
+def _create_node_name(model: OnnxModel, op_type: str, prefix_a: str, prefix_b: str):
+    prefix = ""
+    last_slash = -1
+    for i in range(0, min(len(prefix_a), len(prefix_b))):
+        if prefix_a[i] == prefix_b[i]:
+            prefix += prefix_a[i]
+            if prefix_a[i] == "/":
+                last_slash = i
+        else:
+            break
+
+    if last_slash > 0:
+        prefix = prefix[: last_slash + 1]
+
+    if not prefix.endswith("/"):
+        prefix += "/"
+    prefix += op_type
+
+    return model.create_node_name(op_type, prefix)
+
+
+def _create_ranked_model(
+    nodes: Dict[str, Message],
+    producers: Dict[str, Message],
+    consumers: Dict[str, Message],
+    experts: List[List[str]],
+    world_size: int,
+    num_experts: int,
+    rank: int,
+):
+    experts_per_rank = int(num_experts / world_size)
+    start_index = rank * experts_per_rank
+    end_index = start_index + experts_per_rank
+
+    for expert in experts:
+        div_node = nodes[expert[5]]
+        concat_node = nodes[expert[13]]
+        reshape_node = nodes[expert[1]]
+
+        div_node_oname = div_node.output[0]
+        reshape_node_oname = reshape_node.output[0]
+
+        mul_nodes = [n for n in consumers[div_node_oname] if n.op_type == "Mul"]
+        matmul_nodes = [producers[iname] for iname in concat_node.input if producers[iname].op_type == "MatMul"]
+        slice_nodes = [n for n in consumers[reshape_node_oname] if n.op_type == "Slice"]
+
+        slice_nodes[start_index].input[1] = slice_nodes[0].input[1]
+
+        for i in range(num_experts):
+            if (i < start_index) or (i >= end_index):
+                mul_nodes[i].input.remove(div_node_oname)
+                concat_node.input.remove(matmul_nodes[i].output[0])
+
+                for iname in list(slice_nodes[i].input):
+                    slice_nodes[i].input.remove(iname)
+
+
+def _insert_commop_nodes(model: OnnxModel, nodes: Dict[str, Message], experts: List[List[str]], world_size: int):
+    for expert in experts:
+        for i, j in [(0, 1), (-2, -1)]:
+            prev_node = nodes[expert[i]]
+            next_node = nodes[expert[j]]
+
+            node_name = _create_node_name(model, "AllToAll", prev_node.name, next_node.name)
+            output_name = node_name + "_output_0"
+            alltoall = onnx.helper.make_node(
+                "AllToAll", prev_node.output, [output_name], name=node_name, domain=_domain, group_size=world_size
+            )
+
+            model.add_node(alltoall)
+            OnnxModel.replace_node_input(next_node, prev_node.output[0], output_name)
+
+
+def _replace_constant_value(constant: Message, value: int):
+    for attr in constant.attribute:
+        if attr.name == "value":
+            attr.CopyFrom(
+                onnx.helper.make_attribute(
+                    attr.name, onnx.numpy_helper.from_array(numpy.array([value], numpy.int64)), attr.doc_string
+                )
+            )
+            return
+
+
+def _fix_shapes(
+    model: OnnxModel,
+    nodes: Dict[str, Message],
+    producers: Dict[str, Message],
+    consumers: Dict[str, Message],
+    experts: List[List[str]],
+    world_size: int,
+    num_experts: int,
+):
+    experts_per_rank = num_experts // world_size
+
+    for expert in experts:
+        div_node = nodes[expert[5]]
+        div_node_iname = div_node.input[1]
+        div_node_oname = div_node.output[0]
+        _replace_constant_value(producers[div_node_iname], experts_per_rank)
+
+        add_node = nodes[expert[4]]
+        add_node_iname = add_node.input[1]
+        _replace_constant_value(producers[add_node_iname], experts_per_rank - 1)
+
+        mul_nodes = [n for n in consumers[div_node_oname] if n.op_type == "Mul"]
+        index = 1
+        for mul_node in mul_nodes:
+            if div_node_oname in mul_node.input:
+                _replace_constant_value(producers[mul_node.input[1]], index)
+                index += 1
+
+        reshape_node = nodes[expert[1]]
+        for parent in model.get_parents(reshape_node, producers):
+            if parent.op_type == "Concat":
+                concat_iname_0 = parent.input[0]
+                _replace_constant_value(producers[concat_iname_0], int(num_experts / experts_per_rank))
+
+                concat_iname_1 = parent.input[1]
+                _replace_constant_value(producers[concat_iname_1], experts_per_rank)
+
+                break
+
+
+def run(world_size: int, input_filepath: str, output_dirpath: str, debug: bool = False):
+    basename = Path(input_filepath).stem
+    output_dirpath = Path(output_dirpath)
+
+    model = OnnxModel(onnx.load_model(input_filepath))
+    producers = model.output_name_to_node()
+    consumers = model.input_name_to_nodes()
+
+    if debug:
+        OnnxModel.graph_topological_sort(model.model.graph)
+        _dump_graph(model.model, str(output_dirpath / f"{basename}.graph"))
+
+    experts = []
+    num_experts = None
+    for expert in _iterate_experts(model, producers):
+        if debug:
+            pprint.pprint([n.name for n in expert])
+
+        div_node = expert[5]
+        div_node_oname = div_node.output[0]
+        if not num_experts:
+            num_experts = len(consumers[div_node_oname])
+            if (num_experts % world_size) != 0:
+                raise f"""Number of expert paths on node "{div_node.name}" should be a multiple of
+                        input world-size={world_size} but found {len(consumers[div_node_oname])}"""
+        elif len(consumers[div_node_oname]) != num_experts:
+            raise f"""Inconsistent number of expert across layers.
+                    expected={num_experts}, found={len(consumers[div_node_oname])}"""
+
+        experts.append([n.name for n in expert])
+
+    output_filepaths = []
+    for rank in range(0, world_size):
+        rank_model = OnnxModel(onnx.load_model(input_filepath))
+        producers = rank_model.output_name_to_node()
+        consumers = rank_model.input_name_to_nodes()
+        nodes = {node.name: node for node in rank_model.nodes()}
+
+        _create_ranked_model(nodes, producers, consumers, experts, world_size, num_experts, rank)
+        _insert_commop_nodes(rank_model, nodes, experts, world_size)
+        _fix_shapes(rank_model, nodes, producers, consumers, experts, world_size, num_experts)
+
+        rank_model.prune_graph()
+        output_filepath = str(output_dirpath / f"{basename}_{rank:02d}.onnx")
+        rank_model.save_model_to_file(output_filepath)
+        onnx.checker.check_model(rank_model.model)
+        output_filepaths.append(output_filepath)
+
+        if debug:
+            _dump_graph(rank_model.model, str(output_dirpath / f"{basename}_{rank:02d}.graph"))
+
+    return output_filepaths
+
+
+def _validate_distributor_config(v, values, field):
+    if v is None:
+        return v
+
+    if "world_size" not in values:
+        raise ValueError("Missing world_size")
+    if int(values["world_size"]) < 2:
+        raise ValueError("world_size should be >= 2")
+
+    return v
+
+
+class MoEExpertsDistributor(Pass):
+    """
+    Split the input model (and insert necessary communication operations)
+    to prepare for distributed inferencing.
+    """
+
+    @staticmethod
+    def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        config = {
+            "world_size": PassConfigParam(
+                type_=int,
+                default=2,
+                required=True,
+                description=("Number of GPU nodes to distribute the model for. Must be greater than 1."),
+            ),
+        }
+        config.update(get_external_data_config())
+        return config
+
+    @staticmethod
+    def _validators() -> Dict[str, Callable]:
+        return {"validate_distributor_config": validator("world_size")(_validate_distributor_config)}
+
+    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> DistributedOnnxModel:
+        output_filepaths = run(config["world_size"], model.model_path, output_model_path)
+        return DistributedOnnxModel(output_filepaths)


### PR DESCRIPTION
MoE Experts Distributor

Introducing a pass to distribute experts in onnx model by splitting the graph equally, making each individual such graph capable of running on its own GPU.

NOTE: The implementation requires a custom onnxruntime build with "--use_mpi" flag enabled.

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
