### PR TITLE
Fix OnnxConversion failure in GPTJ example

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -117,7 +117,23 @@ class OnnxConversion(Pass):
             # only handle dict for now since we cannot get the name of the input from a list/tuple
             if isinstance(dummy_inputs, dict):
                 dummy_input_keys = set(dummy_inputs.keys())
+
+                # handle dummy inputs for hf model with past, which has past_key_values
+                # match input names in `past_key_values.(hidden_layer_num).(key|value)` pattern
+                from transformers.modeling_utils import PreTrainedModel
+
+                if issubclass(type(pytorch_model), PreTrainedModel):
+                    for name, input in dummy_inputs.items():
+                        if isinstance(input, list):
+                            key_value_names = set(
+                                [f"{name}.{idx}.key" for idx in range(len(input))]
+                                + [f"{name}.{idx}.value" for idx in range(len(input))]
+                            )
+                            if key_value_names.issubset(set(input_names)):
+                                dummy_input_keys.discard(name)
+
                 unused_keys = dummy_input_keys - set(input_names)
+
                 if unused_keys:
                     logger.debug(f"Removing unused dummy inputs: {unused_keys}")
                 for key in unused_keys:

--- a/test/unit_test/passes/onnx/test_conversion.py
+++ b/test/unit_test/passes/onnx/test_conversion.py
@@ -1,16 +1,18 @@
 import tempfile
 from pathlib import Path
-from test.unit_test.utils import get_pytorch_model
+from test.unit_test.utils import get_hf_model_with_past, get_pytorch_model
+
+import pytest
 
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.conversion import OnnxConversion
 from olive.systems.local import LocalSystem
 
 
-def test_onnx_conversion_pass():
+@pytest.mark.parametrize("input_model", [get_pytorch_model(), get_hf_model_with_past()])
+def test_onnx_conversion_pass(input_model):
     # setup
     local_system = LocalSystem()
-    input_model = get_pytorch_model()
 
     p = create_pass_from_dict(OnnxConversion, {}, disable_search=True)
     with tempfile.TemporaryDirectory() as tempdir:

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -70,6 +70,16 @@ def get_pytorch_model():
     )
 
 
+def get_hf_model_with_past():
+    return PyTorchModel(
+        hf_config={
+            "model_name": "hf-internal-testing/tiny-random-gptj",
+            "task": "text-generation",
+            "feature": "causal-lm-with-past",
+        }
+    )
+
+
 def get_pytorch_model_dummy_input(model):
     return torch.randn(1, 1)
 


### PR DESCRIPTION
## Describe your changes
**summary:** 
Skip removing past_key_values in dummy input in OnnxConversion, which is required for hf model with past.

**Details:**
GPTJ example failed in OnnxConversion with error: `RuntimeError: The size of tensor a (8) must match the size of tensor b (18) at non-singleton dimension 3`
To quickly reproduce the error:
```python
from olive.model import PyTorchModel
from olive.passes.olive_pass import create_pass_from_dict
from olive.passes.onnx.conversion import OnnxConversion
from olive.systems.local import LocalSystem

local_system = LocalSystem()
hf_config={"model_name": "hf-internal-testing/tiny-random-gptj",
                   "task": "text-generation",
                   "feature": "causal-lm-with-past"}
pytorch_model = PyTorchModel(hf_config=hf_config)
onnx_conversion_config = {}

p = create_pass_from_dict(OnnxConversion, onnx_conversion_config, disable_search=True)
output_folder = str("onnx")

# execute
onnx_model = local_system.run_pass(p, pytorch_model, None, output_folder)

```

The error is caused in [conversion.py#L115-L124](https://github.com/microsoft/Olive/blob/9ed6edb1163cbdba88cf198b0cb4ea3f6427829a/olive/passes/onnx/conversion.py#L115-L124). 

```diff
# some dummy inputs might not be used in the model, so we need to remove them
# this can happen when we are using an hf dataset to generate dummy inputs
# only handle dict for now since we cannot get the name of the input from a list/tuple
if isinstance(dummy_inputs, dict):
    dummy_input_keys = set(dummy_inputs.keys())
    unused_keys = dummy_input_keys - set(input_names)
-    # print(dummy_input_keys): {'past_key_values', 'attention_mask', 'input_ids'}
-    # print(set(input_names)): {'past_key_values.3.value', 'past_key_values.2.key', 'attention_mask', 'past_key_values.0.value', 'past_key_values.4.key', 'past_key_values.3.key', 'past_key_values.1.value', 'input_ids', 'past_key_values.1.key', 'past_key_values.4.value', 'past_key_values.2.value', 'past_key_values.0.key'}
-    # print(unused_keys): {'past_key_values'}
-    # past key values in dummy input are removed here mistakenly, which will cause torch.onnx.export failure.
    if unused_keys:
        logger.debug(f"Removing unused dummy inputs: {unused_keys}")
    for key in unused_keys:
        del dummy_inputs[key]
```

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
