### PR TITLE
Keep `preds` and `targets` as torch tensor during accuracy evaluation

### DIFF
--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -64,6 +64,7 @@ class AccuracyBase(AutoConfigClass):
     @staticmethod
     def prepare_tensors(preds, target, dtypes=torch.int):
         dtypes = dtypes if isinstance(dtypes, (list, tuple)) else [dtypes, dtypes]
+        assert len(dtypes) == 2, "dtypes should be a list or tuple with two elements."
         preds = torch.tensor(preds, dtype=dtypes[0]) if not isinstance(preds, torch.Tensor) else preds.to(dtypes[0])
         target = torch.tensor(target, dtype=dtypes[1]) if not isinstance(target, torch.Tensor) else target.to(dtypes[1])
         return preds, target

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -334,8 +334,11 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
                 # convert to dict of torch tensor
                 result = {name: torch.Tensor(res[i]) for i, name in enumerate(output_names)}
             outputs = post_func(result) if post_func else result
-            preds.extend(outputs.tolist())
-            targets.extend(labels.data.tolist())
+            # keep as numpy or torch arrays
+            preds.append(outputs.cpu())
+            targets.append(labels.cpu())
+        preds = torch.cat(preds, dim=0)
+        targets = torch.cat(targets, dim=0)
         return preds, targets
 
     def _evaluate_onnx_accuracy(
@@ -618,12 +621,13 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
             input_data = tensor_data_to_device(input_data, device)
             result = session(**input_data) if isinstance(input_data, dict) else session(input_data)
             outputs = post_func(result) if post_func else result
-            # use the list.extend instead of list.append to avoid the different sub-array has different size when
-            # batch size is greater than 2 so that the residue array has different size with the batch size,
-            # which will result the exception like:
-            #  ValueError: expected sequence of length 128 at dim 1 (got 3)
-            preds.extend(outputs.tolist())
-            targets.extend(labels.data.tolist())
+            # keep the outputs and results as torch tensor on cpu
+            # it is expensive to convert to list and then convert back to torch tensor
+            preds.append(outputs.cpu())
+            targets.append(labels.cpu())
+        # concatenate along the batch dimension
+        preds = torch.cat(preds, dim=0)
+        targets = torch.cat(targets, dim=0)
         return preds, targets
 
     def _evaluate_accuracy(

--- a/test/unit_test/evaluator/test_accuracy.py
+++ b/test/unit_test/evaluator/test_accuracy.py
@@ -9,9 +9,9 @@ import numpy as np
 from olive.evaluator.accuracy import AUC, AccuracyScore, F1Score, Perplexity, Precision, Recall
 
 
-@patch("olive.evaluator.accuracy.torch")
+@patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_accuracyscore(mock_torchmetrics, mock_torch):
+def test_evaluate_accuracyscore(mock_torchmetrics, mock_torch_tensor):
     # setup
     acc = AccuracyScore()
     preds = [1, 0, 1, 1]
@@ -25,14 +25,14 @@ def test_evaluate_accuracyscore(mock_torchmetrics, mock_torch):
     actual_res = acc.measure(preds, targets)
 
     # assert
-    mock_torch.tensor.called_once_with(preds)
-    mock_torch.tensor.called_once_with(targets)
+    mock_torch_tensor.tensor.called_once_with(preds)
+    mock_torch_tensor.tensor.called_once_with(targets)
     assert actual_res == expected_res
 
 
-@patch("olive.evaluator.accuracy.torch")
+@patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_f1score(mock_torchmetrics, mock_torch):
+def test_evaluate_f1score(mock_torchmetrics, mock_torch_tensor):
     # setup
     acc = F1Score()
     preds = [1, 0, 1, 1]
@@ -46,14 +46,14 @@ def test_evaluate_f1score(mock_torchmetrics, mock_torch):
     actual_res = acc.measure(preds, targets)
 
     # assert
-    mock_torch.tensor.called_once_with(preds)
-    mock_torch.tensor.called_once_with(targets)
+    mock_torch_tensor.tensor.called_once_with(preds)
+    mock_torch_tensor.tensor.called_once_with(targets)
     assert actual_res == expected_res
 
 
-@patch("olive.evaluator.accuracy.torch")
+@patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_precision(mock_torchmetrics, mock_torch):
+def test_evaluate_precision(mock_torchmetrics, mock_torch_tensor):
     # setup
     acc = Precision()
     preds = [1, 0, 1, 1]
@@ -67,14 +67,14 @@ def test_evaluate_precision(mock_torchmetrics, mock_torch):
     actual_res = acc.measure(preds, targets)
 
     # assert
-    mock_torch.tensor.called_once_with(preds)
-    mock_torch.tensor.called_once_with(targets)
+    mock_torch_tensor.tensor.called_once_with(preds)
+    mock_torch_tensor.tensor.called_once_with(targets)
     assert actual_res == expected_res
 
 
-@patch("olive.evaluator.accuracy.torch")
+@patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_recall(mock_torchmetrics, mock_torch):
+def test_evaluate_recall(mock_torchmetrics, mock_torch_tensor):
     # setup
     acc = Recall()
     preds = [1, 0, 1, 1]
@@ -88,14 +88,14 @@ def test_evaluate_recall(mock_torchmetrics, mock_torch):
     actual_res = acc.measure(preds, targets)
 
     # assert
-    mock_torch.tensor.called_once_with(preds)
-    mock_torch.tensor.called_once_with(targets)
+    mock_torch_tensor.tensor.called_once_with(preds)
+    mock_torch_tensor.tensor.called_once_with(targets)
     assert actual_res == expected_res
 
 
-@patch("olive.evaluator.accuracy.torch")
+@patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_auc(mock_torchmetrics, mock_torch):
+def test_evaluate_auc(mock_torchmetrics, mock_torch_tensor):
     # setup
     acc = AUC()
     preds = [1, 0, 1, 1]
@@ -109,14 +109,14 @@ def test_evaluate_auc(mock_torchmetrics, mock_torch):
     actual_res = acc.measure(preds, targets)
 
     # assert
-    mock_torch.tensor.called_once_with(preds)
-    mock_torch.tensor.called_once_with(targets)
+    mock_torch_tensor.tensor.called_once_with(preds)
+    mock_torch_tensor.tensor.called_once_with(targets)
     assert actual_res == expected_res
 
 
-@patch("olive.evaluator.accuracy.torch")
+@patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_perplexity(mock_torchmetrics, mock_torch):
+def test_evaluate_perplexity(mock_torchmetrics, mock_torch_tensor):
     # setup
     Perplexity()
     batch = 2
@@ -134,6 +134,6 @@ def test_evaluate_perplexity(mock_torchmetrics, mock_torch):
 
     # assert
     for i in range(batch):
-        mock_torch.tensor.called_once_with(preds[i])
-        mock_torch.tensor.called_once_with(targets[i])
+        mock_torch_tensor.tensor.called_once_with(preds[i])
+        mock_torch_tensor.tensor.called_once_with(targets[i])
     assert actual_res == expected_res

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+import torch
 
 from olive.evaluator.metric import AccuracySubType, LatencySubType, MetricResult, MetricType, joint_metric_key
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
@@ -105,8 +106,8 @@ class TestPythonEnvironmentSystem:
         # python environment call
         actual_call = mock_compute_accuracy.mock_calls[1]
         assert actual_call.args[0] == expected_call.args[0]
-        assert actual_call.args[1] == expected_call.args[1]
-        assert actual_call.args[2] == expected_call.args[2]
+        assert torch.equal(actual_call.args[1], expected_call.args[1])
+        assert torch.equal(actual_call.args[2], expected_call.args[2])
 
     @patch("olive.evaluator.olive_evaluator.OliveEvaluator.compute_latency")
     def test_evaluate_latency(self, mock_compute_latency):


### PR DESCRIPTION
## Describe your changes
During accuracy evaluation, we convert the output and target tensors to list before computing the metric value. However, this method is expensive and not efficient when the tensors are large since we end up converting them back to torch tensors anyways. 
This is felt significantly when evaluating perplexity for large language models where the `preds` tensor is a large logit tensor of size `batch_size, seqlen, vocab` (like `1 X 2048 X 32000`). This is very slow. 

In this PR, we just move the tensors to `cpu` if not already on cpu and concatenate them using `torch.cat`. This has the same effect as `list.extend`. 


## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
