### PR TITLE
Use 13 as default opset for onnx conversion pass

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -43,7 +43,7 @@ class OnnxConversion(Pass):
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
         config = {
             "target_opset": PassConfigParam(
-                type_=int, default_value=18, description="The version of the default (ai.onnx) opset to target."
+                type_=int, default_value=13, description="The version of the default (ai.onnx) opset to target."
             ),
             "use_dynamo_exporter": PassConfigParam(
                 type_=bool, default_value=False, description="Whether to use dynamo_export API to export ONNX model."


### PR DESCRIPTION
## Describe your changes

Use 13 as default opset for onnx conversion pass to be compatible with torch version < 2.0

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
