### PR TITLE
Unify data dir mechanism used by all the places in Olive

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,7 @@ class OliveSystem(ABC):
         self,
         the_pass: Pass,
         model: OliveModel,
+        data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
     ) -> OliveModel:
@@ -207,7 +208,7 @@ class OliveSystem(ABC):
         """
 
     @abstractmethod
-    def evaluate_model(self, model: OliveModel, metrics: List[Metric]) -> Dict[str, Any]:
+    def evaluate_model(self, model: OliveModel, data_root: str, metrics: List[Metric]) -> Dict[str, Any]:
         """
         Evaluate the model
         """

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -145,7 +145,7 @@ Please find the detailed config options from following table for each model type
 ## Data Information
 `data_root: [str]`
 
-This is the root directory that contains the data for the model evaluation.
+This is the root directory that contains the data for the model evaluation, quantization, performance tuning, QAT and all other place that need use data for model optimization.
 if `data_root` is specified, the data_dir in metrics evaluation or other passes which are relative path will be concatenated to the `data_root`. If not specified, the data_dir in metrics evaluation or other passes will be used.
 On the other hand, if the `data_dir` is an absolute path, the `data_root` will be ignored. For exmaple, if the `data_dir` is /home/user/data, then the `data_root` will be ignored and the final data_dir will be /home/user/data.
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -8,6 +8,7 @@ The options are organized into following sections:
 
 - [Azure ML client](#azure-ml-client) `azureml_client`
 - [Input Model Information](#input-model-information) `input_model`
+- [Data Information](#data-information) `data_root`
 - [Systems Information](#systems-information) `systems`
 - [Evaluators Information](#evaluators-information) `evaluators`
 - [Passes Information](#passes-information) `passes`
@@ -140,6 +141,21 @@ Please find the detailed config options from following table for each model type
     }
 }
 ```
+
+## Data Information
+`data_root: [str]`
+
+This is the root directory that contains the data for the model evaluation.
+if `data_root` is specified, the data_dir in metrics evaluation or other passes which are relative path will be concatenated to the `data_root`. If not specified, the data_dir in metrics evaluation or other passes will be used.
+On the other hand, if the `data_dir` is an absolute path, the `data_root` will be ignored. For exmaple, if the `data_dir` is /home/user/data, then the `data_root` will be ignored and the final data_dir will be /home/user/data.
+
+The `data_root` could be passed either in config json or by command line like: python -m olive.workflows.run --config <config_file>.json --data_root /home/user/data config.json. If both are provided, the command line will override the config json.
+
+### Local Examples
+If `data_root` is /home/user/data, and the data_dir in metrics evaluation is `data_dir: "cifar-10-batches-py"`, then the final data_dir will be `/home/user/data/cifar-10-batches-py`.
+
+### Azureml Examples
+If `data_root` is `azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test`, and the data_dir in metrics evaluation is `data_dir: "cifar-10-batches-py"`, then the final data_dir will be `azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test/cifar-10-batches-py`.
 
 ## Systems Information
 `systems: [Dict]`

--- a/docs/source/tutorials/how_to_add_optimization_pass.md
+++ b/docs/source/tutorials/how_to_add_optimization_pass.md
@@ -39,6 +39,7 @@ takes an `AcceleratorSpec` as input and returns `Dict[str, PassConfigParam]`.
 
 - `required` : whether the parameter is required
 - `category`: The param category. It could be the following values:
+
     * `object` : whether the parameter is an object/function. If so, this parameter accepts the object or a string with the
     name of the object in the user script. The type must include `str`.
     * `path` : whether the parameter is a path. If so, this file/folder will be uploaded to the host system.

--- a/docs/source/tutorials/how_to_add_optimization_pass.md
+++ b/docs/source/tutorials/how_to_add_optimization_pass.md
@@ -38,11 +38,11 @@ takes an `AcceleratorSpec` as input and returns `Dict[str, PassConfigParam]`.
 - `type_` : type of the parameter
 
 - `required` : whether the parameter is required
-
-- `is_object` : whether the parameter is an object/function. If so, this parameter accepts the object or a string with the
+- `category`: The param category. It could be the following values:
+    * `object` : whether the parameter is an object/function. If so, this parameter accepts the object or a string with the
     name of the object in the user script. The type must include `str`.
-
-- `is_path` : whether the parameter is a path. If so, this file/folder will be uploaded to the host system.
+    * `path` : whether the parameter is a path. If so, this file/folder will be uploaded to the host system.
+    * `data`: whether the parameter is a data path, which will be used to do data path normalization based on the data root.
 
 - `description` : description of the parameter
 
@@ -65,11 +65,11 @@ takes an `AcceleratorSpec` as input and returns `Dict[str, PassConfigParam]`.
             "param3": PassConfigParam(
                 type_=int, default_value=1, searchable_values=Categorical([1, 2, 3]), description="param3 description"
             ),
-            # optional parameter with `is_object` set to True
+            # optional parameter with `category` set to `object`
             # the value of this parameter can be a string or a function that takes a string and returns the object,
             # say a class ObjectClass
             "param4": PassConfigParam(
-                type_=Union[str, Callable[[str], Pass]], is_object=True, description="param4 description"
+                type_=Union[str, Callable[[str], Pass]], category=ParamCategory.OBJECT, description="param4 description"
             ),
             # optional parameter with default_value that depends on another parameter value
             "param5": PassConfigParam(
@@ -103,5 +103,5 @@ the search space created based on the options defined in `_default_config(accele
 with output path. The method should return a valid OliveModel which can be used as an input for the next Pass.
 
 ```python
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
 ```

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -165,6 +165,25 @@ def get_local_path(resource_path: Optional[ResourcePath], cache_dir: Union[str, 
         return download_resource(resource_path, cache_dir).get_path()
 
 
+def normalize_data_path(data_root: Union[str, Path], data_dir: Union[str, Path]):
+    """
+    Normalize data path, if data_dir is absolute path, return data_dir, else return data_root/data_dir
+    """
+    if not data_dir:
+        return data_root
+    elif Path(data_dir).is_absolute():
+        return data_dir
+    else:
+        if data_root:
+            assert Path(data_dir).is_relative(), f"data_dir {data_dir} should be relative path"
+
+            data_dir = Path(data_root) / data_dir
+            data_dir = data_dir.resolve()
+            return data_dir
+        else:
+            return data_dir
+
+
 def save_model(
     model_number: str,
     output_dir: Union[str, Path] = None,

--- a/olive/common/auto_config.py
+++ b/olive/common/auto_config.py
@@ -25,7 +25,7 @@ class AutoConfigClass(ABC):
         def _default_config():
             return {
                 "str_param": ConfigParam(type_=str, required=True),
-                "func_param" ConfigParam(type_=Union[str, Callable], is_object=True)
+                "func_param" ConfigParam(type_=Union[str, Callable], category=ParamCategory.OBJECT)
             }
     The class dynamically creates its config class through the class method `get_config_class`.
     This config class has validates for types and also automatically validates object/func params

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -5,6 +5,7 @@
 import inspect
 import json
 import logging
+from enum import Enum
 from functools import partial
 from pathlib import Path
 from types import FunctionType, MethodType
@@ -150,6 +151,16 @@ class ConfigDictBase(ConfigBase):
         return len(self.__root__) if self.__root__ else 0
 
 
+class ParamCategory(str, Enum):
+    NONE = "none"
+    OBJECT = "object"
+    PATH = "path"
+    DATA = "data"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class ConfigParam(ConfigBase):
     """
     Dataclass for pass configuration parameters.
@@ -158,13 +169,12 @@ class ConfigParam(ConfigBase):
     type_: Any
     required: bool = False
     default_value: Any = None
-    is_object: bool = False
-    is_path: bool = False
+    category: ParamCategory = ParamCategory.NONE
     description: str = None
 
     def __repr__(self):
         repr_list = []
-        booleans = ["required", "is_object"]
+        booleans = ["required"]
         for k, v in self.__dict__.items():
             if k in booleans:
                 if v:
@@ -218,7 +228,7 @@ def create_config_class(
             validator_name = f"validate_{param}_resource_path"
             validators[validator_name] = validator(param, allow_reuse=True)(validate_resource_path)
         # automatically add validator for object params
-        if param_config.is_object:
+        if param_config.category == ParamCategory.OBJECT:
             validator_name = f"validate_{param}_object"
             count = 0
             while validator_name in validators:

--- a/olive/data/component/load_dataset.py
+++ b/olive/data/component/load_dataset.py
@@ -8,12 +8,12 @@ from olive.data.registry import Registry
 
 
 @Registry.register_default_dataset()
-def local_dataset(data_dir=None, label_cols=None, **kwargs):
+def local_dataset(data_dir, label_cols=None, **kwargs):
     pass
 
 
 @Registry.register_dataset()
-def simple_dataset(input_data, label_cols=None, **kwargs):
+def simple_dataset(data_dir, input_data, label_cols=None, **kwargs):
     """
     This function is used to create a simple dataset from input data which can be:
     1. a text
@@ -23,7 +23,7 @@ def simple_dataset(input_data, label_cols=None, **kwargs):
 
 
 @Registry.register_dataset()
-def huggingface_dataset(data_name=None, subset=None, split="validation", **kwargs):
+def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation", **kwargs):
     """
     This function is used to create a dataset from huggingface datasets
     """
@@ -38,7 +38,7 @@ def huggingface_dataset(data_name=None, subset=None, split="validation", **kwarg
 
 
 @Registry.register_dataset()
-def dummy_dataset(input_shapes, input_names=None, input_types=None):
+def dummy_dataset(data_dir, input_shapes, input_names=None, input_types=None):
     return DummyDataset(input_shapes, input_names, input_types)
 
 

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Union
 
 from olive.common.config_utils import ConfigBase
-from olive.common.user_module_loader import UserModuleLoader
+from olive.common.import_lib import import_user_module
 from olive.data.constants import DataComponentType, DefaultDataComponent, DefaultDataContainer
 from olive.data.registry import Registry
 
@@ -52,8 +52,9 @@ class DataConfig(ConfigBase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # call UserModuleLoader to load the user script once and register the components
-        UserModuleLoader(self.user_script, self.script_dir)
+        # call import_user_module to load the user script once and register the components
+        if self.user_script:
+            import_user_module(self.user_script, self.script_dir)
         self.update_components()
         self.fill_in_params()
 

--- a/olive/data/container/data_container.py
+++ b/olive/data/container/data_container.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Optional
 
 from pydantic import BaseModel
 
-from olive.cache import get_local_path, normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.data.component.dataloader import default_calibration_dataloader
 from olive.data.config import DataConfig, DefaultDataComponentCombos
 from olive.data.constants import DataContainerType, DefaultDataContainer
@@ -39,9 +39,9 @@ class DataContainer(BaseModel):
         """
         params_config = self.config.load_dataset_params
         data_dir = params_config.get("data_dir")
-        data_dir = normalize_data_path(data_root_path, data_dir)
+        data_dir = get_local_path_from_root(data_root_path, data_dir)
         if data_dir:
-            params_config["data_dir"] = get_local_path(data_dir)
+            params_config["data_dir"] = data_dir
         return self.config.load_dataset(**params_config)
 
     def pre_process(self, dataset):

--- a/olive/data/container/data_container.py
+++ b/olive/data/container/data_container.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Optional
 
 from pydantic import BaseModel
 
-from olive.cache import normalize_data_path
+from olive.cache import get_local_path, normalize_data_path
 from olive.data.component.dataloader import default_calibration_dataloader
 from olive.data.config import DataConfig, DefaultDataComponentCombos
 from olive.data.constants import DataContainerType, DefaultDataContainer
@@ -39,7 +39,9 @@ class DataContainer(BaseModel):
         """
         params_config = self.config.load_dataset_params
         data_dir = params_config.get("data_dir")
-        params_config["data_dir"] = normalize_data_path(data_root_path, data_dir)
+        data_dir = normalize_data_path(data_root_path, data_dir)
+        if data_dir:
+            params_config["data_dir"] = get_local_path(data_dir)
         return self.config.load_dataset(**params_config)
 
     def pre_process(self, dataset):

--- a/olive/data/container/data_container.py
+++ b/olive/data/container/data_container.py
@@ -2,11 +2,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from pathlib import Path
 from typing import ClassVar, Optional
 
 from pydantic import BaseModel
 
+from olive.cache import normalize_data_path
 from olive.data.component.dataloader import default_calibration_dataloader
 from olive.data.config import DataConfig, DefaultDataComponentCombos
 from olive.data.constants import DataContainerType, DefaultDataContainer
@@ -38,15 +38,8 @@ class DataContainer(BaseModel):
         Run load dataset
         """
         params_config = self.config.load_dataset_params
-        _data_dir = params_config.get("data_dir")
-        if not _data_dir:
-            data_dir = data_root_path
-        elif Path(_data_dir).is_absolute():
-            data_dir = _data_dir
-        elif Path(_data_dir).is_relative():
-            data_dir = Path(data_root_path) / _data_dir
-            data_dir = data_dir.resolve()
-        params_config["data_dir"] = data_dir
+        data_dir = params_config.get("data_dir")
+        params_config["data_dir"] = normalize_data_path(data_root_path, data_dir)
         return self.config.load_dataset(**params_config)
 
     def pre_process(self, dataset):

--- a/olive/data/registry.py
+++ b/olive/data/registry.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
 import logging
 from typing import Union
 
@@ -38,10 +37,12 @@ class Registry:
         """
 
         def decorator(component):
-            if name is None:
-                cls._REGISTRY[sub_type.value][component.__name__] = component
-            else:
-                cls._REGISTRY[sub_type.value][name] = component
+            component_name = name if name is not None else component.__name__
+            if component_name in cls._REGISTRY[sub_type.value]:
+                logger.warning(
+                    f"Component {component_name} already registered in {sub_type.value}, will override the old one."
+                )
+            cls._REGISTRY[sub_type.value][component_name] = component
             return component
 
         return decorator

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -29,7 +29,7 @@ from olive.systems.olive_system import OliveSystem
 
 logger = logging.getLogger(__name__)
 
-EXCEPTIONS_TO_RAISE = (AttributeError, ImportError, TypeError, ValueError)
+EXCEPTIONS_TO_RAISE = (AssertionError, AttributeError, ImportError, TypeError, ValueError)
 
 
 class Engine:

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -256,6 +256,7 @@ class Engine:
     def run(
         self,
         input_model: OliveModel,
+        data_root: str = None,
         packaging_config: Optional[PackagingConfig] = None,
         output_dir: str = None,
         output_name: str = None,
@@ -304,7 +305,9 @@ class Engine:
                         f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}"
                     )
                     assert self.evaluator_config is not None, "evaluate_input_model is True but no evaluator provided"
-                    results = self._evaluate_model(input_model, input_model_id, self.evaluator_config, accelerator_spec)
+                    results = self._evaluate_model(
+                        input_model, input_model_id, data_root, self.evaluator_config, accelerator_spec
+                    )
                     logger.info(f"Input model evaluation results: {results}")
                     result_name = f"{prefix_output_name}_input_model_metrics"
                     results_path = output_dir / f"{result_name}.json"
@@ -320,6 +323,7 @@ class Engine:
                     output = self.run_no_search(
                         input_model,
                         input_model_id,
+                        data_root,
                         accelerator_spec,
                         output_dir,
                         output_name,
@@ -331,6 +335,7 @@ class Engine:
                     footprint = self.run_search(
                         input_model,
                         input_model_id,
+                        data_root,
                         accelerator_spec,
                         output_dir,
                         output_name,
@@ -378,6 +383,7 @@ class Engine:
         self,
         input_model: OliveModel,
         input_model_id: str,
+        data_root: str,
         accelerator_spec: AcceleratorSpec,
         output_dir: str = None,
         output_name: str = None,
@@ -396,7 +402,7 @@ class Engine:
             objective_dict = {"dummy": {"higher_is_better": True, "goal": 0}}
         else:
             objective_dict = self.resolve_objectives(
-                input_model, input_model_id, evaluator_config.metrics, accelerator_spec
+                input_model, input_model_id, data_root, evaluator_config.metrics, accelerator_spec
             )
 
         # initialize the search strategy
@@ -420,7 +426,7 @@ class Engine:
             _,
             signal,
             model_ids,
-        ) = self._run_passes(next_step["passes"], model, model_id, accelerator_spec)
+        ) = self._run_passes(next_step["passes"], model, model_id, data_root, accelerator_spec)
         # names of the output models of the passes
         pass_output_names = [self.passes[pass_name]["output_name"] for pass_name, _ in next_step["passes"]]
         pass_output_names = [f"{name}_{accelerator_spec}" if name else None for name in pass_output_names]
@@ -467,6 +473,7 @@ class Engine:
         self,
         input_model: OliveModel,
         input_model_id: str,
+        data_root: str,
         accelerator_spec: AcceleratorSpec,
         output_dir: str = None,
         output_name: str = None,
@@ -484,7 +491,7 @@ class Engine:
             raise ValueError("No evaluator provided for the last pass")
         else:
             objective_dict = self.resolve_objectives(
-                input_model, input_model_id, evaluator_config.metrics, accelerator_spec
+                input_model, input_model_id, data_root, evaluator_config.metrics, accelerator_spec
             )
 
         # initialize the search strategy
@@ -514,7 +521,9 @@ class Engine:
             logger.debug(f"Step {iter_num} with search point {next_step['search_point']} ...")
 
             # run all the passes in the step
-            should_prune, signal, model_ids = self._run_passes(next_step["passes"], model, model_id, accelerator_spec)
+            should_prune, signal, model_ids = self._run_passes(
+                next_step["passes"], model, model_id, data_root, accelerator_spec
+            )
 
             # record feedback signal
             self.search_strategy.record_feedback_signal(next_step["search_point"], signal, model_ids, should_prune)
@@ -545,6 +554,7 @@ class Engine:
         self,
         input_model: OliveModel,
         input_model_id: str,
+        data_root: str,
         metrics: List[Metric],
         accelerator_spec: AcceleratorSpec,
     ) -> Dict[str, Dict[str, Any]]:
@@ -553,7 +563,7 @@ class Engine:
 
         {objective_name: {"higher_is_better": bool, "goal": float}}
         """
-        goals = self.resolve_goals(input_model, input_model_id, metrics, accelerator_spec)
+        goals = self.resolve_goals(input_model, input_model_id, data_root, metrics, accelerator_spec)
         objective_dict = {}
         for metric in metrics:
             for sub_type in metric.sub_types:
@@ -573,6 +583,7 @@ class Engine:
         self,
         input_model: OliveModel,
         input_model_id: str,
+        data_root: str,
         metrics: List[Metric],
         accelerator_spec: AcceleratorSpec,
     ) -> Dict[str, float]:
@@ -602,7 +613,7 @@ class Engine:
                     assert self.evaluator_config is not None, "Default evaluator must be provided to resolve goals"
                     logger.debug("Computing baseline for metrics ...")
                     baseline = self._evaluate_model(
-                        input_model, input_model_id, self.evaluator_config, accelerator_spec
+                        input_model, input_model_id, data_root, self.evaluator_config, accelerator_spec
                     )
                     _evaluated = True
                     break
@@ -806,6 +817,7 @@ class Engine:
         passes: List[Tuple[str, Dict[str, Any]]],
         model: OliveModel,
         model_id: str,
+        data_root: str,
         accelerator_spec: AcceleratorSpec,
     ):
         """
@@ -816,7 +828,7 @@ class Engine:
         # run all the passes in the step
         model_ids = []
         for pass_id, pass_search_point in passes:
-            model, model_id = self._run_pass(pass_id, pass_search_point, model, model_id, accelerator_spec)
+            model, model_id = self._run_pass(pass_id, pass_search_point, model, model_id, data_root, accelerator_spec)
             if model == PRUNED_CONFIG:
                 should_prune = True
                 logger.debug("Pruned")
@@ -830,7 +842,7 @@ class Engine:
                 # skip evaluation if no search and no evaluator
                 signal = None
             else:
-                signal = self._evaluate_model(model, model_id, evaluator_config, accelerator_spec)
+                signal = self._evaluate_model(model, model_id, data_root, evaluator_config, accelerator_spec)
             logger.debug(f"Signal: {signal}")
         else:
             signal = None
@@ -844,6 +856,7 @@ class Engine:
         pass_search_point: Dict[str, Any],
         input_model: OliveModel,
         input_model_id: str,
+        data_root: str,
         accelerator_spec: AcceleratorSpec,
     ):
         """
@@ -900,7 +913,7 @@ class Engine:
             if host.system_type != SystemType.AzureML:
                 input_model = self._prepare_non_local_model(input_model)
             try:
-                output_model = host.run_pass(p, input_model, output_model_path, pass_search_point)
+                output_model = host.run_pass(p, input_model, data_root, output_model_path, pass_search_point)
             except OlivePassException as e:
                 logger.error(f"Pass run_pass failed: {e}", exc_info=True)
                 output_model = PRUNED_CONFIG
@@ -976,6 +989,7 @@ class Engine:
         self,
         model: OliveModel,
         model_id: str,
+        data_root: str,
         evaluator_config: OliveEvaluatorConfig,
         accelerator_spec: AcceleratorSpec,
     ):
@@ -1008,7 +1022,7 @@ class Engine:
         metrics = evaluator_config.metrics if evaluator_config else []
         if self.target.system_type != SystemType.AzureML:
             model = self._prepare_non_local_model(model)
-        signal = self.target.evaluate_model(model, metrics, accelerator_spec)
+        signal = self.target.evaluate_model(model, data_root, metrics, accelerator_spec)
 
         # cache evaluation
         self._cache_evaluation(model_id_with_accelerator, signal)

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Union
 
 from pydantic import validator
 
-from olive.common.config_utils import ConfigBase, ConfigParam, create_config_class
+from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, create_config_class
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 WARMUP_NUM = 10
@@ -19,8 +19,8 @@ _common_user_config = {
     "script_dir": ConfigParam(type_=Union[Path, str]),
     "user_script": ConfigParam(type_=Union[Path, str]),
     "inference_settings": ConfigParam(type_=dict),
-    "data_dir": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS, is_path=True),
-    "dataloader_func": ConfigParam(type_=Union[Callable, str], is_object=True),
+    "data_dir": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS, category=ParamCategory.DATA),
+    "dataloader_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
     "batch_size": ConfigParam(type_=int, default_value=1),
     "input_names": ConfigParam(type_=List),
     "input_shapes": ConfigParam(type_=List),
@@ -34,11 +34,11 @@ _type_to_user_config = {
         "io_bind": ConfigParam(type_=bool, default_value=False),
     },
     "accuracy": {
-        "post_processing_func": ConfigParam(type_=Union[Callable, str], is_object=True),
+        "post_processing_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
     },
     "custom": {
-        "evaluate_func": ConfigParam(type_=Union[Callable, str], required=False, is_object=True),
-        "metric_func": ConfigParam(type_=Union[Callable, str], required=False, is_object=True),
+        "evaluate_func": ConfigParam(type_=Union[Callable, str], required=False, category=ParamCategory.OBJECT),
+        "metric_func": ConfigParam(type_=Union[Callable, str], required=False, category=ParamCategory.OBJECT),
     },
 }
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -433,7 +433,9 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
 
         return preds, targets
 
-    def _evaluate_distributed_accuracy(self, model: DistributedOnnxModel, data_root: str, metric: Metric) -> MetricResult:
+    def _evaluate_distributed_accuracy(
+        self, model: DistributedOnnxModel, data_root: str, metric: Metric
+    ) -> MetricResult:
         from copy import deepcopy
 
         from mpi4py.futures import MPIPoolExecutor
@@ -513,7 +515,9 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
 
         return latencies
 
-    def _evaluate_distributed_latency(self, model: DistributedOnnxModel, data_root: str, metric: Metric) -> MetricResult:
+    def _evaluate_distributed_latency(
+        self, model: DistributedOnnxModel, data_root: str, metric: Metric
+    ) -> MetricResult:
         from copy import deepcopy
 
         from mpi4py.futures import MPIPoolExecutor

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -198,33 +198,39 @@ class OliveEvaluator(ABC):
 
     @staticmethod
     def get_user_config(framework: Framework, data_root: str, metric: Metric):
-        user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
+        if metric.user_config.user_script:
+            # load the dataloader, eval_func, post_func if user script is provided.
+            user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
 
-        post_processing_func = getattr(metric.user_config, "post_processing_func", None)
-        post_func = user_module.load_object(post_processing_func)
+            post_processing_func = getattr(metric.user_config, "post_processing_func", None)
+            post_func = user_module.load_object(post_processing_func)
 
-        dataloader_func = getattr(metric.user_config, "dataloader_func", None)
-        if dataloader_func:
-            data_dir = get_local_path_from_root(data_root, metric.user_config.data_dir)
-            dataloader = user_module.call_object(
-                dataloader_func,
-                data_dir,
-                metric.user_config.batch_size,
-                model_framework=framework,
-            )
+            dataloader_func = getattr(metric.user_config, "dataloader_func", None)
+            if dataloader_func:
+                data_dir = get_local_path_from_root(data_root, metric.user_config.data_dir)
+                dataloader = user_module.call_object(
+                    dataloader_func,
+                    data_dir,
+                    metric.user_config.batch_size,
+                    model_framework=framework,
+                )
+            else:
+                dataloader = None
+
+            eval_func = None
+            if metric.type == MetricType.CUSTOM:
+                evaluate_func = getattr(metric.user_config, "evaluate_func", None)
+                if not evaluate_func:
+                    evaluate_func = getattr(metric.user_config, "metric_func", None)
+
+                if not evaluate_func:
+                    raise ValueError("evaluate_func or metric_func is not specified in the metric config")
+
+                eval_func = user_module.load_object(evaluate_func)
         else:
             dataloader = None
-
-        eval_func = None
-        if metric.type == MetricType.CUSTOM:
-            evaluate_func = getattr(metric.user_config, "evaluate_func", None)
-            if not evaluate_func:
-                evaluate_func = getattr(metric.user_config, "metric_func", None)
-
-            if not evaluate_func:
-                raise ValueError("evaluate_func or metric_func is not specified in the metric config")
-
-            eval_func = user_module.load_object(evaluate_func)
+            eval_func = None
+            post_func = None
 
         if (not dataloader or not post_func) and metric.data_config:
             dc = metric.data_config.to_data_container()

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -15,7 +15,7 @@ from pydantic import validator
 from torch.utils.data import Dataset
 
 import olive.data.template as data_config_template
-from olive.cache import get_local_path
+from olive.cache import get_local_path, normalize_data_path
 from olive.common.config_utils import ConfigBase
 from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import tensor_data_to_device
@@ -77,6 +77,7 @@ class OliveEvaluator(ABC):
     def _evaluate_accuracy(
         self,
         model: OliveModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -89,6 +90,7 @@ class OliveEvaluator(ABC):
     def _evaluate_latency(
         self,
         model: OliveModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -100,6 +102,7 @@ class OliveEvaluator(ABC):
     def _evaluate_custom(
         self,
         model: OliveModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         eval_func,
@@ -139,6 +142,7 @@ class OliveEvaluator(ABC):
     def evaluate(
         self,
         model: OliveModel,
+        data_root: str,
         metrics: List[Metric],
         device: Device = Device.CPU,
         execution_providers: Union[str, List[str]] = None,
@@ -149,19 +153,19 @@ class OliveEvaluator(ABC):
             # only do this if data_config or dataloader is not provided
             # priority: dataloader_func > data_config > user_config.input_names/input_shapes > model io_config
             metric = OliveEvaluator.generate_metric_user_config_with_model_io(original_metric, model)
-            dataloader, eval_func, post_func = OliveEvaluator.get_user_config(metric, model.framework)
+            dataloader, eval_func, post_func = OliveEvaluator.get_user_config(model.framework, data_root, metric)
 
             if metric.type == MetricType.ACCURACY:
                 metrics_res[metric.name] = self._evaluate_accuracy(
-                    model, metric, dataloader, post_func, device, execution_providers
+                    model, data_root, metric, dataloader, post_func, device, execution_providers
                 )
             elif metric.type == MetricType.LATENCY:
                 metrics_res[metric.name] = self._evaluate_latency(
-                    model, metric, dataloader, post_func, device, execution_providers
+                    model, data_root, metric, dataloader, post_func, device, execution_providers
                 )
             elif metric.type == MetricType.CUSTOM:
                 metrics_res[metric.name] = self._evaluate_custom(
-                    model, metric, dataloader, eval_func, post_func, device, execution_providers
+                    model, metric, data_root, eval_func, post_func, device, execution_providers
                 )
             else:
                 raise TypeError(f"{metric.type} is not a supported metric type")
@@ -193,16 +197,17 @@ class OliveEvaluator(ABC):
         return metric
 
     @staticmethod
-    def get_user_config(metric: Metric, framework: Framework):
+    def get_user_config(framework: Framework, data_root: str, metric: Metric):
         user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
 
         post_processing_func = getattr(metric.user_config, "post_processing_func", None)
         post_func = user_module.load_object(post_processing_func)
 
         dataloader_func = getattr(metric.user_config, "dataloader_func", None)
+        data_dir = normalize_data_path(data_root, metric.user_config.data_dir)
         dataloader = user_module.call_object(
             dataloader_func,
-            get_local_path(metric.user_config.data_dir),
+            get_local_path(data_dir),
             metric.user_config.batch_size,
             model_framework=framework,
         )
@@ -223,7 +228,7 @@ class OliveEvaluator(ABC):
 
             # TODO remove user_scripts dataloader: we should respect user scripts
             # dataloder to meet back compatibility for time being.
-            dataloader = dataloader or dc.create_dataloader()
+            dataloader = dataloader or dc.create_dataloader(data_root)
             post_func = post_func or dc.config.post_process
 
         if metric.user_config.input_names and metric.user_config.input_shapes and not dataloader and not eval_func:
@@ -234,7 +239,7 @@ class OliveEvaluator(ABC):
                     input_types=metric.user_config.input_types,
                 )
                 .to_data_container()
-                .create_dataloader()
+                .create_dataloader(data_root)
             )
 
         return dataloader, eval_func, post_func
@@ -389,6 +394,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
     @staticmethod
     def _evaluate_distributed_accuracy_worker(config) -> Tuple[List[Any], List[Any]]:
         model_path = config["model_path"]
+        data_root = config["data_root"]
         local_rank = config["local_rank"]
         world_size = config["world_size"]
         inference_settings = config.get("inference_settings", {}) or {}
@@ -408,7 +414,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         inference_settings["provider_options"] = [{"device_id": str(local_rank)}, {}]
 
         model = ONNXModel(model_path, inference_settings=inference_settings)
-        dataloader, _, post_func = OnnxEvaluator.get_user_config(metric, model.framework)
+        dataloader, _, post_func = OnnxEvaluator.get_user_config(model.framework, data_root, metric)
 
         session = model.prepare_session(inference_settings=inference_settings, device=Device.GPU, rank=int(local_rank))
         io_config = model.get_io_config()
@@ -427,7 +433,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
 
         return preds, targets
 
-    def _evaluate_distributed_accuracy(self, model: DistributedOnnxModel, metric: Metric) -> MetricResult:
+    def _evaluate_distributed_accuracy(self, model: DistributedOnnxModel, data_root: str, metric: Metric) -> MetricResult:
         from copy import deepcopy
 
         from mpi4py.futures import MPIPoolExecutor
@@ -445,6 +451,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             cfg = deepcopy(config)
             cfg["local_rank"] = rank
             cfg["model_path"] = model.ranked_model_path(rank)
+            cfg["data_root"] = data_root
             args.append(cfg)
 
         with MPIPoolExecutor(max_workers=model.ranks) as executor:
@@ -456,8 +463,9 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         return OliveEvaluator.compute_accuracy(metric, preds, targets)
 
     @staticmethod
-    def _evaluate_distributed_latency_worker(config) -> List[float]:
+    def _evaluate_distributed_latency_worker(data_root, config) -> List[float]:
         model_path = config["model_path"]
+        data_root = config["data_root"]
         local_rank = config["local_rank"]
         world_size = config["world_size"]
         inference_settings = config.get("inference_settings", {}) or {}
@@ -477,7 +485,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         inference_settings["provider_options"] = [{"device_id": str(local_rank)}, {}]
 
         model = ONNXModel(model_path, inference_settings=inference_settings)
-        dataloader, _, _ = OnnxEvaluator.get_user_config(metric, model.framework)
+        dataloader, _, _ = OnnxEvaluator.get_user_config(model.framework, data_root, metric)
         session = model.prepare_session(inference_settings=inference_settings, device=Device.GPU, rank=int(local_rank))
         io_config = model.get_io_config()
 
@@ -505,7 +513,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
 
         return latencies
 
-    def _evaluate_distributed_latency(self, model: DistributedOnnxModel, metric: Metric) -> MetricResult:
+    def _evaluate_distributed_latency(self, model: DistributedOnnxModel, data_root: str, metric: Metric) -> MetricResult:
         from copy import deepcopy
 
         from mpi4py.futures import MPIPoolExecutor
@@ -523,6 +531,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             cfg = deepcopy(config)
             cfg["local_rank"] = rank
             cfg["model_path"] = model.ranked_model_path(rank)
+            cfg["data_root"] = data_root
             args.append(cfg)
 
         with MPIPoolExecutor(max_workers=model.ranks) as executor:
@@ -535,6 +544,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
     def _evaluate_accuracy(
         self,
         model: ONNXModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -544,13 +554,14 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         if isinstance(model, ONNXModel):
             return self._evaluate_onnx_accuracy(model, metric, dataloader, post_func, device, execution_providers)
         elif isinstance(model, DistributedOnnxModel):
-            return self._evaluate_distributed_accuracy(model, metric)
+            return self._evaluate_distributed_accuracy(model, data_root, metric)
         else:
             raise TypeError(f"Cannot evaluate accuracy for model of type: {type(model)}")
 
     def _evaluate_latency(
         self,
         model: OliveModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -560,7 +571,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         if isinstance(model, ONNXModel):
             return self._evaluate_onnx_latency(model, metric, dataloader, post_func, device, execution_providers)
         elif isinstance(model, DistributedOnnxModel):
-            return self._evaluate_distributed_latency(model, metric)
+            return self._evaluate_distributed_latency(model, data_root, metric)
         else:
             raise TypeError(f"Cannot evaluate latency for model of type: {type(model)}")
 
@@ -576,6 +587,7 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
     def _inference(
         self,
         model: PyTorchModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -617,6 +629,7 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
     def _evaluate_latency(
         self,
         model: PyTorchModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -658,6 +671,7 @@ class SNPEEvaluator(OliveEvaluator, framework=Framework.SNPE):
     def _inference(
         self,
         model: SNPEModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -695,6 +709,7 @@ class SNPEEvaluator(OliveEvaluator, framework=Framework.SNPE):
     def _evaluate_latency(
         self,
         model: SNPEModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -725,6 +740,7 @@ class OpenVINOEvaluator(OliveEvaluator, framework=Framework.OPENVINO):
     def _inference(
         self,
         model: OpenVINOModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -760,6 +776,7 @@ class OpenVINOEvaluator(OliveEvaluator, framework=Framework.OPENVINO):
     def _evaluate_latency(
         self,
         model: OpenVINOModel,
+        data_root: str,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -580,7 +580,7 @@ class PyTorchModel(OliveModel):
                     input_types=self.io_config.get("input_types"),
                 )
                 .to_data_container()
-                .get_first_batch()
+                .get_first_batch(data_root_path=None)
             )
         elif self.hf_config and self.hf_config.model_name and self.hf_config.task:
             if self.hf_config.dataset:
@@ -592,7 +592,7 @@ class PyTorchModel(OliveModel):
                         **self.hf_config.dataset,
                     )
                     .to_data_container()
-                    .get_first_batch()
+                    .get_first_batch(data_root_path=None)
                 )
             elif not self.hf_config.components:
                 logger.debug("Using hf onnx_config to get dummy inputs")

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 from pydantic import validator
 
-from olive.common.config_utils import ConfigBase, validate_config
+from olive.common.config_utils import ConfigBase, ParamCategory, validate_config
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.config import DataConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
@@ -95,8 +95,8 @@ class Pass(ABC):
         # Params that are paths [(param_name, required)]
         self.path_params = []
         for param, param_config in default_config.items():
-            if param_config.is_path:
-                self.path_params.append((param, param_config.required))
+            if param_config.category in (ParamCategory.PATH, ParamCategory.DATA):
+                self.path_params.append((param, param_config.required, param_config.category))
 
         self._initialized = False
 
@@ -182,11 +182,13 @@ class Pass(ABC):
                     searchable_values=Categorical([1, 2, 3]),
                     description="param3 description",
                 ),
-                # optional parameter with `is_object` set to True
+                # optional parameter with `category` set to `object`
                 # the value of this parameter can be a string or a function that takes a string and returns the object,
                 # say a class ObjectClass
                 "param4": PassConfigParam(
-                    type_=Union[str, Callable[[str], Pass]], is_object=True, description="param4 description"
+                    type_=Union[str, Callable[[str], Pass]],
+                    category=ParamCategory.OBJECT,
+                    description="param4 description"
                 ),
                 # optional parameter with default_value that depends on another parameter value
                 "param5": PassConfigParam(
@@ -236,7 +238,7 @@ class Pass(ABC):
         Validate callables in the config.
         """
         for key, value in config.items():
-            if default_config[key].is_object and isinstance(value, str):
+            if default_config[key].category == ParamCategory.OBJECT and isinstance(value, str):
                 assert user_module_loader.user_script, f"'user_script' must be specified if a {key} is a string."
         # TODO: once convention for user_script and script dir is finalized, let config class handle
         # the resolution during serialization
@@ -272,7 +274,7 @@ class Pass(ABC):
             if isinstance(value, SearchParameter):
                 search_space[key] = value
             else:
-                if default_config[key].is_path and value is not None:
+                if default_config[key].category == ParamCategory.PATH and value is not None:
                     if not isinstance(value, ResourcePath):
                         value = str(Path(value).resolve())
                 fixed_params[key] = value
@@ -351,13 +353,17 @@ class Pass(ABC):
         return {key: value for key, value in config.items() if value != SpecialParamValue.IGNORED}
 
     @abstractmethod
-    def _run_for_config(self, model: OliveModel, config: Dict[str, Any], output_model_path: str) -> OliveModel:
+    def _run_for_config(
+        self, model: OliveModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> OliveModel:
         """
         Run the pass on the model with the given configuration.
         """
         raise NotImplementedError()
 
-    def run(self, model: OliveModel, output_model_path: str, point: Optional[Dict[str, Any]] = None) -> OliveModel:
+    def run(
+        self, model: OliveModel, data_root: str, output_model_path: str, point: Optional[Dict[str, Any]] = None
+    ) -> OliveModel:
         """
         Run the pass on the model at a specific point in the search space.
         """
@@ -374,7 +380,7 @@ class Pass(ABC):
             for rank in range(0, model.ranks):
                 input_rank_model = model.load_model(rank)
                 rank_output_path = Path(output_model_path).with_suffix("") / str(rank)
-                output_rank_model = self._run_for_config(input_rank_model, config, rank_output_path)
+                output_rank_model = self._run_for_config(input_rank_model, data_root, config, rank_output_path)
                 output_filepaths.append(output_rank_model.model_path)
             return DistributedOnnxModel(output_filepaths, inference_settings=model.inference_settings)
         elif isinstance(model, CompositeOnnxModel) and not self._accepts_composite_model:
@@ -382,11 +388,11 @@ class Pass(ABC):
             component_names = []
             for cidx, child in enumerate(model.get_model_components()):
                 component_output_path = Path(output_model_path).with_suffix("") / str(cidx)
-                components.append(self._run_for_config(child, config, str(component_output_path)))
+                components.append(self._run_for_config(child, data_root, config, str(component_output_path)))
                 component_names.append(model.get_model_component_name(cidx))
             return CompositeOnnxModel(components, component_names, hf_config=model.hf_config)
         else:
-            return self._run_for_config(model, config, output_model_path)
+            return self._run_for_config(model, data_root, config, output_model_path)
 
     def serialize_config(self, config: Dict[str, Any], check_object: bool = False) -> str:
         """

--- a/olive/passes/onnx/append_pre_post_processing_ops.py
+++ b/olive/passes/onnx/append_pre_post_processing_ops.py
@@ -49,7 +49,9 @@ class AppendPrePostProcessingOps(Pass):
         config.update(get_external_data_config())
         return config
 
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         output_model_path = ONNXModel.resolve_path(output_model_path)
 
         # temporary directory to store the model to

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -53,7 +53,7 @@ class OnnxConversion(Pass):
         return config
 
     def _run_for_config(
-        self, model: PyTorchModel, config: Dict[str, Any], output_model_path: str
+        self, model: PyTorchModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> Union[ONNXModel, CompositeOnnxModel]:
         # check if the model has components
         if model.components:
@@ -62,7 +62,7 @@ class OnnxConversion(Pass):
             for component_name in model.components:
                 component_model = model.get_component(component_name)
                 component_output_path = Path(output_model_path).with_suffix("") / component_name
-                onnx_models.append(self._run_for_config(component_model, config, str(component_output_path)))
+                onnx_models.append(self._run_for_config(component_model, data_root, config, str(component_output_path)))
                 component_names.append(component_name)
             return CompositeOnnxModel(onnx_models, component_names, hf_config=model.hf_config)
 

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -44,7 +44,9 @@ class OnnxFloatToFloat16(Pass):
         config.update(get_external_data_config())
         return config
 
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         from onnxconverter_common import float16
 
         output_model_path = ONNXModel.resolve_path(output_model_path)

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
-from olive.cache import get_local_path, normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.evaluator.metric import Metric, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
 from olive.hardware.accelerator import AcceleratorSpec
@@ -430,10 +430,10 @@ class IncQuantization(Pass):
         inc_calib_dataloader = None
         if is_static:
             if self._user_module_loader:
-                data_dir = normalize_data_path(data_root, config["data_dir"])
+                data_dir = get_local_path_from_root(data_root, config["data_dir"])
                 inc_calib_dataloader = self._user_module_loader.call_object(
                     config["dataloader_func"],
-                    get_local_path(data_dir),
+                    data_dir,
                     config["batch_size"],
                 )
             elif self._data_config:

--- a/olive/passes/onnx/insert_beam_search.py
+++ b/olive/passes/onnx/insert_beam_search.py
@@ -155,7 +155,9 @@ class InsertBeamSearch(Pass):
         )
         model.graph.input.insert(1, mask)
 
-    def _run_for_config(self, model: OliveModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: OliveModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         if isinstance(model, ONNXModel):
             return model
 

--- a/olive/passes/onnx/mixed_precision.py
+++ b/olive/passes/onnx/mixed_precision.py
@@ -29,7 +29,9 @@ class OrtMixedPrecision(Pass):
         config.update(get_external_data_config())
         return config
 
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         """Convert model to mixed precision.
         It detects whether original model has fp16 precision weights,
         and set parameters for float16 conversion automatically.

--- a/olive/passes/onnx/model_optimizer.py
+++ b/olive/passes/onnx/model_optimizer.py
@@ -122,7 +122,9 @@ class OnnxModelOptimizer(Pass):
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
         return get_external_data_config()
 
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         output_model_path = ONNXModel.resolve_path(output_model_path)
 
         # optimize model

--- a/olive/passes/onnx/optimum_conversion.py
+++ b/olive/passes/onnx/optimum_conversion.py
@@ -28,7 +28,7 @@ class OptimumConversion(Pass):
         return config
 
     def _run_for_config(
-        self, model: OptimumModel, config: Dict[str, Any], output_model_path: str
+        self, model: OptimumModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> Union[ONNXModel, CompositeOnnxModel]:
         assert len(model.model_components) > 0
 

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -37,7 +37,7 @@ class OptimumMerging(Pass):
         return config
 
     def _run_for_config(
-        self, model: CompositeOnnxModel, config: Dict[str, Any], output_model_path: str
+        self, model: CompositeOnnxModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> Union[ONNXModel, CompositeOnnxModel]:
         assert len(model.model_components) == 2
 

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Union
 import onnx
 from packaging import version
 
-from olive.cache import get_local_path, normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.common.utils import hash_string
 from olive.exception import OlivePassException
 from olive.hardware.accelerator import AcceleratorSpec
@@ -381,10 +381,10 @@ class OnnxQuantization(Pass):
             # get the dataloader
             # TODO: only use data config
             if config["dataloader_func"]:
-                data_dir = normalize_data_path(data_root, config["data_dir"])
+                data_dir = get_local_path_from_root(data_root, config["data_dir"])
                 dataloader = self._user_module_loader.call_object(
                     config["dataloader_func"],
-                    get_local_path(data_dir),
+                    data_dir,
                     config["batch_size"],
                 )
             elif self._data_config:

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -80,7 +80,9 @@ class OrtTransformersOptimization(Pass):
         fusion_options.__dict__.update(run_config["optimization_options"])
         run_config["optimization_options"] = fusion_options
 
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         from onnxruntime.transformers import optimizer as transformers_optimizer
 
         # start with a copy of the config

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -12,7 +12,7 @@ import onnx
 from onnxruntime.quantization.preprocess import quant_pre_process
 from onnxruntime.quantization.quant_utils import QuantFormat, QuantType
 
-from olive.cache import get_local_path, normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.common.utils import hash_string
 from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModel
@@ -333,10 +333,10 @@ class VitisAIQuantization(Pass):
         # get the dataloader
         # TODO: only use data config
         if config["dataloader_func"]:
-            data_dir = normalize_data_path(data_root, config["data_dir"])
+            data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(
                 config["dataloader_func"],
-                get_local_path(data_dir),
+                data_dir,
                 config["batch_size"],
             )
         elif self._data_config:

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -12,7 +12,7 @@ import onnx
 from onnxruntime.quantization.preprocess import quant_pre_process
 from onnxruntime.quantization.quant_utils import QuantFormat, QuantType
 
-from olive.cache import get_local_path
+from olive.cache import get_local_path, normalize_data_path
 from olive.common.utils import hash_string
 from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModel
@@ -20,7 +20,7 @@ from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_file, model_proto_to_olive_model
 from olive.passes.onnx.vitis_ai import quantize_static
 from olive.passes.onnx.vitis_ai.quant_utils import PowerOfTwoMethod
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import ParamCategory, PassConfigParam
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS, LocalFile
 from olive.strategy.search_parameter import Boolean, Categorical, Conditional
 
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 vai_q_onnx_quantization_config = {
     "data_dir": PassConfigParam(
         type_=OLIVE_RESOURCE_ANNOTATIONS,
-        is_path=True,
+        category=ParamCategory.DATA,
         description="""
             Path to the directory containing the dataset.
         """,
@@ -45,7 +45,7 @@ vai_q_onnx_quantization_config = {
     "dataloader_func": PassConfigParam(
         type_=Union[Callable, str],
         required=True,
-        is_object=True,
+        category=ParamCategory.OBJECT,
         description="""
             Function/function name to generate dataloader for calibration,
             required'
@@ -255,8 +255,9 @@ class VitisAIQuantization(Pass):
         config.update(get_external_data_config())
         return config
 
-    def _run_for_config(self, model: ONNXModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
-
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         # start with a copy of the config
         run_config = deepcopy(config)
 
@@ -332,13 +333,14 @@ class VitisAIQuantization(Pass):
         # get the dataloader
         # TODO: only use data config
         if config["dataloader_func"]:
+            data_dir = normalize_data_path(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(
                 config["dataloader_func"],
-                get_local_path(config["data_dir"]),
+                get_local_path(data_dir),
                 config["batch_size"],
             )
         elif self._data_config:
-            dataloader = self._data_config.to_data_container().create_calibration_dataloader()
+            dataloader = self._data_config.to_data_container().create_calibration_dataloader(data_root)
 
         execution_provider = self._accelerator_spec.execution_provider
 
@@ -358,7 +360,6 @@ class VitisAIQuantization(Pass):
         return model_proto_to_olive_model(onnx_model, output_model_path, config)
 
     def _quant_preprocess(self, model: ONNXModel, output_model_path: str) -> ONNXModel:
-
         try:
             quant_pre_process(input_model_path=model.model_path, output_model_path=output_model_path, auto_merge=True)
         except Exception as e:

--- a/olive/passes/openvino/conversion.py
+++ b/olive/passes/openvino/conversion.py
@@ -51,7 +51,7 @@ class OpenVINOConversion(Pass):
         }
 
     def _run_for_config(
-        self, model: Union[PyTorchModel, ONNXModel], config: Dict[str, Any], output_model_path: str
+        self, model: Union[PyTorchModel, ONNXModel], data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> OpenVINOModel:
         import torch
 

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
 
-from olive.cache import get_local_path, normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import OpenVINOModel
 from olive.passes import Pass
@@ -83,9 +83,9 @@ class OpenVINOQuantization(Pass):
         model_name = "ov_model"
 
         if config["dataloader_func"]:
-            data_dir = normalize_data_path(data_root, config["data_dir"])
+            data_dir = get_local_path_from_root(data_root, config["data_dir"])
             data_loader = self._user_module_loader.call_object(
-                config["dataloader_func"], get_local_path(data_dir), config["batch_size"]
+                config["dataloader_func"], data_dir, config["batch_size"]
             )
         elif self._data_config:
             common_dataloader = self._data_config.to_data_container().create_dataloader(data_root)

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -5,7 +5,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Union
 
-from olive.cache import normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import PyTorchModel
 from olive.passes import Pass
@@ -110,11 +110,11 @@ class QuantizationAwareTraining(Pass):
             qat_trainer_config.train_dataloader_func = self._user_module_loader.load_object(
                 config["train_dataloader_func"]
             )
-        qat_trainer_config.train_data_dir = normalize_data_path(data_root, qat_trainer_config.train_data_dir)
+        qat_trainer_config.train_data_dir = get_local_path_from_root(data_root, qat_trainer_config.train_data_dir)
 
         if config["training_loop_func"]:
             qat_trainer_config.training_loop_func = self._user_module_loader.load_object(config["training_loop_func"])
-        qat_trainer_config.val_data_dir = normalize_data_path(data_root, qat_trainer_config.val_data_dir)
+        qat_trainer_config.val_data_dir = get_local_path_from_root(data_root, qat_trainer_config.val_data_dir)
         if config["ptl_module"]:
             qat_trainer_config.ptl_module = self._user_module_loader.load_object(config["ptl_module"])
         if config["ptl_data_module"]:

--- a/olive/passes/snpe/conversion.py
+++ b/olive/passes/snpe/conversion.py
@@ -93,7 +93,7 @@ class SNPEConversion(Pass):
         }
 
     def _run_for_config(
-        self, model: Union[ONNXModel, TensorFlowModel], config: Dict[str, Any], output_model_path: str
+        self, model: Union[ONNXModel, TensorFlowModel], data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> SNPEModel:
         config = self._config_class(**config)
 

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -5,7 +5,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
-from olive.cache import normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import SNPEModel
 from olive.passes.olive_pass import Pass
@@ -81,7 +81,7 @@ class SNPEQuantization(Pass):
             output_model_path += ".dlc"
 
         if config["dataloader_func"]:
-            data_dir = normalize_data_path(data_root, config["data_dir"])
+            data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
         elif self._data_config:
             dataloader = self._data_config.to_data_container().create_dataloader(data_root)

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -5,10 +5,11 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
+from olive.cache import normalize_data_path
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import SNPEModel
 from olive.passes.olive_pass import Pass
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import ParamCategory, PassConfigParam
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS, LocalFile
 from olive.snpe import SNPECommonDataLoader, SNPEDataLoader
 from olive.snpe.tools.dev import quantize_dlc
@@ -30,13 +31,13 @@ class SNPEQuantization(Pass):
             "data_dir": PassConfigParam(
                 type_=OLIVE_RESOURCE_ANNOTATIONS,
                 required=False,
-                is_path=True,
+                category=ParamCategory.DATA,
                 description="Path to the data directory. Required is data_config is None.",
             ),
             "dataloader_func": PassConfigParam(
                 type_=Union[Callable, str],
                 required=False,
-                is_object=True,
+                category=ParamCategory.OBJECT,
                 description=(
                     "Function or function name to create dataloader for quantization. Function should take data"
                     " directory as an argument and return a olive.snpe.SNPEDataLoader or torch.data.DataLoader-like"
@@ -73,14 +74,17 @@ class SNPEQuantization(Pass):
             ),
         }
 
-    def _run_for_config(self, model: SNPEModel, config: Dict[str, Any], output_model_path: str) -> SNPEModel:
+    def _run_for_config(
+        self, model: SNPEModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> SNPEModel:
         if Path(output_model_path).suffix != ".dlc":
             output_model_path += ".dlc"
 
         if config["dataloader_func"]:
-            dataloader = self._user_module_loader.call_object(config["dataloader_func"], config["data_dir"])
+            data_dir = normalize_data_path(data_root, config["data_dir"])
+            dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
         elif self._data_config:
-            dataloader = self._data_config.to_data_container().create_dataloader()
+            dataloader = self._data_config.to_data_container().create_dataloader(data_root)
 
         # convert dataloader to SNPEDataLoader if it is not already
         if not isinstance(dataloader, SNPEDataLoader):

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -47,7 +47,9 @@ class SNPEtoONNXConversion(Pass):
             "validate_target_device": validator("target_device", allow_reuse=True)(_validate_target_device),
         }
 
-    def _run_for_config(self, model: SNPEModel, config: Dict[str, Any], output_model_path: str) -> ONNXModel:
+    def _run_for_config(
+        self, model: SNPEModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
         config = self._config_class(**config)
 
         output_model_path = ONNXModel.resolve_path(output_model_path)

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -74,6 +74,14 @@ class ResourcePath(AutoConfigClass):
         json_data = {"type": self.type, "config": self.config.to_json()}
         return serialize_to_json(json_data)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ResourcePath):
+            return False
+        return self.type == other.type and self.config.to_json() == other.config.to_json()
+
+    def __hash__(self) -> int:
+        return hash((self.config.to_json(), self.type))
+
 
 class ResourcePathConfig(ConfigBase):
     type: ResourceType = Field(..., description="Type of the resource.")

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -65,7 +65,7 @@ def main(raw_args=None):
     target: OliveSystem = LocalSystem()
 
     # metric result
-    metric_result = target.evaluate_model(model, [metric], accelerator_spec)
+    metric_result = target.evaluate_model(model, None, [metric], accelerator_spec)
 
     # save metric result json
     with open(Path(common_args.pipeline_output) / "metric_result.json", "w") as f:

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -91,7 +91,7 @@ def main(raw_args=None):
     output_model_path = str(Path(common_args.pipeline_output) / "output_model")
 
     # run pass
-    output_model = p.run(input_model, output_model_path)
+    output_model = p.run(input_model, None, output_model_path)
 
     # save model json
     model_json = output_model.to_json()

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from olive.common.config_utils import ParamCategory
 from olive.hardware import AcceleratorSpec
 from olive.model import ModelConfig
 from olive.passes import REGISTRY as PASS_REGISTRY
@@ -36,7 +37,7 @@ def parse_pass_args(pass_type, accelerator_spec, raw_args):
 
     # parse pass args
     for param, param_config in pass_class.default_config(accelerator_spec).items():
-        if param_config.is_path:
+        if param_config.category in (ParamCategory.PATH, ParamCategory.DATA):
             parser.add_argument(f"--pass_{param}", type=str, help=f"pass {param}", required=param_config.required)
 
     return parser.parse_args(raw_args)

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -241,7 +241,7 @@ class AzureMLSystem(OliveSystem):
 
     def _create_pass_inputs(self, pass_path_params: List[Tuple[str, bool, ParamCategory]]):
         inputs = {"pass_config": Input(type=AssetTypes.URI_FILE)}
-        for param, required in pass_path_params:
+        for param, required, category in pass_path_params:
             # aml supports uploading file/folder even though this is typed as URI_FOLDER
             inputs[f"pass_{param}"] = Input(type=AssetTypes.URI_FOLDER, optional=not required)
 
@@ -254,6 +254,9 @@ class AzureMLSystem(OliveSystem):
         for param, _, category in pass_path_params:
             param_val = pass_config["config"].get(param, None)
             if category == ParamCategory.DATA:
+                if param_val:
+                    # convert the dict to a resource path
+                    param_val = create_resource_path(param_val)
                 param_val = normalize_data_path(data_root, param_val)
             if not param_val:
                 continue
@@ -421,6 +424,8 @@ class AzureMLSystem(OliveSystem):
             metric_config["user_config"]["script_dir"] = None
 
         metric_data_dir = metric_config["user_config"]["data_dir"]
+        # convert the dict to a resource path object
+        metric_data_dir = create_resource_path(metric_data_dir)
         metric_data_dir = normalize_data_path(data_root, metric_data_dir)
         if metric_data_dir:
             metric_data_dir = self._create_args_from_resource_path(metric_data_dir)

--- a/olive/systems/docker/eval.py
+++ b/olive/systems/docker/eval.py
@@ -25,7 +25,7 @@ def evaluate_entry(config, model_path, output_path, output_name):
     model = ModelConfig.from_json(model_json).create_model()
 
     evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-    metrics_res = evaluator.evaluate(model, evaluator_config.metrics)
+    metrics_res = evaluator.evaluate(model, None, evaluator_config.metrics)
 
     with open(os.path.join(output_path, f"{output_name}"), "w") as f:
         f.write(metrics_res.json())

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -8,7 +8,7 @@ import shutil
 from pathlib import Path
 from typing import List
 
-from olive.cache import get_local_path
+from olive.cache import get_local_path, normalize_data_path
 from olive.constants import Framework
 from olive.evaluator.metric import Metric
 from olive.model import OliveModel
@@ -55,7 +55,9 @@ def create_run_command(run_params: dict):
     return run_command_dict
 
 
-def create_metric_volumes_list(metrics: List[Metric], container_root_path: Path, mount_list: list) -> List[str]:
+def create_metric_volumes_list(
+    data_root: str, metrics: List[Metric], container_root_path: Path, mount_list: list
+) -> List[str]:
     for metric in metrics:
         metric_path = container_root_path / "metrics" / metric.name
         if metric.user_config.user_script:
@@ -75,7 +77,8 @@ def create_metric_volumes_list(metrics: List[Metric], container_root_path: Path,
             metric.user_config.script_dir = script_dir_mount_path
 
         if metric.user_config.data_dir:
-            data_dir = get_local_path(metric.user_config.data_dir)
+            data_dir = normalize_data_path(data_root, metric.user_config.data_dir)
+            data_dir = get_local_path(data_dir)
             mount_list.append(f"{data_dir}:{str(metric_path / 'data_dir')}")
             metric.user_config.data_dir = str(metric_path / "data_dir")
 

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -8,7 +8,7 @@ import shutil
 from pathlib import Path
 from typing import List
 
-from olive.cache import get_local_path, normalize_data_path
+from olive.cache import get_local_path_from_root
 from olive.constants import Framework
 from olive.evaluator.metric import Metric
 from olive.model import OliveModel
@@ -76,9 +76,8 @@ def create_metric_volumes_list(
             mount_list.append(f"{script_dir_path}:{script_dir_mount_path}")
             metric.user_config.script_dir = script_dir_mount_path
 
-        if metric.user_config.data_dir:
-            data_dir = normalize_data_path(data_root, metric.user_config.data_dir)
-            data_dir = get_local_path(data_dir)
+        if data_root or metric.user_config.data_dir:
+            data_dir = get_local_path_from_root(data_root, metric.user_config.data_dir)
             mount_list.append(f"{data_dir}:{str(metric_path / 'data_dir')}")
             metric.user_config.data_dir = str(metric_path / "data_dir")
 

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -23,15 +23,18 @@ class LocalSystem(OliveSystem):
         self,
         the_pass: Pass,
         model: OliveModel,
+        data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
     ) -> OliveModel:
         """
         Run the pass on the model at a specific point in the search space.
         """
-        return the_pass.run(model, output_model_path, point)
+        return the_pass.run(model, data_root, output_model_path, point)
 
-    def evaluate_model(self, model: OliveModel, metrics: List[Metric], accelerator: AcceleratorSpec) -> MetricResult:
+    def evaluate_model(
+        self, model: OliveModel, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
+    ) -> MetricResult:
         """
         Evaluate the model
         """
@@ -42,7 +45,7 @@ class LocalSystem(OliveSystem):
         execution_providers = accelerator.execution_provider if accelerator else None
 
         evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-        return evaluator.evaluate(model, metrics, device=device, execution_providers=execution_providers)
+        return evaluator.evaluate(model, data_root, metrics, device=device, execution_providers=execution_providers)
 
     @staticmethod
     def get_supported_execution_providers():

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -26,6 +26,7 @@ class OliveSystem(ABC):
         self,
         the_pass: Pass,
         model: OliveModel,
+        data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
     ) -> OliveModel:
@@ -35,7 +36,9 @@ class OliveSystem(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def evaluate_model(self, model: OliveModel, metrics: List[Metric], accelerator: AcceleratorSpec) -> MetricResult:
+    def evaluate_model(
+        self, model: OliveModel, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
+    ) -> MetricResult:
         """
         Evaluate the model
         """

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -94,12 +94,14 @@ class PythonEnvironmentSystem(OliveSystem):
         for original_metric in metrics:
             metric = OliveEvaluator.generate_metric_user_config_with_model_io(original_metric, model)
             if metric.type == MetricType.ACCURACY:
-                metrics_res[metric.name] = self.evaluate_accuracy(model, metric, accelerator)
+                metrics_res[metric.name] = self.evaluate_accuracy(model, data_root, metric, accelerator)
             elif metric.type == MetricType.LATENCY:
-                metrics_res[metric.name] = self.evaluate_latency(model, metric, accelerator)
+                metrics_res[metric.name] = self.evaluate_latency(model, data_root, metric, accelerator)
         return flatten_metric_result(metrics_res)
 
-    def evaluate_accuracy(self, model: ONNXModel, data_root: str, metric: Metric, accelerator: AcceleratorSpec) -> float:
+    def evaluate_accuracy(
+        self, model: ONNXModel, data_root: str, metric: Metric, accelerator: AcceleratorSpec
+    ) -> float:
         """
         Evaluate the accuracy of the model.
         """

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -68,6 +68,7 @@ class PythonEnvironmentSystem(OliveSystem):
         self,
         the_pass: Pass,
         model: OliveModel,
+        data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
     ) -> OliveModel:
@@ -76,7 +77,9 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         raise ValueError("PythonEnvironmentSystem does not support running passes.")
 
-    def evaluate_model(self, model: OliveModel, metrics: List[Metric], accelerator: AcceleratorSpec) -> MetricResult:
+    def evaluate_model(
+        self, model: OliveModel, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
+    ) -> MetricResult:
         """
         Evaluate the model
         """
@@ -96,11 +99,11 @@ class PythonEnvironmentSystem(OliveSystem):
                 metrics_res[metric.name] = self.evaluate_latency(model, metric, accelerator)
         return flatten_metric_result(metrics_res)
 
-    def evaluate_accuracy(self, model: ONNXModel, metric: Metric, accelerator: AcceleratorSpec) -> float:
+    def evaluate_accuracy(self, model: ONNXModel, data_root: str, metric: Metric, accelerator: AcceleratorSpec) -> float:
         """
         Evaluate the accuracy of the model.
         """
-        dataloader, _, post_func = OliveEvaluator.get_user_config(metric, model.framework)
+        dataloader, _, post_func = OliveEvaluator.get_user_config(model.framework, data_root, metric)
 
         preds = []
         targets = []
@@ -149,11 +152,11 @@ class PythonEnvironmentSystem(OliveSystem):
 
         return OliveEvaluator.compute_accuracy(metric, preds, targets)
 
-    def evaluate_latency(self, model: ONNXModel, metric: Metric, accelerator: AcceleratorSpec) -> float:
+    def evaluate_latency(self, model: ONNXModel, data_root: str, metric: Metric, accelerator: AcceleratorSpec) -> float:
         """
         Evaluate the latency of the model.
         """
-        dataloader, _, _ = OliveEvaluator.get_user_config(metric, model.framework)
+        dataloader, _, _ = OliveEvaluator.get_user_config(model.framework, data_root, metric)
         warmup_num, repeat_test_num, sleep_num = get_latency_config_from_metric(metric)
 
         latencies = []

--- a/olive/workflows/run/__main__.py
+++ b/olive/workflows/run/__main__.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Olive Workflow: Custom Run")
     parser.add_argument("--config", type=str, help="Path to json config file", required=True)
     parser.add_argument("--setup", help="Whether run environment setup", action="store_true")
+    parser.add_argument("--data_root", help="The data root path for optimization", required=False)
 
     args = parser.parse_args()
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -55,6 +55,7 @@ class RunConfig(ConfigBase):
     azureml_client: AzureMLClientConfig = None
     input_model: ModelConfig
     systems: Dict[str, SystemConfig] = None
+    data_root: str = None
     data_configs: Dict[str, DataConfig] = {
         DefaultDataContainer.DATA_CONTAINER.value: DataConfig(),
         DEFAULT_HF_DATA_CONTAINER_NAME: DataConfig(

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -166,7 +166,7 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
             )
 
         if data_root is None:
-            data_root = config.engine.data_root
+            data_root = config.data_root
 
         # run
         best_execution = engine.run(

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -123,7 +123,7 @@ def dependency_setup(config):
         )
 
 
-def run(config: Union[str, Path, dict], setup: bool = False):
+def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = None):
     # we use parse_file and parse_obj to be safe. If implemented as expected, both should be equivalent.
     if isinstance(config, str) or isinstance(config, Path):
         config = RunConfig.parse_file(config)
@@ -165,9 +165,13 @@ def run(config: Union[str, Path, dict], setup: bool = False):
                 output_name=pass_config.output_name,
             )
 
+        if data_root is None:
+            data_root = config.engine.data_root
+
         # run
         best_execution = engine.run(
             input_model,
+            data_root,
             config.engine.packaging_config,
             config.engine.output_dir,
             config.engine.output_name,

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -45,7 +45,7 @@ def test_aml_model_pass_run():
     with tempfile.TemporaryDirectory() as tempdir:
         onnx_model_file = str(Path(tempdir) / "model.onnx")
         onnx_conversion_pass = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
-        onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model, onnx_model_file)
+        onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model, None, onnx_model_file)
         assert Path(onnx_model.model_path).is_file()
 
 

--- a/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
+++ b/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
@@ -44,7 +44,7 @@ class TestAMLEvaluation:
     def test_evaluate_model(self, model_cls, model_path, metric, expected_res):
         aml_target = get_aml_target()
         olive_model = model_cls(model_path=model_path)
-        actual_res = aml_target.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        actual_res = aml_target.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
+++ b/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
@@ -52,7 +52,7 @@ class TestDockerEvaluation:
     def test_evaluate_model(self, model_cls, model_config, metric, expected_res):
         docker_target = get_docker_target()
         olive_model = model_cls(**model_config)
-        actual_res = docker_target.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        actual_res = docker_target.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/integ_test/evaluator/local_eval/test_local_evaluation.py
+++ b/test/integ_test/evaluator/local_eval/test_local_evaluation.py
@@ -49,7 +49,7 @@ class TestLocalEvaluation:
     )
     def test_evaluate_model(self, model_cls, model_config, metric, expected_res):
         olive_model = model_cls(**model_config)
-        actual_res = LocalSystem().evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        actual_res = LocalSystem().evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/unit_test/data_container/test_data_container.py
+++ b/test/unit_test/data_container/test_data_container.py
@@ -44,8 +44,8 @@ class TestDataConfig:
         # override the default components from task_type
         assert dc_config.components["post_process_data"].type == "text_classification_post_process"
         dc = dc_config.to_data_container()
-        dc.create_dataloader()
-        dc.create_calibration_dataloader()
+        dc.create_dataloader(data_root_path=None)
+        dc.create_calibration_dataloader(data_root_path=None)
 
     def test_raw_data_constructor(self):
         dc_config = DataConfig(type="RawDataContainer")
@@ -79,8 +79,8 @@ class TestDataConfig:
             assert input_data[input_name].dtype == input_types[input_names.index(input_name)]
             assert np.array_equal(input_data[input_name], data[input_name][0])
 
-        dc.create_dataloader()
-        dc.create_calibration_dataloader()
+        dc.create_dataloader(data_root_path=None)
+        dc.create_calibration_dataloader(data_root_path=None)
 
     def test_dc_runner(self):
         try:

--- a/test/unit_test/data_container/test_template.py
+++ b/test/unit_test/data_container/test_template.py
@@ -25,7 +25,7 @@ class TestDataConfigTemplate:
             label_cols=["label"],
             batch_size=32,
         )
-        dataloader = dataloader.to_data_container().create_dataloader()
+        dataloader = dataloader.to_data_container().create_dataloader(data_root_path=None)
         assert dataloader is not None, "Failed to create dataloader from huggingface template."
 
     @pytest.mark.parametrize(

--- a/test/unit_test/engine/packaging/test_packaging_generator.py
+++ b/test/unit_test/engine/packaging/test_packaging_generator.py
@@ -44,7 +44,7 @@ def test_generate_zipfile_artifacts():
     output_dir = Path(tempdir.name) / "outputs"
 
     # execute
-    engine.run(input_model=input_model, packaging_config=packaging_config, output_dir=output_dir)
+    engine.run(input_model=input_model, data_root=None, packaging_config=packaging_config, output_dir=output_dir)
 
     # assert
     artifacts_path = output_dir / "OutputModels.zip"

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -497,5 +497,5 @@ class TestEngine:
             engine.register(OnnxDynamicQuantization, disable_search=True)
             with patch("onnxruntime.quantization.quantize_dynamic") as mock_quantize_dynamic:
                 mock_quantize_dynamic.side_effect = AttributeError("test")
-                actual_res = engine.run(onnx_model, data_root=None, output_dir=output_dir)
+                actual_res = engine.run(onnx_model, data_root=None, output_dir=output_dir, evaluate_input_model=False)
                 assert actual_res == {}, "Expect empty dict when quantization fails"

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -162,6 +162,7 @@ class TestEngine:
         assert engine.get_model_json_path(actual_res.nodes[model_id].model_id).exists()
         mock_local_system.run_pass.assert_called_once()
         mock_local_system.evaluate_model.call_count == 2
+        mock_local_system.evaluate_model.assert_called_with(onnx_model, None, [metric], accelerator_spec)
 
     @patch("olive.systems.local.LocalSystem")
     def test_run_no_search(self, mock_local_system):
@@ -485,7 +486,7 @@ class TestEngine:
             engine.register(OnnxStaticQuantization)
             with patch("onnxruntime.quantization.quantize_static") as mock_quantize_static:
                 mock_quantize_static.side_effect = AttributeError("test")
-                actual_res = engine.run(onnx_model, output_dir=output_dir)
+                actual_res = engine.run(onnx_model, data_root=None, output_dir=output_dir)
                 pf = actual_res[DEFAULT_CPU_ACCELERATOR]
                 assert not pf.nodes, "Expect empty dict when quantization fails"
         else:
@@ -496,5 +497,5 @@ class TestEngine:
             engine.register(OnnxDynamicQuantization, disable_search=True)
             with patch("onnxruntime.quantization.quantize_dynamic") as mock_quantize_dynamic:
                 mock_quantize_dynamic.side_effect = AttributeError("test")
-                actual_res = engine.run(onnx_model, output_dir=output_dir)
+                actual_res = engine.run(onnx_model, data_root=None, output_dir=output_dir)
                 assert actual_res == {}, "Expect empty dict when quantization fails"

--- a/test/unit_test/evaluator/test_metric_backend.py
+++ b/test/unit_test/evaluator/test_metric_backend.py
@@ -57,7 +57,7 @@ class TestMetricBackend:
             system = LocalSystem()
 
             # execute
-            actual_res = system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+            actual_res = system.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
             # assert
             mock_measure.call_count == len(metric.sub_types)

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR
 from test.unit_test.utils import (
     get_accuracy_metric,
     get_custom_eval,
@@ -19,6 +18,7 @@ import pytest
 
 from olive.evaluator.metric import AccuracySubType, LatencySubType
 from olive.evaluator.olive_evaluator import OnnxEvaluator, OpenVINOEvaluator, PyTorchEvaluator, SNPEEvaluator
+from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR
 from olive.systems.local import LocalSystem
 
 
@@ -107,7 +107,7 @@ class TestOliveEvaluator:
             mock_acc.return_value = expected_res
 
             # execute
-            actual_res = evaluator.evaluate(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
+            actual_res = evaluator.evaluate(olive_model, None, [metric])
 
             # assert
             mock_acc.assert_called_once()
@@ -141,7 +141,7 @@ class TestOliveEvaluator:
     )
     def test_evaluate_latency(self, evaluator, olive_model, metric, expected_res):
         # execute
-        actual_res = evaluator.evaluate(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
+        actual_res = evaluator.evaluate(olive_model, None, [metric])
 
         # assert
         for sub_type in metric.sub_types:
@@ -160,7 +160,7 @@ class TestOliveEvaluator:
     )
     def test_evaluate_custom(self, evaluator, olive_model, metric, expected_res):
         # execute
-        actual_res = evaluator.evaluate(olive_model, [metric])
+        actual_res = evaluator.evaluate(olive_model, None, [metric])
 
         # assert
         for sub_type in metric.sub_types:
@@ -171,7 +171,7 @@ class TestOliveEvaluator:
         olive_model = get_pytorch_model()
         metric = get_custom_metric_no_eval()
         with pytest.raises(ValueError, match="evaluate_func or metric_func is not specified in the metric config"):
-            evaluator.evaluate(olive_model, [metric])
+            evaluator.evaluate(olive_model, None, [metric])
 
 
 @pytest.mark.skip(reason="Requires custom onnxruntime build with mpi enabled")

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR
 from test.unit_test.utils import (
     get_accuracy_metric,
     get_custom_eval,
@@ -106,7 +107,7 @@ class TestOliveEvaluator:
             mock_acc.return_value = expected_res
 
             # execute
-            actual_res = evaluator.evaluate(olive_model, [metric])
+            actual_res = evaluator.evaluate(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
             # assert
             mock_acc.assert_called_once()
@@ -140,7 +141,7 @@ class TestOliveEvaluator:
     )
     def test_evaluate_latency(self, evaluator, olive_model, metric, expected_res):
         # execute
-        actual_res = evaluator.evaluate(olive_model, [metric])
+        actual_res = evaluator.evaluate(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
         # assert
         for sub_type in metric.sub_types:
@@ -194,7 +195,7 @@ class TestDistributedOnnxEvaluator:
         target = LocalSystem()
 
         # execute
-        actual_res = target.evaluate_model(model, metrics)
+        actual_res = target.evaluate_model(model, None, metrics, DEFAULT_CPU_ACCELERATOR)
 
         # assert
         for sub_type in latency_metric.sub_types:

--- a/test/unit_test/passes/inc/test_inc_quantization.py
+++ b/test/unit_test/passes/inc/test_inc_quantization.py
@@ -34,7 +34,7 @@ def test_inc_quantization():
         # create IncQuantization pass
         p = create_pass_from_dict(IncQuantization, config, disable_search=True)
         # execute
-        quantized_model = local_system.run_pass(p, ov_model, output_folder)
+        quantized_model = local_system.run_pass(p, ov_model, None, output_folder)
         # assert
         assert quantized_model.model_path.endswith(".onnx")
         assert Path(quantized_model.model_path).exists()
@@ -46,7 +46,7 @@ def test_inc_quantization():
         # create IncDynamicQuantization pass
         p = create_pass_from_dict(IncDynamicQuantization, config, disable_search=True)
         # execute
-        quantized_model = local_system.run_pass(p, ov_model, output_folder)
+        quantized_model = local_system.run_pass(p, ov_model, None, output_folder)
         # assert
         assert quantized_model.model_path.endswith(".onnx")
         assert Path(quantized_model.model_path).exists()
@@ -58,7 +58,7 @@ def test_inc_quantization():
         # create IncStaticQuantization pass
         p = create_pass_from_dict(IncStaticQuantization, config, disable_search=True)
         # execute
-        quantized_model = local_system.run_pass(p, ov_model, output_folder)
+        quantized_model = local_system.run_pass(p, ov_model, None, output_folder)
         # assert
         assert quantized_model.model_path.endswith(".onnx")
         assert Path(quantized_model.model_path).exists()
@@ -82,7 +82,7 @@ def get_onnx_model(tempdir):
     output_folder = str(Path(tempdir) / "onnx")
 
     # execute
-    onnx_model = local_system.run_pass(p, pytorch_model, output_folder)
+    onnx_model = local_system.run_pass(p, pytorch_model, None, output_folder)
     return onnx_model
 
 

--- a/test/unit_test/passes/onnx/test_conversion.py
+++ b/test/unit_test/passes/onnx/test_conversion.py
@@ -16,8 +16,9 @@ def test_onnx_conversion_pass():
     with tempfile.TemporaryDirectory() as tempdir:
         output_folder = str(Path(tempdir) / "onnx")
 
-        # execute
-        onnx_model = local_system.run_pass(p, input_model, output_folder)
+        # The conversion need torch version > 1.13.1, otherwise, it will complain
+        # Unsupported ONNX opset version: 18
+        onnx_model = local_system.run_pass(p, input_model, None, output_folder)
 
         # assert
         assert Path(onnx_model.model_path).exists()

--- a/test/unit_test/passes/onnx/test_insert_beam_search.py
+++ b/test/unit_test/passes/onnx/test_insert_beam_search.py
@@ -25,4 +25,4 @@ def test_insert_beam_search_pass():
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, composite_model, output_folder)
+        local_system.run_pass(p, composite_model, None, output_folder)

--- a/test/unit_test/passes/onnx/test_mixed_precision.py
+++ b/test/unit_test/passes/onnx/test_mixed_precision.py
@@ -16,4 +16,4 @@ def test_ort_mixed_precision_pass():
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, input_model, output_folder)
+        local_system.run_pass(p, input_model, None, output_folder)

--- a/test/unit_test/passes/onnx/test_model_optimizer.py
+++ b/test/unit_test/passes/onnx/test_model_optimizer.py
@@ -20,4 +20,4 @@ def test_onnx_model_optimizer_pass():
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, input_model, output_folder)
+        local_system.run_pass(p, input_model, None, output_folder)

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -24,7 +24,7 @@ def test_ort_perf_tuning_pass(config):
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, input_model, output_folder)
+        local_system.run_pass(p, input_model, None, output_folder)
 
 
 @patch("olive.model.ONNXModel.get_io_config")
@@ -46,5 +46,5 @@ def test_ort_perf_tuning_pass_with_dynamic_shapes(mock_get_io_config):
 
         with pytest.raises(TypeError) as e:
             # execute
-            local_system.run_pass(p, input_model, output_folder)
+            local_system.run_pass(p, input_model, None, output_folder)
             assert "ones() received an invalid combination of arguments" in str(e.value)

--- a/test/unit_test/passes/onnx/test_pre_post_processing_op.py
+++ b/test/unit_test/passes/onnx/test_pre_post_processing_op.py
@@ -21,7 +21,7 @@ def test_pre_post_processing_op():
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, input_model, output_folder)
+        local_system.run_pass(p, input_model, None, output_folder)
 
 
 def get_superresolution_model(tempdir, local_system):
@@ -82,6 +82,6 @@ def get_superresolution_model(tempdir, local_system):
         },
     )
     onnx_conversion_pass = create_pass_from_dict(OnnxConversion, {"target_opset": 15}, disable_search=True)
-    onnx_model = local_system.run_pass(onnx_conversion_pass, pytorch_model, str(Path(tempdir) / "onnx"))
+    onnx_model = local_system.run_pass(onnx_conversion_pass, pytorch_model, None, str(Path(tempdir) / "onnx"))
 
     return onnx_model

--- a/test/unit_test/passes/onnx/test_transformer_optimization.py
+++ b/test/unit_test/passes/onnx/test_transformer_optimization.py
@@ -50,4 +50,4 @@ def test_ort_transformer_optimization_pass():
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, input_model, output_folder)
+        local_system.run_pass(p, input_model, None, output_folder)

--- a/test/unit_test/passes/openvino/test_openvino_conversion.py
+++ b/test/unit_test/passes/openvino/test_openvino_conversion.py
@@ -15,7 +15,7 @@ def test_openvino_conversion_pass():
     # setup
     local_system = LocalSystem()
     input_model = get_pytorch_model()
-    dummy_input = get_pytorch_model_dummy_input()
+    dummy_input = get_pytorch_model_dummy_input(input_model)
     openvino_conversion_config = {"extra_config": {"example_input": dummy_input}}
 
     p = create_pass_from_dict(OpenVINOConversion, openvino_conversion_config, disable_search=True)

--- a/test/unit_test/passes/openvino/test_openvino_conversion.py
+++ b/test/unit_test/passes/openvino/test_openvino_conversion.py
@@ -23,7 +23,7 @@ def test_openvino_conversion_pass():
         output_folder = str(Path(tempdir) / "openvino")
 
         # execute
-        openvino_model = local_system.run_pass(p, input_model, output_folder)
+        openvino_model = local_system.run_pass(p, input_model, None, output_folder)
 
         # assert
         assert Path(openvino_model.model_path).exists()
@@ -44,7 +44,7 @@ def test_openvino_conversion_pass_no_example_input():
         output_folder = str(Path(tempdir) / "openvino")
 
         # execute
-        openvino_model = local_system.run_pass(p, input_model, output_folder)
+        openvino_model = local_system.run_pass(p, input_model, None, output_folder)
 
         # assert
         assert Path(openvino_model.model_path).exists()

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -98,7 +98,7 @@ def get_openvino_model(tempdir):
     output_folder = str(Path(tempdir) / "openvino")
 
     # execute
-    openvino_model = local_system.run_pass(p, pytorch_model, output_folder)
+    openvino_model = local_system.run_pass(p, pytorch_model, None, output_folder)
     return openvino_model
 
 

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -67,7 +67,7 @@ def test_openvino_quantization(data_source):
         output_folder = str(Path(tempdir) / "quantized")
 
         # execute
-        quantized_model = local_system.run_pass(p, ov_model, output_folder)
+        quantized_model = local_system.run_pass(p, ov_model, None, output_folder)
 
         # assert
         assert Path(quantized_model.model_path).exists()

--- a/test/unit_test/passes/pytorch/test_quantization_aware_training.py
+++ b/test/unit_test/passes/pytorch/test_quantization_aware_training.py
@@ -26,4 +26,4 @@ def test_quantization_aware_training_pass_default():
         output_folder = str(Path(tempdir) / "onnx")
 
         # execute
-        local_system.run_pass(p, input_model, output_folder)
+        local_system.run_pass(p, input_model, None, output_folder)

--- a/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
+++ b/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
@@ -54,7 +54,7 @@ def test_vitis_ai_quantization_pass():
         # create VitisAIQuantization pass
         p = create_pass_from_dict(VitisAIQuantization, config, disable_search=True)
         # execute
-        quantized_model = local_system.run_pass(p, input_model, output_folder)
+        quantized_model = local_system.run_pass(p, input_model, None, output_folder)
         # assert
         assert quantized_model.model_path.endswith(".onnx")
         assert Path(quantized_model.model_path).exists()

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -73,10 +73,12 @@ class TestAzureMLSystem:
         self.system.azureml_client_config.operation_retry_interval = 5
 
         # execute
-        res = self.system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        res = self.system.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
         # assert
-        mock_create_pipeline.assert_called_once_with(output_folder, olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        mock_create_pipeline.assert_called_once_with(
+            None, output_folder, olive_model, [metric], DEFAULT_CPU_ACCELERATOR
+        )
         ml_client.jobs.stream.assert_called_once()
         assert mock_retry_func.call_count == 2
         if metric.name == "accuracy":
@@ -131,10 +133,10 @@ class TestAzureMLSystem:
         with patch("olive.systems.azureml.aml_system.tempfile.TemporaryDirectory") as mock_tempdir:
             mock_tempdir.return_value.__enter__.return_value = output_folder
             # execute
-            actual_res = self.system.run_pass(p, olive_model, output_model_path)
+            actual_res = self.system.run_pass(p, olive_model, None, output_model_path)
 
         # assert
-        mock_create_pipeline.assert_called_once_with(output_folder, olive_model, p.to_json(), p.path_params)
+        mock_create_pipeline.assert_called_once_with(None, output_folder, olive_model, p.to_json(), p.path_params)
         assert mock_retry_func.call_count == 2
         ml_client.jobs.stream.assert_called_once()
         assert expected_model.to_json() == actual_res.to_json()
@@ -221,7 +223,7 @@ class TestAzureMLSystem:
         }
 
         # execute
-        actual_res = self.system._create_metric_args(metric_config, tem_dir)
+        actual_res = self.system._create_metric_args(None, metric_config, tem_dir)
 
         # assert
         assert actual_res == expected_res
@@ -289,7 +291,7 @@ class TestAzureMLSystem:
         else:
             model_resource_path = create_resource_path(ONNX_MODEL_PATH)
         actual_res = self.system._create_metric_component(
-            tem_dir, metric, model_args, model_resource_path, accelerator_config_path
+            None, tem_dir, metric, model_args, model_resource_path, accelerator_config_path
         )
 
         # assert

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -201,7 +201,8 @@ class TestAzureMLSystem:
 
     def test__create_metric_args(self):
         # setup
-        tem_dir = Path(__file__).absolute().parent
+        # the reason why we need resolve: sometimes, windows system would change c:\\ to C:\\ when calling resolve.
+        tem_dir = Path(__file__).absolute().parent.resolve()
         metric_config = {
             "user_config": {
                 "user_script": "user_script",

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -142,6 +142,7 @@ class TestDockerSystem:
         container_root_path = Path("/olive/")
         eval_output_path = "eval_output"
         eval_output_name = "eval_res.json"
+        data_root = None
         mock_copy = MagicMock()
         mock_copy.return_value = mock_copy
 
@@ -176,14 +177,14 @@ class TestDockerSystem:
                 docker.errors.ContainerError,
                 match=r".*returned non-zero exit status 1: Docker container evaluation failed with: mock_error",
             ):
-                actual_res = docker_system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+                actual_res = docker_system.evaluate_model(olive_model, data_root, [metric], DEFAULT_CPU_ACCELERATOR)
         else:
-            actual_res = docker_system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+            actual_res = docker_system.evaluate_model(olive_model, data_root, [metric], DEFAULT_CPU_ACCELERATOR)
             # assert
             self.mock_create_eval_script_mount.called_once_with(container_root_path)
             self.mock_create_model_mount.called_once_with(mock_copy, container_root_path)
             vol_list = [eval_file_mount_str] + model_mount_str_list
-            self.mock_create_metric_volumes_list.called_once_with(mock_copy, container_root_path, vol_list)
+            self.mock_create_metric_volumes_list.called_once_with(data_root, mock_copy, container_root_path, vol_list)
             self.mock_create_config_file.called_once_with(tempdir, mock_copy, mock_copy, container_root_path)
             self.mock_create_output_mount.called_once_with(tempdir, eval_output_path, container_root_path)
             self.mock_create_evaluate_command.called_once_with(

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -62,7 +62,7 @@ class TestPythonEnvironmentSystem:
         )
 
         # execute
-        res = self.system.evaluate_model(model, metrics, DEFAULT_CPU_ACCELERATOR)
+        res = self.system.evaluate_model(model, None, metrics, DEFAULT_CPU_ACCELERATOR)
 
         # assert
         assert res[metrics_key[0]].value == 0.9
@@ -88,10 +88,14 @@ class TestPythonEnvironmentSystem:
 
         # expected result
         local_system = LocalSystem()
-        expected_res = local_system.evaluate_model(model, [metric], DEFAULT_CPU_ACCELERATOR)["accuracy-accuracy_score"]
+        expected_res = local_system.evaluate_model(model, None, [metric], DEFAULT_CPU_ACCELERATOR)[
+            "accuracy-accuracy_score"
+        ]
 
         # execute
-        actual_res = self.system.evaluate_model(model, [metric], DEFAULT_CPU_ACCELERATOR)["accuracy-accuracy_score"]
+        actual_res = self.system.evaluate_model(model, None, [metric], DEFAULT_CPU_ACCELERATOR)[
+            "accuracy-accuracy_score"
+        ]
 
         # assert
         assert actual_res == expected_res
@@ -127,7 +131,7 @@ class TestPythonEnvironmentSystem:
         expected_res = 10
 
         # execute
-        actual_res = self.system.evaluate_latency(model, metric, DEFAULT_CPU_ACCELERATOR)
+        actual_res = self.system.evaluate_latency(model, None, metric, DEFAULT_CPU_ACCELERATOR)
 
         # assert
         assert actual_res[LatencySubType.AVG].value == expected_res

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -25,7 +25,7 @@ class TestLocalSystem:
         output_model_path = "output_model_path"
 
         # execute
-        self.system.run_pass(p, olive_model, output_model_path)
+        self.system.run_pass(p, olive_model, None, output_model_path)
 
         # assert
         p.run.called_once_with(olive_model, output_model_path, None)
@@ -78,7 +78,7 @@ class TestLocalSystem:
         mock_get_user_config.return_value = (None, None, None)
 
         # execute
-        actual_res = self.system.evaluate_model(olive_model, [metric], DEFAULT_CPU_ACCELERATOR)
+        actual_res = self.system.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
         # assert
         if metric.type == MetricType.ACCURACY:

--- a/test/unit_test/test_data_root.py
+++ b/test/unit_test/test_data_root.py
@@ -1,0 +1,218 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from pathlib import Path
+from test.unit_test.utils import get_pytorch_model_dummy_input, pytorch_model_loader
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from olive.data.config import DataConfig
+from olive.data.registry import Registry
+from olive.resource_path import create_resource_path
+from olive.workflows import run as olive_run
+
+
+class DummyDataset(Dataset):
+    def __init__(self, size):
+        self.size = size
+
+    def __getitem__(self, idx):
+        return torch.randn(1), torch.rand(10).argmax()
+
+    def __len__(self):
+        return self.size
+
+
+@Registry.register_dataset()
+def dummy_dataset_dataroot(data_dir):
+    return DummyDataset(1)
+
+
+@Registry.register_post_process()
+def post_processing_func(output):
+    return output.argmax(axis=1)
+
+
+def create_dataloader(datadir, batchsize, *args, **kwargs):
+    dataloader = DataLoader(DummyDataset(1))
+    return dataloader
+
+
+def get_dataloader_config():
+    return {
+        "input_model": {
+            "type": "PyTorchModel",
+            "config": {
+                "model_loader": pytorch_model_loader,
+                "dummy_inputs_func": get_pytorch_model_dummy_input,
+                "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+            },
+        },
+        "evaluators": {
+            "common_evaluator": {
+                "metrics": [
+                    {
+                        "name": "accuracy",
+                        "type": "accuracy",
+                        "sub_types": [{"name": "accuracy_score", "priority": 1}],
+                        "user_config": {
+                            "data_dir": "data",
+                            "dataloader_func": create_dataloader,
+                            "batch_size": 16,
+                            "post_processing_func": post_processing_func,
+                        },
+                    }
+                ]
+            }
+        },
+        "passes": {
+            "onnx_conversion": {"type": "OnnxConversion", "config": {"target_opset": 13}},
+            "perf_tuning": {
+                "type": "OrtPerfTuning",
+                "config": {
+                    "dataloader_func": create_dataloader,
+                    "batch_size": 16,
+                    "data_dir": "data",
+                },
+            },
+        },
+        "engine": {
+            "search_strategy": {"execution_order": "joint", "search_algorithm": "exhaustive"},
+            "evaluator": "common_evaluator",
+            "clean_cache": True,
+            "cache_dir": "./cache",
+        },
+    }
+
+
+def get_data_config():
+    return {
+        "input_model": {
+            "type": "PyTorchModel",
+            "config": {
+                "model_loader": pytorch_model_loader,
+                "dummy_inputs_func": get_pytorch_model_dummy_input,
+                "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+            },
+        },
+        "evaluators": {
+            "common_evaluator": {
+                "metrics": [
+                    {
+                        "name": "accuracy",
+                        "type": "accuracy",
+                        "sub_types": [{"name": "accuracy_score", "priority": 1}],
+                        "data_config": DataConfig(
+                            components={
+                                "load_dataset": {
+                                    "name": "dummy_dataset_dataroot",
+                                    "type": "dummy_dataset_dataroot",
+                                    "params": {"data_dir": "data"},
+                                },
+                                "post_process_data": {
+                                    "type": "post_processing_func",
+                                },
+                            }
+                        ),
+                    }
+                ]
+            }
+        },
+        "passes": {
+            "onnx_conversion": {"type": "OnnxConversion", "config": {"target_opset": 13}},
+            "perf_tuning": {
+                "type": "OrtPerfTuning",
+                "config": {
+                    "data_config": DataConfig(
+                        components={
+                            "load_dataset": {
+                                "name": "dummy_dataset_dataroot",
+                                "type": "dummy_dataset_dataroot",
+                                "params": {"data_dir": "data"},
+                            },
+                            "post_process_data": {
+                                "type": "post_processing_func",
+                            },
+                        }
+                    )
+                },
+            },
+        },
+        "engine": {
+            "search_strategy": {"execution_order": "joint", "search_algorithm": "exhaustive"},
+            "evaluator": "common_evaluator",
+            "clean_cache": True,
+            "cache_dir": "./cache",
+        },
+    }
+
+
+@pytest.fixture(params=[None, "azureml://CIFAR-10/1", "local"])
+def config(tmpdir, request):
+    config_obj = get_dataloader_config()
+
+    data_root = request.param
+    if data_root is not None:
+        if data_root == "local":
+            tmpdir.mkdir("data")
+            data_root = str(tmpdir)
+        config_obj["data_root"] = data_root
+
+    return config_obj
+
+
+@patch("olive.cache.get_local_path")
+@pytest.mark.parametrize("is_cmdline", [True, False])
+def test_data_root_for_dataloader_func(mock_get_local_path, config, is_cmdline):
+    mock_get_local_path.side_effect = lambda x, cache_dir=".olive-cache": x.get_path()
+    if is_cmdline:
+        data_root = config.pop("data_root", None)
+        best = olive_run(config, data_root=data_root)
+    else:
+        data_root = config.get("data_root")
+        best = olive_run(config)
+
+    if data_root is None:
+        data_dir = "data"
+    elif data_root.startswith("azureml://"):
+        data_dir = data_root + "/data"
+    else:
+        data_dir = str(Path(data_root) / "data")
+    mock_get_local_path.assert_called_with(create_resource_path(data_dir), ".olive-cache")
+    assert best is not None
+
+
+@pytest.fixture(params=[None, "azureml://CIFAR-10/1", "local"])
+def data_config(tmpdir, request):
+    config_obj = get_data_config()
+
+    data_root = request.param
+    if data_root is not None:
+        if data_root == "local":
+            tmpdir.mkdir("data")
+            data_root = str(tmpdir)
+        config_obj["data_root"] = data_root
+
+    return config_obj
+
+
+def test_data_root_for_dataset(data_config):
+    config = get_data_config()
+
+    data_root = config.get("data_root")
+    if data_root is None:
+        data_dir = "data"
+    elif data_root.startswith("azureml://"):
+        data_dir = data_root + "/data"
+    else:
+        data_dir = str(Path(data_root) / "data")
+
+    mock = MagicMock(side_effect=dummy_dataset_dataroot)
+    Registry.register_dataset("dummy_dataset_dataroot")(mock)
+    best = olive_run(config)
+    mock.assert_called_with(data_dir=data_dir)
+    assert best is not None

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -70,13 +70,13 @@ def get_pytorch_model():
     )
 
 
-def get_pytorch_model_dummy_input():
+def get_pytorch_model_dummy_input(model):
     return torch.randn(1, 1)
 
 
 def create_onnx_model_file():
     pytorch_model = pytorch_model_loader(model_path=None)
-    dummy_input = get_pytorch_model_dummy_input()
+    dummy_input = get_pytorch_model_dummy_input(pytorch_model)
     torch.onnx.export(
         pytorch_model, dummy_input, ONNX_MODEL_PATH, opset_version=10, input_names=["input"], output_names=["output"]
     )

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -187,7 +187,7 @@ def get_onnx_dynamic_quantization_pass(disable_search=False):
 
 def get_data_config():
     @Registry.register_dataset("test_dataset")
-    def _test_dataset(test_value):
+    def _test_dataset(data_dir, test_value):
         ...
 
     @Registry.register_dataloader()

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -30,7 +30,7 @@ class TestRunConfig:
     def test_dataset_config_file(self, config_file):
         run_config = RunConfig.parse_file(config_file)
         for dc in run_config.data_configs.values():
-            dc.to_data_container().create_dataloader()
+            dc.to_data_container().create_dataloader(data_root_path=None)
 
     @pytest.mark.parametrize("system", ["local_system", "azureml_system"])
     def test_user_script_config(self, system):


### PR DESCRIPTION
## Describe your changes
Currently, the following passes and evaluators using the data_dir:
* all quantization pass
* perf-tuning
* QAT including train_data_dir and val_data_dir
* metric config

The absolute path processing make the integration to AzureML very painful. We introduce the uniform data_root, which requires all the data used by all techniques should be put under the same data root directory. And the data_root should be able to passed to Olive from command line.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
