### PR TITLE
➕ Opt in input model evaluation

### DIFF
--- a/.azure_pipelines/job_templates/olive-build-doc-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-doc-template.yaml
@@ -18,7 +18,7 @@ jobs:
         versionSpec: 3.8
       displayName: Use Python 3.8
 
-    # checout release branch if doc_version provided
+    # checkout release branch if doc_version provided
     - script: |
         git config --global user.email "olivedevteam@microsoft.com"
         git config --global user.name "olivedevteam"

--- a/.azure_pipelines/job_templates/olive-build-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-template.yaml
@@ -3,10 +3,12 @@
 parameters:
   name: ''
   pool: ''
+  gpu: False
 
 jobs:
 - job: ${{parameters.name}}_Test_Olive
   timeoutInMinutes: 300
+  condition: eq('${{ parameters.gpu }}', 'False')
   pool:
     name: ${{ parameters.pool}}
   variables:
@@ -78,6 +80,7 @@ jobs:
   variables:
     WINDOWS: ${{ parameters.windows }}
     runCodesignValidationInjection: false
+    GPU: ${{ parameters.gpu }}
 
   steps:
   - task: UsePythonVersion@0
@@ -92,7 +95,7 @@ jobs:
     inputs:
       azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
       scriptLocation: 'inlineScript'
-      inlineScript: make test-examples
+      inlineScript: make test-examples IS_GPU=$(GPU)
     displayName: Test Examples
     env:
       OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)

--- a/.azure_pipelines/job_templates/olive-build-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-template.yaml
@@ -3,71 +3,72 @@
 parameters:
   name: ''
   pool: ''
-  gpu: False
+  device: 'cpu'
 
 jobs:
-- job: ${{parameters.name}}_Test_Olive
-  timeoutInMinutes: 300
-  condition: eq('${{ parameters.gpu }}', 'False')
-  pool:
-    name: ${{ parameters.pool}}
-  variables:
-    WINDOWS: ${{ parameters.windows}}
-    runCodesignValidationInjection: false
+- ${{ if eq(parameters.device, 'cpu') }}:
+  - job: ${{parameters.name}}_Test_Olive
+    timeoutInMinutes: 300
+    pool:
+      name: ${{ parameters.pool}}
+    variables:
+      WINDOWS: ${{ parameters.windows}}
+      runCodesignValidationInjection: false
+      device: ${{ parameters.device }}
 
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: 3.8
-    displayName: Use Python 3.8
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.8
+      displayName: Use Python 3.8
 
-  - script: make install-olive PIPELINE=True INSTALL_EXTRAS=[cpu]
-    displayName: Install Olive
+    - script: make install-olive PIPELINE=True INSTALL_EXTRAS=[$(device)]
+      displayName: Install Olive
 
-  - task: AzureCLI@1
-    inputs:
-      azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
-      scriptLocation: 'inlineScript'
-      inlineScript: make test
-    displayName: Test Olive
-    env:
-      OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)
-      WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
-      WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
-      WORKSPACE_NAME: $(workspace-name)
-      AZURE_TENANT_ID: $(azure-tenant-id)
-      AZURE_CLIENT_ID: $(olive-rg-sp-id)
-      AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
-      PIPELINE: True
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
+        scriptLocation: 'inlineScript'
+        inlineScript: make test
+      displayName: Test Olive
+      env:
+        OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)
+        WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
+        WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
+        WORKSPACE_NAME: $(workspace-name)
+        AZURE_TENANT_ID: $(azure-tenant-id)
+        AZURE_CLIENT_ID: $(olive-rg-sp-id)
+        AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
+        PIPELINE: True
 
-  - task: CredScan@3
-    displayName: 'Run CredScan'
-    inputs:
-      debugMode: false
-    continueOnError: true
+    - task: CredScan@3
+      displayName: 'Run CredScan'
+      inputs:
+        debugMode: false
+      continueOnError: true
 
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
-    displayName: Component Detection
+    - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        scanType: 'Register'
+        verbosity: 'Verbose'
+        alertWarningLevel: 'High'
+      displayName: Component Detection
 
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: '**/*TestOlive*.xml'
-      testRunTitle: '$(Build.BuildNumber)[$(Agent.JobName)]'
-    displayName: Upload pipeline run test results
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: '**/*TestOlive*.xml'
+        testRunTitle: '$(Build.BuildNumber)[$(Agent.JobName)]'
+      displayName: Upload pipeline run test results
 
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: 'Cobertura'
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: 'Cobertura'
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
 
-  - script: make clean WINDOWS=$(WINDOWS)
-    condition: always()
-    displayName: Clean remaining artifacts
+    - script: make clean WINDOWS=$(WINDOWS)
+      condition: always()
+      displayName: Clean remaining artifacts
 
 
 - job: ${{parameters.name}}_Test_Examples
@@ -80,7 +81,7 @@ jobs:
   variables:
     WINDOWS: ${{ parameters.windows }}
     runCodesignValidationInjection: false
-    GPU: ${{ parameters.gpu }}
+    device: ${{ parameters.device }}
 
   steps:
   - task: UsePythonVersion@0
@@ -88,14 +89,14 @@ jobs:
       versionSpec: 3.8
     displayName: Use Python 3.8
 
-  - script: make install-olive PIPELINE=True INSTALL_EXTRAS=[cpu]
+  - script: make install-olive PIPELINE=True INSTALL_EXTRAS=[$(device)]
     displayName: Install Olive
 
   - task: AzureCLI@1
     inputs:
       azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
       scriptLocation: 'inlineScript'
-      inlineScript: make test-examples IS_GPU=$(GPU)
+      inlineScript: make test-examples
     displayName: Test Examples
     env:
       OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -74,6 +74,17 @@ jobs:
         exampleFolder: bert
         exampleName: bert_ptq_cpu_aml
 
+- template: job_templates/olive-build-template.yaml
+  parameters:
+    name: Linux_GPU_CI
+    pool: $(OLIVE_POOL_UBUNTU2004)
+    windows: False
+    gpu: True
+    examples:
+      bert_cuda_gpu:
+        exampleFolder: bert
+        exampleName: bert_cuda_gpu
+
 - template: job_templates/olive-build-doc-template.yaml
   parameters:
     job_name: Test_BuildDocs

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -79,7 +79,7 @@ jobs:
     name: Linux_GPU_CI
     pool: $(OLIVE_POOL_UBUNTU2004)
     windows: False
-    gpu: True
+    device: gpu
     examples:
       bert_cuda_gpu:
         exampleFolder: bert

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 WINDOWS                    ?= False
 PIPELINE                   ?= False
 INSTALL_DEV_MODE           ?= False
+IS_GPU                     ?= False
 EXAMPLE_FOLDER             ?=
 EXAMPLE_NAME               ?=
 INSTALL_EXTRAS             ?=
@@ -43,7 +44,7 @@ test:
 .PHONY: test-examples
 test-examples: logs/
 test-examples:
-	$(TEST_EXAMPLES_CMD) $(PIPELINE) $(CURRENT_DIR) $(EXAMPLE_FOLDER) $(EXAMPLE_NAME)
+	$(TEST_EXAMPLES_CMD) $(PIPELINE) $(CURRENT_DIR) $(EXAMPLE_FOLDER) $(EXAMPLE_NAME) $(IS_GPU)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 WINDOWS                    ?= False
 PIPELINE                   ?= False
 INSTALL_DEV_MODE           ?= False
-IS_GPU                     ?= False
 EXAMPLE_FOLDER             ?=
 EXAMPLE_NAME               ?=
 INSTALL_EXTRAS             ?=
@@ -44,7 +43,7 @@ test:
 .PHONY: test-examples
 test-examples: logs/
 test-examples:
-	$(TEST_EXAMPLES_CMD) $(PIPELINE) $(CURRENT_DIR) $(EXAMPLE_FOLDER) $(EXAMPLE_NAME) $(IS_GPU)
+	$(TEST_EXAMPLES_CMD) $(PIPELINE) $(CURRENT_DIR) $(EXAMPLE_FOLDER) $(EXAMPLE_NAME)
 
 .PHONY: clean
 clean:

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -224,7 +224,7 @@ information of the evaluator contains following items:
         - `batch_size: [int]` The batch size for the metric evaluation.
 
         - `dataloader_func: [str]` The name of the function provided by the user to load the data for the metric evaluation. The
-        function should take the `data_dir` and `batch_size` as input and return the data loader. Only valid for `accuracy` and `latency`
+        function should take the `data_dir`, `batch_size`, `*args`, `**kwargs` as input and return the data loader. Only valid for `accuracy` and `latency`
          type.
 
         - `inference_settings: [Dict]` Inference settings for the different runtime. Only valid for `accuracy` and `latency` type.

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -329,8 +329,8 @@ will be used.
 - `clean_run_cache: [Boolean]` This decides whether to clean the run cache of the pass before running the pass. This is `false` by default.
 
 - `output_name: str` In no-search mode (i.e., `search_strategy` is `null`), if `output_name` is provided, the output model of the pass will be
-saved to the engine's `output_dir` with the prefix of `output_name`. For the final pass, the engine's `output_name`, if provided, overrides the
-`output_name` of the pass.
+saved to the engine's `output_dir` with the prefix of `output_name`. For the final pass, if the engine's `output_name` is provided, it will override
+the `output_name` of the pass.
 
 Please refer to [Configuring Pass](configuring_pass) for more details on `type`, `disable_search` and `config`.
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -411,8 +411,7 @@ This is a dictionary that contains the information of the engine. The informatio
   If `search_strategy` is `true`, the search strategy will be the default search strategy. The default search strategy is `exhaustive` search
   algorithm with `joint` execution order.
 
-- `evaluation_only: [Boolean]` This decides whether to run the engine in evaluation only mode. In this mode, the engine will evaluate the input
-    model using the engine's evaluator and return the results. If the engine has no evaluator, it will raise an error. This is `false` by default.
+- `evaluate_input_model: [Boolean]` In this mode, the engine will evaluate the input model using the engine's evaluator and return the results. If the engine has no evaluator, it will raise an error. This is `true` by default.
 
 - `host: [str | Dict]` The host of the engine. It can be a string or a dictionary. If it is a string, it is the name of a system in `systems`.
     If it is a dictionary, it contains the system information. If not specified, it is the local system.

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -246,7 +246,7 @@ information of the evaluator contains following items:
         }
     }
     // provide azureml datastore url
-    "data_dir": "azureml://azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test/cifar-10-batches-py"
+    "data_dir": "azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test/cifar-10-batches-py"
     ```
 
 ### Example

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -75,7 +75,7 @@ latency_metric = Metric(
 evaluator_config =  OliveEvaluatorConfig(metrics=[latency_metric])
 ```
 
-`latency_metric` requires you to provide a function as value for `dataloader_func` that returns a dataloader object when called on `data_dir` and `batch_size`. You can provide the function object directly but here, let's give it a function name `"create_dataloader"` that can be imported from `user_script`.
+`latency_metric` requires you to provide a function as value for `dataloader_func` that returns a dataloader object when called on `data_dir`, `batch_size`, optional positional argument list and keyword argument dictionary. You can provide the function object directly but here, let's give it a function name `"create_dataloader"` that can be imported from `user_script`.
 
 [This file](https://github.com/microsoft/Olive/blob/main/examples/resnet/user_script.py) for
 has an example of how to write user scripts.

--- a/docs/source/tutorials/configure_metrics.rst
+++ b/docs/source/tutorials/configure_metrics.rst
@@ -165,6 +165,14 @@ In your :code:`"user_script.py"`, you need to define a function that takes in an
             # evaluate model
             # return metric value
 
+Alternatively, if you only need Olive run the inference and you will calculate the metric by yourself, you can speficy :code:`"metric_func": "None"` in the metric configuration.
+Olive will run the inference with you model with the data you provided, and return the inference results to you. You can then calculate the metric by yourself::
+
+        def metric_func(preds, targets):
+            # calculate metric
+            # return metric value
+
+If you provide both :code:`"evaluate_func"` and :code:`"metric_func"`, Olive will call :code:`"evaluate_func"` only.
 
 Multi Metrics configuration
 ----------------------------

--- a/docs/source/tutorials/huggingface_model_optimization.md
+++ b/docs/source/tutorials/huggingface_model_optimization.md
@@ -46,5 +46,52 @@ Please refer to [hf_config](../overview/options.md#hf_config) for more details.
 ```
 Please refer to [metrics](../overview/options.md#metrics) for more details.
 
+### Custom components config
+You can use your own custom compenents functions for your model. You will need to define the details of your components in your script as functions.
+```json
+{
+    "input_model": {
+        "type": "PyTorchModel",
+        "config": {
+            "model_script": "code/user_script.py",
+            "script_dir": "code",
+            "hf_config": {
+                "model_class": "WhisperForConditionalGeneration",
+                "model_name": "openai/whisper-medium",
+                "components": [
+                    {
+                        "name": "encoder_decoder_init",
+                        "io_config": "get_encdec_io_config",
+                        "component_func": "get_encoder_decoder_init",
+                        "dummy_inputs_func": "encoder_decoder_init_dummy_inputs"
+                    },
+                    {
+                        "name": "decoder",
+                        "io_config": "get_dec_io_config",
+                        "component_func": "get_decoder",
+                        "dummy_inputs_func": "decoder_dummy_inputs"
+                    }
+                ]
+            }
+        }
+    },
+}
+```
+#### Script example
+```
+# my_script.py
+def get_dec_io_config(model_name: str):
+    # return your io dict
+    ...
+
+def get_decoder(model_name: str):
+    # your component implementation
+    ...
+
+def dummy_inputs_func():
+    # return the dummy imput for your component
+    ...
+```
+
 ### E2E example
 For the complete example, please refer to [Bert Optimization with PTQ on CPU](https://github.com/microsoft/Olive/tree/main/examples/bert#bert-optimization-with-ptq-on-cpu).

--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -74,11 +74,14 @@ This workflow performs BERT optimization on GPU with CUDA/TensorRT. It performs 
 ## How to run
 ### Pip requirements
 Install the necessary python packages:
-```
-[CPU]
+```sh
+# [CPU]
+pip install git+https://github.com/microsoft/Olive#egg=olive-ai[cpu]
+# [GPU]
+pip install git+https://github.com/microsoft/Olive#egg=olive-ai[gpu]
+
+# Other dependencies
 python -m pip install -r requirements.txt
-[GPU]
-python -m pip install -r requirements-gpu.txt
 ```
 
 ### Run sample using config
@@ -86,12 +89,12 @@ python -m pip install -r requirements-gpu.txt
 The optimization techniques to run are specified in the relevant config json file.
 
 First, install required packages according to passes.
-```
+```sh
 python -m olive.workflows.run --config <config_file>.json --setup
 ```
 
 Then, optimize the model
-```
+```sh
 python -m olive.workflows.run --config <config_file>.json
 ```
 

--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -57,6 +57,26 @@ The workflow in [bert_inc_static_ptq_cpu.json](bert_inc_static_ptq_cpu.json) is 
 #### Dynamic Quantization
 The workflow in [bert_inc_dynamic_ptq_cpu.json](bert_inc_dynamic_ptq_cpu.json) is similar to the above workflow, but specifically uses dynamic quantization instead of static/dynamic quantization.
 
+#### Run with SmoothQuant
+
+Quantizing activations in large language models (LLMs) with huge parameter sizes can be challenging due to the presence of outliers. The SmoothQuant method, introduced in this [paper](https://arxiv.org/abs/2211.10438), addresses this issue by transferring the quantization difficulty from activations to weights through a mathematically equivalent transformation by using a fixed-value $\alpha$ for the entire model. However, the distributions of activation outliers vary not only across different models but also across different layers within a model. To resolve this, Intel® Neural Compressor proposes a method to obtain layer-wise optimal $\alpha$ values with the ability to tune automatically. Please refer to this [link](https://github.com/intel/neural-compressor/blob/master/docs/source/smooth_quant.md) for more algorithm details.
+
+User can use SmoothQuant by setting `smooth_quant` in `recipes` as shown below. Refer to [bert_inc_smoothquant_ptq_cpu.json](bert_inc_smoothquant_ptq_cpu.json) for an example of SmoothQuant.
+
+```json
+"passes": {
+    "quantization": {
+        "type": "IncStaticQuantization",
+        "config": {
+            "recipes":{
+                "smooth_quant": true,
+                "smooth_quant_args": {"alpha": 0.5}
+            }
+        }
+    }
+}
+```
+
 ### BERT optimization with QAT Customized Training Loop on CPU
 This workflow performs BERT optimization on CPU with QAT Customized Training Loop. It performs the optimization pipeline:
 - *PyTorch Model -> PyTorch Model after QAT -> Onnx Model -> Transformers Optimized Onnx Model -> ONNX Runtime performance tuning*

--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -59,7 +59,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "io_bind": true
+                "enable_cuda_graph": true
             }
 
         }

--- a/examples/bert/bert_inc_smoothquant_ptq_cpu.json
+++ b/examples/bert/bert_inc_smoothquant_ptq_cpu.json
@@ -55,22 +55,25 @@
             "config": {"model_type": "bert"}
         },
         "quantization": {
-            "type": "IncQuantization",
+            "type": "IncStaticQuantization",
             "disable_search": true,
             "config": {
-                "approach": "SEARCHABLE_VALUES",
+                "quant_format": "QOperator",
                 "user_script": "user_script.py",
                 "dataloader_func": "inc_glue_calibration_reader",
+                "recipes":{
+                    "smooth_quant": true,
+                    "smooth_quant_args": {"alpha": 0.7}
+                },
                 "metric": {
                     "name": "accuracy",
-                    "type": "accuracy",
+                    "type": "custom",
                     "sub_types": [
-                        {"name": "accuracy_score", "priority": 1, "goal": {"type": "percent-max-degradation", "value": 2}}
+                        {"name": "accuracy_custom", "priority": 1, "higher_is_better": true, "goal": {"type": "percent-max-degradation", "value": 2}}
                     ],
                     "user_config":{
-                        "post_processing_func": "post_process",
                         "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
+                        "evaluate_func": "eval_accuracy",
                         "batch_size": 1
                     }
                 }
@@ -84,6 +87,6 @@
         },
         "evaluator": "common_evaluator",
         "cache_dir": "cache",
-        "output_dir": "models/bert_inc_ptq_cpu"
+        "output_dir": "models/bert_inc_static_ptq_cpu"
     }
 }

--- a/examples/bert/conda.yaml
+++ b/examples/bert/conda.yaml
@@ -5,10 +5,9 @@ dependencies:
   - python=3.8.13
   - pip=22.3.1
   - pip:
-      - onnxruntime
       - datasets
       - evaluate
       - scipy
       - scikit-learn
       - transformers
-      - git+https://github.com/microsoft/Olive.git
+      - git+https://github.com/microsoft/Olive#egg=olive-ai[cpu]

--- a/examples/bert/conda_gpu.yaml
+++ b/examples/bert/conda_gpu.yaml
@@ -5,11 +5,10 @@ dependencies:
   - python=3.8.13
   - pip=22.3.1
   - pip:
-      - onnxruntime-gpu
       - datasets
       - evaluate
       - psutil
       - scipy
       - scikit-learn
       - transformers
-      - git+https://github.com/microsoft/Olive.git
+      - git+https://github.com/microsoft/Olive#egg=olive-ai[gpu]

--- a/examples/bert/conda_gpu.yaml
+++ b/examples/bert/conda_gpu.yaml
@@ -1,0 +1,15 @@
+name: project_environment
+channels:
+  - defaults
+dependencies:
+  - python=3.8.13
+  - pip=22.3.1
+  - pip:
+      - onnxruntime-gpu
+      - datasets
+      - evaluate
+      - psutil
+      - scipy
+      - scikit-learn
+      - transformers
+      - git+https://github.com/microsoft/Olive.git

--- a/examples/bert/requirements-gpu.txt
+++ b/examples/bert/requirements-gpu.txt
@@ -1,9 +1,0 @@
-azure-ai-ml
-azure-identity
-datasets
-evaluate
-docker
-onnxruntime-gpu
-scipy
-scikit-learn
-transformers

--- a/examples/bert/requirements.txt
+++ b/examples/bert/requirements.txt
@@ -3,7 +3,6 @@ azure-identity
 datasets
 evaluate
 docker
-onnxruntime
 neural-compressor
 scipy
 scikit-learn

--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -146,7 +146,7 @@ def post_process(output):
 # -------------------------------------------------------------------------
 
 
-def create_dataloader(data_dir, batchsize):
+def create_dataloader(data_dir, batchsize, *args, **kwargs):
     bert_dataset = BertDataset("Intel/bert-base-uncased-mrpc")
     eval_dataloader = torch.utils.data.DataLoader(
         BertDatasetWrapper(bert_dataset.get_eval_dataset()), batch_size=batchsize, drop_last=True
@@ -182,7 +182,7 @@ class IncBertDataset:
         return input_dict, label
 
 
-def inc_glue_calibration_reader(data_dir, batch_size=1):
+def inc_glue_calibration_reader(data_dir, batch_size=1, *args, **kwargs):
     bert_dataset = BertDataset("Intel/bert-base-uncased-mrpc")
     bert_dataset = IncBertDataset(bert_dataset.get_eval_dataset())
     calib_dataloader = DefaultDataLoader(dataset=bert_dataset, batch_size=batch_size)

--- a/examples/cifar10_openvino_intel_hw/config.json
+++ b/examples/cifar10_openvino_intel_hw/config.json
@@ -80,6 +80,7 @@
         "evaluator": "common_evaluator",
         "host": "local_system",
         "target": "local_system",
-        "cache_dir": "cache"
+        "cache_dir": "cache",
+        "evaluate_input_model": false
     }
 }

--- a/examples/cifar10_openvino_intel_hw/user_script.py
+++ b/examples/cifar10_openvino_intel_hw/user_script.py
@@ -19,7 +19,7 @@ def post_process(result):
     return [np.argmax(result)]
 
 
-def create_dataloader(data_dir, batchsize):
+def create_dataloader(data_dir, batchsize, *args, **kwargs):
     dataset_config = {"data_source": data_dir}
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))]

--- a/examples/directml/dolly_v2/user_script.py
+++ b/examples/directml/dolly_v2/user_script.py
@@ -40,5 +40,5 @@ def dolly_v2_inputs(batch_size, torch_dtype):
     return inputs
 
 
-def dolly_v2_data_loader(data_dir, batch_size):
+def dolly_v2_data_loader(data_dir, batch_size, *args, **kwargs):
     return RandomDataLoader(dolly_v2_inputs, batch_size, torch.float16)

--- a/examples/directml/squeezenet/user_script.py
+++ b/examples/directml/squeezenet/user_script.py
@@ -19,5 +19,5 @@ class DataLoader:
         return input_data, label
 
 
-def create_dataloader(data_dir, batchsize):
+def create_dataloader(data_dir, batchsize, *args, **kwargs):
     return DataLoader(batchsize)

--- a/examples/directml/stable_diffusion/README.md
+++ b/examples/directml/stable_diffusion/README.md
@@ -1,6 +1,6 @@
 # Stable Diffusion Optimization with DirectML <!-- omit in toc -->
 
-This sample shows how to optimize [Stable Diffusion v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5) to run with ONNX Runtime and DirectML.
+This sample shows how to optimize [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4), [Stable Diffusion v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5) or [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2) to run with ONNX Runtime and DirectML.
 
 Stable Diffusion comprises multiple PyTorch models tied together into a *pipeline*. This Olive sample will convert each PyTorch model to ONNX, and then run the converted ONNX models through the `OrtTransformersOptimization` pass. The transformer optimization pass performs several time-consuming graph transformations that make the models more efficient for inference at runtime. Output models are only guaranteed to be compatible with onnxruntime-directml 1.15.0 or newer.
 
@@ -45,8 +45,8 @@ The above command will enumerate the `config_<model_name>.json` files and optimi
 The stable diffusion models are large, and the optimization process is resource intensive. It is recommended to run optimization on a system with a minimum of 16GB of memory (preferably 32GB). Expect optimization to take several minutes (especially the U-Net model).
 
 Once the script successfully completes:
-- The optimized ONNX pipeline will be stored under `models/optimized/runwayml/stable-diffusion-v1-5`.
-- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/runwayml/stable-diffusion-v1-5`.
+- The optimized ONNX pipeline will be stored under `models/optimized/[model_id]` (for example `models/optimized/runwayml/stable-diffusion-v1-5`).
+- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/[model_id]` (for example `models/unoptimized/runwayml/stable-diffusion-v1-5`).
 
 Re-running the script with `--optimize` will delete the output models, but it will *not* delete the Olive cache. Subsequent runs will complete much faster since it will simply be copying previously optimized models; you may use the `--clean_cache` option to start from scratch (not typically used unless you are modifying the scripts, for example).
 
@@ -77,6 +77,8 @@ Run `python stable_diffusion.py --help` for additional options. A few particular
 - `--model_id <string>` : name of a stable diffusion model ID hosted by huggingface.co. This script has been tested with the following:
   - `CompVis/stable-diffusion-v1-4`
   - `runwayml/stable-diffusion-v1-5` (default)
+  - `sayakpaul/sd-model-finetuned-lora-t4`
+  - `stabilityai/stable-diffusion-2`
   - LoRA variants of the above base models may work as well. See [LoRA Models (Experimental)](#lora-models-experimental).
 - `--num_inference_steps <int>` : the number of sampling steps per inference. The default value is 50. A lower value (e.g. 20) will speed up inference at the expensive of quality, and a higher value (e.g. 100) may produce higher quality images.
 - `--num_images <int>` : the number of images to generate per script invocation (non-interactive UI) or per click of the generate button (interactive UI). The default value is 1.

--- a/examples/directml/stable_diffusion/config.py
+++ b/examples/directml/stable_diffusion/config.py
@@ -1,0 +1,6 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+image_size = 512

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import config
 import torch
 from diffusers import AutoencoderKL, UNet2DConditionModel
 from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
@@ -135,7 +136,7 @@ def unet_inputs(batchsize, torch_dtype):
     return {
         "sample": torch.rand((batchsize, 4, 64, 64), dtype=torch_dtype),
         "timestep": torch.rand((batchsize,), dtype=torch_dtype),
-        "encoder_hidden_states": torch.rand((batchsize, 77, 768), dtype=torch_dtype),
+        "encoder_hidden_states": torch.rand((batchsize, 77, config.image_size + 256), dtype=torch_dtype),
         "return_dict": False,
     }
 
@@ -163,7 +164,7 @@ def unet_data_loader(data_dir, batchsize, *args, **kwargs):
 
 def vae_encoder_inputs(batchsize, torch_dtype):
     return {
-        "sample": torch.rand((batchsize, 3, 512, 512), dtype=torch_dtype),
+        "sample": torch.rand((batchsize, 3, config.image_size, config.image_size), dtype=torch_dtype),
         "return_dict": False,
     }
 
@@ -218,7 +219,7 @@ def vae_decoder_data_loader(data_dir, batchsize, *args, **kwargs):
 def safety_checker_inputs(batchsize, torch_dtype):
     return {
         "clip_input": torch.rand((batchsize, 3, 224, 224), dtype=torch_dtype),
-        "images": torch.rand((batchsize, 512, 512, 3), dtype=torch_dtype),
+        "images": torch.rand((batchsize, config.image_size, config.image_size, 3), dtype=torch_dtype),
     }
 
 

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -122,7 +122,7 @@ def text_encoder_conversion_inputs(model):
     return text_encoder_inputs(1, torch.int32)
 
 
-def text_encoder_data_loader(data_dir, batchsize):
+def text_encoder_data_loader(data_dir, batchsize, *args, **kwargs):
     return RandomDataLoader(text_encoder_inputs, batchsize, torch.int32)
 
 
@@ -152,7 +152,7 @@ def unet_conversion_inputs(model):
     return tuple(unet_inputs(1, torch.float32).values())
 
 
-def unet_data_loader(data_dir, batchsize):
+def unet_data_loader(data_dir, batchsize, *args, **kwargs):
     return RandomDataLoader(unet_inputs, batchsize, torch.float16)
 
 
@@ -179,7 +179,7 @@ def vae_encoder_conversion_inputs(model):
     return tuple(vae_encoder_inputs(1, torch.float32).values())
 
 
-def vae_encoder_data_loader(data_dir, batchsize):
+def vae_encoder_data_loader(data_dir, batchsize, *args, **kwargs):
     return RandomDataLoader(vae_encoder_inputs, batchsize, torch.float16)
 
 
@@ -206,7 +206,7 @@ def vae_decoder_conversion_inputs(model):
     return tuple(vae_decoder_inputs(1, torch.float32).values())
 
 
-def vae_decoder_data_loader(data_dir, batchsize):
+def vae_decoder_data_loader(data_dir, batchsize, *args, **kwargs):
     return RandomDataLoader(vae_decoder_inputs, batchsize, torch.float16)
 
 
@@ -233,5 +233,5 @@ def safety_checker_conversion_inputs(model):
     return tuple(safety_checker_inputs(1, torch.float32).values())
 
 
-def safety_checker_data_loader(data_dir, batchsize):
+def safety_checker_data_loader(data_dir, batchsize, *args, **kwargs):
     return RandomDataLoader(safety_checker_inputs, batchsize, torch.float16)

--- a/examples/mobilenet_qnn_qualcomm_npu/mobilenet_config_template.json
+++ b/examples/mobilenet_qnn_qualcomm_npu/mobilenet_config_template.json
@@ -53,7 +53,7 @@
         "cache_dir": "cache",
         "output_dir": "models",
         "evaluator": "common_evaluator",
-        "evaluation_only": false,
+        "evaluate_input_model": false,
         "clean_cache": true,
         "target": {
             "type": "PythonEnvironment",

--- a/examples/mobilenet_qnn_qualcomm_npu/user_script.py
+++ b/examples/mobilenet_qnn_qualcomm_npu/user_script.py
@@ -46,7 +46,7 @@ class MobileNetCalibrationDataReader(CalibrationDataReader):
         self.iter = None
 
 
-def evaluation_dataloader(data_dir, batch_size=1):
+def evaluation_dataloader(data_dir, batch_size=1, *args, **kwargs):
     dataset = MobileNetDataset(data_dir)
     return DataLoader(dataset, batch_size=batch_size)
 
@@ -55,5 +55,5 @@ def post_process(output):
     return output.argmax(axis=1)
 
 
-def mobilenet_calibration_reader(data_dir, batch_size=1):
+def mobilenet_calibration_reader(data_dir, batch_size=1, *args, **kwargs):
     return MobileNetCalibrationDataReader(data_dir, batch_size=batch_size)

--- a/examples/open_llama/README.md
+++ b/examples/open_llama/README.md
@@ -7,6 +7,54 @@ This workflow also demonstrates how to use:
 
 This example config file [open_llama_config.json](open_llama_config.json) is meant to be a starting point for optimizing Open LLaMA for target hardware. One can add additional passes as well as set different options for Transformer Optimization pass as per need. See [Olive documentation](https://microsoft.github.io/Olive/) for more information on optimizations passes available.
 
+Note that this example config uses [openlm-research/open_llama_3b](https://huggingface.co/openlm-research/open_llama_3b) for demonstration purpose. There are other models available in [Open LLaMA](https://huggingface.co/openlm-research) that can be used for optimization. The following table shows a few models' configurations:
+
+| Model | Num Hidden Layers| Num Attention Heads | Hidden Size |
+| --- | --- | --- | --- |
+| [openlm-research/open_llama_3b](https://huggingface.co/openlm-research/open_llama_3b) | 26 | 32 | 3200 |
+| [openlm-research/open_llama_7b](https://huggingface.co/openlm-research/open_llama_7b) | 32 | 32 | 4096 |
+| [openlm-research/open_llama_13b](https://huggingface.co/openlm-research/open_llama_13b) | 40 | 40 | 5120 |
+
+
+When you run the example config for other larger models, you may need
+1. change the `model_path` to the one you use.
+```json
+"input_model":{
+    "type": "OptimumModel",
+    "config": {
+        "model_path": "openlm-research/open_llama_3b", // to change based on the model you use
+        "model_components": ["decoder_model.onnx", "decoder_with_past_model.onnx"],
+        "hf_config": {
+            "model_class": "LlamaForCausalLM"
+        }
+    }
+}
+```
+2. change the transformer optimization pass options in `open_llama_config.json` based on the above table:
+```json
+"optimize": {
+    "type": "OrtTransformersOptimization",
+    "config": {
+        "model_type": "gpt2",
+        "float16": true,
+        "use_gpu": false,
+        "keep_io_types": true,
+        "num_heads": 32, // to change based on the model you use
+        "hidden_size": 4096, // to change based on the model you use
+        "optimization_options": {
+            "use_multi_head_attention": false
+        }
+    }
+}
+```
+3. increase the `num_hidden_layers` for dummy inputs in `user_script.py`.
+```python
+// to increase `num_hidden_layers` to conduct proper inputs data
+def dummy_inputs(batch_size, torch_dtype, model_framework=Framework.PYTORCH, num_hidden_layers=26):
+    past_sequence_length = 1
+    attention_mask_sequence_length = 1
+```
+
 ### Run sample using config
 
 The optimization techniques to run are specified in the relevant config json file.

--- a/examples/open_llama/open_llama_config.json
+++ b/examples/open_llama/open_llama_config.json
@@ -3,7 +3,10 @@
         "type": "OptimumModel",
         "config": {
             "model_path": "openlm-research/open_llama_3b",
-            "model_components": ["decoder_model.onnx", "decoder_with_past_model.onnx"]
+            "model_components": ["decoder_model.onnx", "decoder_with_past_model.onnx"],
+            "hf_config": {
+                "model_class": "LlamaForCausalLM"
+            }
         }
     },
     "systems": {
@@ -20,7 +23,7 @@
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [{"name": "avg"}],
+                    "sub_types": [{"name": "avg", "goal": {"type": "percent-min-improvement", "value": 10}}],
                     "user_config": {
                         "user_script": "user_script.py",
                         "dataloader_func": "dataloader_func",
@@ -54,9 +57,7 @@
             }
         },
         "merge": {
-            "type": "OptimumMerging",
-            "config": {
-            }
+            "type": "OptimumMerging"
         }
     },
     "engine": {

--- a/examples/open_llama/user_script.py
+++ b/examples/open_llama/user_script.py
@@ -4,20 +4,22 @@
 # --------------------------------------------------------------------------
 import torch
 
+from olive.constants import Framework
 
-# Helper latency-only dataloader that creates random tensors with no label
+
 class RandomDataLoader:
-    def __init__(self, create_inputs_func, batch_size, torch_dtype):
+    def __init__(self, create_inputs_func, batch_size, torch_dtype, model_framework=Framework.PYTORCH):
         self.create_input_func = create_inputs_func
         self.batch_size = batch_size
         self.torch_dtype = torch_dtype
+        self.model_framework = model_framework
 
     def __getitem__(self, idx):
         label = None
-        return self.create_input_func(self.batch_size, self.torch_dtype), label
+        return self.create_input_func(self.batch_size, self.torch_dtype, self.model_framework), label
 
 
-def dummy_inputs(batch_size, torch_dtype):
+def dummy_inputs(batch_size, torch_dtype, model_framework=Framework.PYTORCH):
     past_sequence_length = 1
     attention_mask_sequence_length = 1
     sequence_length = 2
@@ -27,18 +29,20 @@ def dummy_inputs(batch_size, torch_dtype):
         "attention_mask": torch.randint(10, (batch_size, attention_mask_sequence_length), dtype=torch.int64),
     }
 
-    for layer_index in range(26):
-        inputs[f"past_key_values.{layer_index}.key"] = torch.rand(
-            (batch_size, 32, past_sequence_length, 100), dtype=torch_dtype
-        )
-        inputs[f"past_key_values.{layer_index}.value"] = torch.rand(
-            (batch_size, 32, past_sequence_length, 100), dtype=torch_dtype
-        )
+    if model_framework == Framework.ONNX:
+        for layer_index in range(26):
+            inputs[f"past_key_values.{layer_index}.key"] = torch.rand(
+                (batch_size, 32, past_sequence_length, 100), dtype=torch_dtype
+            )
+            inputs[f"past_key_values.{layer_index}.value"] = torch.rand(
+                (batch_size, 32, past_sequence_length, 100), dtype=torch_dtype
+            )
 
-    inputs["use_cache_branch"] = torch.ones((1,), dtype=torch.bool)
+        inputs["use_cache_branch"] = torch.ones((1,), dtype=torch.bool)
 
     return inputs
 
 
 def dataloader_func(data_dir, batch_size, *args, **kwargs):
-    return RandomDataLoader(dummy_inputs, batch_size, torch.float16)
+    model_framework = kwargs.get("model_framework", Framework.PYTORCH)
+    return RandomDataLoader(dummy_inputs, batch_size, torch.float16, model_framework)

--- a/examples/open_llama/user_script.py
+++ b/examples/open_llama/user_script.py
@@ -19,7 +19,7 @@ class RandomDataLoader:
         return self.create_input_func(self.batch_size, self.torch_dtype, self.model_framework), label
 
 
-def dummy_inputs(batch_size, torch_dtype, model_framework=Framework.PYTORCH):
+def dummy_inputs(batch_size, torch_dtype, model_framework=Framework.PYTORCH, num_hidden_layers=26):
     past_sequence_length = 1
     attention_mask_sequence_length = 1
     sequence_length = 2
@@ -30,7 +30,7 @@ def dummy_inputs(batch_size, torch_dtype, model_framework=Framework.PYTORCH):
     }
 
     if model_framework == Framework.ONNX:
-        for layer_index in range(26):
+        for layer_index in range(num_hidden_layers):
             inputs[f"past_key_values.{layer_index}.key"] = torch.rand(
                 (batch_size, 32, past_sequence_length, 100), dtype=torch_dtype
             )

--- a/examples/open_llama/user_script.py
+++ b/examples/open_llama/user_script.py
@@ -40,5 +40,5 @@ def dummy_inputs(batch_size, torch_dtype):
     return inputs
 
 
-def dataloader_func(data_dir, batch_size):
+def dataloader_func(data_dir, batch_size, *args, **kwargs):
     return RandomDataLoader(dummy_inputs, batch_size, torch.float16)

--- a/examples/resnet/user_script.py
+++ b/examples/resnet/user_script.py
@@ -69,7 +69,7 @@ def post_process(output):
 # -------------------------------------------------------------------------
 
 
-def create_dataloader(data_dir, batch_size):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     cifar10_dataset = CIFAR10DataSet(data_dir)
     _, val_set = torch.utils.data.random_split(cifar10_dataset.val_dataset, [49000, 1000])
     benchmark_dataloader = DataLoader(PytorchResNetDataset(val_set), batch_size=batch_size, drop_last=True)
@@ -93,7 +93,7 @@ class ResnetCalibrationDataReader(CalibrationDataReader):
             return None
 
 
-def resnet_calibration_reader(data_dir, batch_size=16):
+def resnet_calibration_reader(data_dir, batch_size=16, *args, **kwargs):
     return ResnetCalibrationDataReader(data_dir, batch_size=batch_size)
 
 
@@ -156,7 +156,7 @@ def create_qat_config():
 # -------------------------------------------------------------------------
 
 
-def create_train_dataloader(data_dir, batchsize):
+def create_train_dataloader(data_dir, batchsize, *args, **kwargs):
     cifar10_dataset = CIFAR10DataSet()
     train_dataset, _ = torch.utils.data.random_split(cifar10_dataset.train_dataset, [40000, 10000])
     train_dataloader = DataLoader(PytorchResNetDataset(train_dataset), batch_size=batchsize, drop_last=True)

--- a/examples/resnet/user_script.py
+++ b/examples/resnet/user_script.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import torch
+import torchmetrics
 from onnxruntime.quantization.calibrate import CalibrationDataReader
 from pytorch_lightning import LightningDataModule, LightningModule
 from torch.utils.data import DataLoader, Dataset
@@ -10,7 +11,6 @@ from torchvision import transforms
 from torchvision.datasets import CIFAR10
 
 from olive.constants import Framework
-from olive.evaluator.accuracy import AccuracyScore
 from olive.model import OliveModel
 
 # -------------------------------------------------------------------------
@@ -137,7 +137,11 @@ def eval_accuracy(model: OliveModel, data_dir, batch_size, device, execution_pro
             preds.extend(outputs.tolist())
             target.extend(labels.data.tolist())
 
-    return AccuracyScore().measure(preds, target)
+    preds_tensor = torch.tensor(preds, dtype=torch.int)
+    target_tensor = torch.tensor(target, dtype=torch.int)
+    accuracy = torchmetrics.Accuracy()
+    result = accuracy(preds_tensor, target_tensor)
+    return result.item()
 
 
 # -------------------------------------------------------------------------

--- a/examples/switch/README.md
+++ b/examples/switch/README.md
@@ -1,0 +1,32 @@
+# Experts distributor for MoE models (using ORT MoE implementation)
+This folder contains a sample use case of Olive to distribute experts across multiple onnx graphs for use with distributed inferencing with MoE models.
+
+## Prerequisites
+### Clone the repository and install Olive
+
+Refer to the instructions in the [examples README](../README.md) to clone the repository and install Olive.
+
+**Important:** To run the example, you would need a custom onnxruntime build with support for cuda, nccl & mpi.
+
+### Pip requirements
+Install the necessary python packages:
+```
+python -m pip install -r requirements.txt
+```
+
+## Run the config to distribute the model
+```bash
+python -m olive.workflows.run --config examples/switch/config.json --setup
+```
+
+## Test the generated models
+```bash
+python examples/switch/inference.py --filename-pattern {base_model_name}{{:02d}}.onnx --world-size {gpu count}
+
+```
+
+## To compare the results of non-distributed model to the distributed one
+```bash
+python examples/switch/inference.py --filepath {base_model_name}.onnx --filename-pattern {base_model_name}_{{:02d}}.onnx --world-size {gpu count} --compare
+
+```

--- a/examples/switch/config.json
+++ b/examples/switch/config.json
@@ -1,0 +1,31 @@
+{
+    "verbose": true,
+    "input_model":{
+        "type": "OnnxModel",
+        "config": {
+            "model_path": "model_4n_2l_8e.onnx"
+        }
+    },
+    "passes": {
+        "distribute": {
+            "type": "MoEExpertsDistributor",
+            "config": {
+                "world_size": 2
+            }
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "config": {
+                "accelerators": ["gpu"]
+            }
+        }
+    },
+    "engine": {
+        "host": "local_system",
+        "clean_cache": true,
+        "cache_dir": "cache",
+        "output_dir": "models"
+    }
+}

--- a/examples/switch/inference.py
+++ b/examples/switch/inference.py
@@ -1,0 +1,134 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import argparse
+import os
+import pprint
+import sys
+
+import numpy
+import onnxruntime
+
+
+def _run_non_distributed(filepath):
+    session = onnxruntime.InferenceSession(filepath, providers=["CPUExecutionProvider", "CUDAExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    data = numpy.full((40, 40), 2, dtype=numpy.int64)
+    output = session.run(None, {input_name: data})[0]
+
+    return output
+
+
+def _mpipool_worker(args):
+    local_rank, world_size, filepath = args
+
+    os.environ["OMPI_COMM_WORLD_RANK"] = str(local_rank)
+    os.environ["OMPI_COMM_WORLD_SIZE"] = str(world_size)
+
+    from mpi4py import MPI
+
+    local_rank = MPI.COMM_WORLD.Get_rank()
+    MPI.COMM_WORLD.barrier()
+
+    print(f"rank: {local_rank}, filepath: {filepath}")
+
+    session = onnxruntime.InferenceSession(
+        filepath,
+        providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+        provider_options=[{"device_id": str(local_rank)}, {}],
+    )
+    input_name = session.get_inputs()[0].name
+    data = numpy.full((40, 40), 2, dtype=numpy.int64)
+    output = session.run(None, {input_name: data})[0]
+
+    return output
+
+
+def _run_using_mpipool(filepath, world_size):
+    from mpi4py.futures import MPIPoolExecutor
+    from mpi4py.MPI import COMM_WORLD
+
+    args = [(rank, world_size, filepath.format(rank)) for rank in range(world_size)]
+    with MPIPoolExecutor(max_workers=world_size) as executor:
+        outputs = executor.map(_mpipool_worker, args)
+        executor.shutdown()
+
+    COMM_WORLD.barrier()
+
+    return list(outputs)
+
+
+def _main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--filepath", dest="filepath", type=str, help="Onnx model file to load for non-distributed run")
+    parser.add_argument(
+        "--filename-pattern",
+        dest="filename_pattern",
+        type=str,
+        help="Onnx model file name pattern to use for distributed run",
+    )
+    parser.add_argument("--world-size", dest="world_size", type=int, help="World size for distributed run")
+    parser.add_argument(
+        "--compare",
+        dest="compare",
+        action="store_true",
+        default=False,
+        help="Compare results from distributed session to non-distributed session",
+    )
+    parser.add_argument("--debug", action="store_true", default=False, help="Enable debug output")
+    args = parser.parse_args()
+
+    distributed_session_outputs = None
+    if args.filename_pattern and (args.world_size > 1):
+        distributed_session_outputs = _run_using_mpipool(args.filename_pattern, args.world_size)
+
+    # For some unidentified reason, running a non-distributed session before a distributed one doesn't work.
+    # The distributed session fails on MPI initialization.
+    non_distributed_session_outputs = None
+    if args.filepath:
+        non_distributed_session_outputs = _run_non_distributed(args.filepath)
+
+    if args.debug:
+        pprint.pprint(
+            {
+                "non_distributed_session_outputs": non_distributed_session_outputs,
+                "distributed_session_outputs": distributed_session_outputs,
+            }
+        )
+
+    if args.compare and (non_distributed_session_outputs is not None) and (distributed_session_outputs is not None):
+        atol = 1e-04
+        results = {}
+        for i in range(args.world_size):
+            results[f"nondist vs. dist_{i:02d}"] = numpy.allclose(
+                non_distributed_session_outputs, distributed_session_outputs[i], atol=atol
+            )
+
+            if i > 0:
+                results[f"dist_00 vs. dist_{i:02d}"] = numpy.allclose(
+                    distributed_session_outputs[0], distributed_session_outputs[i], atol=atol
+                )
+
+        pprint.pprint(results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())
+
+
+# python3 inference.py \
+#   --filepath model_4n_2l_8e.onnx
+#
+# python3 inference.py \
+#   --filename-pattern model_4n_2l_8e_{:02d}.onnx \
+#   --world-size 2
+#
+# python3 inference.py \
+#   --filepath model_4n_2l_8e.onnx \
+#   --filename-pattern model_4n_2l_8e_{:02d}.onnx \
+#   --world-size 2
+#   --compare

--- a/examples/test/test_bert_cuda_gpu.py
+++ b/examples/test/test_bert_cuda_gpu.py
@@ -1,0 +1,35 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import os
+from pathlib import Path
+
+import pytest
+from utils import check_search_output, patch_config
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    """setup any state specific to the execution of the given module."""
+    cur_dir = Path(__file__).resolve().parent.parent
+    example_dir = cur_dir / "bert"
+    os.chdir(example_dir)
+    yield
+    os.chdir(cur_dir)
+
+
+@pytest.mark.parametrize("search_algorithm", ["tpe"])
+@pytest.mark.parametrize("execution_order", ["joint"])
+@pytest.mark.parametrize("system", ["aml_system"])
+@pytest.mark.parametrize("olive_json", ["bert_cuda_gpu.json"])
+@pytest.mark.parametrize("enable_cuda_graph", [True, False])
+def test_bert(search_algorithm, execution_order, system, olive_json, enable_cuda_graph):
+
+    from olive.workflows import run as olive_run
+
+    olive_config = patch_config(olive_json, search_algorithm, execution_order, system, is_gpu=True)
+    olive_config["passes"]["perf_tuning"]["config"]["enable_cuda_graph"] = enable_cuda_graph
+
+    footprint = olive_run(olive_config)
+    check_search_output(footprint)

--- a/examples/test/test_whisper.py
+++ b/examples/test/test_whisper.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import json
 import os
+import platform
 import sys
 from pathlib import Path
 
@@ -29,9 +30,12 @@ def setup():
     sys.path.remove(example_dir)
 
 
-@pytest.mark.parametrize("device_precision", [("cpu", "fp32"), ("cpu", "int8")])
+@pytest.mark.parametrize("device_precision", [("cpu", "fp32"), ("cpu", "int8"), ("cpu", "inc_int8")])
 def test_whisper(device_precision):
     from olive.workflows import run as olive_run
+
+    if platform.system() == "Windows" and device_precision[1].startswith("inc_int8"):
+        pytest.skip("Skip test on Windows. neural-compressor import is hanging on Windows.")
 
     device, precision = device_precision
     config_file = f"whisper_{device}_{precision}.json"

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -23,7 +23,7 @@ def check_no_search_output(outputs):
             assert item.value > 0
 
 
-def patch_config(config_json_path: str, search_algorithm: str, execution_order: str, system: str):
+def patch_config(config_json_path: str, search_algorithm: str, execution_order: str, system: str, is_gpu: bool = False):
     """Load the config json file and patch it with the given search algorithm, execution order and system."""
     with open(config_json_path, "r") as fin:
         olive_config = json.load(fin)
@@ -41,7 +41,7 @@ def patch_config(config_json_path: str, search_algorithm: str, execution_order: 
     update_azureml_config(olive_config)
     if system == "aml_system":
         # set aml_system
-        set_aml_system(olive_config)
+        set_aml_system(olive_config, is_gpu=is_gpu)
         olive_config["engine"]["host"] = system
         olive_config["engine"]["target"] = system
     elif system == "docker_system":
@@ -73,23 +73,38 @@ def update_azureml_config(olive_config):
     }
 
 
-def set_aml_system(olive_config):
+def set_aml_system(olive_config, is_gpu=False):
     """Set the aml_system in the olive config."""
     if "systems" not in olive_config:
         olive_config["systems"] = {}
 
-    olive_config["systems"]["aml_system"] = {
-        "type": "AzureML",
-        "config": {
-            "accelerators": ["CPU"],
-            "aml_compute": "cpu-cluster",
-            "aml_docker_config": {
-                "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
-                "conda_file_path": "conda.yaml",
+    if is_gpu:
+        olive_config["systems"]["aml_system"] = {
+            "type": "AzureML",
+            "config": {
+                "accelerators": ["GPU"],
+                "aml_compute": "gpu-cluster",
+                "aml_docker_config": {
+                    "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04:20230608.v1",
+                    "conda_file_path": "conda_gpu.yaml",
+                },
+                "is_dev": True,
             },
-            "is_dev": True,
-        },
-    }
+        }
+
+    else:
+        olive_config["systems"]["aml_system"] = {
+            "type": "AzureML",
+            "config": {
+                "accelerators": ["CPU"],
+                "aml_compute": "cpu-cluster",
+                "aml_docker_config": {
+                    "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
+                    "conda_file_path": "conda.yaml",
+                },
+                "is_dev": True,
+            },
+        }
 
 
 def set_docker_system(olive_config):

--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -4,6 +4,7 @@ This folder contains a sample use case of Olive to optimize a [Whisper](https://
 Performs optimization pipeline:
 - CPU, FP32: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 - CPU, INT8: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Dynamic Quantized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
+- CPU, INT8: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Intel® Neural Compressor Dynamic Quantized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 - GPU, FP32: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 - GPU, FP16: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Mixed Precision Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 - GPU, INT8: *PyTorch Model -> Onnx Model -> Dynamic Quantized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
@@ -16,6 +17,8 @@ Outputs the final model and latency results.
 ### Clone the repository and install Olive
 
 Refer to the instructions in the [examples README](../README.md) to clone the repository and install Olive.
+
+If you want to run the optimization pipeline with Intel® Neural Compressor, please make sure that `olive-ai[inc]` is installed.
 
 ### Pip requirements
 Install the necessary python packages:

--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -25,9 +25,13 @@ python -m pip install -r requirements.txt
 
 ### Prepare workflow config json
 ```
-python prepare_whisper_configs.py [--no_audio_decoder] [--multilingual]
+python prepare_whisper_configs.py [--model_name MODEL_NAME] [--no_audio_decoder] [--multilingual]
+
+# For example, using whisper tiny model
+python prepare_whisper_configs.py --model_name openai/whisper-tiny.en
 ```
 
+`--model_name MODEL_NAME` is the name or path of the whisper model. The default value is `openai/whisper-tiny.en`.  
 `--no_audio_decoder` is optional. If not provided, will use audio decoder in the preprocessing ops.
 
 **Note:** If `--no_audio_decoder` is provided, you need to install `librosa` package before running the optimization steps below.

--- a/examples/whisper/code/user_script.py
+++ b/examples/whisper/code/user_script.py
@@ -164,9 +164,9 @@ def decoder_dummy_inputs(model):
     return tuple(inputs.to_list())
 
 
-def whisper_audio_decoder_dataloader(data_dir, batch_size=None):
+def whisper_audio_decoder_dataloader(data_dir, batch_size=None, *args, **kwargs):
     return WhisperDataset(data_dir=data_dir, use_audio_decoder=True)
 
 
-def whisper_no_audio_decoder_dataloader(data_dir, batch_size=None):
+def whisper_no_audio_decoder_dataloader(data_dir, batch_size=None, *args, **kwargs):
     return WhisperDataset(data_dir=data_dir, use_audio_decoder=False)

--- a/examples/whisper/code/user_script.py
+++ b/examples/whisper/code/user_script.py
@@ -9,8 +9,8 @@ from whisper_decoder import WhisperDecoder, WhisperDecoderInputs
 from whisper_encoder_decoder_init import WhisperEncoderDecoderInit, WhisperEncoderDecoderInitInputs
 
 
-def get_encoder_decoder_init():
-    model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
+def get_encoder_decoder_init(model_name):
+    model = WhisperForConditionalGeneration.from_pretrained(model_name)
     return WhisperEncoderDecoderInit(
         model,
         model,
@@ -19,13 +19,13 @@ def get_encoder_decoder_init():
     )
 
 
-def get_decoder():
-    model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
+def get_decoder(model_name):
+    model = WhisperForConditionalGeneration.from_pretrained(model_name)
     return WhisperDecoder(model, model.config)
 
 
-def get_encdec_io_config():
-    model = get_encoder_decoder_init()
+def get_encdec_io_config(model_name):
+    model = get_encoder_decoder_init(model_name)
     use_decoder_input_ids = True
 
     inputs = WhisperEncoderDecoderInitInputs.create_dummy(
@@ -96,10 +96,10 @@ def get_encdec_io_config():
     }
 
 
-def get_dec_io_config():
+def get_dec_io_config(model_name):
     # Fix past disappearing bug - duplicate first past entry
     # input_list.insert(2, input_list[2])
-    model = get_decoder()
+    model = get_decoder(model_name)
     past_names = PastKeyValuesHelper.get_past_names(model.config.decoder_layers, present=False)
     present_names = PastKeyValuesHelper.get_past_names(model.config.decoder_layers, present=True)
     present_self_names = present_names[: 2 * model.config.decoder_layers]

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -21,6 +21,13 @@ SUPPORTED_WORKFLOWS = {
         "insert_beam_search",
         "prepost",
     ],
+    ("cpu", "inc_int8"): [
+        "conversion",
+        "transformers_optimization",
+        "inc_dynamic_quantization",
+        "insert_beam_search",
+        "prepost",
+    ],
     ("gpu", "fp32"): ["conversion", "transformers_optimization", "insert_beam_search", "prepost"],
     ("gpu", "fp16"): ["conversion", "transformers_optimization", "mixed_precision", "insert_beam_search", "prepost"],
     ("gpu", "int8"): ["conversion", "onnx_dynamic_quantization", "insert_beam_search", "prepost"],

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -29,6 +29,7 @@ SUPPORTED_WORKFLOWS = {
 
 def get_args(raw_args):
     parser = argparse.ArgumentParser(description="Prepare config file for Whisper")
+    parser.add_argument("--model_name", type=str, default="openai/whisper-tiny.en", help="Model name")
     parser.add_argument(
         "--no_audio_decoder",
         action="store_true",
@@ -54,8 +55,12 @@ def main(raw_args=None):
 
     # load template
     template_json = json.load(open("whisper_template.json", "r"))
+    model_name = args.model_name
 
-    whisper_config = WhisperConfig.from_pretrained(template_json["input_model"]["config"]["hf_config"]["model_name"])
+    whisper_config = WhisperConfig.from_pretrained(model_name)
+
+    # update model name
+    template_json["input_model"]["config"]["hf_config"]["model_name"] = model_name
 
     # set dataloader
     template_json["evaluators"]["common_evaluator"]["metrics"][0]["user_config"]["dataloader_func"] = (
@@ -68,6 +73,9 @@ def main(raw_args=None):
 
     # update multi-lingual support
     template_json["passes"]["insert_beam_search"]["config"]["use_forced_decoder_ids"] = args.multilingual
+
+    # set model name in prepost
+    template_json["passes"]["prepost"]["config"]["tool_command_args"]["model_name"] = model_name
 
     # download audio test data
     test_audio_path = download_audio_test_data()
@@ -97,6 +105,10 @@ def main(raw_args=None):
         # dump config
         json.dump(config, open(f"whisper_{device}_{precision}.json", "w"), indent=4)
 
+    # update user script
+    user_script_path = Path(__file__).parent / "code" / "user_script.py"
+    update_user_script(user_script_path, model_name)
+
 
 def download_audio_test_data():
     cur_dir = Path(__file__).parent
@@ -111,6 +123,20 @@ def download_audio_test_data():
     request.urlretrieve(test_audio_url, test_audio_path)
 
     return test_audio_path.relative_to(cur_dir)
+
+
+def update_user_script(file_path, model_name):
+    with open(file_path, "r") as file:
+        lines = file.readlines()
+
+    new_lines = []
+    for line in lines:
+        if "<model_name>" in line:
+            line = line.replace("<model_name>", model_name)
+        new_lines.append(line)
+
+    with open(file_path, "w") as file:
+        file.writelines(new_lines)
 
 
 if __name__ == "__main__":

--- a/examples/whisper/requirements.txt
+++ b/examples/whisper/requirements.txt
@@ -3,3 +3,4 @@ onnxruntime>=1.15.0
 onnxruntime-extensions>=0.8.0
 torch>=1.13.1
 transformers>=4.23.1
+neural-compressor

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -79,6 +79,10 @@
                 "MatMulConstBOnly": false
             }
         },
+        "inc_dynamic_quantization": {
+            "type": "IncDynamicQuantization",
+            "disable_search": true
+        },
         "insert_beam_search" : {
             "type" : "InsertBeamSearch",
             "config": {

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -107,6 +107,7 @@
         "host": "local_system",
         "target": "local_system",
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "clean_cache": false,
         "cache_dir": "cache",
         "output_dir": "models",

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -6,7 +6,7 @@
             "script_dir": "code",
             "hf_config": {
                 "model_class" : "WhisperForConditionalGeneration",
-                "model_name" : "openai/whisper-tiny",
+                "model_name" : "<place_holder>",
                 "components" : [
                     {
                         "name": "encoder_decoder_init",
@@ -90,7 +90,7 @@
             "config": {
                 "tool_command": "whisper",
                 "tool_command_args": {
-                    "model_name": "openai/whisper-tiny",
+                    "model_name" : "<place_holder>",
                     "testdata_filepath": "<place_holder>",
                     "use_audio_decoder" : "<place_holder>"
                 }

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -187,8 +187,8 @@ def save_model(
     with model_jsons[0].open("r") as f:
         model_json = serialize_to_json(json.load(f))
 
-    if model_json["type"].lower() == "compositeonnxmodel":
-        logger.warning("Saving composite ONNX models is not supported yet.")
+    if model_json["type"].lower() in ["compositeonnxmodel", "distributedonnxmodel"]:
+        logger.warning(f"Saving models of type '{model_json['type']}' is not supported yet.")
         return
 
     model_path = model_json["config"]["model_path"]

--- a/olive/data/component/post_process_data.py
+++ b/olive/data/component/post_process_data.py
@@ -30,3 +30,22 @@ def text_classification_post_process(_output_data, **kwargs):
         _, preds = torch.max(_output_data, dim=1)
 
     return preds
+
+
+@Registry.register_post_process()
+def ner_post_process(_output_data, **kwargs):
+    """Post-process data for NER task.
+
+    Args:
+        data (object): Model output to be post-processed.
+        **kwargs: Additional arguments.
+
+    Returns:
+        object: Post-processed data.
+    """
+    if isinstance(_output_data, transformers.modeling_outputs.TokenClassifierOutput):
+        logits = _output_data.logits
+    else:
+        logits = _output_data
+    preds = torch.argmax(logits, dim=-1)
+    return preds

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -22,6 +22,26 @@ def pre_process(_dataset):
     return _dataset
 
 
+def _huggingface_pre_precess_helper(dataset, model_name, input_cols, label_cols, map_func, **kwargs):
+    """Pre-process data.
+
+    Args:
+        data (object): Data to be pre-processed.
+        **kwargs: Additional arguments.
+
+    Returns:
+        object: Pre-processed data.
+    """
+    # output type is list
+    tokenized_datasets = dataset.map(
+        map_func,
+        batched=kwargs.get("batched", True),
+        remove_columns=dataset.column_names,
+    )
+    tokenized_datasets.set_format("torch", output_all_columns=True)
+    return tokenized_datasets
+
+
 @Registry.register_pre_process()
 def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwargs):
     """Pre-process data.
@@ -34,8 +54,6 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwar
         object: Pre-processed data.
     """
     from transformers import AutoTokenizer
-
-    dataset = _dataset
 
     def _tokenizer_and_align_labels(examples):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -51,12 +69,60 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwar
         # huggingface dataset api limit to return dict and arrow table
         return tokenized_inputs
 
-    # output type is list
-    tokenized_datasets = dataset.map(
-        _tokenizer_and_align_labels,
-        batched=kwargs.get("batched", True),
-        remove_columns=dataset.column_names,
+    tokenized_datasets = _huggingface_pre_precess_helper(
+        _dataset, model_name, input_cols, label_cols, _tokenizer_and_align_labels, **kwargs
     )
-    tokenized_datasets.set_format("torch", output_all_columns=True)
     # label_cols is ["label"] since we added label_cols[0] as "label" to tokenized_inputs
+    return BaseDataset(tokenized_datasets, label_cols=["label"])
+
+
+@Registry.register_pre_process()
+def ner_huggingface_preprocess(_dataset, model_name, input_cols, label_cols, **kwargs):
+    """
+    Pre-process data for ner task.
+    """
+    from transformers import AutoTokenizer
+
+    def _align_labels_with_tokens(labels, word_ids):
+        new_labels = []
+        current_word = None
+        for word_id in word_ids:
+            if word_id != current_word:
+                # Start of a new word!
+                current_word = word_id
+                label = 0 if word_id is None else labels[word_id]
+                new_labels.append(label)
+            elif word_id is None:
+                # Special token
+                new_labels.append(0)
+            else:
+                # Same word as previous token
+                label = labels[word_id]
+                # If the label is B-XXX we change it to I-XXX
+                if label % 2 == 1:
+                    label += 1
+                new_labels.append(label)
+        return new_labels
+
+    def _tokenizer_and_align_labels(examples):
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenized_inputs = tokenizer(
+            *[examples[input_col] for input_col in input_cols],
+            padding=kwargs.get("padding", True),
+            truncation=kwargs.get("truncation", True),
+            is_split_into_words=kwargs.get("is_split_into_words", True),
+            add_special_tokens=kwargs.get("add_special_tokens", False),
+        )
+        all_labels = examples[label_cols[0]]
+        new_labels = []
+        for i, labels in enumerate(all_labels):
+            word_ids = tokenized_inputs.word_ids(i)
+            new_labels.append(_align_labels_with_tokens(labels, word_ids))
+
+        tokenized_inputs["label"] = new_labels
+        return tokenized_inputs
+
+    tokenized_datasets = _huggingface_pre_precess_helper(
+        _dataset, model_name, input_cols, label_cols, _tokenizer_and_align_labels, **kwargs
+    )
     return BaseDataset(tokenized_datasets, label_cols=["label"])

--- a/olive/data/container/huggingface_container.py
+++ b/olive/data/container/huggingface_container.py
@@ -23,4 +23,8 @@ class HuggingfaceContainer(DataContainer):
         "text-classification": {
             DataComponentType.POST_PROCESS_DATA.value: "text_classification_post_process",
         },
+        "ner": {
+            DataComponentType.PRE_PROCESS_DATA.value: "ner_huggingface_preprocess",
+            DataComponentType.POST_PROCESS_DATA.value: "ner_post_process",
+        },
     }

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -259,7 +259,7 @@ class Engine:
         packaging_config: Optional[PackagingConfig] = None,
         output_dir: str = None,
         output_name: str = None,
-        evaluation_only: bool = False,
+        evaluate_input_model: bool = True,
     ):
         """
         Run all the registered Olive passes on the input model and produce one or more candidate models.
@@ -270,7 +270,7 @@ class Engine:
             output_dir: output directory for the output model
             output_name: output name for the output model, if output_name is provided, the output
                 model will be saved to engine's output_dir with the prefix of output_name.
-            evaluation_only: if evaluation_only is True, run the evaluation on the input model and return the results.
+            evaluate_input_model: if evaluate_input_model is True, run the evaluation on the input model.
 
         Return:
             if search strategy is None, all passes are run in the order they were registered.
@@ -299,18 +299,21 @@ class Engine:
             self.footprints[accelerator_spec].record(model_id=input_model_id)
 
             try:
-                if evaluation_only:
+                if evaluate_input_model:
                     prefix_output_name = (
-                        f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}_"
+                        f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}"
                     )
-                    assert self.evaluator_config is not None, "Evaluation only is True but no evaluator provided"
+                    assert self.evaluator_config is not None, "evaluate_input_model is True but no evaluator provided"
                     results = self._evaluate_model(input_model, input_model_id, self.evaluator_config, accelerator_spec)
-                    result_name = f"{prefix_output_name}metrics"
+                    logger.info(f"Input model evaluation results: {results}")
+                    result_name = f"{prefix_output_name}_input_model_metrics"
                     results_path = output_dir / f"{result_name}.json"
                     with open(results_path, "w") as f:
                         json.dump(results.to_json(), f, indent=4)
+                    logger.info(f"Saved evaluation results of input model to {results_path}")
                     outputs[accelerator_spec] = results
-                elif self.no_search:
+
+                if self.no_search:
                     output = self.run_no_search(
                         input_model,
                         input_model_id,

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -312,6 +312,9 @@ class Engine:
                         json.dump(results.to_json(), f, indent=4)
                     logger.info(f"Saved evaluation results of input model to {results_path}")
                     outputs[accelerator_spec] = results
+                    if not self.passes:
+                        logger.debug("No passes registered, return input model evaluation results.")
+                        return outputs
 
                 if self.no_search:
                     output = self.run_no_search(

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -18,7 +18,9 @@ user_path_config = ["data_dir"]
 _common_user_config = {
     "script_dir": ConfigParam(type_=Union[Path, str]),
     "user_script": ConfigParam(type_=Union[Path, str]),
+    "inference_settings": ConfigParam(type_=dict),
     "data_dir": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS, is_path=True),
+    "dataloader_func": ConfigParam(type_=Union[Callable, str], is_object=True),
     "batch_size": ConfigParam(type_=int, default_value=1),
     "input_names": ConfigParam(type_=List),
     "input_shapes": ConfigParam(type_=List),
@@ -29,17 +31,14 @@ _common_user_config_validators = {}
 
 _type_to_user_config = {
     "latency": {
-        "dataloader_func": ConfigParam(type_=Union[Callable, str], is_object=True),
-        "inference_settings": ConfigParam(type_=dict),
         "io_bind": ConfigParam(type_=bool, default_value=False),
     },
     "accuracy": {
-        "dataloader_func": ConfigParam(type_=Union[Callable, str], is_object=True),
         "post_processing_func": ConfigParam(type_=Union[Callable, str], is_object=True),
-        "inference_settings": ConfigParam(type_=dict),
     },
     "custom": {
-        "evaluate_func": ConfigParam(type_=Union[Callable, str], required=True, is_object=True),
+        "evaluate_func": ConfigParam(type_=Union[Callable, str], required=False, is_object=True),
+        "metric_func": ConfigParam(type_=Union[Callable, str], required=False, is_object=True),
     },
 }
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -134,7 +134,7 @@ class OliveEvaluator(ABC):
             # only do this if data_config or dataloader is not provided
             # priority: dataloader_func > data_config > user_config.input_names/input_shapes > model io_config
             metric = OliveEvaluator.generate_metric_user_config_with_model_io(original_metric, model)
-            dataloader, eval_func, post_func = OliveEvaluator.get_user_config(metric)
+            dataloader, eval_func, post_func = OliveEvaluator.get_user_config(metric, model)
 
             if metric.type == MetricType.ACCURACY:
                 metrics_res[metric.name] = self._evaluate_accuracy(
@@ -178,7 +178,7 @@ class OliveEvaluator(ABC):
         return metric
 
     @staticmethod
-    def get_user_config(metric: Metric):
+    def get_user_config(metric: Metric, model: OliveModel):
         user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
 
         post_processing_func = getattr(metric.user_config, "post_processing_func", None)
@@ -186,7 +186,10 @@ class OliveEvaluator(ABC):
 
         dataloader_func = getattr(metric.user_config, "dataloader_func", None)
         dataloader = user_module.call_object(
-            dataloader_func, get_local_path(metric.user_config.data_dir), metric.user_config.batch_size
+            dataloader_func,
+            get_local_path(metric.user_config.data_dir),
+            metric.user_config.batch_size,
+            model_framework=model.framework,
         )
 
         evaluate_func = getattr(metric.user_config, "evaluate_func", None)
@@ -355,7 +358,6 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         world_size = config["world_size"]
         inference_settings = config.get("inference_settings", {}) or {}
         metric = Metric.from_json(config["metric"])
-        dataloader, _, post_func = OnnxEvaluator.get_user_config(metric)
 
         import os
 
@@ -371,6 +373,8 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         inference_settings["provider_options"] = [{"device_id": str(local_rank)}, {}]
 
         model = ONNXModel(model_path, inference_settings=inference_settings)
+        dataloader, _, post_func = OnnxEvaluator.get_user_config(metric, model)
+
         session = model.prepare_session(inference_settings=inference_settings, device=Device.GPU, rank=int(local_rank))
         io_config = model.get_io_config()
 
@@ -423,7 +427,6 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         world_size = config["world_size"]
         inference_settings = config.get("inference_settings", {}) or {}
         metric = Metric.from_json(config["metric"])
-        dataloader, _, _ = OnnxEvaluator.get_user_config(metric)
 
         import os
 
@@ -439,6 +442,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         inference_settings["provider_options"] = [{"device_id": str(local_rank)}, {}]
 
         model = ONNXModel(model_path, inference_settings=inference_settings)
+        dataloader, _, _ = OnnxEvaluator.get_user_config(metric, model)
         session = model.prepare_session(inference_settings=inference_settings, device=Device.GPU, rank=int(local_rank))
         io_config = model.get_io_config()
 

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -670,20 +670,13 @@ class PyTorchModel(OliveModel):
         return serialize_to_json(config, check_object)
 
 
-class OptimumModel(OliveModel):
-    def __init__(self, model_path: OLIVE_RESOURCE_ANNOTATIONS, model_components: List[str]):
+class OptimumModel(PyTorchModel):
+    def __init__(self, model_components: List[str], **kwargs):
         super().__init__(
-            framework=Framework.PYTORCH,
             model_file_format=ModelFileFormat.OPTIMUM,
-            model_path=model_path,
+            **(kwargs or {}),
         )
         self.model_components = model_components
-
-    def load_model(self, rank: int = None):
-        raise NotImplementedError()
-
-    def prepare_session(self, inference_settings: Dict[str, Any], device: Device, rank: int = None):
-        raise NotImplementedError()
 
     def to_json(self, check_object: bool = False):
         config = super().to_json(check_object)

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -635,12 +635,12 @@ class PyTorchModel(OliveModel):
         hf_component = components_dict[component_name]
 
         user_module_loader = UserModuleLoader(self.model_script, self.script_dir)
-        model_component = user_module_loader.call_object(hf_component.component_func)
+        model_component = user_module_loader.call_object(hf_component.component_func, self.hf_config.model_name)
 
         io_config = hf_component.io_config
         if isinstance(io_config, str):
             user_module_loader = UserModuleLoader(self.model_script, self.script_dir)
-            io_config = user_module_loader.call_object(hf_component.io_config)
+            io_config = user_module_loader.call_object(hf_component.io_config, self.hf_config.model_name)
         io_config = validate_config(io_config, IOConfig)
 
         def model_loader(_):

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -32,7 +32,7 @@ class HFConfig(ConfigBase):
         if values["model_name"]:
             if not v and not values.get("task", None):
                 raise ValueError("Either task or model_class must be specified")
-            return v
+        return v
 
 
 def load_huggingface_model_from_task(task: str, name: str):

--- a/olive/model/model_config.py
+++ b/olive/model/model_config.py
@@ -72,4 +72,6 @@ class IOConfig(ConfigBase):
 def is_io_config_static(config: Union[IOConfig, Dict]):
     if isinstance(config, IOConfig):
         config = config.dict()
+    if not config["input_shapes"]:
+        return False
     return all(all(isinstance(dim, int) for dim in shape) for shape in config["input_shapes"])

--- a/olive/passes/onnx/__init__.py
+++ b/olive/passes/onnx/__init__.py
@@ -9,6 +9,7 @@ from olive.passes.onnx.inc_quantization import IncDynamicQuantization, IncQuanti
 from olive.passes.onnx.insert_beam_search import InsertBeamSearch
 from olive.passes.onnx.mixed_precision import OrtMixedPrecision
 from olive.passes.onnx.model_optimizer import OnnxModelOptimizer
+from olive.passes.onnx.moe_experts_distributor import MoEExpertsDistributor
 from olive.passes.onnx.optimum_conversion import OptimumConversion
 from olive.passes.onnx.optimum_merging import OptimumMerging
 from olive.passes.onnx.perf_tuning import OrtPerfTuning
@@ -25,6 +26,7 @@ __all__ = [
     "IncDynamicQuantization",
     "IncQuantization",
     "IncStaticQuantization",
+    "MoEExpertsDistributor",
     "OrtPerfTuning",
     "OrtTransformersOptimization",
     "OnnxModelOptimizer",

--- a/olive/passes/onnx/moe_experts_distributor.py
+++ b/olive/passes/onnx/moe_experts_distributor.py
@@ -1,0 +1,275 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import json
+import pprint
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+import numpy
+import onnx
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message
+from onnxruntime.transformers.onnx_model import OnnxModel
+from pydantic import validator
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import DistributedOnnxModel, ONNXModel
+from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config
+from olive.passes.pass_config import PassConfigParam
+
+_domain = "com.microsoft"
+_json_separators = (",", ": ")
+_expert_pattern = [
+    "Slice",  # 14
+    "Concat",  # 13
+    "MatMul",  # 12
+    "Cast",  # 11
+    "Relu",  # 10
+    "MatMul",  # 9
+    "Cast",  # 8
+    "Slice",  # 7
+    "Mul",  # 6
+    "Div",  # 5
+    "Add",  # 4
+    "Gather",  # 3
+    "Shape",  # 2
+    "Reshape",  # 1
+    "Reshape",  # 0
+]
+
+
+def _dump_graph(node: Message, filepath: str):
+    with open(filepath, "wt") as strm:
+        json.dump(MessageToDict(node), fp=strm, indent=2, sort_keys=True, separators=_json_separators)
+        strm.flush()
+
+
+def _iterate_experts(model: OnnxModel, producers: Dict[str, Message]):
+    for node in model.get_nodes_by_op_type(_expert_pattern[0]):
+        path = model.match_parent_path(node, _expert_pattern[1:], output_name_to_node=producers)
+        if path:
+            path.reverse()
+            path.append(node)
+            yield path
+
+
+def _create_node_name(model: OnnxModel, op_type: str, prefix_a: str, prefix_b: str):
+    prefix = ""
+    last_slash = -1
+    for i in range(0, min(len(prefix_a), len(prefix_b))):
+        if prefix_a[i] == prefix_b[i]:
+            prefix += prefix_a[i]
+            if prefix_a[i] == "/":
+                last_slash = i
+        else:
+            break
+
+    if last_slash > 0:
+        prefix = prefix[: last_slash + 1]
+
+    if not prefix.endswith("/"):
+        prefix += "/"
+    prefix += op_type
+
+    return model.create_node_name(op_type, prefix)
+
+
+def _create_ranked_model(
+    nodes: Dict[str, Message],
+    producers: Dict[str, Message],
+    consumers: Dict[str, Message],
+    experts: List[List[str]],
+    world_size: int,
+    num_experts: int,
+    rank: int,
+):
+    experts_per_rank = int(num_experts / world_size)
+    start_index = rank * experts_per_rank
+    end_index = start_index + experts_per_rank
+
+    for expert in experts:
+        div_node = nodes[expert[5]]
+        concat_node = nodes[expert[13]]
+        reshape_node = nodes[expert[1]]
+
+        div_node_oname = div_node.output[0]
+        reshape_node_oname = reshape_node.output[0]
+
+        mul_nodes = [n for n in consumers[div_node_oname] if n.op_type == "Mul"]
+        matmul_nodes = [producers[iname] for iname in concat_node.input if producers[iname].op_type == "MatMul"]
+        slice_nodes = [n for n in consumers[reshape_node_oname] if n.op_type == "Slice"]
+
+        slice_nodes[start_index].input[1] = slice_nodes[0].input[1]
+
+        for i in range(num_experts):
+            if (i < start_index) or (i >= end_index):
+                mul_nodes[i].input.remove(div_node_oname)
+                concat_node.input.remove(matmul_nodes[i].output[0])
+
+                for iname in list(slice_nodes[i].input):
+                    slice_nodes[i].input.remove(iname)
+
+
+def _insert_commop_nodes(model: OnnxModel, nodes: Dict[str, Message], experts: List[List[str]], world_size: int):
+    for expert in experts:
+        for i, j in [(0, 1), (-2, -1)]:
+            prev_node = nodes[expert[i]]
+            next_node = nodes[expert[j]]
+
+            node_name = _create_node_name(model, "AllToAll", prev_node.name, next_node.name)
+            output_name = node_name + "_output_0"
+            alltoall = onnx.helper.make_node(
+                "AllToAll", prev_node.output, [output_name], name=node_name, domain=_domain, group_size=world_size
+            )
+
+            model.add_node(alltoall)
+            OnnxModel.replace_node_input(next_node, prev_node.output[0], output_name)
+
+
+def _replace_constant_value(constant: Message, value: int):
+    for attr in constant.attribute:
+        if attr.name == "value":
+            attr.CopyFrom(
+                onnx.helper.make_attribute(
+                    attr.name, onnx.numpy_helper.from_array(numpy.array([value], numpy.int64)), attr.doc_string
+                )
+            )
+            return
+
+
+def _fix_shapes(
+    model: OnnxModel,
+    nodes: Dict[str, Message],
+    producers: Dict[str, Message],
+    consumers: Dict[str, Message],
+    experts: List[List[str]],
+    world_size: int,
+    num_experts: int,
+):
+    experts_per_rank = num_experts // world_size
+
+    for expert in experts:
+        div_node = nodes[expert[5]]
+        div_node_iname = div_node.input[1]
+        div_node_oname = div_node.output[0]
+        _replace_constant_value(producers[div_node_iname], experts_per_rank)
+
+        add_node = nodes[expert[4]]
+        add_node_iname = add_node.input[1]
+        _replace_constant_value(producers[add_node_iname], experts_per_rank - 1)
+
+        mul_nodes = [n for n in consumers[div_node_oname] if n.op_type == "Mul"]
+        index = 1
+        for mul_node in mul_nodes:
+            if div_node_oname in mul_node.input:
+                _replace_constant_value(producers[mul_node.input[1]], index)
+                index += 1
+
+        reshape_node = nodes[expert[1]]
+        for parent in model.get_parents(reshape_node, producers):
+            if parent.op_type == "Concat":
+                concat_iname_0 = parent.input[0]
+                _replace_constant_value(producers[concat_iname_0], int(num_experts / experts_per_rank))
+
+                concat_iname_1 = parent.input[1]
+                _replace_constant_value(producers[concat_iname_1], experts_per_rank)
+
+                break
+
+
+def run(world_size: int, input_filepath: str, output_dirpath: str, debug: bool = False):
+    basename = Path(input_filepath).stem
+    output_dirpath = Path(output_dirpath)
+
+    model = OnnxModel(onnx.load_model(input_filepath))
+    producers = model.output_name_to_node()
+    consumers = model.input_name_to_nodes()
+
+    if debug:
+        OnnxModel.graph_topological_sort(model.model.graph)
+        _dump_graph(model.model, str(output_dirpath / f"{basename}.graph"))
+
+    experts = []
+    num_experts = None
+    for expert in _iterate_experts(model, producers):
+        if debug:
+            pprint.pprint([n.name for n in expert])
+
+        div_node = expert[5]
+        div_node_oname = div_node.output[0]
+        if not num_experts:
+            num_experts = len(consumers[div_node_oname])
+            if (num_experts % world_size) != 0:
+                raise f"""Number of expert paths on node "{div_node.name}" should be a multiple of
+                        input world-size={world_size} but found {len(consumers[div_node_oname])}"""
+        elif len(consumers[div_node_oname]) != num_experts:
+            raise f"""Inconsistent number of expert across layers.
+                    expected={num_experts}, found={len(consumers[div_node_oname])}"""
+
+        experts.append([n.name for n in expert])
+
+    output_filepaths = []
+    for rank in range(0, world_size):
+        rank_model = OnnxModel(onnx.load_model(input_filepath))
+        producers = rank_model.output_name_to_node()
+        consumers = rank_model.input_name_to_nodes()
+        nodes = {node.name: node for node in rank_model.nodes()}
+
+        _create_ranked_model(nodes, producers, consumers, experts, world_size, num_experts, rank)
+        _insert_commop_nodes(rank_model, nodes, experts, world_size)
+        _fix_shapes(rank_model, nodes, producers, consumers, experts, world_size, num_experts)
+
+        rank_model.prune_graph()
+        output_filepath = str(output_dirpath / f"{basename}_{rank:02d}.onnx")
+        rank_model.save_model_to_file(output_filepath)
+        onnx.checker.check_model(rank_model.model)
+        output_filepaths.append(output_filepath)
+
+        if debug:
+            _dump_graph(rank_model.model, str(output_dirpath / f"{basename}_{rank:02d}.graph"))
+
+    return output_filepaths
+
+
+def _validate_distributor_config(v, values, field):
+    if v is None:
+        return v
+
+    if "world_size" not in values:
+        raise ValueError("Missing world_size")
+    if int(values["world_size"]) < 2:
+        raise ValueError("world_size should be >= 2")
+
+    return v
+
+
+class MoEExpertsDistributor(Pass):
+    """
+    Split the input model (and insert necessary communication operations)
+    to prepare for distributed inferencing.
+    """
+
+    @staticmethod
+    def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        config = {
+            "world_size": PassConfigParam(
+                type_=int,
+                default=2,
+                required=True,
+                description=("Number of GPU nodes to distribute the model for. Must be greater than 1."),
+            ),
+        }
+        config.update(get_external_data_config())
+        return config
+
+    @staticmethod
+    def _validators() -> Dict[str, Callable]:
+        return {"validate_distributor_config": validator("world_size")(_validate_distributor_config)}
+
+    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> DistributedOnnxModel:
+        output_filepaths = run(config["world_size"], model.model_path, output_model_path)
+        return DistributedOnnxModel(output_filepaths)

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -18,7 +18,7 @@ from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 logger = logging.getLogger(__name__)
 
 
-def generate_tuning_combos(model, config):
+def generate_tuning_combos(config):
     import onnxruntime as ort
 
     providers_list = (
@@ -33,13 +33,16 @@ def generate_tuning_combos(model, config):
     )
     opt_level_list = config.opt_level_list if config.opt_level_list else [99]
 
-    io_bind_list = [True, False] if config.io_bind else [False]
+    if config.io_bind:
+        io_bind_list = [True, False]
+    else:
+        io_bind_list = [False]
 
     tuning_combos = itertools.product(providers_list, execution_mode_list, opt_level_list, io_bind_list)
     yield from tuning_combos
 
 
-def valid_config(tuning_combos):
+def valid_config(tuning_combos, config):
     # the order of combos: "provider", "execution_mode", "ort_opt_level", "io_bind"
 
     # Parallel execution mode does not support the CUDA Execution Provider.
@@ -49,6 +52,12 @@ def valid_config(tuning_combos):
     if tuning_combos[0] == "CPUExecutionProvider" and tuning_combos[3]:
         logger.info("[Skipped] Because EPs is CPUExecutionProvider, the io_bind should not be True")
         return False
+    if tuning_combos[0] != "CUDAExecutionProvider" and config.enable_cuda_graph:
+        logger.info("[Ignored] Because EPs is not CUDAExecutionProvider, the enable_cuda_graph is ignored")
+        return True
+    if tuning_combos[0] != "TensorrtExecutionProvider" and config.trt_fp16_enable:
+        logger.info("[Ignored] Because EPs is not TensorrtExecutionProvider, the trt_fp16_enable is ignored")
+        return True
     return True
 
 
@@ -75,10 +84,10 @@ def tune_onnx_model(model, config):
     pretuning_inference_result = get_benchmark(model, latency_metric, config)
 
     tuning_results = []
-    for tuning_combo in generate_tuning_combos(model, config):
+    for tuning_combo in generate_tuning_combos(config):
         tuning_item = ["provider", "execution_mode", "ort_opt_level", "io_bind"]
         logger.info("Run tuning for: {}".format(list(zip(tuning_item, tuning_combo))))
-        if not valid_config(tuning_combo):
+        if not valid_config(tuning_combo, config):
             continue
         tuning_results.extend(threads_num_tuning(model, latency_metric, config, tuning_combo))
 
@@ -107,6 +116,10 @@ def threads_num_tuning(model, latency_metric, config, tuning_combo):
     io_bind = tuning_combo[3]
 
     test_params = dict()
+
+    # params starts with _ are not used in inference setting, we need add special handling for io_bind
+    test_params["_io_bind"] = io_bind
+
     if provider == "TensorrtExecutionProvider":
         test_params["execution_provider"] = [
             (
@@ -114,6 +127,15 @@ def threads_num_tuning(model, latency_metric, config, tuning_combo):
                 {"trt_fp16_enable": config.trt_fp16_enable},
             )
         ]
+    elif provider == "CUDAExecutionProvider":
+        test_params["execution_provider"] = [
+            (
+                "CUDAExecutionProvider",
+                {"enable_cuda_graph": config.enable_cuda_graph},
+            )
+        ]
+        if config.enable_cuda_graph:
+            test_params["_io_bind"] = True
     else:
         test_params["execution_provider"] = [(provider, dict())]
     test_params["session_options"] = {
@@ -121,8 +143,7 @@ def threads_num_tuning(model, latency_metric, config, tuning_combo):
         "graph_optimization_level": ort_opt_level,
         "extra_session_config": config.extra_session_config,
     }
-    # params starts with _ are not used in inference setting, we need add special handling for io_bind
-    test_params["_io_bind"] = io_bind
+
     try:
         for inter in config.inter_thread_num_list:
             test_params["session_options"]["inter_op_num_threads"] = inter
@@ -279,6 +300,11 @@ class OrtPerfTuning(Pass):
                 type_=bool,
                 default_value=False,
                 description="Whether enable IOBinding Search for ONNX Runtime inference.",
+            ),
+            "enable_cuda_graph": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="Whether enable CUDA Graph for CUDA execution provider.",
             ),
             "providers_list": PassConfigParam(
                 type_=list,

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -100,7 +100,7 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         Evaluate the accuracy of the model.
         """
-        dataloader, post_func, _ = OliveEvaluator.get_user_config(metric, model)
+        dataloader, _, post_func = OliveEvaluator.get_user_config(metric, model.framework)
 
         preds = []
         targets = []
@@ -153,7 +153,7 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         Evaluate the latency of the model.
         """
-        dataloader, _, _ = OliveEvaluator.get_user_config(metric, model)
+        dataloader, _, _ = OliveEvaluator.get_user_config(metric, model.framework)
         warmup_num, repeat_test_num, sleep_num = get_latency_config_from_metric(metric)
 
         latencies = []

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -100,7 +100,7 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         Evaluate the accuracy of the model.
         """
-        dataloader, post_func, _ = OliveEvaluator.get_user_config(metric)
+        dataloader, post_func, _ = OliveEvaluator.get_user_config(metric, model)
 
         preds = []
         targets = []
@@ -153,7 +153,7 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         Evaluate the latency of the model.
         """
-        dataloader, _, _ = OliveEvaluator.get_user_config(metric)
+        dataloader, _, _ = OliveEvaluator.get_user_config(metric, model)
         warmup_num, repeat_test_num, sleep_num = get_latency_config_from_metric(metric)
 
         latencies = []

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -29,7 +29,7 @@ class RunPassConfig(FullPassConfig):
 
 
 class RunEngineConfig(EngineConfig):
-    evaluation_only: bool = False
+    evaluate_input_model: bool = True
     output_dir: Union[Path, str] = None
     output_name: str = None
     packaging_config: PackagingConfig = None
@@ -39,7 +39,7 @@ class RunEngineConfig(EngineConfig):
     def create_engine(self):
         config = self.dict()
         to_del = [
-            "evaluation_only",
+            "evaluate_input_model",
             "output_dir",
             "output_name",
             "packaging_config",
@@ -118,8 +118,8 @@ class RunConfig(ConfigBase):
         return _resolve_evaluator(v, values)
 
     @validator("engine")
-    def validate_evaluation_only(cls, v):
-        if v.evaluation_only and v.evaluator is None:
+    def validate_evaluate_input_model(cls, v):
+        if v.evaluate_input_model and v.evaluator is None:
             raise ValueError("Evaluation only requires evaluator")
         return v
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -141,7 +141,7 @@ def run(config: Union[str, Path, dict], setup: bool = False):
     # engine
     engine = config.engine.create_engine()
 
-    if (config.passes is None or not config.passes) and (not config.engine.evaluation_only):
+    if (config.passes is None or not config.passes) and (not config.engine.evaluate_input_model):
         # TODO enhance this logic for more passes templates
         engine, config = automatically_insert_passes(config)
 
@@ -168,6 +168,6 @@ def run(config: Union[str, Path, dict], setup: bool = False):
             config.engine.packaging_config,
             config.engine.output_dir,
             config.engine.output_name,
-            config.engine.evaluation_only,
+            config.engine.evaluate_input_model,
         )
         return best_execution

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ onnx
 optuna
 pandas
 pydantic<2.0.0
-protobuf !=3.20.0, !=3.20.1
+protobuf<4.0.0
 pyyaml
 torch
 torchmetrics>=0.7.0, <0.10.1

--- a/scripts/test_examples.bat
+++ b/scripts/test_examples.bat
@@ -8,6 +8,7 @@ set PIPELINE=%1
 set ROOT_DIR=%2
 set EXAMPLE_FOLDER=%3
 set EXAMPLE_NAME=%4
+set IS_GPU=%5
 
 if "%PIPELINE%"=="True" (
     call olive-venv\\Scripts\\activate.bat || goto :error
@@ -22,6 +23,11 @@ call python -m pip install -r %ROOT_DIR%\\examples\\%EXAMPLE_FOLDER%\\requiremen
 
 call python -m pytest -v -s --log-cli-level=WARNING --junitxml=%ROOT_DIR%\\logs\\test_examples-TestOlive.xml^
  %ROOT_DIR%\\examples\\test\\test_%EXAMPLE_NAME%.py || goto :error
+
+if "%IS_GPU%"=="True" (
+    call python -m pip uninstall onnxruntime -y || goto :error
+    call python -m pip install onnxruntime-gpu || goto :error
+)
 
 goto :EOF
 

--- a/scripts/test_examples.bat
+++ b/scripts/test_examples.bat
@@ -8,7 +8,6 @@ set PIPELINE=%1
 set ROOT_DIR=%2
 set EXAMPLE_FOLDER=%3
 set EXAMPLE_NAME=%4
-set IS_GPU=%5
 
 if "%PIPELINE%"=="True" (
     call olive-venv\\Scripts\\activate.bat || goto :error
@@ -23,11 +22,6 @@ call python -m pip install -r %ROOT_DIR%\\examples\\%EXAMPLE_FOLDER%\\requiremen
 
 call python -m pytest -v -s --log-cli-level=WARNING --junitxml=%ROOT_DIR%\\logs\\test_examples-TestOlive.xml^
  %ROOT_DIR%\\examples\\test\\test_%EXAMPLE_NAME%.py || goto :error
-
-if "%IS_GPU%"=="True" (
-    call python -m pip uninstall onnxruntime -y || goto :error
-    call python -m pip install onnxruntime-gpu || goto :error
-)
 
 goto :EOF
 

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -9,6 +9,7 @@ PIPELINE=$1
 ROOT_DIR=$2
 EXAMPLE_FOLDER=$3
 EXAMPLE_NAME=$4
+IS_GPU=$5
 
 echo $PIPELINE
 if [[ "$PIPELINE" == "True" ]]; then
@@ -23,5 +24,11 @@ python -m pip install pytest
 # test samples
 echo "Testing examples"
 python -m pip install -r $ROOT_DIR/examples/$EXAMPLE_FOLDER/requirements.txt
+
+echo $IS_GPU
+if [[ "$IS_GPU" == "True" ]]; then
+    python -m pip uninstall onnxruntime -y
+    python -m pip install onnxruntime-gpu
+fi
 
 python -m pytest -v -s --log-cli-level=WARNING --junitxml=$ROOT_DIR/logs/test_examples-TestOlive.xml $ROOT_DIR/examples/test/test_$EXAMPLE_NAME.py

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -9,7 +9,6 @@ PIPELINE=$1
 ROOT_DIR=$2
 EXAMPLE_FOLDER=$3
 EXAMPLE_NAME=$4
-IS_GPU=$5
 
 echo $PIPELINE
 if [[ "$PIPELINE" == "True" ]]; then
@@ -24,11 +23,5 @@ python -m pip install pytest
 # test samples
 echo "Testing examples"
 python -m pip install -r $ROOT_DIR/examples/$EXAMPLE_FOLDER/requirements.txt
-
-echo $IS_GPU
-if [[ "$IS_GPU" == "True" ]]; then
-    python -m pip uninstall onnxruntime -y
-    python -m pip install onnxruntime-gpu
-fi
 
 python -m pytest -v -s --log-cli-level=WARNING --junitxml=$ROOT_DIR/logs/test_examples-TestOlive.xml $ROOT_DIR/examples/test/test_$EXAMPLE_NAME.py

--- a/test/integ_test/evaluator/azureml_eval/user_script.py
+++ b/test/integ_test/evaluator/azureml_eval/user_script.py
@@ -11,6 +11,6 @@ def post_process(res):
     return res.argmax(1)
 
 
-def create_dataloader(data_dir, batch_size):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     dataset = datasets.MNIST(data_dir, transform=ToTensor())
     return torch.utils.data.DataLoader(dataset, batch_size)

--- a/test/integ_test/evaluator/docker_eval/user_script.py
+++ b/test/integ_test/evaluator/docker_eval/user_script.py
@@ -11,7 +11,7 @@ def post_process(res):
     return res.argmax(1)
 
 
-def create_dataloader(data_dir, batch_size):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     dataset = datasets.MNIST(data_dir, transform=ToTensor())
     return torch.utils.data.DataLoader(dataset, batch_size)
 
@@ -26,7 +26,7 @@ def hf_post_process(res):
     return preds
 
 
-def create_hf_dataloader(data_dir, batch_size):
+def create_hf_dataloader(data_dir, batch_size, *args, **kwargs):
     from datasets import load_dataset
     from torch.utils.data import Dataset
     from transformers import AutoTokenizer

--- a/test/integ_test/evaluator/local_eval/utils.py
+++ b/test/integ_test/evaluator/local_eval/utils.py
@@ -38,7 +38,7 @@ def openvino_post_process(res):
     return res.argmax(1)
 
 
-def create_dataloader(data_dir, batch_size):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     dataset = datasets.MNIST(data_dir, train=True, download=True, transform=ToTensor())
     return torch.utils.data.DataLoader(dataset, batch_size)
 
@@ -48,7 +48,7 @@ def hf_post_process(res):
     return preds
 
 
-def create_hf_dataloader(data_dir, batch_size):
+def create_hf_dataloader(data_dir, batch_size, *args, **kwargs):
     from datasets import load_dataset
     from torch.utils.data import Dataset
     from transformers import AutoTokenizer

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -21,3 +21,5 @@ mlflow
 # issue: https://github.com/mlflow/mlflow/issues/8629
 mlflow-skinny==2.3.2
 evaluate
+sentencepiece
+protobuf==3.20.3

--- a/test/unit_test/assets/user_script.py
+++ b/test/unit_test/assets/user_script.py
@@ -1,0 +1,9 @@
+from olive.model import OliveModel
+
+
+def eval_func(model: OliveModel, data_dir, batch_size, device, execution_providers):
+    return 0.382715310
+
+
+def metric_func(preds, actuals):
+    return 0.382715311

--- a/test/unit_test/engine/packaging/test_packaging_generator.py
+++ b/test/unit_test/engine/packaging/test_packaging_generator.py
@@ -75,7 +75,9 @@ def test_generate_zipfile_artifacts_no_search():
     output_dir = Path(tempdir.name) / "outputs"
 
     # execute
-    engine.run(input_model=input_model, packaging_config=packaging_config, output_dir=output_dir)
+    engine.run(
+        input_model=input_model, packaging_config=packaging_config, output_dir=output_dir, evaluate_input_model=False
+    )
 
     # assert
     artifacts_path = output_dir / "OutputModels.zip"

--- a/test/unit_test/passes/inc/test_inc_quantization.py
+++ b/test/unit_test/passes/inc/test_inc_quantization.py
@@ -86,7 +86,7 @@ def get_onnx_model(tempdir):
     return onnx_model
 
 
-def create_dataloader(data_dir, batchsize):
+def create_dataloader(data_dir, batchsize, *args, **kwargs):
     # import neural_compressor here to avoid hanging on Windows
     from neural_compressor.data import DefaultDataLoader
 

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -110,7 +110,7 @@ def cifar10_dataset(data_dir):
     return CIFAR10(root=data_dir, train=False, transform=transform, download=True)
 
 
-def create_dataloader(data_dir, batchsize):
+def create_dataloader(data_dir, batchsize, *args, **kwargs):
     from addict import Dict
     from openvino.tools.pot.api import DataLoader
 

--- a/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
+++ b/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
@@ -32,7 +32,7 @@ class RandomDataReader(CalibrationDataReader):
         return next(self.enum_data_dicts, None)
 
 
-def dummy_calibration_reader(data_dir=None, batch_size=1):
+def dummy_calibration_reader(data_dir=None, batch_size=1, *args, **kwargs):
     return RandomDataReader()
 
 

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -67,8 +67,8 @@ class TestPythonEnvironmentSystem:
         # assert
         assert res[metrics_key[0]].value == 0.9
         assert res[metrics_key[1]].value == 10
-        assert mock_evaluate_accuracy.call_once_with(model, metrics[0])
-        assert mock_evaluate_latency.call_once_with(model, metrics[1])
+        assert mock_evaluate_accuracy.call_once_with(model, metrics[0], DEFAULT_CPU_ACCELERATOR)
+        assert mock_evaluate_latency.call_once_with(model, metrics[1], DEFAULT_CPU_ACCELERATOR)
 
     @patch("olive.evaluator.olive_evaluator.OliveEvaluator.compute_accuracy")
     def test_evaluate_accuracy(self, mock_compute_accuracy):
@@ -127,7 +127,7 @@ class TestPythonEnvironmentSystem:
         expected_res = 10
 
         # execute
-        actual_res = self.system.evaluate_latency(model, metric)
+        actual_res = self.system.evaluate_latency(model, metric, DEFAULT_CPU_ACCELERATOR)
 
         # assert
         assert actual_res[LatencySubType.AVG].value == expected_res

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from test.unit_test.utils import get_accuracy_metric, get_custom_metric, get_latency_metric
+from test.unit_test.utils import get_accuracy_metric, get_custom_eval, get_latency_metric
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -45,7 +45,7 @@ class TestLocalSystem:
         (get_latency_metric(LatencySubType.P95)),
         (get_latency_metric(LatencySubType.P99)),
         (get_latency_metric(LatencySubType.P999)),
-        (get_custom_metric()),
+        (get_custom_eval()),
     ]
 
     @pytest.mark.parametrize(

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -4,12 +4,14 @@
 # --------------------------------------------------------------------------
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset
 
+from olive.constants import Framework
 from olive.data.config import DataComponentConfig, DataConfig
 from olive.data.registry import Registry
 from olive.evaluator.metric import Metric, MetricType
@@ -89,6 +91,18 @@ def delete_onnx_model_files():
         os.remove(ONNX_MODEL_PATH)
 
 
+def get_mock_snpe_model():
+    olive_model = MagicMock()
+    olive_model.framework = Framework.SNPE
+    return olive_model
+
+
+def get_mock_openvino_model():
+    olive_model = MagicMock()
+    olive_model.framework = Framework.OPENVINO
+    return olive_model
+
+
 def create_dataloader(datadir, batchsize, *args, **kwargs):
     dataloader = DataLoader(DummyDataset(1))
     return dataloader
@@ -121,13 +135,26 @@ def get_accuracy_metric(*acc_subtype, random_dataloader=True, user_config=None, 
     return accuracy_metric
 
 
-def get_custom_metric():
+def get_custom_eval():
+    user_script_path = str(Path(__file__).absolute().parent / "assets" / "user_script.py")
     custom_metric = Metric(
         name="custom",
         type=MetricType.CUSTOM,
         sub_types=[{"name": "custom"}],
-        user_config={"evaluate_func": "val", "user_script": "user_script"},
+        user_config={"evaluate_func": "eval_func", "user_script": user_script_path, "need_inference": False},
     )
+    return custom_metric
+
+
+def get_custom_metric():
+    custom_metric = get_custom_eval()
+    custom_metric.user_config.metric_func = "metric_func"
+    return custom_metric
+
+
+def get_custom_metric_no_eval():
+    custom_metric = get_custom_eval()
+    custom_metric.user_config.evaluate_func = None
     return custom_metric
 
 

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -89,12 +89,12 @@ def delete_onnx_model_files():
         os.remove(ONNX_MODEL_PATH)
 
 
-def create_dataloader(datadir, batchsize):
+def create_dataloader(datadir, batchsize, *args, **kwargs):
     dataloader = DataLoader(DummyDataset(1))
     return dataloader
 
 
-def create_fixed_dataloader(datadir, batchsize):
+def create_fixed_dataloader(datadir, batchsize, *args, **kwargs):
     dataloader = DataLoader(FixedDummyDataset(1))
     return dataloader
 

--- a/test/unit_test/workflows/mock_data/ner_task_dataset.json
+++ b/test/unit_test/workflows/mock_data/ner_task_dataset.json
@@ -1,0 +1,83 @@
+{
+    "input_model":{
+        "type": "PyTorchModel",
+        "config": {
+            "hf_config": {
+                "model_name": "Jean-Baptiste/camembert-ner",
+                "task": "ner",
+                "dataset": {
+                    "data_name":"Jean-Baptiste/wikiner_fr",
+                    "split": "test",
+                    "input_cols": ["tokens"],
+                    "label_cols": ["ner_tags"],
+                    "batch_size": 1
+                }
+            }
+        }
+    },
+    "evaluators": {
+        "common_evaluator": {
+            "metrics":[
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "sub_types": [
+                        {
+                            "name": "accuracy_score",
+                            "priority": 1,
+                            "goal": {"type": "max-degradation", "value": 0.01},
+                            "metric_config": {
+                                "task": "multiclass",
+                                "num_classes": "5",
+                                "top_k": 1
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "sub_types": [
+                        {"name": "avg", "priority": 2, "goal": {"type": "percent-min-improvement", "value": 20}},
+                        {"name": "max"},
+                        {"name": "min"}
+                    ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": {
+            "type": "OnnxConversion"
+        },
+        "transformers_optimization": {
+            "type": "OrtTransformersOptimization",
+            "config": {
+                "model_type": "bert",
+                "num_heads": 12,
+                "hidden_size": 768,
+                "float16": false
+            }
+        },
+        "quantization": {
+            "type": "OnnxQuantization"
+        },
+        "perf_tuning": {
+            "type": "OrtPerfTuning"
+        }
+    },
+    "engine": {
+        "log_severity_level": 0,
+        "search_strategy": {
+            "execution_order": "joint",
+            "search_algorithm": "tpe",
+            "search_algorithm_config": {
+                "num_samples": 3,
+                "seed": 0
+            }
+        },
+        "evaluator": "common_evaluator",
+        "clean_cache": true,
+        "cache_dir": "cache"
+    }
+}

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -17,20 +17,18 @@ class TestRunConfig:
     # like: Systems/Evaluation/Model and etc.
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.transformer_dataset_config_file = Path(__file__).parent / "mock_data" / "transformer_dataset.json"
-        self.only_transformer_dataset_config_file = (
-            Path(__file__).parent / "mock_data" / "only_transformer_dataset.json"
-        )
         self.user_script_config_file = Path(__file__).parent / "mock_data" / "user_script.json"
 
-    def test_transformer_dataset_config_file(self):
-        run_config = RunConfig.parse_file(self.transformer_dataset_config_file)
-        for dc in run_config.data_configs.values():
-            dc.to_data_container().create_dataloader()
-
-    def test_only_transformer_dataset_config_file(self):
-        # test for the case where user want to use the hf dataset but not huggingface models
-        run_config = RunConfig.parse_file(self.only_transformer_dataset_config_file)
+    @pytest.mark.parametrize(
+        "config_file",
+        [
+            Path(__file__).parent / "mock_data" / "transformer_dataset.json",
+            Path(__file__).parent / "mock_data" / "only_transformer_dataset.json",
+            Path(__file__).parent / "mock_data" / "ner_task_dataset.json",
+        ],
+    )
+    def test_dataset_config_file(self, config_file):
+        run_config = RunConfig.parse_file(config_file)
         for dc in run_config.data_configs.values():
             dc.to_data_container().create_dataloader()
 


### PR DESCRIPTION
## Describe your changes
Currently, if you want to get the evaluation result from input_model, they need to set:
1. `evaluation_only`: in this case, olive only evaluate input model without passes run.
2. or to set metric `goal` to tell the metric tolerance based on the baseline.

Several customers would love to compare the input model metrics with output model's metrics by default. So in this PR, we make input model is evaluated as long as there is the given metrics. 
If user do not need to evaluate input model, they can manually set `evalute_input_model` as `False`.

With the PR, the default behaviors. is like:
1. evaluate input model with given metrics.
2. if user gives the metric goal, olive read the result in step 1 from cache.
3. then olive will run search or no_search passes w.r.t given metrics.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
   Replace  `evaluation_only` with `evaluate_input_model` and set False by default.

## (Optional) Issue link
