### PR TITLE
Remove unused dummy input in `OnnxConversion`

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -92,7 +92,7 @@ class OnnxConversion(Pass):
             exported = dynamo_export(
                 pytorch_model,
                 *dummy_inputs,
-                export_options=torch.onnx.ExportOptions(opset_version=config["target_opset"], dynamic_shapes=True)
+                export_options=torch.onnx.ExportOptions(opset_version=config["target_opset"], dynamic_shapes=True),
             )
             onnx_model = exported.model_proto
         else:
@@ -116,10 +116,11 @@ class OnnxConversion(Pass):
             # this can happen when we are using an hf dataset to generate dummy inputs
             # only handle dict for now since we cannot get the name of the input from a list/tuple
             if isinstance(dummy_inputs, dict):
-                dummy_input_keys = list(dummy_inputs.keys())
-                for key in dummy_input_keys:
-                    if key not in input_names:
-                        del dummy_inputs[key]
+                dummy_input_keys = set(dummy_inputs.keys())
+                unused_keys = dummy_input_keys - set(input_names)
+                logger.debug(f"Removing unused dummy inputs: {unused_keys}")
+                for key in unused_keys:
+                    del dummy_inputs[key]
 
             output_model_path = ONNXModel.resolve_path(output_model_path)
 

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -112,6 +112,15 @@ class OnnxConversion(Pass):
             output_names = io_config.output_names
             dynamic_axes = io_config.dynamic_axes
 
+            # some dummy inputs might not be used in the model, so we need to remove them
+            # this can happen when we are using an hf dataset to generate dummy inputs
+            # only handle dict for now since we cannot get the name of the input from a list/tuple
+            if isinstance(dummy_inputs, dict):
+                dummy_input_keys = list(dummy_inputs.keys())
+                for key in dummy_input_keys:
+                    if key not in input_names:
+                        del dummy_inputs[key]
+
             output_model_path = ONNXModel.resolve_path(output_model_path)
 
             # there might be multiple files created during export, so we need to track the dir


### PR DESCRIPTION
## Describe your changes
We use huggingface data config to auto-generate dummy inputs for onnx conversion. However, sometimes the data has more inputs that the inputs we want for the converted models. This PR removes the unused dummy inputs so that the converted onnx model doesn't have the unused input as one of its required inputs. 

For example if the `input_names=['input_ids', 'attention_mask']` and the data has items `['input_ids', 'attention_mask','token_type_ids']`, the converted `.onnx` model has input names `['input_ids', 'attention_mask','input.1']`. 
This is not what we want. 
Removing `'token_type_ids'` prevents this issue. 

Try this model+dataset to replicate the bug:
```json
"input_model": {
        "type": "PyTorchModel",
        "config": {
            "hf_config": {
                "model_name": "finiteautomata/bertweet-base-sentiment-analysis",
                "task": "text-classification",
                "dataset": {
                    "data_name": "cardiffnlp/tweet_sentiment_multilingual",
                    "subset": "english",
                    "split": "test",
                    "input_cols": [
                        "text"
                    ],
                    "label_cols": [
                        "label"
                    ],
                    "batch_size": 1
                }
            }
        }
    }
```

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
