### PR TITLE
🪂 Ensure markdown file under docs can be parsed solely

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,10 @@ extensions = [
     "sphinxcontrib.jquery",
 ]
 
+myst_enable_extensions = [
+    "html_image",
+]
+
 source_suffix = {
     ".rst": "restructuredtext",
     ".txt": "markdown",

--- a/docs/source/getstarted/installation.md
+++ b/docs/source/getstarted/installation.md
@@ -1,4 +1,3 @@
-(Installation)=
 # Installation
 
 We recommend installing Olive in a [virtual environment](https://docs.python.org/3/library/venv.html) or a

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -149,7 +149,7 @@ dictionary is the name of the system. The value of the dictionary is another dic
 information of the system contains following items:
 
 - `type: [str]` The type of the system. The supported types are `LocalSystem`, `AzureML` and `Docker`.
-  There are some built-in system alias which could also be used as type. For exmaple, `AzureNDV2System`. Please refer to [System Alias](system_alias) for the complete list of system alias.
+  There are some built-in system alias which could also be used as type. For example, `AzureNDV2System`. Please refer to [System Alias](system_alias) for the complete list of system alias.
 
 - `config: [Dict]` The system config dictionary that contains the system specific information.
 

--- a/docs/source/overview/quicktour.md
+++ b/docs/source/overview/quicktour.md
@@ -1,4 +1,3 @@
-(Quick-tour)=
 # Quick Tour
 
 Here is a quick guide on using Olive for model optimization. We will focus on accelerating a PyTorch model on the CPU. It is a simple three step process.

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -1,7 +1,6 @@
-(Advanced-user-tour)=
 # Advanced User Tour
 
-Olive provides simple  Python and command line interface to optimize the input model. See [Quick Tour](Quick-tour) for more information.
+Olive provides simple  Python and command line interface to optimize the input model. See [Quick Tour](../overview/quicktour.md) for more information.
 ```bash
 python -m olive.workflows.run --config user_provided_info.json
 ```

--- a/docs/source/tutorials/configure_model_path.md
+++ b/docs/source/tutorials/configure_model_path.md
@@ -1,4 +1,3 @@
-(configuring_model_path)=
 # Configuring Model Path
 
 This document describes how to configure model paths in Olive for both local and remote model resources.

--- a/docs/source/tutorials/design.md
+++ b/docs/source/tutorials/design.md
@@ -1,4 +1,3 @@
-(Design)=
 # Design
 In this section, we discuss the core design concepts of Olive. Olive is composed of modular components
 that are composed to construct a model optimization workflow.
@@ -16,11 +15,7 @@ that meets some metric goals.
 
 The following diagram illustrates the relationship between the different components:
 
-```{figure} ../images/olive-design.png
-:align: center
-:alt: olive-design
-:width: 1000px
-```
+<img align="center" alt="olive-design" width="1000px" src="../images/olive-design.png">
 
 ## Pass
 Passes are the building blocks of an Olive workflow. A Pass performs a specific model optimization technique such as ONNX

--- a/docs/source/tutorials/how_to_add_optimization_pass.md
+++ b/docs/source/tutorials/how_to_add_optimization_pass.md
@@ -1,4 +1,3 @@
-(How-to-add-optimization-pass)=
 # How to add new optimization Pass
 
 Olive provides simple interface to introduce new model optimization techniques. Each optimization technique is

--- a/docs/source/tutorials/how_to_write_userscript.md
+++ b/docs/source/tutorials/how_to_write_userscript.md
@@ -1,4 +1,3 @@
-(user_script)=
 # How to write `user_script`
 
 ## `user_script`

--- a/docs/source/tutorials/huggingface_model_optimization.md
+++ b/docs/source/tutorials/huggingface_model_optimization.md
@@ -1,5 +1,3 @@
-(Huggingface-Model-Optimization)=
-
 # Huggingface Model Optimization
 
 


### PR DESCRIPTION
## Describe your changes
The markdown under olive docs contains the flag from `myst-parser` which makes the `git markdown preview` weird. Just found that it can be simply fixed and keep the `myst_parser` worked.


![image](https://github.com/microsoft/Olive/assets/13343117/9df28b9f-6c42-4a03-ad0e-67e9fbf59be0)

![image](https://github.com/microsoft/Olive/assets/13343117/de0ac521-6444-4e5f-9036-bd54de8666fd)


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
