### PR TITLE
☂️Opt in input model eval

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -411,8 +411,7 @@ This is a dictionary that contains the information of the engine. The informatio
   If `search_strategy` is `true`, the search strategy will be the default search strategy. The default search strategy is `exhaustive` search
   algorithm with `joint` execution order.
 
-- `evaluation_only: [Boolean]` This decides whether to run the engine in evaluation only mode. In this mode, the engine will evaluate the input
-    model using the engine's evaluator and return the results. If the engine has no evaluator, it will raise an error. This is `false` by default.
+- `evaluate_input_model: [Boolean]` In this mode, the engine will evaluate the input model using the engine's evaluator and return the results. If the engine has no evaluator, it will raise an error. This is `true` by default.
 
 - `host: [str | Dict]` The host of the engine. It can be a string or a dictionary. If it is a string, it is the name of a system in `systems`.
     If it is a dictionary, it contains the system information. If not specified, it is the local system.

--- a/examples/cifar10_openvino_intel_hw/config.json
+++ b/examples/cifar10_openvino_intel_hw/config.json
@@ -80,6 +80,7 @@
         "evaluator": "common_evaluator",
         "host": "local_system",
         "target": "local_system",
-        "cache_dir": "cache"
+        "cache_dir": "cache",
+        "evaluate_input_model": false
     }
 }

--- a/examples/mobilenet_qnn_qualcomm_npu/mobilenet_config_template.json
+++ b/examples/mobilenet_qnn_qualcomm_npu/mobilenet_config_template.json
@@ -53,7 +53,7 @@
         "cache_dir": "cache",
         "output_dir": "models",
         "evaluator": "common_evaluator",
-        "evaluation_only": false,
+        "evaluate_input_model": false,
         "clean_cache": true,
         "target": {
             "type": "PythonEnvironment",

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -107,6 +107,7 @@
         "host": "local_system",
         "target": "local_system",
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "clean_cache": false,
         "cache_dir": "cache",
         "output_dir": "models",

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -259,7 +259,7 @@ class Engine:
         packaging_config: Optional[PackagingConfig] = None,
         output_dir: str = None,
         output_name: str = None,
-        evaluation_only: bool = False,
+        evaluate_input_model: bool = True,
     ):
         """
         Run all the registered Olive passes on the input model and produce one or more candidate models.
@@ -270,7 +270,7 @@ class Engine:
             output_dir: output directory for the output model
             output_name: output name for the output model, if output_name is provided, the output
                 model will be saved to engine's output_dir with the prefix of output_name.
-            evaluation_only: if evaluation_only is True, run the evaluation on the input model and return the results.
+            evaluate_input_model: if evaluate_input_model is True, run the evaluation on the input model.
 
         Return:
             if search strategy is None, all passes are run in the order they were registered.
@@ -299,18 +299,21 @@ class Engine:
             self.footprints[accelerator_spec].record(model_id=input_model_id)
 
             try:
-                if evaluation_only:
+                if evaluate_input_model:
                     prefix_output_name = (
-                        f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}_"
+                        f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}"
                     )
-                    assert self.evaluator_config is not None, "Evaluation only is True but no evaluator provided"
+                    assert self.evaluator_config is not None, "evaluate_input_model is True but no evaluator provided"
                     results = self._evaluate_model(input_model, input_model_id, self.evaluator_config, accelerator_spec)
-                    result_name = f"{prefix_output_name}metrics"
+                    logger.info(f"Input model evaluation results: {results}")
+                    result_name = f"{prefix_output_name}_input_model_metrics"
                     results_path = output_dir / f"{result_name}.json"
                     with open(results_path, "w") as f:
                         json.dump(results.to_json(), f, indent=4)
+                    logger.info(f"Saved evaluation results of input model to {results_path}")
                     outputs[accelerator_spec] = results
-                elif self.no_search:
+
+                if self.no_search:
                     output = self.run_no_search(
                         input_model,
                         input_model_id,

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -312,6 +312,9 @@ class Engine:
                         json.dump(results.to_json(), f, indent=4)
                     logger.info(f"Saved evaluation results of input model to {results_path}")
                     outputs[accelerator_spec] = results
+                    if not self.passes:
+                        logger.debug("No passes registered, return input model evaluation results.")
+                        return outputs
 
                 if self.no_search:
                     output = self.run_no_search(

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -355,3 +355,7 @@ class Footprint:
             return False
 
         return model_config.get("config", {}).get("use_ort_extensions", False)
+
+    def get_input_node(self):
+        input_node = [v for _, v in self.nodes.items() if v.parent_model_id is None][0]
+        return input_node

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -66,6 +66,7 @@ def _package_candidate_models(
 ) -> None:
     candidate_models_dir = tempdir / "CandidateModels"
     model_rank = 1
+    input_node = footprint.get_input_node()
     for model_id, node in pf_footprint.nodes.items():
         model_dir = candidate_models_dir / f"{accelerator_spec}" / f"BestCandidateModel_{model_rank}"
         model_dir.mkdir(parents=True, exist_ok=True)
@@ -122,7 +123,11 @@ def _package_candidate_models(
         if node.metrics:
             metric_path = str(model_dir / "metrics.json")
             with open(metric_path, "w") as f:
-                f.write(str(node.metrics.value))
+                metrics = {
+                    "input_model_metrics": input_node.metrics.value.to_json() if input_node.metrics else None,
+                    "candidate_model_metrics": node.metrics.value.to_json(),
+                }
+                json.dump(metrics, f, indent=4)
 
 
 def _package_onnxruntime_packages(tempdir, pf_footprint: Footprint):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -29,7 +29,7 @@ class RunPassConfig(FullPassConfig):
 
 
 class RunEngineConfig(EngineConfig):
-    evaluation_only: bool = False
+    evaluate_input_model: bool = True
     output_dir: Union[Path, str] = None
     output_name: str = None
     packaging_config: PackagingConfig = None
@@ -39,7 +39,7 @@ class RunEngineConfig(EngineConfig):
     def create_engine(self):
         config = self.dict()
         to_del = [
-            "evaluation_only",
+            "evaluate_input_model",
             "output_dir",
             "output_name",
             "packaging_config",
@@ -118,8 +118,8 @@ class RunConfig(ConfigBase):
         return _resolve_evaluator(v, values)
 
     @validator("engine")
-    def validate_evaluation_only(cls, v):
-        if v.evaluation_only and v.evaluator is None:
+    def validate_evaluate_input_model(cls, v):
+        if v.evaluate_input_model and v.evaluator is None:
             raise ValueError("Evaluation only requires evaluator")
         return v
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -141,7 +141,7 @@ def run(config: Union[str, Path, dict], setup: bool = False):
     # engine
     engine = config.engine.create_engine()
 
-    if (config.passes is None or not config.passes) and (not config.engine.evaluation_only):
+    if (config.passes is None or not config.passes) and (not config.engine.evaluate_input_model):
         # TODO enhance this logic for more passes templates
         engine, config = automatically_insert_passes(config)
 
@@ -168,6 +168,6 @@ def run(config: Union[str, Path, dict], setup: bool = False):
             config.engine.packaging_config,
             config.engine.output_dir,
             config.engine.output_name,
-            config.engine.evaluation_only,
+            config.engine.evaluate_input_model,
         )
         return best_execution

--- a/test/unit_test/engine/packaging/test_packaging_generator.py
+++ b/test/unit_test/engine/packaging/test_packaging_generator.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 import tempfile
 import zipfile
 from pathlib import Path
@@ -53,6 +54,13 @@ def test_generate_zipfile_artifacts():
     assert (output_dir / "SampleCode").exists()
     assert (output_dir / "CandidateModels").exists()
     assert (output_dir / "ONNXRuntimePackages").exists()
+
+    # contain the evaluation result
+    metrics_file = output_dir / "CandidateModels" / "cpu-cpu" / "BestCandidateModel_1" / "metrics.json"
+    with open(metrics_file, "r") as f:
+        metrics = json.load(f)
+        assert "input_model_metrics" in metrics
+        assert "candidate_model_metrics" in metrics
 
 
 def test_generate_zipfile_artifacts_no_search():

--- a/test/unit_test/engine/packaging/test_packaging_generator.py
+++ b/test/unit_test/engine/packaging/test_packaging_generator.py
@@ -75,7 +75,9 @@ def test_generate_zipfile_artifacts_no_search():
     output_dir = Path(tempdir.name) / "outputs"
 
     # execute
-    engine.run(input_model=input_model, packaging_config=packaging_config, output_dir=output_dir)
+    engine.run(
+        input_model=input_model, packaging_config=packaging_config, output_dir=output_dir, evaluate_input_model=False
+    )
 
     # assert
     artifacts_path = output_dir / "OutputModels.zip"


### PR DESCRIPTION
## Describe your changes
Currently, if you want to get the evaluation result from input_model, they need to set:
1. `evaluation_only`: in this case, olive only evaluate input model without passes run.
2. or to set metric `goal` to tell the metric tolerance based on the baseline.

Several customers would love to compare the input model metrics with output model's metrics by default. So in this PR, we make input model is evaluated as long as there is the given metrics. 
If user do not need to evaluate input model, they can manually set `evalute_input_model` as `False`.

With the PR, the default behaviors. is like:
1. evaluate input model with given metrics.
2. if user gives the metric goal, olive read the result in step 1 from cache.
3. then olive will run search or no_search passes w.r.t given metrics.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
   Replace  `evaluation_only` with `evaluate_input_model` and set False by default.

## (Optional) Issue link
