### PR TITLE
Disable input model evaluation for DirectML examples

### DIFF
--- a/examples/directml/dolly_v2/config_dolly_v2.json
+++ b/examples/directml/dolly_v2/config_dolly_v2.json
@@ -83,6 +83,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/examples/directml/squeezenet/squeezenet_config.json
+++ b/examples/directml/squeezenet/squeezenet_config.json
@@ -68,6 +68,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "clean_cache": true,

--- a/examples/directml/stable_diffusion/config_safety_checker.json
+++ b/examples/directml/stable_diffusion/config_safety_checker.json
@@ -84,6 +84,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/examples/directml/stable_diffusion/config_text_encoder.json
+++ b/examples/directml/stable_diffusion/config_text_encoder.json
@@ -81,6 +81,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/examples/directml/stable_diffusion/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion/config_text_encoder_2.json
@@ -81,6 +81,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -88,6 +88,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/examples/directml/stable_diffusion/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion/config_vae_decoder.json
@@ -81,6 +81,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/examples/directml/stable_diffusion/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion/config_vae_encoder.json
@@ -81,6 +81,7 @@
             "search_algorithm": "exhaustive"
         },
         "evaluator": "common_evaluator",
+        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",


### PR DESCRIPTION
Input model evaluation doesn't currently work for DirectML because Olive equates `gpu` accelerators to `cuda` pytorch devices, which doesn't work when torch cuda isn't installed (and it won't usually be when people are running DML examples).

This PR is meant to unblock those examples, but in the future we should have a path to fallback to the CPU or use pytorch-directml when using `"evaluate_input_model": true`.