### PR TITLE
🤯 Expose docker logs

### DIFF
--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -167,13 +167,20 @@ class DockerSystem(OliveSystem):
             environment=environment,
             **run_command,
         )
+        docker_logs = []
         for line in container.logs(stream=True):
-            logger.info(line.strip().decode())
+            # containers.logs can accept stdout/stderr as arguments, but it doesn't work
+            # as we cannot ensure that all the logs will be printed in the correct channel(out/err)
+            # so, we collect all the logs and print them in the end if there is an error.
+            log = line.strip().decode()
+            logger.debug(log)
+            docker_logs.append(log)
         exit_code = container.wait()["StatusCode"]
         container.remove()
         if exit_code != 0:
+            error_msg = "\n".join(docker_logs)
             raise docker.errors.ContainerError(
-                container, exit_code, eval_command, self.image, "Docker container evaluation failed"
+                container, exit_code, eval_command, self.image, f"Docker container evaluation failed with {error_msg}"
             )
         logger.debug("Docker container evaluation completed successfully")
 

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -172,7 +172,7 @@ class DockerSystem(OliveSystem):
             # containers.logs can accept stdout/stderr as arguments, but it doesn't work
             # as we cannot ensure that all the logs will be printed in the correct channel(out/err)
             # so, we collect all the logs and print them in the end if there is an error.
-            log = line.strip().decode()
+            log = line.decode().strip()
             logger.debug(log)
             docker_logs.append(log)
         exit_code = container.wait()["StatusCode"]
@@ -180,7 +180,7 @@ class DockerSystem(OliveSystem):
         if exit_code != 0:
             error_msg = "\n".join(docker_logs)
             raise docker.errors.ContainerError(
-                container, exit_code, eval_command, self.image, f"Docker container evaluation failed with {error_msg}"
+                container, exit_code, eval_command, self.image, f"Docker container evaluation failed with: {error_msg}"
             )
         logger.debug("Docker container evaluation completed successfully")
 

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -129,6 +129,8 @@ class TestDockerSystem:
         mock_docker_client = MagicMock()
         self.mock_from_env.return_value = mock_docker_client
         self.mock_from_env.return_value.containers.run.return_value.wait.return_value = {"StatusCode": exit_code}
+        if exit_code != 0:
+            self.mock_from_env.return_value.containers.run.return_value.logs.return_value = [b"mock_error"]
         tempdir = self.tmp_dir.name
         self.mock_tempdir.return_value.__enter__.return_value = tempdir
         olive_model = get_pytorch_model()
@@ -172,7 +174,7 @@ class TestDockerSystem:
         if exit_code != 0:
             with pytest.raises(
                 docker.errors.ContainerError,
-                match=r".*returned non-zero exit status 1: Docker container evaluation failed",
+                match=r".*returned non-zero exit status 1: Docker container evaluation failed with: mock_error",
             ):
                 actual_res = docker_system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
         else:


### PR DESCRIPTION
## Describe your changes
Currently, there are a few concerns about docker logs
1. docker logs are printed with `info` level even if the docker logs container errors.
2. the failure log in docker container cannot be exposed in raised exception.

This pr is used to improve above issues.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
