### PR TITLE
💾  Disable pip cache for docker image building

### DIFF
--- a/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
+++ b/test/integ_test/evaluator/docker_eval/dockerfile/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install onnxruntime \
             openvino \
             openvino-dev \
             onnxconverter_common \
-            git+https://github.com/microsoft/Olive.git
+            git+https://github.com/microsoft/Olive.git \
+            --no-cache-dir
 
 WORKDIR /olive


### PR DESCRIPTION
## Describe your changes

Disable pip cache for docker image building

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
