### PR TITLE
Add `component_kwargs` in `DataConfig.params_config`

### DIFF
--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -157,6 +157,8 @@ def text_generation_huggingface_pre_process(
     from datasets import Dataset as HFDataset
     from transformers import AutoTokenizer
 
+    assert seqlen is not None, "Must specify seqlen"
+
     # get tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_name)
 

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -98,23 +98,30 @@ class DataConfig(ConfigBase):
     def fill_in_params(self):
         """
         Fill in the default parameters for each component.
-        1. if prams_config is not None, use the params_config to fill in the params
-        2. if params_config is None, use the default params from the function signature
-        3. if there is already define params under the component, use the params directly
+        1. If params_config["component_kwargs"] is not None, use the params_config["component_kwargs"]
+        to update component.params
+        2. if params_config is not None, use the params_config to fill in the params. Overrides the
+        component.params
+        3. if params_config is None, use the default params from the function signature
+        4. if there is already define params under the component, use the params directly
         """
         from inspect import signature
 
         self.params_config = self.params_config or {}
+        component_kwargs = self.params_config.pop("component_kwargs", {})
         for k, v in self.components.items():
             component = Registry.get_component(k, v.type)
-            # 1. user function signature to fill params firstly
+            # 1. use the params_config["component_kwargs"] to update component.params
+            if k in component_kwargs:
+                v.params.update(component_kwargs[k])
+            # 2. user function signature to fill params firstly
             params = signature(component).parameters
             for param, info in params.items():
-                # 2. override the params with params_config
+                # 3. override the params with params_config
                 if param in self.params_config:
                     v.params[param] = self.params_config[param]
                     continue
-                # 3. if it already defined params under the component, use the params directly
+                # 4. if it already defined params under the component, use the params directly
                 if param not in v.params and not param.startswith("_"):
                     if info.kind == info.VAR_POSITIONAL or info.kind == info.VAR_KEYWORD:
                         continue

--- a/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
@@ -1,0 +1,62 @@
+{
+    "input_model":{
+        "type": "PyTorchModel",
+        "config": {
+            "hf_config": {
+                "model_name": "gpt2",
+                "task": "text-generation",
+                "dataset": {
+                    "data_name": "ptb_text_only",
+                    "subset": "penn_treebank",
+                    "split": "train",
+                    "input_cols": ["sentence"],
+                    "component_kwargs": {
+                        "pre_process_data": {
+                            "seqlen": 1024,
+                            "max_samples": 5,
+                            "random_seed": 42
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "evaluators": {
+        "common_evaluator": {
+            "metrics":[
+                {
+                    "name": "perplexity",
+                    "type": "accuracy",
+                    "sub_types": [
+                        {"name": "perplexity"}
+                    ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": {
+            "type": "OnnxConversion"
+        },
+        "quantization": {
+            "type": "OnnxQuantization"
+        },
+        "perf_tuning": {
+            "type": "OrtPerfTuning"
+        }
+    },
+    "engine": {
+        "log_severity_level": 0,
+        "search_strategy": {
+            "execution_order": "joint",
+            "search_algorithm": "tpe",
+            "search_algorithm_config": {
+                "num_samples": 3,
+                "seed": 0
+            }
+        },
+        "evaluator": "common_evaluator",
+        "clean_cache": true,
+        "cache_dir": "cache"
+    }
+}

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -26,6 +26,7 @@ class TestRunConfig:
             Path(__file__).parent / "mock_data" / "only_transformer_dataset.json",
             Path(__file__).parent / "mock_data" / "ner_task_dataset.json",
             Path(__file__).parent / "mock_data" / "text_generation_dataset.json",
+            Path(__file__).parent / "mock_data" / "text_generation_dataset_random.json",
         ],
     )
     def test_dataset_config_file(self, config_file):


### PR DESCRIPTION
## Describe your changes
`DataConfig` supports multiple ways to pass parameters to the components. They are:
- `DataConfig.params_config` - the parameters for different components are provided as members of this dictionaries. Only the named parameters of components are updated using this. There is no way to specify component specific kwargs. 
- `DataConfig.components["component_name"].params` - We can provide component specific kwargs using this but it is hard to access. Moreover, there is not way to provide this for hf datatemplate or `HFConfig.datasets` for input model. 

This PR introduces a reserved member in `DataConfig.params_config` called `component_kwargs` where we can provide component specific kwargs. An example usage is:
```
{
    "name": "c4_train",
    "type": "HuggingfaceContainer",
    "params_config": {
        "model_name": "gpt2",
        "task": "text-generation",
        "data_name": "allenai/c4",
        "subset": "allenai--c4",
        "split": "train",
        "data_files": {"train": "en/c4-train.00000-of-01024.json.gz"},
        "input_cols": ["text"],
        "component_kwargs": {
            "pre_process_data": {
                "max_samples": 128,
                "random_seed": 42,
                "seqlen": 2048,
            }
        }
    }
  }
```
This has automatic support for all templates and `HFConfig.dataset`. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
