### PR TITLE
⛏️Pin protobuf to 3.20.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ onnx
 optuna
 pandas
 pydantic
-protobuf !=3.20.0, !=3.20.1
+protobuf==3.20.3
 pyyaml
 torch
 torchmetrics>=0.7.0, <0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ onnx
 optuna
 pandas
 pydantic<2.0.0
-protobuf==3.20.3
+protobuf<4.0.0
 pyyaml
 torch
 torchmetrics>=0.7.0, <0.10.1


### PR DESCRIPTION
## Describe your changes

With onnx is released to version 1.14.0, the required protobuf is set as >3.20.2. But for `transformers`, I met the error of protobuf version. It failed when run following importing:
`from transformers import AutoModelForMaskedLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase`

<img width="913" alt="image" src="https://github.com/microsoft/Olive/assets/13343117/95a3c5b5-e32a-4b49-9eab-9248198e10ce">

So I tried to pin the protobuf version as 3.20.3 to meet the requirements from `onnx` and `transformers`


LInks:
1. onnx protobuf limitation: https://github.com/onnx/onnx/blob/rel-1.14.0/requirements.txt

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
