### PR TITLE
🛺 Auto infer accelerators with EPs

### DIFF
--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -64,14 +64,6 @@
 
         }
     },
-    "systems": {
-        "local_system": {
-            "type": "LocalSystem",
-            "config": {
-                "accelerators": ["gpu"]
-            }
-        }
-    },
     "engine": {
         "search_strategy": {
             "execution_order": "joint",
@@ -82,8 +74,6 @@
             }
         },
         "evaluator": "common_evaluator",
-        "target": "local_system",
-        "host": "local_system",
         "execution_providers": ["CUDAExecutionProvider"],
         "clean_cache": true,
         "cache_dir": "cache",

--- a/examples/bert/bert_trt_gpu.json
+++ b/examples/bert/bert_trt_gpu.json
@@ -56,14 +56,6 @@
 
         }
     },
-    "systems": {
-        "local_system": {
-            "type": "LocalSystem",
-            "config": {
-                "accelerators": ["gpu"]
-            }
-        }
-    },
     "engine": {
         "search_strategy": {
             "execution_order": "joint",
@@ -74,8 +66,6 @@
             }
         },
         "evaluator": "common_evaluator",
-        "target": "local_system",
-        "host": "local_system",
         "execution_providers": ["TensorrtExecutionProvider"],
         "clean_cache": true,
         "cache_dir": "cache",

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -105,7 +105,8 @@ class Engine:
                 accelerators = ["CPU"]
             else:
                 logger.debug(
-                    f"Use inferred accelerators {inferred_accelerators} from given execution providers {self.execution_providers}."
+                    f"Use inferred accelerators {inferred_accelerators} "
+                    f"from given execution providers {self.execution_providers}."
                 )
                 accelerators = inferred_accelerators
 

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -94,14 +94,20 @@ class Engine:
                 # for docker system and python system, we default use CPUExecutionProvider
                 execution_providers = ["CPUExecutionProvider"]
 
-        self.execution_providers = execution_providers
-
         # Flatten the accelerators to list of AcceleratorSpec
         accelerators: List[str] = self.target.accelerators
         if accelerators is None:
-            logger.warning("No accelerators specified for target system. Using CPU.")
-            accelerators = ["CPU"]
+            inferred_accelerators = AcceleratorLookup.infer_accelerators_from_execution_provider(
+                self.execution_providers
+            )
+            if not inferred_accelerators:
+                logger.warning("Cannot infer the accelerators from the target system. Use CPU as default.")
+                accelerators = ["CPU"]
+            else:
+                logger.info(f"Use inferred accelerators {inferred_accelerators} from given execution providers.")
+                accelerators = inferred_accelerators
 
+        self.execution_providers = execution_providers
         not_supported_ep = set()
         processed_ep = set()
         self.accelerator_specs: List[AcceleratorSpec] = []

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -77,8 +77,7 @@ class Engine:
         elif self._config.target is not None:
             self.target = self._config.target.create_system()
         else:
-            # set default accelerator to CPU
-            self.target = LocalSystem([Device.CPU])
+            self.target = LocalSystem()
 
         if execution_providers is None:
             execution_providers = self._config.execution_providers
@@ -94,6 +93,7 @@ class Engine:
                 # for docker system and python system, we default use CPUExecutionProvider
                 execution_providers = ["CPUExecutionProvider"]
 
+        self.execution_providers = execution_providers
         # Flatten the accelerators to list of AcceleratorSpec
         accelerators: List[str] = self.target.accelerators
         if accelerators is None:
@@ -104,10 +104,11 @@ class Engine:
                 logger.warning("Cannot infer the accelerators from the target system. Use CPU as default.")
                 accelerators = ["CPU"]
             else:
-                logger.info(f"Use inferred accelerators {inferred_accelerators} from given execution providers.")
+                logger.debug(
+                    f"Use inferred accelerators {inferred_accelerators} from given execution providers {self.execution_providers}."
+                )
                 accelerators = inferred_accelerators
 
-        self.execution_providers = execution_providers
         not_supported_ep = set()
         processed_ep = set()
         self.accelerator_specs: List[AcceleratorSpec] = []
@@ -126,7 +127,13 @@ class Engine:
                     self.accelerator_specs.append(AcceleratorSpec(device, ep))
                     processed_ep.add(ep)
 
-        assert self.accelerator_specs, "No valid accelerator specified for target system."
+        assert self.accelerator_specs, (
+            "No valid accelerator specified for target system. "
+            "Please specify the accelerators in the target system or provide valid execution providers. "
+            f"Given execution providers: {self.execution_providers}. "
+            f"Current accelerators: {accelerators}."
+            f"Supported execution providers: {AcceleratorLookup.EXECUTION_PROVIDERS}."
+        )
         if not_supported_ep:
             logger.warning(
                 f"The following execution provider is not supported: {','.join(not_supported_ep)}. "

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -2,9 +2,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import List, Union
+
+logger = logging.getLogger(__name__)
 
 
 class Device(str, Enum):
@@ -83,3 +86,37 @@ class AcceleratorLookup:
         assert isinstance(available_providers, list)
 
         return [ep for ep in execution_providers if ep in available_providers]
+
+    @staticmethod
+    def infer_accelerators_from_execution_provider(execution_provider: List[str]):
+        """
+        Infer the device from the execution provider name.
+        If all the execution provider is uniquely mapped to a device, return the device list.
+        Otherwise, return None.
+        For example:
+            execution_provider = ["CPUExecutionProvider", "CUDAExecutionProvider"]
+            return None (CPUExecutionProvider is mapped to CPU and GPU, Olive cannot infer the device)
+            execution_provider = ["CUDAExecutionProvider", "TensorrtExecutionProvider"]
+            return ["gpu"]
+        """
+        if not execution_provider:
+            return None
+
+        is_unique_inferring = True
+        accelerators = []
+        for idx, ep in enumerate(execution_provider):
+            accelerators.append([])
+            for accelerator, eps in AcceleratorLookup.EXECUTION_PROVIDERS.items():
+                if ep in eps:
+                    accelerators[idx].append(accelerator)
+                    if len(accelerators[idx]) > 1:
+                        logger.warning(
+                            f"Execution provider {ep} is mapped to multiple accelerators {accelerators[idx]}. "
+                            "Olive cannot infer the device which may cause unexpected behavior"
+                            "Please specify the accelerator in the accelerator configs"
+                        )
+                        is_unique_inferring = False
+
+        if is_unique_inferring:
+            return list(set([accelerator[0] for accelerator in accelerators]))
+        return None

--- a/test/unit_test/hardare/test_accelerator.py
+++ b/test/unit_test/hardare/test_accelerator.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import pytest
+from olive.hardware.accelerator import AcceleratorLookup
+
+
+class TestAcceleratorLookup:
+
+    @pytest.mark.parametrize(
+        "execution_providers_test",
+        [
+            (["CPUExecutionProvider"], None),
+            (["CUDAExecutionProvider"], ["gpu"]),
+            (["DmlExecutionProvider", "CUDAExecutionProvider"], ["gpu"]),
+            (["QNNExecutionProvider", "CUDAExecutionProvider"], ["npu", "gpu"]),
+        ]
+    )
+    def test_infer_accelerators_from_execution_provider(self, execution_providers_test):
+        execution_providers, expected_accelerators = execution_providers_test
+        actual_rls = AcceleratorLookup.infer_accelerators_from_execution_provider(execution_providers)
+        assert actual_rls == expected_accelerators

--- a/test/unit_test/hardare/test_accelerator.py
+++ b/test/unit_test/hardare/test_accelerator.py
@@ -3,11 +3,11 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import pytest
+
 from olive.hardware.accelerator import AcceleratorLookup
 
 
 class TestAcceleratorLookup:
-
     @pytest.mark.parametrize(
         "execution_providers_test",
         [
@@ -15,7 +15,7 @@ class TestAcceleratorLookup:
             (["CUDAExecutionProvider"], ["gpu"]),
             (["DmlExecutionProvider", "CUDAExecutionProvider"], ["gpu"]),
             (["QNNExecutionProvider", "CUDAExecutionProvider"], ["npu", "gpu"]),
-        ]
+        ],
     )
     def test_infer_accelerators_from_execution_provider(self, execution_providers_test):
         execution_providers, expected_accelerators = execution_providers_test


### PR DESCRIPTION
## Describe your changes

From many users' feedback, when they ensure cuda/trt ep is run on gpu certainly, they have to write the accelerators configs to tell current device is [`gpu`]

This PR is used to remedy this. The logic is like:
If Olive can find unique accelerator for each EP provided by users, then use it unless if user set it explicitly.
For examples:

Eps, inferred acceleartors:
(["CPUExecutionProvider"], None),
(["CUDAExecutionProvider"], ["gpu"]),
(["CUDAExecutionProvider", "CPUExecutionProvider"], None), // as we find multi-accelerators(cpu/gpu/npu) for CPU ep.
(["DmlExecutionProvider", "CUDAExecutionProvider"], ["gpu"]),
(["QNNExecutionProvider", "CUDAExecutionProvider"], ["npu", "gpu"]),

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
