### PR TITLE
Separate `failed` and `invalid` pass run configs

### DIFF
--- a/olive/engine/config.py
+++ b/olive/engine/config.py
@@ -12,8 +12,12 @@ from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.strategy.search_strategy import SearchStrategyConfig
 from olive.systems.system_config import SystemConfig
 
-# pass search-point/config was pruned due invalid config or failed run
-PRUNED_CONFIG = "pruned-config"
+# pass search-point was pruned due to failed run
+FAILED_CONFIG = "failed-config"
+# pass search-point was pruned due to invalid config
+INVALID_CONFIG = "invalid-config"
+# list of all pruned configs
+PRUNED_CONFIGS = [FAILED_CONFIG, INVALID_CONFIG]
 
 
 class EngineConfig(ConfigBase):

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -142,7 +142,3 @@ class OrtTransformersOptimization(Pass):
 
         # save the model to the output path and return the model
         return model_proto_to_olive_model(optimizer.model, output_model_path, config)
-
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
-        return False


### PR DESCRIPTION
## Describe your changes
Separate `PRUNED_CONFIG` into `INVALID_CONFIG` and `FAILED_CONFIG`. 
`INVALID_CONFIG` is used when the run config is invalid for a given accelerator spec.
`FAILED_CONFIG` is used when the run config is valid, but the pass run fails for some reason. 

This helps us make the search more efficient. the transformer optimizer pass was made `not accelerator_agnostic` even though the pass run itself doesn't depend on the accelerator. All information is already in the `run_config`. 
It is okay for a pass to be `accelerator_agnostic` but the search space to have points invalid for specific `accelerator_specs`. 

What matters when determining if a pass is `accelerator_agnostic` is if the pass run uses the accelerator specs and the output depends on it. 
In the transformer optimizer case, the `use_gpu` information already contains the necessary accelerator information so the run config has all information needed. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
