### PR TITLE
🎏 Multi passes run in same olive workflow

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -341,8 +341,9 @@ information of the evaluator contains following items:
 `passes: [Dict]`
 
 This is a dictionary that contains the information of passes that are executed by the engine. The passes are executed
-in order of their definition in this dictionary. The key of the dictionary is the name of the pass. The value of the dictionary is
-another dictionary that contains the information of the pass. The information of the pass contains following items:
+in order of their definition in this dictionary if `pass_flows` is not specified. The key of the dictionary is the name
+of the pass. The value of the dictionary is another dictionary that contains the information of the pass. The information
+of the pass contains following items:
 
 - `type: [str]` The type of the pass.
 
@@ -410,6 +411,48 @@ Please also find the detailed options from following table for each pass:
         }
     }
 }
+```
+
+## Pass Flows Information
+`pass_flows: List[List[str]]`
+
+This is a list of list of pass names. Each list of pass names is a pass flow which will be executed in order.
+When `pass_flows` is not specified, the passes are executed in the order of the `passes` dictionary.
+
+
+### Example
+```json
+"passes": {
+    "onnx_conversion": {
+        "type": "OnnxConversion",
+        "config": {
+            "target_opset": 13
+        }
+    },
+    "transformers_optimization": {
+        "type": "OrtTransformersOptimization",
+        "config": {
+            "model_type": "bert",
+            "num_heads": 12,
+            "hidden_size": 768,
+            "float16": true
+        }
+    },
+    "onnx_quantization": {
+        "type": "OnnxQuantization",
+        "config": {
+            "user_script": "user_script.py",
+            "data_dir": "data",
+            "dataloader_func": "resnet_calibration_reader",
+            "weight_type": "QUInt8"
+        }
+    }
+},
+"pass_flows": [
+    ["onnx_conversion", "transformers_optimization"],
+    ["onnx_conversion", "transformers_optimization", "onnx_quantization"],
+    ["onnx_conversion", "onnx_quantization"],
+]
 ```
 
 ## Engine Information

--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -64,6 +64,10 @@
 
         }
     },
+    "pass_flows": [
+        ["conversion", "transformers_optimization", "perf_tuning"],
+        ["conversion", "perf_tuning"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -61,7 +61,6 @@
             "config": {
                 "enable_cuda_graph": true
             }
-
         }
     },
     "pass_flows": [

--- a/examples/test/test_bert_cuda_gpu.py
+++ b/examples/test/test_bert_cuda_gpu.py
@@ -20,7 +20,7 @@ def setup():
 
 
 @pytest.mark.parametrize("search_algorithm", ["tpe"])
-@pytest.mark.parametrize("execution_order", ["joint"])
+@pytest.mark.parametrize("execution_order", ["joint", "pass-by-pass"])
 @pytest.mark.parametrize("system", ["aml_system"])
 @pytest.mark.parametrize("olive_json", ["bert_cuda_gpu.json"])
 @pytest.mark.parametrize("enable_cuda_graph", [True, False])

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -17,10 +17,13 @@ def check_search_output(footprints):
 
 def check_no_search_output(outputs):
     assert outputs, "outputs is empty. The run must have failed for all accelerator specs."
-    for output in outputs.values():
-        output_metrics = output["metrics"]
-        for item in output_metrics.values():
-            assert item.value > 0
+    # k:v => accelerator_spec: pass_flow_output
+    for pass_flow_output in outputs.values():
+        # k:v => pass_flow: output
+        for output in pass_flow_output.values():
+            output_metrics = output["metrics"]
+            for item in output_metrics.values():
+                assert item.value > 0
 
 
 def patch_config(config_json_path: str, search_algorithm: str, execution_order: str, system: str, is_gpu: bool = False):

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -66,10 +66,10 @@ def main(raw_args=None):
         print("Model is not multilingual but custom language/task provided. Will ignore custom language/task.")
 
     # load output model json
-    output_model_json_path = (
-        Path(config["engine"]["output_dir"]) / f"{config['engine']['output_name']}_cpu-cpu_model.json"
-    )
-    output_model_json = json.load(open(output_model_json_path, "r"))
+    output_model_json_path = Path(config["engine"]["output_dir"])
+    for model_json in output_model_json_path.glob(f"**/{config['engine']['output_name']}_cpu-cpu_model.json"):
+        output_model_json = json.load(open(model_json, "r"))
+        break
 
     # load output model onnx
     olive_model = ONNXModel(**output_model_json["config"])

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -360,7 +360,9 @@ class Engine:
                     )
                     if output:
                         outputs[accelerator_spec] = output
-                        pf_footprints[accelerator_spec] = self.footprints[accelerator_spec].get_last_node()
+                        pf_footprints[accelerator_spec] = self.get_pareto_frontier_footprints(
+                            accelerator_spec, len(self.pass_flows), None, output_dir, output_name or ""
+                        )
                 else:
                     footprint = self.run_search(
                         input_model,
@@ -425,6 +427,10 @@ class Engine:
         """
         Run all the registered Olive passes in no-search model where search strategy is None.
         """
+        assert (
+            self.search_strategy._config.execution_order == "joint"
+        ), "run_no_search only supports default joint execution order"
+
         for pass_item in self.passes.values():
             if len(pass_item["pass"].search_space()) > 0:
                 pass_name = pass_item["name"]
@@ -442,66 +448,81 @@ class Engine:
         # initialize the search strategy
         self.search_strategy.initialize(self.pass_flows_search_spaces, input_model_id, objective_dict)
 
-        # get the next step
-        next_step = self.search_strategy.next_step()
-        assert next_step is not None, "Search strategy returned None for the first step"
+        iter_num = 0
+        flows_output = {}
+        while True:
+            iter_num += 1
 
-        # get the model id of the first input model
-        model_id = next_step["model_id"]
-        if model_id == input_model_id:
-            model = input_model
-        else:
-            model = self._load_model(model_id)
+            # get the next step
+            next_step = self.search_strategy.next_step()
+            if iter_num == 1:
+                assert next_step is not None, "Search strategy returned None for the first step"
+            # if no more steps, break
+            if next_step is None:
+                break
 
-        logger.debug(f"Step no search with search point {next_step['search_point']} ...")
+            assert iter_num <= len(self.pass_flows), "No more pass flows to run"
 
-        # run all the passes in the step
-        (
-            _,
-            signal,
-            model_ids,
-        ) = self._run_passes(next_step["passes"], model, model_id, data_root, accelerator_spec)
-        # names of the output models of the passes
-        pass_output_names = [self.passes[pass_name]["output_name"] for pass_name, _ in next_step["passes"]]
-        pass_output_names = [f"{name}_{accelerator_spec}" if name else None for name in pass_output_names]
+            # get the model id of the first input model
+            model_id = next_step["model_id"]
+            if model_id == input_model_id:
+                model = input_model
+            else:
+                model = self._load_model(model_id)
 
-        final_output_name = pass_output_names[-1]
-        if output_name:
-            # override the output name of the last pass
-            logger.debug("Engine output_name is provided. Will ignore output_name for final pass")
-            final_output_name = f"{output_name}_{accelerator_spec}"
-        elif not final_output_name:
-            # use the default output name
-            final_output_name = str(accelerator_spec)
-        pass_output_names[-1] = final_output_name
+            logger.debug(f"Step no search with search point {next_step['search_point']} ...")
 
-        output_model_json = None
-        for pass_output_name, pass_output_model_id in zip(pass_output_names, model_ids):
-            if not pass_output_name:
-                continue
-            output_model_json = cache_utils.save_model(
-                model_number=pass_output_model_id,
-                output_dir=output_dir,
-                output_name=f"{pass_output_name}_model",
-                overwrite=True,
-                cache_dir=self._config.cache_dir,
-            )
+            # run all the passes in the step
+            (
+                _,
+                signal,
+                model_ids,
+            ) = self._run_passes(next_step["passes"], model, model_id, data_root, accelerator_spec)
+            # names of the output models of the passes
+            pass_output_names = [self.passes[pass_name]["output_name"] for pass_name, _ in next_step["passes"]]
+            pass_output_names = [f"{name}_{accelerator_spec}" if name else None for name in pass_output_names]
 
-        # save the evaluation results to output_dir
-        if signal is not None:
-            result_name = f"{final_output_name}_metrics"
-            results_path = output_dir / f"{result_name}.json"
-            with open(results_path, "w") as f:
-                json.dump(signal.to_json(), f, indent=4)
+            pass_flow = self.pass_flows[iter_num - 1]
+            result_prefix = "-".join(pass_flow)
 
-        if output_model_json:
-            output = {"model": output_model_json}
+            final_output_name = pass_output_names[-1]
+            if output_name:
+                # override the output name of the last pass
+                logger.debug("Engine output_name is provided. Will ignore output_name for final pass")
+                final_output_name = f"{output_name}_{accelerator_spec}_{result_prefix}"
+            elif not final_output_name:
+                # use the default output name
+                final_output_name = f"{accelerator_spec}_{result_prefix}"
+            pass_output_names[-1] = final_output_name
+
+            output_model_json = None
+            for pass_output_name, pass_output_model_id in zip(pass_output_names, model_ids):
+                if not pass_output_name:
+                    continue
+                output_model_json = cache_utils.save_model(
+                    model_number=pass_output_model_id,
+                    output_dir=output_dir,
+                    output_name=f"{pass_output_name}_model",
+                    overwrite=True,
+                    cache_dir=self._config.cache_dir,
+                )
+
+            # save the evaluation results to output_dir
+
             if signal is not None:
-                output["metrics"] = signal
-        else:
-            output = None
+                result_name = f"{result_prefix}_metrics"
+                results_path = output_dir / f"{result_name}.json"
+                with open(results_path, "w") as f:
+                    json.dump(signal.to_json(), f, indent=4)
 
-        return output
+            if output_model_json:
+                output = {"model": output_model_json}
+                if signal is not None:
+                    output["metrics"] = signal
+            else:
+                output = None
+            flows_output[tuple(pass_flow)] = output
+        return flows_output
 
     def run_search(
         self,
@@ -565,8 +586,13 @@ class Engine:
             time_diff = time.time() - start_time
             self.search_strategy.check_exit_criteria(iter_num, time_diff, signal)
 
-        self.footprints[accelerator_spec].to_file(output_dir / f"{prefix_output_name}footprints.json")
+        return self.get_pareto_frontier_footprints(
+            accelerator_spec, output_model_num, objective_dict, output_dir, prefix_output_name
+        )
 
+    def get_pareto_frontier_footprints(
+        self, accelerator_spec, output_model_num, objective_dict, output_dir, prefix_output_name
+    ):
         pf_footprints = self.footprints[accelerator_spec].get_pareto_frontier()
         if output_model_num is None or len(pf_footprints.nodes) <= output_model_num:
             logger.info(f"Output all {len(pf_footprints.nodes)} models")

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -483,16 +483,16 @@ class Engine:
             pass_output_names = [f"{name}_{accelerator_spec}" if name else None for name in pass_output_names]
 
             pass_flow = self.pass_flows[iter_num - 1]
-            result_prefix = "-".join(pass_flow)
+            output_dir_with_pf = Path(output_dir) / "-".join(pass_flow)
 
             final_output_name = pass_output_names[-1]
             if output_name:
                 # override the output name of the last pass
                 logger.debug("Engine output_name is provided. Will ignore output_name for final pass")
-                final_output_name = f"{output_name}_{accelerator_spec}_{result_prefix}"
+                final_output_name = f"{output_name}_{accelerator_spec}"
             elif not final_output_name:
                 # use the default output name
-                final_output_name = f"{accelerator_spec}_{result_prefix}"
+                final_output_name = f"{accelerator_spec}"
             pass_output_names[-1] = final_output_name
 
             output_model_json = None
@@ -503,7 +503,7 @@ class Engine:
                     continue
                 output_model_json = cache_utils.save_model(
                     model_number=pass_output_model_id,
-                    output_dir=output_dir,
+                    output_dir=output_dir_with_pf,
                     output_name=f"{pass_output_name}_model",
                     overwrite=True,
                     cache_dir=self._config.cache_dir,
@@ -513,8 +513,7 @@ class Engine:
             # save the evaluation results to output_dir
 
             if signal is not None:
-                result_name = f"{final_output_name}_metrics"
-                results_path = output_dir / f"{result_name}.json"
+                results_path = output_dir_with_pf / f"{final_output_name}_metrics.json"
                 with open(results_path, "w") as f:
                     json.dump(signal.to_json(), f, indent=4)
 

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -153,12 +153,11 @@ class Footprint:
             self.nodes[k].is_pareto_frontier = cmp_flag
         self.is_marked_pareto_frontier = True
 
-    def get_last_node(self):
-        return Footprint(
-            nodes=OrderedDict({list(self.nodes.keys())[-1]: list(self.nodes.values())[-1]}),
-            objective_dict=self.objective_dict,
-            is_marked_pareto_frontier=True,
-        )
+    def get_footprints_by_model_ids(self, model_ids):
+        nodes = OrderedDict()
+        for model_id in model_ids:
+            nodes[model_id] = self.nodes[model_id]
+        return Footprint(nodes=nodes, objective_dict=self.objective_dict, is_marked_pareto_frontier=True)
 
     def get_pareto_frontier(self):
         self.mark_pareto_frontier()

--- a/olive/strategy/search_strategy.py
+++ b/olive/strategy/search_strategy.py
@@ -71,24 +71,30 @@ class SearchStrategy(ABC):
 
     def initialize(
         self,
-        search_spaces_list: List[Tuple[str, Dict[str, SearchParameter]]],
+        pass_flows_search_spaces: List[List[Tuple[str, Dict[str, SearchParameter]]]],
         init_model_id: str,
         objective_dict: Dict[str, dict],
     ):
         """
         Initialize the search strategy.
 
-        search_spaces_list: list of tuples of format (search_space_name, {param_name: SearchParameter})
+        pass_flows_search_spaces: list of list of tuples of format (search_space_name, {param_name: SearchParameter})
         objective_dict: dictionary of format {objective_name: {"higher_is_better": bool, "goal": float}}
         """
         self._objective_dict = objective_dict
 
         # search spaces
-        self._spaces_order = [search_space[0] for search_space in search_spaces_list]
-        self._spaces_dict = {search_space[0]: search_space[1] for search_space in search_spaces_list}
+        self._spaces_order = [[pass_ss[0] for pass_ss in pass_flow_ss] for pass_flow_ss in pass_flows_search_spaces]
+        self._spaces_dict = {}
+        for pass_flow_ss in pass_flows_search_spaces:
+            for pass_ss in pass_flow_ss:
+                self._spaces_dict[pass_ss[0]] = pass_ss[1]
 
         # search space dictionaries for pass are grouped based on execution_order
         self._spaces_groups = self._group_search_spaces(self._spaces_order)
+        # sub spaces group in pass-by-pass execution order
+        self._pass_by_pass_sg = None
+
         self._done_spaces_groups = []
         self._active_spaces_group = None
 
@@ -96,6 +102,7 @@ class SearchStrategy(ABC):
         self._searchers: Dict[Any, SearchAlgorithm] = {}
         self._search_results: Dict[Any, SearchResults] = {}
         self._init_model_ids: Dict[Any, str] = {}
+        self.init_model_id = init_model_id
         self._best_search_points = {}
 
         # initialize the first search space
@@ -103,16 +110,22 @@ class SearchStrategy(ABC):
 
         self._initialized = True
 
-    def _group_search_spaces(self, search_space_names: List[str]):
+    def _group_search_spaces(self, search_space_names: List[List]):
         """
         Group search spaces based on execution order.
         """
         # joint: all passes grouped together
         # pass-by-pass: each pass is a separate group
         if self._config.execution_order == "joint":
-            search_spaces_groups = [search_space_names]
+            search_spaces_groups = search_space_names
         elif self._config.execution_order == "pass-by-pass":
-            search_spaces_groups = [[search_space_name] for search_space_name in search_space_names]
+            # run pass-by-pass for each pass flow which is defined as a list of registered passes
+            search_spaces_groups = []
+            for pass_flow_ss in search_space_names:
+                pass_flow_groups = []
+                for pass_ss in pass_flow_ss:
+                    pass_flow_groups.append([pass_ss])
+                search_spaces_groups.append(pass_flow_groups)
         else:
             raise ValueError(f"Unknown execution order: {self._config.execution_order}")
 
@@ -122,7 +135,24 @@ class SearchStrategy(ABC):
         """
         Get the next search space group and initialize the search algorithm.
         """
-        # TODO: organize the state better and make execution order more flexible using a graph
+        if not (self._spaces_groups or self._pass_by_pass_sg):
+            self._active_spaces_group = None
+            return None
+        if init_model_id is None and self._active_spaces_group is None:
+            raise ValueError("init_model_id must be provided for the first search group")
+
+        if self._config.execution_order == "joint":
+            next_sg = self._next_search_group_joint(init_model_id)
+        elif self._config.execution_order == "pass-by-pass":
+            next_sg = self._next_search_group_pass_by_pass(init_model_id)
+        return next_sg
+
+    def _next_search_group_pass_by_pass(self, init_model_id: Optional[str] = None) -> Optional[SearchAlgorithm]:
+        if not self._pass_by_pass_sg:
+            self._pass_by_pass_sg = self._spaces_groups.pop(0)
+            self._active_spaces_group = None
+            init_model_id = self.init_model_id
+
         if self._active_spaces_group is not None:
             self._done_spaces_groups.append(self._active_spaces_group)
             # legacy, will update once search results has info function
@@ -148,23 +178,25 @@ class SearchStrategy(ABC):
                 self._best_search_points[tuple(self._active_spaces_group)] = best_search_point
                 init_model_id = best_search_point[2][-1]
 
-        if len(self._spaces_groups) == 0:
-            self._active_spaces_group = None
-            return None
-
-        if init_model_id is None and self._active_spaces_group is None:
-            raise ValueError("init_model_id must be provided for the first search group")
         if init_model_id is None and self._active_spaces_group is not None:
             raise ValueError(
                 f"The previous search group {self._active_spaces_group} has no output models that were created and"
                 " evaluated successfully. Cannot continue."
             )
 
-        self._active_spaces_group = self._spaces_groups.pop(0)
+        self._active_spaces_group = self._pass_by_pass_sg.pop(0)
         self._searchers[tuple(self._active_spaces_group)] = self._create_searcher(self._active_spaces_group)
         self._search_results[tuple(self._active_spaces_group)] = SearchResults(self._objective_dict)
         self._init_model_ids[tuple(self._active_spaces_group)] = init_model_id
+        return self._active_spaces_group
 
+    def _next_search_group_joint(self, init_model_id: Optional[str] = None) -> Optional[SearchAlgorithm]:
+        init_model_id = init_model_id or self.init_model_id
+        sg = self._spaces_groups.pop(0)
+        self._searchers[tuple(sg)] = self._create_searcher(sg)
+        self._search_results[tuple(sg)] = SearchResults(self._objective_dict)
+        self._init_model_ids[tuple(sg)] = init_model_id
+        self._active_spaces_group = sg
         return self._active_spaces_group
 
     def _create_searcher(self, search_space_names: List[str]) -> SearchAlgorithm:

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 from pydantic import validator
 
@@ -64,6 +64,7 @@ class RunConfig(ConfigBase):
         ),
     }
     evaluators: Dict[str, OliveEvaluatorConfig] = None
+    pass_flows: List[List[str]] = None
     engine: RunEngineConfig
     passes: Dict[str, RunPassConfig]
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -164,6 +164,7 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
                 clean_run_cache=pass_config.clean_run_cache,
                 output_name=pass_config.output_name,
             )
+        engine.set_pass_flows(config.pass_flows)
 
         if data_root is None:
             data_root = config.data_root


### PR DESCRIPTION
## Describe your changes
Provide the interface to let use set the multi pass flows to run in save olive workflow. 

The search strategy will traverse multi-passes sequentially:
for example, for the flows of `[[pass_a, pass_b, pass_c], [pass_a, pass_c]]`
1. `joint`: 
    - `[pass_a, pass_b, pass_c]`
    - `[pass_a, pass_c]`
3. `pass-by-pass`: 
    - `[[pass_a], [pass_b], [pass_c]]`
        - `[pass_a]`
        - `[pass_b]`
        - `[pass_c]`
    -  `[[pass_a], [pass_c]]`
        - `[pass_a]`
        - `[pass_c]`


## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
Provide the interface to let use set the multi pass flows to run in save olive workflow. 
```json
"passes": {
    "onnx_conversion": {
        "type": "OnnxConversion",
        "config": {
            "target_opset": 13
        }
    },
    "transformers_optimization": {
        "type": "OrtTransformersOptimization",
        "config": {
            "model_type": "bert",
            "num_heads": 12,
            "hidden_size": 768,
            "float16": true
        }
    },
    "onnx_quantization": {
        "type": "OnnxQuantization",
        "config": {
            "user_script": "user_script.py",
            "data_dir": "data",
            "dataloader_func": "resnet_calibration_reader",
            "weight_type": "QUInt8"
        }
    }
},
"pass_flows": [
    ["onnx_conversion", "transformers_optimization"],
    ["onnx_conversion", "transformers_optimization", "onnx_quantization"],
    ["onnx_conversion", "onnx_quantization"],
]
```