### PR TITLE
OnnxConversion support for gpu export

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -14,6 +14,8 @@ import shutil
 import subprocess
 import time
 
+from olive.hardware import Device
+
 logger = logging.getLogger(__name__)
 
 
@@ -162,3 +164,9 @@ def tensor_data_to_device(data, device: str):
         return set(tensor_data_to_device(v, device) for v in data)
     else:
         return data
+
+
+def device_string_to_torch_device(device: Device):
+    import torch
+
+    return torch.device("cuda") if device == Device.GPU else torch.device(device)

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -18,7 +18,7 @@ import olive.data.template as data_config_template
 from olive.cache import get_local_path_from_root
 from olive.common.config_utils import ConfigBase
 from olive.common.user_module_loader import UserModuleLoader
-from olive.common.utils import tensor_data_to_device
+from olive.common.utils import device_string_to_torch_device, tensor_data_to_device
 from olive.constants import Framework
 from olive.evaluator.metric import (
     LatencySubType,
@@ -596,10 +596,6 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
     def __init__(self):
         super().__init__()
 
-    @staticmethod
-    def _device_string_to_torch_device(device: Device):
-        return torch.device("cuda") if device == Device.GPU else torch.device(device)
-
     @torch.no_grad()
     def _inference(
         self,
@@ -614,7 +610,7 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
 
         preds = []
         targets = []
-        device = PyTorchEvaluator._device_string_to_torch_device(device)
+        device = device_string_to_torch_device(device)
         if device:
             session.to(device)
         for input_data, labels in dataloader:
@@ -662,7 +658,7 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
         session = model.prepare_session(inference_settings=self.get_inference_settings(metric), device=device)
 
         input_data, _ = next(iter(dataloader))
-        device = PyTorchEvaluator._device_string_to_torch_device(device)
+        device = device_string_to_torch_device(device)
         if device:
             session.to(device)
             input_data = tensor_data_to_device(input_data, device)


### PR DESCRIPTION
OnnxConversion support for gpu export

## Describe your changes

Move the model and the data to the device based on accelerator spec instead of forcing it to cpu.
Moved a function from PyTorchEvaluator to common utils so it's in shared location.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
