### PR TITLE
add Olive exception skeleton

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -18,7 +18,7 @@ from olive.engine.packaging.packaging_config import PackagingConfig
 from olive.engine.packaging.packaging_generator import generate_output_artifacts
 from olive.evaluator.metric import Metric, MetricResult, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
-from olive.exception import OliveException
+from olive.exception import OlivePassException
 from olive.hardware import AcceleratorLookup, AcceleratorSpec, Device
 from olive.model import ModelConfig, OliveModel
 from olive.passes.olive_pass import Pass
@@ -812,7 +812,6 @@ class Engine:
                 break
             model_ids.append(model_id)
 
-        signal = {}
         if not should_prune:
             # evaluate the model
             evaluator_config = self.evaluator_for_pass(pass_id)
@@ -891,7 +890,7 @@ class Engine:
                 input_model = self._prepare_non_local_model(input_model)
             try:
                 output_model = host.run_pass(p, input_model, output_model_path, pass_search_point)
-            except OliveException as e:
+            except OlivePassException as e:
                 logger.error(f"Pass run_pass failed: {e}", exc_info=True)
                 output_model = PRUNED_CONFIG
             except EXCEPTIONS_TO_RAISE:

--- a/olive/exception/__init__.py
+++ b/olive/exception/__init__.py
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+class OliveException(Exception):
+    """
+    Base class for Olive exceptions.
+    """
+
+    pass
+
+
+class OlivePassException(OliveException):
+    """
+    Base class for Olive pass exceptions.
+    """
+
+    pass
+
+
+class OliveEvaluationException(OliveException):
+    """
+    Base class for Olive evaluation exceptions.
+    """
+
+    pass

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -394,7 +394,7 @@ class OnnxQuantization(Pass):
                     use_external_data_format=True,
                     **run_config,
                 )
-            except ValueError as e:
+            except AttributeError as e:
                 raise OlivePassException("quantize_static failed.") from e
         else:
             try:
@@ -404,7 +404,7 @@ class OnnxQuantization(Pass):
                     use_external_data_format=True,
                     **run_config,
                 )
-            except ValueError as e:
+            except AttributeError as e:
                 raise OlivePassException("quantize_dynamic failed.") from e
 
         # load the model

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -484,7 +484,7 @@ class TestEngine:
             engine = Engine(options, evaluator_config=evaluator_config)
             engine.register(OnnxStaticQuantization)
             with patch("onnxruntime.quantization.quantize_static") as mock_quantize_static:
-                mock_quantize_static.side_effect = ValueError("test")
+                mock_quantize_static.side_effect = AttributeError("test")
                 actual_res = engine.run(onnx_model, output_dir=output_dir)
                 pf = actual_res[DEFAULT_CPU_ACCELERATOR]
                 assert not pf.nodes, "Expect empty dict when quantization fails"
@@ -495,6 +495,6 @@ class TestEngine:
             engine = Engine(options)
             engine.register(OnnxDynamicQuantization, disable_search=True)
             with patch("onnxruntime.quantization.quantize_dynamic") as mock_quantize_dynamic:
-                mock_quantize_dynamic.side_effect = ValueError("test")
+                mock_quantize_dynamic.side_effect = AttributeError("test")
                 actual_res = engine.run(onnx_model, output_dir=output_dir)
                 assert actual_res == {}, "Expect empty dict when quantization fails"


### PR DESCRIPTION
## Describe your changes
Sometimes, the quantization would fail https://dev.azure.com/aiinfra/Model%20optimization%20Toolkit/_build/results?buildId=321080&view=logs&j=83e9455c-f768-5dd6-ffb8-4d16293cb8a9&t=8c02a2da-1821-5532-3cad-c631fe1ed2f8 

Olive should have the ability to handle this kind of error not caused by Olive bug. when this happens, the quantization should be ignored. 

As the result, we introduce OliveException system to allow Olive throw the ignorable exception in pass run

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
