### PR TITLE
Huggingface DataConfig: Add support for `data_files` and `max_samples`

### DIFF
--- a/olive/data/component/dataset.py
+++ b/olive/data/component/dataset.py
@@ -19,18 +19,23 @@ class BaseDataset(Dataset):
     The data should be a list or dict of numpy arrays or torch tensors
     """
 
-    def __init__(self, data, label_cols=None, **kwargs):
+    def __init__(self, data, label_cols=None, max_samples=None, **kwargs):
         """
         This function is used to initialize the dataset
         """
         self.data = data
         self.label_cols = label_cols or []
+        self.max_samples = max_samples
 
     def __len__(self):
         """
         This function is used to return the length of the dataset
         """
-        return len(self.data)
+        num_samples = len(self.data)
+        if self.max_samples is not None:
+            # if max_samples is not None, return the min of num_samples and max_samples
+            num_samples = min(num_samples, self.max_samples)
+        return num_samples
 
     def __getitem__(self, index):
         data = {k: v for k, v in self.data[index].items() if k not in self.label_cols}

--- a/olive/data/component/load_dataset.py
+++ b/olive/data/component/load_dataset.py
@@ -23,7 +23,7 @@ def simple_dataset(data_dir, input_data, label_cols=None, **kwargs):
 
 
 @Registry.register_dataset()
-def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation", **kwargs):
+def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation", data_files=None, **kwargs):
     """
     This function is used to create a dataset from huggingface datasets
     """
@@ -34,7 +34,7 @@ def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation
     from datasets import load_dataset
 
     assert data_name is not None, "Please specify the data name"
-    return load_dataset(path=data_name, name=subset, split=split, **kwargs)
+    return load_dataset(path=data_name, name=subset, split=split, data_files=data_files, **kwargs)
 
 
 @Registry.register_dataset()

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -43,7 +43,7 @@ def _huggingface_pre_precess_helper(dataset, model_name, input_cols, label_cols,
 
 
 @Registry.register_pre_process()
-def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwargs):
+def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, max_samples=None, **kwargs):
     """Pre-process data.
 
     Args:
@@ -73,11 +73,11 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, **kwar
         _dataset, model_name, input_cols, label_cols, _tokenizer_and_align_labels, **kwargs
     )
     # label_cols is ["label"] since we added label_cols[0] as "label" to tokenized_inputs
-    return BaseDataset(tokenized_datasets, label_cols=["label"])
+    return BaseDataset(tokenized_datasets, label_cols=["label"], max_samples=max_samples)
 
 
 @Registry.register_pre_process()
-def ner_huggingface_preprocess(_dataset, model_name, input_cols, label_cols, **kwargs):
+def ner_huggingface_preprocess(_dataset, model_name, input_cols, label_cols, max_samples=None, **kwargs):
     """
     Pre-process data for ner task.
     """
@@ -125,4 +125,4 @@ def ner_huggingface_preprocess(_dataset, model_name, input_cols, label_cols, **k
     tokenized_datasets = _huggingface_pre_precess_helper(
         _dataset, model_name, input_cols, label_cols, _tokenizer_and_align_labels, **kwargs
     )
-    return BaseDataset(tokenized_datasets, label_cols=["label"])
+    return BaseDataset(tokenized_datasets, label_cols=["label"], max_samples=max_samples)

--- a/olive/data/template.py
+++ b/olive/data/template.py
@@ -39,9 +39,11 @@ def huggingface_data_config_template(model_name, task, **kwargs) -> DataConfig:
         - `data_name`: str, data name in huggingface dataset, e.g.: "glue", "squad"
         - `subset`: str, subset of data, e.g.: "train", "validation", "test"
         - `split`: str, split of data, e.g.: "train", "validation", "test"
+        - `data_files`: str | list | dict, path to source data file(s).
         - `input_cols`: list, input columns of data
         - `label_cols`: list, label columns of data
         - `batch_size`: int, batch size of data
+        - `max_samples`: int, maximum number of samples in the dataset
         and other arguments in
             - olive.data.component.load_dataset.huggingface_dataset
             - olive.data.component.pre_process_data.huggingface_pre_process

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -118,7 +118,8 @@ class OnnxConversion(Pass):
             if isinstance(dummy_inputs, dict):
                 dummy_input_keys = set(dummy_inputs.keys())
                 unused_keys = dummy_input_keys - set(input_names)
-                logger.debug(f"Removing unused dummy inputs: {unused_keys}")
+                if unused_keys:
+                    logger.debug(f"Removing unused dummy inputs: {unused_keys}")
                 for key in unused_keys:
                     del dummy_inputs[key]
 


### PR DESCRIPTION
## Describe your changes
This PR exposes the `data_files` argument for load_dataset. Sometimes we only want specific files from the dataset to be used. 

`max_samples` is used during pre-processing to limit the maximum number of samples. Some datasets have a large number of samples which might be too much for evaluation or calibration purposes. 
In the future, we could provide other arguments such as `max_calibration_samples` or `max_calibration_batches` if needed. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
