### PR TITLE
Automatic onnx conversion for opt, llama, gptneox. Infer `feature` from `task`

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -101,7 +101,8 @@ case insensitive.
         - `task: [str]`: This is the task type for the model such as `text-classification`. The complete list of supported task can be found
         at [huggingface-tasks](https://huggingface.co/docs/transformers/v4.28.1/en/main_classes/pipelines#transformers.pipeline.task).
 
-        - `feature: [str]`: The ONNX export features. This is only needed for HuggingFace hub model. Default to `default`. You can find more info at [Export to ONNX](https://huggingface.co/docs/transformers/serialization)
+        - `feature: [str]`: The ONNX export features. This is only needed for HuggingFace hub model. It is inferred from `task` if not provided. You must provide the feature if you need past. For instance,
+        `"causal-lm-with-past"`. You can find more info at [Export to ONNX](https://huggingface.co/docs/transformers/serialization)
 
         - `model_class: [str]`: Instead of the `task`, the class of the model can be provided as well. Such as `DistilBertForSequenceClassification`
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -101,8 +101,8 @@ case insensitive.
         - `task: [str]`: This is the task type for the model such as `text-classification`. The complete list of supported task can be found
         at [huggingface-tasks](https://huggingface.co/docs/transformers/v4.28.1/en/main_classes/pipelines#transformers.pipeline.task).
 
-        - `feature: [str]`: The ONNX export features. This is only needed for HuggingFace hub model. It is inferred from `task` if not provided. You must provide the feature if you need past. For instance,
-        `"causal-lm-with-past"`. You can find more info at [Export to ONNX](https://huggingface.co/docs/transformers/serialization)
+        - `feature: [str]`: The ONNX export features. This is only needed for HuggingFace hub model. It is inferred from `task` if not provided. You must provide the feature if you need past key value cache.
+        For instance, `"causal-lm-with-past"`. You can find more info at [Export to ONNX](https://huggingface.co/docs/transformers/serialization)
 
         - `model_class: [str]`: Instead of the `task`, the class of the model can be provided as well. Such as `DistilBertForSequenceClassification`
 

--- a/olive/model/hf_onnx_config.py
+++ b/olive/model/hf_onnx_config.py
@@ -1,0 +1,130 @@
+from typing import Any, Mapping, Optional, OrderedDict
+
+from transformers import PreTrainedTokenizer, TensorType, is_torch_available
+from transformers.onnx import OnnxConfigWithPast
+
+ADDITIONAL_MODEL_TYPES = {
+    "gpt-neox": (
+        [
+            "default",
+            "default-with-past",
+            "causal-lm",
+            "causal-lm-with-past",
+            "sequence-classification",
+            "token-classification",
+        ],
+        "TextDecoderOnnxConfig",
+    ),
+    "llama": (
+        [
+            "default",
+            "default-with-past",
+            "causal-lm",
+            "causal-lm-with-past",
+            "sequence-classification",
+        ],
+        "TextDecoderOnnxConfig",
+    ),
+    "opt": (
+        [
+            "default",
+            "default-with-past",
+            "causal-lm",
+            "causal-lm-with-past",
+            "question-answering",
+            "sequence-classification",
+        ],
+        "TextDecoderOnnxConfig",
+    ),
+}
+
+
+class TextDecoderOnnxConfig(OnnxConfigWithPast):
+    # in OnnxConfigWithPast.fill_with_past_key_values_
+    # there is a bug in the name for the present sequence length dimension
+    # it should be `past_sequence` instead of `past_sequence + sequence`
+    def fill_with_past_key_values_(
+        self, inputs_or_outputs: Mapping[str, Mapping[int, str]], direction: str, inverted_values_shape: bool = False
+    ):
+        """
+        Fill the input_or_outputs mapping with past_key_values dynamic axes considering.
+
+        Args:
+            inputs_or_outputs: The mapping to fill.
+            direction: either "inputs" or "outputs", it specifies whether input_or_outputs is the input mapping or the
+                output mapping, this is important for axes naming.
+            inverted_values_shape:
+                If `True`, store values on dynamic axis 1, else on axis 2.
+
+        """
+        if direction not in ["inputs", "outputs"]:
+            raise ValueError(f'direction must either be "inputs" or "outputs", but {direction} was given')
+
+        name = "past_key_values" if direction == "inputs" else "present"
+        sequence_length_name = "past_sequence" if direction == "inputs" else "past_sequence + sequence"
+        for i in range(self.num_layers):
+            inputs_or_outputs[f"{name}.{i}.key"] = {0: "batch", 2: sequence_length_name}
+            if inverted_values_shape:
+                inputs_or_outputs[f"{name}.{i}.value"] = {0: "batch", 1: sequence_length_name}
+            else:
+                inputs_or_outputs[f"{name}.{i}.value"] = {0: "batch", 2: sequence_length_name}
+
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        common_inputs = OrderedDict({"input_ids": {0: "batch", 1: "sequence"}})
+        if self.use_past:
+            self.fill_with_past_key_values_(common_inputs, direction="inputs")
+            # there seems to be a bug in the size of the past_key_values dim 2
+            common_inputs["attention_mask"] = {0: "batch", 1: "past_sequence + sequence"}
+        else:
+            common_inputs["attention_mask"] = {0: "batch", 1: "sequence"}
+
+        return common_inputs
+
+    def generate_dummy_inputs(
+        self,
+        tokenizer: PreTrainedTokenizer,
+        batch_size: int = -1,
+        seq_length: int = -1,
+        is_pair: bool = False,
+        framework: Optional[TensorType] = None,
+    ) -> Mapping[str, Any]:
+        common_inputs = super(OnnxConfigWithPast, self).generate_dummy_inputs(
+            tokenizer, batch_size=batch_size, seq_length=seq_length, is_pair=is_pair, framework=framework
+        )
+
+        # We need to order the input in the way they appears in the forward()
+        ordered_inputs = OrderedDict({"input_ids": common_inputs["input_ids"]})
+
+        # Need to add the past_keys
+        if self.use_past:
+            if not is_torch_available():
+                raise ValueError("Cannot generate dummy past_keys inputs without PyTorch installed.")
+            else:
+                import torch
+
+                batch, seqlen = common_inputs["input_ids"].shape
+                # Not using the same length for past_key_values
+                past_key_values_length = seqlen + 2
+                past_shape = (
+                    batch,
+                    self.num_attention_heads,
+                    past_key_values_length,
+                    self._config.hidden_size // self.num_attention_heads,
+                )
+                ordered_inputs["past_key_values"] = [
+                    (torch.zeros(past_shape), torch.zeros(past_shape)) for _ in range(self.num_layers)
+                ]
+
+        ordered_inputs["attention_mask"] = common_inputs["attention_mask"]
+        if self.use_past:
+            mask_dtype = ordered_inputs["attention_mask"].dtype
+            ordered_inputs["attention_mask"] = torch.cat(
+                [ordered_inputs["attention_mask"], torch.ones(batch, past_key_values_length, dtype=mask_dtype)], dim=1
+            )
+
+        return ordered_inputs
+
+    @property
+    def num_layers(self) -> int:
+        return self._config.num_hidden_layers

--- a/olive/model/hf_onnx_config.py
+++ b/olive/model/hf_onnx_config.py
@@ -3,6 +3,10 @@ from typing import Any, Mapping, Optional, OrderedDict
 from transformers import PreTrainedTokenizer, TensorType
 from transformers.onnx import OnnxConfigWithPast
 
+# dictionary of model types and their (supported features list, config class name)
+# the supported features list is the list of features that are supported by the model type
+# similar to the tasks supported by the model type. Refer to `task_to_feature` under `get_onnx_config` in
+# `hf_utils.py` for a mapping from task to feature.
 ADDITIONAL_MODEL_TYPES = {
     "gpt-neox": (
         [

--- a/olive/model/hf_onnx_config.py
+++ b/olive/model/hf_onnx_config.py
@@ -1,6 +1,6 @@
 from typing import Any, Mapping, Optional, OrderedDict
 
-from transformers import PreTrainedTokenizer, TensorType, is_torch_available
+from transformers import PreTrainedTokenizer, TensorType
 from transformers.onnx import OnnxConfigWithPast
 
 ADDITIONAL_MODEL_TYPES = {
@@ -89,40 +89,17 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
         is_pair: bool = False,
         framework: Optional[TensorType] = None,
     ) -> Mapping[str, Any]:
-        common_inputs = super(OnnxConfigWithPast, self).generate_dummy_inputs(
+        common_inputs = super().generate_dummy_inputs(
             tokenizer, batch_size=batch_size, seq_length=seq_length, is_pair=is_pair, framework=framework
         )
 
         # We need to order the input in the way they appears in the forward()
-        ordered_inputs = OrderedDict({"input_ids": common_inputs["input_ids"]})
-
-        # Need to add the past_keys
+        input_order = ["input_ids"]
         if self.use_past:
-            if not is_torch_available():
-                raise ValueError("Cannot generate dummy past_keys inputs without PyTorch installed.")
-            else:
-                import torch
+            input_order += ["past_key_values"]
+        input_order += ["attention_mask"]
 
-                batch, seqlen = common_inputs["input_ids"].shape
-                # Not using the same length for past_key_values
-                past_key_values_length = seqlen + 2
-                past_shape = (
-                    batch,
-                    self.num_attention_heads,
-                    past_key_values_length,
-                    self._config.hidden_size // self.num_attention_heads,
-                )
-                ordered_inputs["past_key_values"] = [
-                    (torch.zeros(past_shape), torch.zeros(past_shape)) for _ in range(self.num_layers)
-                ]
-
-        ordered_inputs["attention_mask"] = common_inputs["attention_mask"]
-        if self.use_past:
-            mask_dtype = ordered_inputs["attention_mask"].dtype
-            ordered_inputs["attention_mask"] = torch.cat(
-                [ordered_inputs["attention_mask"], torch.ones(batch, past_key_values_length, dtype=mask_dtype)], dim=1
-            )
-
+        ordered_inputs = OrderedDict({k: common_inputs[k] for k in input_order})
         return ordered_inputs
 
     @property

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -123,9 +123,8 @@ def patched_supported_features_mapping(*supported_features: str, onnx_config_cls
     if onnx_config_cls is None:
         raise ValueError("A OnnxConfig class must be provided")
 
-    import olive.model.hf_onnx_config as hf_onnx_config
+    import olive.model.hf_onnx_config as config_cls
 
-    config_cls = hf_onnx_config
     for attr_name in onnx_config_cls.split("."):
         config_cls = getattr(config_cls, attr_name)
     mapping = {}

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -3,8 +3,9 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from functools import partial
 from itertools import chain
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from pydantic import validator
 
@@ -24,7 +25,9 @@ class HFComponent(ConfigBase):
 class HFConfig(ConfigBase):
     model_name: str = None
     task: str = None
-    feature: str = "default"
+    # feature is optional if task is specified and don't need past
+    # else, provide feature such as "causal-lm-with-past"
+    feature: str = None
     # TODO: remove model_class and only use task
     model_class: str = None
     components: List[HFComponent] = None
@@ -104,15 +107,90 @@ def load_huggingface_model_from_model_class(model_class: str, name: str):
     return huggingface_model_loader(model_class)(name)
 
 
-def get_onnx_config(model_name: str, task: str, feature: str):
+# patched version of transforrmers.onnx.features.supported_features_mapping
+# to support additional models in olive
+def patched_supported_features_mapping(*supported_features: str, onnx_config_cls: str = None) -> Dict[str, Callable]:
+    """
+    Generate the mapping between supported the features and their corresponding OnnxConfig for a given model.
+
+    Args:
+        *supported_features: The names of the supported features.
+        onnx_config_cls: The OnnxConfig full name corresponding to the model.
+
+    Returns:
+        The dictionary mapping a feature to an OnnxConfig constructor.
+    """
+    if onnx_config_cls is None:
+        raise ValueError("A OnnxConfig class must be provided")
+
+    import olive.model.hf_onnx_config as hf_onnx_config
+
+    config_cls = hf_onnx_config
+    for attr_name in onnx_config_cls.split("."):
+        config_cls = getattr(config_cls, attr_name)
+    mapping = {}
+    for feature in supported_features:
+        if "-with-past" in feature:
+            task = feature.replace("-with-past", "")
+            mapping[feature] = partial(config_cls.with_past, task=task)
+        else:
+            mapping[feature] = partial(config_cls.from_model_config, task=feature)
+
+    return mapping
+
+
+def get_onnx_config(model_name: str, task: str, feature: Optional[str] = None):
     from transformers.onnx import FeaturesManager
 
-    model = load_huggingface_model_from_task(task, model_name)
-    _, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=feature)
-    return model_onnx_config(model.config)
+    from olive.model.hf_onnx_config import ADDITIONAL_MODEL_TYPES
+
+    # patch FeaturesManager._SUPPORTED_MODEL_TYPE to support additional models in olive
+    for model_type in ADDITIONAL_MODEL_TYPES:
+        if model_type in FeaturesManager._SUPPORTED_MODEL_TYPE:
+            continue
+        features, onnx_config_cls = ADDITIONAL_MODEL_TYPES[model_type]
+        FeaturesManager._SUPPORTED_MODEL_TYPE[model_type] = patched_supported_features_mapping(
+            *features, onnx_config_cls=onnx_config_cls
+        )
+
+    # mapping from task to feature
+    task_to_feature = {
+        "automatic-speech-recognition": "speech2seq-lm",
+        "fill-mask": "masked-lm",
+        "image-classification": "image-classification",
+        "image-segmentation": "image-segmentation",
+        "image-to-text": "vision2seq-lm",
+        "multiple-choice": "multiple-choice",
+        "ner": "token-classification",
+        "object-detection": "object-detection",
+        "question-answering": "question-answering",
+        "sentiment-analysis": "sequence-classification",
+        "summarization": "seq2seq-lm",
+        "text2text-generation": "seq2seq-lm",
+        "text-classification": "sequence-classification",
+        "text-generation": "causal-lm",
+        "token-classification": "token-classification",
+        "translation": "seq2seq-lm",
+    }
+    # if feature is not provided, try to get it from task
+    # else use "default"
+    feature = feature or task_to_feature.get(task, "default")
+
+    # don't want to load the model here since all we need is the config
+    # model loading is expensive computationally and memory-wise for large models
+    config = get_hf_model_config(model_name)
+    # recreate the logic for FeaturesManager.check_supported_model_or_raise to get the model_onnx_config
+    # https://github.com/huggingface/transformers/blob/main/src/transformers/onnx/features.py#L712
+    model_type = config.model_type.replace("_", "-")
+    model_features = FeaturesManager.get_supported_features_for_model_type(model_type, model_name=model_name)
+    if feature not in model_features:
+        raise ValueError(
+            f"{config.model_type} doesn't support feature {feature}. Supported values are: {model_features}"
+        )
+    return FeaturesManager.get_config(model_type, feature)(config)
 
 
-def get_hf_model_io_config(model_name: str, task: str, feature: str):
+def get_hf_model_io_config(model_name: str, task: str, feature: Optional[str] = None):
     model_config = get_onnx_config(model_name, task, feature)
     inputs = model_config.inputs
     outputs = model_config.outputs
@@ -123,7 +201,7 @@ def get_hf_model_io_config(model_name: str, task: str, feature: str):
     return io_config
 
 
-def get_hf_model_dummy_input(model_name: str, task: str, feature: str):
+def get_hf_model_dummy_input(model_name: str, task: str, feature: Optional[str] = None):
     from transformers import AutoTokenizer
 
     model_config = get_onnx_config(model_name, task, feature)

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -2,9 +2,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import pytest
 import torch
+from transformers.onnx import OnnxConfig
 
-from olive.model.hf_utils import load_huggingface_model_from_model_class, load_huggingface_model_from_task
+from olive.model.hf_utils import (
+    get_onnx_config,
+    load_huggingface_model_from_model_class,
+    load_huggingface_model_from_task,
+)
 
 
 def test_load_huggingface_model_from_task():
@@ -22,3 +28,15 @@ def test_load_huggingface_model_from_model_class():
     model_name = "Intel/bert-base-uncased-mrpc"
     model = load_huggingface_model_from_model_class(model_class, model_name)
     assert isinstance(model, torch.nn.Module)
+
+
+@pytest.mark.parametrize(
+    "model_name,task,feature",
+    [
+        ("Intel/bert-base-uncased-mrpc", "text-classification", "default"),
+        ("facebook/opt-125m", "text-generation", "default"),
+    ],
+)
+def test_get_onnx_config(model_name, task, feature):
+    onnx_config = get_onnx_config(model_name, task, feature)
+    assert isinstance(onnx_config, OnnxConfig)

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -171,5 +171,5 @@ class TestPytorchDummyInput:
         # get dummy inputs
         dummy_inputs = olive_model.get_dummy_inputs()
 
-        get_hf_model_dummy_input.assert_called_once_with(self.model_name, self.task, "default")
+        get_hf_model_dummy_input.assert_called_once_with(self.model_name, self.task, None)
         assert dummy_inputs == 1


### PR DESCRIPTION
## Describe your changes
Olive uses `transformer.onnx.FeaturesManager` to automatically get onnx conversion args. However, huggingface has started using `optimum` for this instead and haven't added support for newer models in `transformers.onnx`. 

In this PR, we add support for `opt`, `llama` and `gptneox` (model type for dolly) by extending `FeaturesManager`. All of these models are text decoder model so they are using the same onnx config. 

Also, infer `feature` from `task` if not provided. We previously used `default` but that doesn't work as expected if the `task` is different from the default. Such as `sequence-classification` for gpt2 whose default is `causal-lm`. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
