### PR TITLE
Whisper: Expose language,task in dataset, support different file ext. Improve setup logging

### DIFF
--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -26,6 +26,14 @@ Install the necessary python packages:
 python -m pip install -r requirements.txt
 ```
 
+**Note:** Multilingual support requires ONNX Runtime 1.16.0+ which is not released yet. Must be built from or after commit https://github.com/microsoft/onnxruntime/commit/4b69226fca914753844a3291818ce23ac2f00d8c.
+
+After running the above, uninstall pre-existing ONNX Runtime package and install the latest nightly build of ONNX Runtime as follows:
+```bash
+python -m pip uninstall -y onnxruntime ort-nightly
+python -m pip install ort-nightly --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
+```
+
 ### Prepare workflow config json
 ```
 python prepare_whisper_configs.py [--model_name MODEL_NAME] [--no_audio_decoder] [--multilingual]
@@ -70,13 +78,6 @@ forced_decoder_ids = [config.decoder_start_token_id] + list(map(lambda token: to
 decoder_input_ids = np.array([forced_decoder_ids], dtype=np.int32)
 ```
 
-**Note:** `--multiligual` is only supported in ONNX Runtime 1.16.0+ which is not released yet. Must be built from or after commit https://github.com/microsoft/onnxruntime/commit/4b69226fca914753844a3291818ce23ac2f00d8c.
-
-Latest nightly build of ONNX Runtime can be installed using the following commands:
-```bash
-python -m pip uninstall -y onnxruntime
-python -m pip install ort-nightly --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-```
 
 ## Run the config to optimize the model
 First, install required packages according to passes.
@@ -115,10 +116,15 @@ python -m olive.workflows.run --config whisper_cpu_int8.json 2> $null
 
 ## Test the transcription of the optimized model
 ```bash
-python test_transcription.py --config whisper_{device}_{precision}.json [--auto_path AUDIO_PATH]
+python test_transcription.py --config whisper_{device}_{precision}.json [--auto_path AUDIO_PATH] [--language LANGUAGE] [--task {transcribe,translate}]
 
 # For example, to test CPU, INT8 with default audio path
 python test_transcription.py --config whisper_cpu_int8.json
 ```
 
-`--audio_path` is optional. If not provided, will use test auto path from the config.
+`--audio_path` Optional. Path to audio file. If not provided, will use the test data from the config
+
+`--language` Optional. Language spoken in audio. Default is `english`. Only used when `--multilingual` is provided to `prepare_whisper_configs.py`
+
+`--task` Optional. Whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate'). Default is `transcribe`. Only used
+when `--multilingual` is provided to `prepare_whisper_configs.py`

--- a/examples/whisper/code/whisper_dataset.py
+++ b/examples/whisper/code/whisper_dataset.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 import numpy as np
+from transformers import AutoConfig, AutoProcessor
 
 
 class WhisperDataset:
@@ -16,9 +17,16 @@ class WhisperDataset:
     N_SAMPLES = CHUNK_LENGTH * SAMPLE_RATE  # 480000 samples in a 30-second chunk
     N_FRAMES = N_SAMPLES // HOP_LENGTH
 
-    def __init__(self, data_dir: str, use_audio_decoder: bool = True):
+    def __init__(
+        self,
+        data_dir: str,
+        use_audio_decoder: bool = True,
+        file_ext: str = ".mp3",
+        language: str = "english",
+        task: str = "transcribe",
+    ):
         data_dir = Path(data_dir)
-        audio_files = list(data_dir.glob("*.mp3"))
+        audio_files = list(data_dir.glob(f"*{file_ext}"))
         audio_files.sort(key=lambda x: x.name)
         assert len(audio_files) > 0, f"No audio files found in {data_dir}"
 
@@ -45,12 +53,15 @@ class WhisperDataset:
                 "repetition_penalty": np.asarray([1.0], dtype=np.float32),
                 # attention_mask only used when version < 1.16.0
                 "attention_mask": np.zeros((1, self.N_MELS, self.N_FRAMES)).astype(np.int32),
-                # decoder_input_ids only used when version >= 1.16.0 and multilingual is True
-                # auto detect language and task
-                "decoder_input_ids": np.asarray([[50258]], dtype=np.int32),
-                # English, transcription
-                # "decoder_input_ids": np.asarray([[50258, 50259, 50359, 50363]], dtype=np.int32),
             }
+            # decoder_input_ids only used when version >= 1.16.0 and multilingual is True
+            model_name = "openai/whisper-tiny"
+            config = AutoConfig.from_pretrained(model_name)
+            processor = AutoProcessor.from_pretrained(model_name)
+            forced_decoder_ids = processor.get_decoder_prompt_ids(language=language, task=task)
+            forced_decoder_ids = [config.decoder_start_token_id] + list(map(lambda token: token[1], forced_decoder_ids))
+            inputs["decoder_input_ids"] = np.asarray([forced_decoder_ids], dtype=np.int32)
+
             self.data.append(inputs)
 
         self.labels = None

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -36,7 +36,7 @@ SUPPORTED_WORKFLOWS = {
 
 def get_args(raw_args):
     parser = argparse.ArgumentParser(description="Prepare config file for Whisper")
-    parser.add_argument("--model_name", type=str, default="openai/whisper-tiny.en", help="Model name")
+    parser.add_argument("--model_name", type=str, default="openai/whisper-tiny", help="Model name")
     parser.add_argument(
         "--no_audio_decoder",
         action="store_true",

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -87,8 +87,8 @@ def dependency_setup(config):
             remote_packages.extend(DEPENDENCY_MAPPING["pass"].get(pass_config.type, []))
         if pass_config.type in ["SNPEConversion", "SNPEQuantization", "SNPEtoONNXConversion"]:
             logger.info(
-                "Please refer to https://microsoft.github.io/Olive/tutorials/passes/snpe.html                 to"
-                " install SNPE Prerequisites for pass {}".format(pass_config.type)
+                "Please refer to https://microsoft.github.io/Olive/tutorials/passes/snpe.html to install SNPE"
+                f" prerequisites for pass {pass_config.type}"
             )
 
     # add dependencies for engine
@@ -105,13 +105,16 @@ def dependency_setup(config):
     else:
         local_packages.extend(DEPENDENCY_MAPPING["device"][config.engine.host.type])
 
-    # install packages to local or tell user to install packages in their environment
-    logger.info("The following packages will be installed: {}".format(" ".join(local_packages)))
+    # install missing packages to local or tell user to install packages in their environment
+    logger.info(f"The following packages are required in the local environment: {local_packages}")
     for package in set(local_packages):
         try:
             __import__(package)
+            logger.info(f"{package} is already installed.")
         except ImportError:
+            logger.info(f"Installing {package}...")
             subprocess.check_call(["python", "-m", "pip", "install", "{}".format(package)])
+            logger.info(f"Successfully installed {package}.")
     if remote_packages:
         logger.info(
             "Please make sure the following packages are installed in {} environment: {}".format(


### PR DESCRIPTION
## Describe your changes
This PR contains changes to improve the whisper example:
- `WhisperDataset` now takes in additional init parameters: `file_ext`, `language` and 'task`
- `test_transcription.py` infers `file_ext` from `audio_path`. User can override default values for `language` and `task`. 
- README updated to make it clear that the `ort-nightly` installation is done after installing the requirements.txt 

Logging is improved for setup. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
