### PR TITLE
Pin `torchmetrics` version to `~=0.10.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pydantic<2.0.0
 protobuf<4.0.0
 pyyaml
 torch
-torchmetrics>=0.7.0, <0.10.1
+torchmetrics~=0.10.0
 transformers


### PR DESCRIPTION
## Describe your changes
`perplexity` support was added in https://github.com/microsoft/Olive/pull/444. However, `torchmetrics` only supports this metrics in versions >= 0.10.0. So, we update the requirement to `~=0.10.0`. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
