### PR TITLE
🐞 Bugfix: Fail to packaging olive output when save mode with external…

### DIFF
--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -89,9 +89,13 @@ def _package_candidate_models(
                     model_config = pf_footprint.get_model_config(model_id)
                     onnx_file_name = model_config.get("onnx_file_name")
                     onnx_model = ONNXModel(temp_resource_path, onnx_file_name)
+                    model_name = Path(onnx_model.model_path).name
                     for file in Path(temp_resource_path.get_path()).iterdir():
-                        if file.name == Path(onnx_model.model_path).name:
-                            file_name = "model.onnx"
+                        if file.name.startswith(model_name):
+                            if file.name.endswith(".onnx"):
+                                file_name = "model.onnx"
+                            elif file.name.endswith(".onnx.data"):
+                                file_name = "model.onnx.data"
                         else:
                             file_name = file.name
                         Path(file).rename(model_dir / file_name)

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -91,11 +91,8 @@ def _package_candidate_models(
                     onnx_model = ONNXModel(temp_resource_path, onnx_file_name)
                     model_name = Path(onnx_model.model_path).name
                     for file in Path(temp_resource_path.get_path()).iterdir():
-                        if file.name.startswith(model_name):
-                            if file.name.endswith(".onnx"):
-                                file_name = "model.onnx"
-                            elif file.name.endswith(".onnx.data"):
-                                file_name = "model.onnx.data"
+                        if file.name == model_name:
+                            file_name = "model.onnx"
                         else:
                             file_name = file.name
                         Path(file).rename(model_dir / file_name)

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -312,7 +312,6 @@ class ONNXModel(ONNXModelBase):
         return str(path)
 
     def load_model(self, rank: int = None) -> onnx.ModelProto:
-        # HACK: ASSUME no external data
         return onnx.load(self.model_path)
 
     def prepare_session(


### PR DESCRIPTION
## Describe your changes
When the olive output model is saved with external data, our packaging logic will try to read the file which already be moved to other directories. This led to the failure when packaging.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
