### PR TITLE
Use pydantic<2.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-autodoc_pydantic
+autodoc_pydantic<2.0.0
 azure-ai-ml>=0.1.0b6
 azure-identity
 azureml-fsspec

--- a/examples/bert/docker/Dockerfile
+++ b/examples/bert/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
 RUN pip install onnxruntime \
             datasets \
             evaluate \
-            pydantic<2.0.0 \
+            "pydantic<2.0.0" \
             scikit-learn \
             transformers \
             git+https://github.com/microsoft/Olive.git

--- a/examples/bert/docker/Dockerfile
+++ b/examples/bert/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
 RUN pip install onnxruntime \
             datasets \
             evaluate \
-            # TODO: remove this once the main branch requirements.txt is updated
             pydantic<2.0.0 \
             scikit-learn \
             transformers \

--- a/examples/bert/docker/Dockerfile
+++ b/examples/bert/docker/Dockerfile
@@ -3,6 +3,8 @@ FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
 RUN pip install onnxruntime \
             datasets \
             evaluate \
+            # TODO: remove this once the main branch requirements.txt is updated
+            pydantic<2.0.0 \
             scikit-learn \
             transformers \
             git+https://github.com/microsoft/Olive.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 onnx
 optuna
 pandas
-pydantic
+pydantic<2.0.0
 protobuf !=3.20.0, !=3.20.1
 pyyaml
 torch

--- a/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
+++ b/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install onnxruntime \
             openvino \
             openvino-dev \
             onnxconverter_common \
-            pydantic<2.0.0 \
+            "pydantic<2.0.0" \
             git+https://github.com/microsoft/Olive.git
 
 WORKDIR /olive

--- a/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
+++ b/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
@@ -11,7 +11,6 @@ RUN pip install onnxruntime \
             openvino \
             openvino-dev \
             onnxconverter_common \
-            # TODO: remove this once the main branch requirements.txt is updated
             pydantic<2.0.0 \
             git+https://github.com/microsoft/Olive.git
 

--- a/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
+++ b/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
@@ -11,6 +11,8 @@ RUN pip install onnxruntime \
             openvino \
             openvino-dev \
             onnxconverter_common \
+            # TODO: remove this once the main branch requirements.txt is updated
+            pydantic<2.0.0 \
             git+https://github.com/microsoft/Olive.git
 
 WORKDIR /olive


### PR DESCRIPTION
## Describe your changes
There is a new major release for pydantic 2.0.0 which has multiple breaking changes. So we pin pydantic to version < 2.0.0. We can consider upgrading to the latest major release in the future. 

There is no corresponding release for `autodoc_pydantic` yet but also changing it to be safe.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
