### PR TITLE
🐛 Bugfix: remove kwargs from accuracy config when measuring

### DIFF
--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -35,6 +35,13 @@ class AccuracyBase(AutoConfigClass):
 
     def __init__(self, config: Union[ConfigBase, Dict[str, Any]] = None) -> None:
         super().__init__(config)
+        self.resolve_kwargs()
+
+    def resolve_kwargs(self):
+        config_dict = self.config.dict()
+        kwargs = config_dict.pop("kwargs", {})
+        config_dict.update(kwargs or {})
+        self.config_dict = config_dict
 
     @classmethod
     def _metric_config_from_torch_metrics(cls):
@@ -79,7 +86,7 @@ class AccuracyScore(AccuracyBase):
 
     def measure(self, preds, target):
         preds_tensor, target_tensor = self.prepare_tensors(preds, target)
-        accuracy = torchmetrics.Accuracy(**self.config.dict())
+        accuracy = torchmetrics.Accuracy(**self.config_dict)
         result = accuracy(preds_tensor, target_tensor)
         return result.item()
 
@@ -89,7 +96,7 @@ class F1Score(AccuracyBase):
 
     def measure(self, preds, target):
         preds_tensor, target_tensor = self.prepare_tensors(preds, target)
-        f1 = torchmetrics.F1Score(**self.config.dict())
+        f1 = torchmetrics.F1Score(**self.config_dict)
         result = f1(preds_tensor, target_tensor)
         return result.item()
 
@@ -99,7 +106,7 @@ class Precision(AccuracyBase):
 
     def measure(self, preds, target):
         preds_tensor, target_tensor = self.prepare_tensors(preds, target)
-        precision = torchmetrics.Precision(**self.config.dict())
+        precision = torchmetrics.Precision(**self.config_dict)
         result = precision(preds_tensor, target_tensor)
         return result.item()
 
@@ -109,7 +116,7 @@ class Recall(AccuracyBase):
 
     def measure(self, preds, target):
         preds_tensor, target_tensor = self.prepare_tensors(preds, target)
-        recall = torchmetrics.Recall(**self.config.dict())
+        recall = torchmetrics.Recall(**self.config_dict)
         result = recall(preds_tensor, target_tensor)
         return result.item()
 
@@ -130,7 +137,7 @@ class Perplexity(AccuracyBase):
 
     def measure(self, preds, target):
         # update ignore_index if not set
-        config = self.config.dict()
+        config = self.config_dict
         if config["ignore_index"] is None:
             config["ignore_index"] = -100
 

--- a/test/unit_test/evaluator/test_accuracy.py
+++ b/test/unit_test/evaluator/test_accuracy.py
@@ -5,15 +5,25 @@
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 
 from olive.evaluator.accuracy import AUC, AccuracyScore, F1Score, Perplexity, Precision, Recall
 
 
 @patch("olive.evaluator.accuracy.torch.tensor")
 @patch("olive.evaluator.accuracy.torchmetrics")
-def test_evaluate_accuracyscore(mock_torchmetrics, mock_torch_tensor):
+@pytest.mark.parametrize(
+    "metric_config",
+    [
+        {"task": "binary"},
+        {"task": "binary", "kwargs": {"test": 2}},
+    ],
+)
+def test_evaluate_accuracyscore(mock_torchmetrics, mock_torch_tensor, metric_config):
     # setup
-    acc = AccuracyScore()
+    acc = AccuracyScore(metric_config)
+    assert "kwargs" in acc.config.dict()
+    assert "kwargs" not in acc.config_dict
     preds = [1, 0, 1, 1]
     targets = [1, 1, 1, 1]
     expected_res = 0.99


### PR DESCRIPTION
## Describe your changes
Olive metrics will generate metrics config regarding various downstream metrics.
![image](https://github.com/microsoft/Olive/assets/13343117/621205e8-3398-44b1-9508-367fa378a974)

There is a bug about `kwargs` which need be expanded when measuring. But Olive metrics configs contain that before this fixing.


## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
