### PR TITLE
Add `TorchTRTConversion` pass

### DIFF
--- a/docs/source/api/passes.rst
+++ b/docs/source/api/passes.rst
@@ -138,6 +138,12 @@ SparseGPT
 --------------------
 .. autoconfigclass:: olive.passes.SparseGPT
 
+.. _torch_trt_conversion:
+
+TorchTRTConversion
+--------------------
+.. autoconfigclass:: olive.passes.TorchTRTConversion
+
 .. _vitis_ai_quantization:
 
 VitisAIQuantization

--- a/docs/source/api/passes.rst
+++ b/docs/source/api/passes.rst
@@ -15,7 +15,7 @@ OnnxConversion
 .. _device_specific_onnx_conversion:
 
 DeviceSpecificOnnxConversion
------------------
+----------------------------
 .. autoconfigclass:: olive.passes.DeviceSpecificOnnxConversion
 
 .. _onnx_model_optimizer:

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -67,6 +67,8 @@ as 2:4 and 4:8 patterns.
 
 Please refer to the original paper linked above for more details on the algorithm and performance results for different models, sparsities and datasets.
 
+This pass only supports Hugging Face transformers PyTorch models. Please refer to [SparseGPT](sparse_gpt) for more details on the types of transformers models supported.
+
 **Note:** TensorRT can accelerate inference on 2:4 sparse models as described in [this blog](https://developer.nvidia.com/blog/accelerating-inference-with-sparsity-using-ampere-and-tensorrt/).
 
 ### Example Configuration
@@ -87,6 +89,8 @@ Please refer to the original paper linked above for more details on the algorith
 `TorchTRTConversion` converts the `torch.nn.Linear` modules in the transformer layers in a Hugging Face PyTorch model to `TRTModules` from `torch_tensorrt` with fp16 precision and sparse weights, if
 applicable. `torch_tensorrt` is an extension to `torch` where TensorRT compiled engines can be used like regular `torch.nn.Module`s. This pass can be used to accelerate inference on transformer models
 with sparse weights by taking advantage of the 2:4 structured sparsity pattern supported by TensorRT.
+
+This pass only supports Hugging Face transformers PyTorch models. Please refer to [TorchTRTConversion](torch_trt_conversion) for more details on the types of transformers models supported.
 
 ### Example Configuration
 ```json

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -67,7 +67,7 @@ as 2:4 and 4:8 patterns.
 
 Please refer to the original paper linked above for more details on the algorithm and performance results for different models, sparsities and datasets.
 
-This pass only supports Hugging Face transformers PyTorch models. Please refer to [SparseGPT](sparse_gpt) for more details on the types of transformers models supported.
+This pass only supports Hugging Face transformers PyTorch models. Please refer to [SparseGPT](sparsegpt) for more details on the types of transformers models supported.
 
 **Note:** TensorRT can accelerate inference on 2:4 sparse models as described in [this blog](https://developer.nvidia.com/blog/accelerating-inference-with-sparsity-using-ampere-and-tensorrt/).
 

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -82,3 +82,15 @@ Please refer to the original paper linked above for more details on the algorith
     "config": {"sparsity": [2,4]}
 }
 ```
+
+## TorchTRTConversion
+`TorchTRTConversion` converts the `torch.nn.Linear` modules in the transformer layers in a Hugging Face PyTorch model to `TRTModules` from `torch_tensorrt` with fp16 precision and sparse weights, if
+applicable. `torch_tensorrt` is an extension to `torch` where TensorRT compiled engines can be used like regular `torch.nn.Module`s. This pass can be used to accelerate inference on transformer models
+with sparse weights by taking advantage of the 2:4 structured sparsity pattern supported by TensorRT.
+
+### Example Configuration
+```json
+{
+    "type": "TorchTRTConversion"
+}
+```

--- a/examples/open_llama/README.md
+++ b/examples/open_llama/README.md
@@ -64,7 +64,11 @@ This workflow sparsifies Open LLaMA model using [SparseGPT](https://arxiv.org/ab
 sparsified. The given config has sparsity set to `[2,4]` for [structured 2:4 sparsity pattern](https://developer.nvidia.com/blog/accelerating-inference-with-sparsity-using-ampere-and-tensorrt/) but
 can be changed to other sparsity pattern such as `0.5` for 50% unstructured sparsity or `[4,8]` for 4:8 structured sparsity pattern.
 
-The relevant config file is [open_llaopen_llama_sparsegpt_gpuma_config.json](open_llama_sparsegpt_gpu.json)
+To take advantage of the sparsity using TensorRT, the sparse `torch.nn.Linear` modules in the transformer layers are then converted to `TRTModule` from `torch-tensorrt` with fp16 precision and sparsity enabled.
+This is done using the `TorchTRTConversion` pass in Olive which saves the entire model. This saved model can then be loaded using `torch.load` but requires Olive to be installed.
+Inference is done like a normal pytorch model.
+
+The relevant config file is [open_llama_sparsegpt_gpu.json](open_llama_sparsegpt_gpu.json)
 
 ## How to run
 ### Pip requirements

--- a/examples/open_llama/open_llama_sparsegpt_gpu.json
+++ b/examples/open_llama/open_llama_sparsegpt_gpu.json
@@ -65,6 +65,12 @@
                 "sparsity": [2,4],
                 "data_config": "c4_train"
             }
+        },
+        "trt_conversion": {
+            "type": "TorchTRTConversion",
+            "config": {
+                "data_config": "c4_train"
+            }
         }
     },
     "engine": {

--- a/examples/open_llama/requirements.txt
+++ b/examples/open_llama/requirements.txt
@@ -1,2 +1,3 @@
 datasets
 sentencepiece
+torch-tensorrt

--- a/olive/extra_dependencies.json
+++ b/olive/extra_dependencies.json
@@ -28,5 +28,8 @@
     ],
     "optimum": [
         "optimum"
+    ],
+    "torch-tensorrt": [
+        "torch-tensorrt"
     ]
 }

--- a/olive/passes/pytorch/__init__.py
+++ b/olive/passes/pytorch/__init__.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from olive.passes.pytorch.quantization_aware_training import QuantizationAwareTraining
-from olive.passes.pytorch.sparse_trt_conversion import SparseTRTConversion
 from olive.passes.pytorch.sparsegpt import SparseGPT
+from olive.passes.pytorch.torch_trt_conversion import TorchTRTConversion
 
-__all__ = ["QuantizationAwareTraining", "SparseGPT", "SparseTRTConversion"]
+__all__ = ["QuantizationAwareTraining", "SparseGPT", "TorchTRTConversion"]

--- a/olive/passes/pytorch/__init__.py
+++ b/olive/passes/pytorch/__init__.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from olive.passes.pytorch.quantization_aware_training import QuantizationAwareTraining
+from olive.passes.pytorch.sparse_trt_conversion import SparseTRTConversion
 from olive.passes.pytorch.sparsegpt import SparseGPT
 
-__all__ = ["QuantizationAwareTraining", "SparseGPT"]
+__all__ = ["QuantizationAwareTraining", "SparseGPT", "SparseTRTConversion"]

--- a/olive/passes/pytorch/sparse_trt_conversion.py
+++ b/olive/passes/pytorch/sparse_trt_conversion.py
@@ -1,0 +1,204 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+# Based on the original implementation at
+# https://github.com/IST-DASLab/sparsegpt
+# https://arxiv.org/abs/2301.00774
+# -------------------------------------------------------------------------
+import io
+import logging
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import torch
+
+from olive.common.utils import tensor_data_to_device
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import PyTorchModel
+from olive.passes import Pass
+from olive.passes.olive_pass import PassConfigParam
+from olive.passes.pytorch.sparsegpt_utils import _get_attr, get_layer_submodules, get_layers, seqlens
+
+logger = logging.getLogger(__name__)
+
+
+class SparseTRTConversion(Pass):
+    """Convert a PyTorch model to a sparse fp16 Pytorch model with TRT Modules."""
+
+    _requires_data_config = True
+
+    @staticmethod
+    def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        return {
+            "min_layer": PassConfigParam(
+                type_=int, default_value=None, description="Convert all layers with id >= min_layer."
+            ),
+            "max_layer": PassConfigParam(
+                type_=int, default_value=None, description="Convert all layers with id < max_layer."
+            ),
+            "layer_name_filter": PassConfigParam(
+                type_=Union[str, List[str]],
+                default_value=None,
+                description="Only convert layers whose name contains the given string(s).",
+            ),
+        }
+
+    @torch.no_grad()
+    def _run_for_config(
+        self, model: PyTorchModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> PyTorchModel:
+        model_config = model.get_model_config()
+        model_type = model_config.model_type
+        if model_type not in seqlens:
+            raise ValueError(f"Unsupported model type: {model_type}. Supported types: {seqlens.keys()}")
+
+        if not torch.cuda.is_available():
+            raise ValueError("SparseTRTConversion requires a GPU to run.")
+        device = "cuda"
+
+        # load_data
+        assert config["data_config"] is not None, "Data config is required for SparseTRTConversion."
+        first_batch = self._data_config.to_data_container().get_first_batch(data_root_path=data_root)[0]
+        first_batch = tensor_data_to_device(first_batch, device=device)
+        batch_size = first_batch["input_ids"].shape[0]
+        seqlen = seqlens[model_type]
+
+        # load model
+        pytorch_model = model.load_model()
+        # we will update the model inplace
+        # since the models are large, it is expensive to copy and maintain two copies
+        # set model.model to None so that the input model doesn't use this same model object when it is loaded
+        model.model = None
+        # alternative is to copy the model and use the copy
+        # pytorch_model = copy.deepcopy(model.model)
+        pytorch_model.eval()
+        # convert model to fp16 on GPU
+        pytorch_model.to(dtype=torch.float16, device=device)
+        # disable cache
+        use_cache = pytorch_model.config.use_cache
+        pytorch_model.config.use_cache = False
+
+        # get module list of layers
+        layers = get_layers(pytorch_model, model_type)
+
+        # get layer information
+        min_layer = config["min_layer"] or 0
+        max_layer = config["max_layer"] or len(layers)
+        layer_name_filter = config["layer_name_filter"] or []
+        if isinstance(layer_name_filter, str):
+            layer_name_filter = [layer_name_filter]
+        # layer information storage
+        layer_info = {}
+        # loop over layers
+        for i in range(min_layer, max_layer):
+            layer = layers[i]
+            layer_info[i] = {"submodules": {}, "handles": [], "input_shapes": {}}
+
+            # get list of submodules in layer
+            layer_info[i]["submodules"] = get_layer_submodules(
+                layer, submodule_types=[torch.nn.Linear], layer_name_filter=layer_name_filter
+            )
+
+            # add forward hook to submodules in layer
+            def get_handler(layer_idx, submodule_name):
+                def handler(_, input, output):
+                    layer_info[layer_idx]["input_shapes"][submodule_name] = input[0].shape
+
+                return handler
+
+            for name, submodule in layer_info[i]["submodules"].items():
+                layer_info[i]["handles"].append(submodule.register_forward_hook(get_handler(i, name)))
+
+        # run a forward pass
+        pytorch_model(**first_batch)
+
+        # remove handles
+        for info in layer_info.values():
+            for handle in info["handles"]:
+                handle.remove()
+            del info["handles"]
+
+        # convert submodules to trt modules
+        logger.debug(f"Converting layers {min_layer} to {max_layer}...")
+        for layer_index, info in layer_info.items():
+            logger.debug(f"Converting layer {layer_index}...")
+            for name, shape in info["input_shapes"].items():
+                input = torch.zeros(shape, dtype=torch.float16, device=device)
+                # create trt module
+                trt_module = self._compile_trt_model(info["submodules"][name], input, batch_size, seqlen)
+                # get parent module
+                parent_name = ".".join(name.split(".")[:-1])
+                parent_module = (
+                    _get_attr(layers[layer_index], ".".join(name.split(".")[:-1]))
+                    if parent_name
+                    else layers[layer_index]
+                )
+                # get submodule name
+                module_name = name.split(".")[-1]
+                # replace submodule with trt module
+                setattr(parent_module, module_name, trt_module)
+                # remove submodule from layer_info
+                del info["submodules"][name]
+                # TODO: is the empty cache necessary? does it add processing time?
+                # torch.cuda.empty_cache()
+                # gc.collect()
+
+        # restore cache
+        pytorch_model.config.use_cache = use_cache
+
+        # save save entire model to output_model_path
+        output_model_path = Path(output_model_path).with_suffix(".pt")
+        torch.save(pytorch_model, output_model_path)
+        return PyTorchModel(model_path=output_model_path)
+
+    def _compile_trt_model(
+        self, torch_module: torch.nn.Module, hidden_states: torch.Tensor, batch_size: int, seqlen: int
+    ):
+        """Compile a torch module to a TensorRT module.
+
+        :param torch_module: The torch module to compile. Only torch.nn.Linear modules are supported currently.
+        :param hidden_states: The input tensor to the torch module.
+        :param batch_size: The batch size of the input tensor.
+        :param seqlen: The maximum sequence length of the input tensor. seqlen dimension is treated as dynamic.
+        """
+        import tensorrt as trt
+        import torch_tensorrt.fx.tracer.acc_tracer.acc_tracer as acc_tracer
+        from torch_tensorrt.fx import InputTensorSpec, TRTInterpreter, TRTModule, compile
+
+        logging.getLogger("torch_tensorrt").setLevel(logging.ERROR)
+
+        if not isinstance(torch_module, torch.nn.Linear):
+            raise TypeError("torch_module must be a torch.nn.Linear module. Other modules are not supported.")
+
+        # whether the batch and seqlen dimensions are flattened
+        flattened = len(hidden_states.shape) == 2
+
+        # redirect stdout to avoid printing
+        f = io.StringIO()
+        with redirect_stdout(f):
+            # compile torch module to TensorRT module
+            low_model = compile(torch_module, [hidden_states]).eval()
+        f.close()
+        acc_model = acc_tracer.trace(low_model, [hidden_states])
+        # get input specs
+        hidden_size = hidden_states.shape[-1]
+        if not flattened:
+            shape = [batch_size, -1, hidden_size]
+            shape_ranges = [
+                ((batch_size, 1, hidden_size), (batch_size, 100, hidden_size), (batch_size, seqlen, hidden_size))
+            ]
+        else:
+            shape = [-1, hidden_size]
+            shape_ranges = [
+                ((batch_size, hidden_size), (batch_size * 100, hidden_size), (batch_size * seqlen, hidden_size))
+            ]
+        input_specs = [InputTensorSpec(shape=shape, dtype=torch.float16, shape_ranges=shape_ranges)]
+        # create TensorRT module
+        interpreter = TRTInterpreter(
+            acc_model, input_specs, explicit_batch_dimension=True, logger_level=trt.Logger.ERROR
+        )
+        result = interpreter.run(sparse_weights=True)
+        trt_module = TRTModule(result.engine, result.input_names, result.output_names)
+        return trt_module

--- a/olive/passes/pytorch/sparse_trt_conversion.py
+++ b/olive/passes/pytorch/sparse_trt_conversion.py
@@ -2,13 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-# Based on the original implementation at
-# https://github.com/IST-DASLab/sparsegpt
-# https://arxiv.org/abs/2301.00774
-# -------------------------------------------------------------------------
-import io
 import logging
-from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -43,12 +37,19 @@ class SparseTRTConversion(Pass):
                 default_value=None,
                 description="Only convert layers whose name contains the given string(s).",
             ),
+            "float16": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="Convert entire model to fp16. If False, only the sparse modules are converted to fp16.",
+            ),
         }
 
     @torch.no_grad()
     def _run_for_config(
         self, model: PyTorchModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> PyTorchModel:
+        from olive.passes.pytorch.trt_utils import compile_trt_model
+
         model_config = model.get_model_config()
         model_type = model_config.model_type
         if model_type not in seqlens:
@@ -74,8 +75,11 @@ class SparseTRTConversion(Pass):
         # alternative is to copy the model and use the copy
         # pytorch_model = copy.deepcopy(model.model)
         pytorch_model.eval()
-        # convert model to fp16 on GPU
-        pytorch_model.to(dtype=torch.float16, device=device)
+        # move model to device
+        pytorch_model.to(device=device)
+        # convert model to fp16 if needed
+        if config["float16"]:
+            pytorch_model = pytorch_model.to(dtype=torch.float16)
         # disable cache
         use_cache = pytorch_model.config.use_cache
         pytorch_model.config.use_cache = False
@@ -127,7 +131,7 @@ class SparseTRTConversion(Pass):
             for name, shape in info["input_shapes"].items():
                 input = torch.zeros(shape, dtype=torch.float16, device=device)
                 # create trt module
-                trt_module = self._compile_trt_model(info["submodules"][name], input, batch_size, seqlen)
+                trt_module = compile_trt_model(info["submodules"][name], input, batch_size, seqlen)
                 # get parent module
                 parent_name = ".".join(name.split(".")[:-1])
                 parent_module = (
@@ -152,53 +156,3 @@ class SparseTRTConversion(Pass):
         output_model_path = Path(output_model_path).with_suffix(".pt")
         torch.save(pytorch_model, output_model_path)
         return PyTorchModel(model_path=output_model_path)
-
-    def _compile_trt_model(
-        self, torch_module: torch.nn.Module, hidden_states: torch.Tensor, batch_size: int, seqlen: int
-    ):
-        """Compile a torch module to a TensorRT module.
-
-        :param torch_module: The torch module to compile. Only torch.nn.Linear modules are supported currently.
-        :param hidden_states: The input tensor to the torch module.
-        :param batch_size: The batch size of the input tensor.
-        :param seqlen: The maximum sequence length of the input tensor. seqlen dimension is treated as dynamic.
-        """
-        import tensorrt as trt
-        import torch_tensorrt.fx.tracer.acc_tracer.acc_tracer as acc_tracer
-        from torch_tensorrt.fx import InputTensorSpec, TRTInterpreter, TRTModule, compile
-
-        logging.getLogger("torch_tensorrt").setLevel(logging.ERROR)
-
-        if not isinstance(torch_module, torch.nn.Linear):
-            raise TypeError("torch_module must be a torch.nn.Linear module. Other modules are not supported.")
-
-        # whether the batch and seqlen dimensions are flattened
-        flattened = len(hidden_states.shape) == 2
-
-        # redirect stdout to avoid printing
-        f = io.StringIO()
-        with redirect_stdout(f):
-            # compile torch module to TensorRT module
-            low_model = compile(torch_module, [hidden_states]).eval()
-        f.close()
-        acc_model = acc_tracer.trace(low_model, [hidden_states])
-        # get input specs
-        hidden_size = hidden_states.shape[-1]
-        if not flattened:
-            shape = [batch_size, -1, hidden_size]
-            shape_ranges = [
-                ((batch_size, 1, hidden_size), (batch_size, 100, hidden_size), (batch_size, seqlen, hidden_size))
-            ]
-        else:
-            shape = [-1, hidden_size]
-            shape_ranges = [
-                ((batch_size, hidden_size), (batch_size * 100, hidden_size), (batch_size * seqlen, hidden_size))
-            ]
-        input_specs = [InputTensorSpec(shape=shape, dtype=torch.float16, shape_ranges=shape_ranges)]
-        # create TensorRT module
-        interpreter = TRTInterpreter(
-            acc_model, input_specs, explicit_batch_dimension=True, logger_level=trt.Logger.ERROR
-        )
-        result = interpreter.run(sparse_weights=True)
-        trt_module = TRTModule(result.engine, result.input_names, result.output_names)
-        return trt_module

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -31,6 +31,9 @@ class SparseGPT(Pass):
     """
     Run SparseGPT on a Hugging Face PyTorch model.
     See https://arxiv.org/abs/2301.00774 for more details on the algorithm.
+
+    This pass only supports PyTorchModel with hf_config. The transformers model type
+    must be one of [bloom, gpt2, gpt_neox, llama, opt].
     """
 
     _requires_data_config = True

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -27,7 +27,10 @@ logger = logging.getLogger(__name__)
 
 
 class SparseGPT(Pass):
-    """Run SparseGPT on Hugging Face PyTorch model."""
+    """
+    Run SparseGPT on a Hugging Face PyTorch model.
+    See https://arxiv.org/abs/2301.00774 for more details on the algorithm.
+    """
 
     _requires_data_config = True
 

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -21,6 +21,7 @@ from olive.passes.pytorch.sparsegpt_utils import (
     get_layer_submodules,
     get_layers,
     layers_map,
+    validate_min_max_layers,
 )
 
 logger = logging.getLogger(__name__)
@@ -129,8 +130,7 @@ class SparseGPT(Pass):
         outputs = torch.zeros_like(inputs)
 
         # prune layers
-        min_layer = config["min_layer"] or 0
-        max_layer = config["max_layer"] or len(layers)
+        min_layer, max_layer = validate_min_max_layers(config["min_layer"], config["max_layer"], len(layers))
         layer_name_filter = config["layer_name_filter"] or []
         if isinstance(layer_name_filter, str):
             layer_name_filter = [layer_name_filter]

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class SparseGPT(Pass):
-    """Run SparseGPT on PyTorch model."""
+    """Run SparseGPT on Hugging Face PyTorch model."""
 
     _requires_data_config = True
 

--- a/olive/passes/pytorch/sparsegpt_utils.py
+++ b/olive/passes/pytorch/sparsegpt_utils.py
@@ -38,6 +38,15 @@ embedding_map = {
 # all model types are expected to have "input_ids" and "attention_mask"
 additional_inputs = {"bloom": ["alibi"], "gpt_neox": ["position_ids"]}
 
+# max sequence length for each model type
+seqlens = {
+    "bloom": 2048,
+    "gpt2": 1024,
+    "gpt_neox": 2048,
+    "llama": 2048,
+    "opt": 2048,
+}
+
 
 def _get_attr(module, attr):
     """Get attribute from module.

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -22,6 +22,9 @@ class TorchTRTConversion(Pass):
     """
     Convert torch.nn.Linear modules in the transformer layers of a Hugging Face PyTorch model to TensorRT modules with
     fp16 precision and sparse weights, if applicable.
+
+    The entire model is saved using `torch.save` and can be loaded using `torch.load`. Loading the model requires
+    `torch-tensorrt` and Olive to be installed.
     """
 
     _requires_data_config = True

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -13,7 +13,13 @@ from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import PyTorchModel
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
-from olive.passes.pytorch.sparsegpt_utils import _get_attr, get_layer_submodules, get_layers, seqlens
+from olive.passes.pytorch.sparsegpt_utils import (
+    _get_attr,
+    get_layer_submodules,
+    get_layers,
+    seqlens,
+    validate_min_max_layers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,8 +108,7 @@ class TorchTRTConversion(Pass):
         layers = get_layers(pytorch_model, model_type)
 
         # get layer information
-        min_layer = config["min_layer"] or 0
-        max_layer = config["max_layer"] or len(layers)
+        min_layer, max_layer = validate_min_max_layers(config["min_layer"], config["max_layer"], len(layers))
         layer_name_filter = config["layer_name_filter"] or []
         if isinstance(layer_name_filter, str):
             layer_name_filter = [layer_name_filter]

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 class TorchTRTConversion(Pass):
     """
-    Convert the nn.Linear modules in the transformer layers of a Hugging Face PyTorch model to TensorRT modules with
-    fp16 precision and sparse weights, if present.
+    Convert torch.nn.Linear modules in the transformer layers of a Hugging Face PyTorch model to TensorRT modules with
+    fp16 precision and sparse weights, if applicable.
     """
 
     _requires_data_config = True

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -31,6 +31,9 @@ class TorchTRTConversion(Pass):
 
     The entire model is saved using `torch.save` and can be loaded using `torch.load`. Loading the model requires
     `torch-tensorrt` and Olive to be installed.
+
+    This pass only supports PyTorchModel with hf_config. The transformers model type
+    must be one of [bloom, gpt2, gpt_neox, llama, opt].
     """
 
     _requires_data_config = True

--- a/olive/passes/pytorch/trt_utils.py
+++ b/olive/passes/pytorch/trt_utils.py
@@ -32,6 +32,9 @@ def compile_trt_model(torch_module: torch.nn.Module, hidden_states: torch.Tensor
     :param seqlen: The maximum sequence length of the input tensor. seqlen dimension is treated as dynamic.
     """
 
+    # disable logging from torch_tensorrt
+    # torch_tensorrt logs are very verbose and produces multiple lines of log per module
+    # this makes the log file very large and hard to read
     logging.getLogger("torch_tensorrt").setLevel(logging.ERROR)
 
     if not isinstance(torch_module, torch.nn.Linear):

--- a/olive/passes/pytorch/trt_utils.py
+++ b/olive/passes/pytorch/trt_utils.py
@@ -1,0 +1,77 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+try:
+    import torch_tensorrt  # noqa: F401
+except ImportError:
+    raise ImportError("Please install torch_tensorrt with: pip install torch-tensorrt")
+
+import io
+import logging
+from contextlib import redirect_stdout
+
+import tensorrt as trt
+import torch
+import torch_tensorrt.fx.tracer.acc_tracer.acc_tracer as acc_tracer
+from torch_tensorrt.fx import InputTensorSpec, TRTInterpreter, TRTModule, compile
+
+
+class TRTLinearLayer(TRTModule):
+    def forward(self, *input):
+        """Forward pass of the module. Casts input to fp16 and casts output back to original data type."""
+        # original data type of input
+        dtype = input[0].dtype
+        # cast input to fp16
+        input = [x.to(torch.float16) for x in input]
+        output = super().forward(*input)
+        # cast output back to original data type
+        if isinstance(output, tuple):
+            output = tuple(x.to(dtype) for x in output)
+        else:
+            output = output.to(dtype)
+        return output
+
+
+def compile_trt_model(torch_module: torch.nn.Module, hidden_states: torch.Tensor, batch_size: int, seqlen: int):
+    """Compile a torch module to a TensorRT module.
+
+    :param torch_module: The torch module to compile. Only torch.nn.Linear modules are supported currently.
+    :param hidden_states: The input tensor to the torch module.
+    :param batch_size: The batch size of the input tensor.
+    :param seqlen: The maximum sequence length of the input tensor. seqlen dimension is treated as dynamic.
+    """
+
+    logging.getLogger("torch_tensorrt").setLevel(logging.ERROR)
+
+    if not isinstance(torch_module, torch.nn.Linear):
+        raise TypeError("torch_module must be a torch.nn.Linear module. Other modules are not supported.")
+
+    # whether the batch and seqlen dimensions are flattened
+    flattened = len(hidden_states.shape) == 2
+
+    # redirect stdout to avoid printing
+    f = io.StringIO()
+    with redirect_stdout(f):
+        # compile torch module to TensorRT module
+        low_model = compile(torch_module.to(torch.float16), [hidden_states.to(torch.float16)]).eval()
+    f.close()
+    acc_model = acc_tracer.trace(low_model, [hidden_states.to(torch.float16)])
+    # get input specs
+    hidden_size = hidden_states.shape[-1]
+    if not flattened:
+        shape = [batch_size, -1, hidden_size]
+        shape_ranges = [
+            ((batch_size, 1, hidden_size), (batch_size, 100, hidden_size), (batch_size, seqlen, hidden_size))
+        ]
+    else:
+        shape = [-1, hidden_size]
+        shape_ranges = [
+            ((batch_size, hidden_size), (batch_size * 100, hidden_size), (batch_size * seqlen, hidden_size))
+        ]
+    input_specs = [InputTensorSpec(shape=shape, dtype=torch.float16, shape_ranges=shape_ranges)]
+    # create TensorRT module
+    interpreter = TRTInterpreter(acc_model, input_specs, explicit_batch_dimension=True, logger_level=trt.Logger.ERROR)
+    result = interpreter.run(sparse_weights=True)
+    trt_module = TRTLinearLayer(result.engine, result.input_names, result.output_names)
+    return trt_module

--- a/olive/passes/pytorch/trt_utils.py
+++ b/olive/passes/pytorch/trt_utils.py
@@ -18,19 +18,9 @@ from torch_tensorrt.fx import InputTensorSpec, TRTInterpreter, TRTModule, compil
 
 
 class TRTLinearLayer(TRTModule):
-    def forward(self, *input):
+    def forward(self, input):
         """Forward pass of the module. Casts input to fp16 and casts output back to original data type."""
-        # original data type of input
-        dtype = input[0].dtype
-        # cast input to fp16
-        input = [x.to(torch.float16) for x in input]
-        output = super().forward(*input)
-        # cast output back to original data type
-        if isinstance(output, tuple):
-            output = tuple(x.to(dtype) for x in output)
-        else:
-            output = output.to(dtype)
-        return output
+        return super().forward(input.to(torch.float16)).to(input.dtype)
 
 
 def compile_trt_model(torch_module: torch.nn.Module, hidden_states: torch.Tensor, batch_size: int, seqlen: int):

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -72,6 +72,7 @@ def dependency_setup(config):
             "IncStaticQuantization": EXTRAS.get("inc"),
             "OptimumConversion": EXTRAS.get("optimum"),
             "OptimumMerging": EXTRAS.get("optimum"),
+            "SparseTRTConversion": EXTRAS.get("torch-tensorrt"),
         },
     }
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -72,7 +72,7 @@ def dependency_setup(config):
             "IncStaticQuantization": EXTRAS.get("inc"),
             "OptimumConversion": EXTRAS.get("optimum"),
             "OptimumMerging": EXTRAS.get("optimum"),
-            "SparseTRTConversion": EXTRAS.get("torch-tensorrt"),
+            "TorchTRTConversion": EXTRAS.get("torch-tensorrt"),
         },
     }
 

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -1,0 +1,85 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import olive.passes.pytorch.sparsegpt_utils as sparsegpt_utils
+from olive.data.template import huggingface_data_config_template
+from olive.model import PyTorchModel
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.pytorch import TorchTRTConversion
+from olive.systems.local import LocalSystem
+
+
+class MockTRTLinearLayer(torch.nn.Module):
+    pass
+
+
+def mocked_torch_zeros(*args, **kwargs):
+    if "device" in kwargs:
+        del kwargs["device"]
+    return torch.ones(*args, **kwargs) * 0
+
+
+# all the following patches are needed to run the test on CPU
+# make torch.cuda.is_available return True
+@patch("torch.cuda.is_available", return_value=True)
+# make tensor_data_to_device return the input tensor, ignore device
+@patch("olive.common.utils.tensor_data_to_device", side_effect=lambda x, y: x)
+# make torch.nn.Module.to do nothing
+@patch("torch.nn.Module.to", side_effect=lambda device: None)
+# replace device in kwargs with "cpu"
+@patch("torch.zeros", side_effect=mocked_torch_zeros)
+def test_sparsegpt(mock_is_cuda_available, mock_tensor_data_to_device, mock_module_to, mock_torch_zeros):
+    # setup
+    # mock trt utils since we don't have tensorrt and torch-tensorrt installed
+    mock_trt_utils = MagicMock()
+    mock_compile_trt_model = MagicMock()
+    mock_compile_trt_model.return_value = MockTRTLinearLayer()
+    mock_trt_utils.compile_trt_model = mock_compile_trt_model
+
+    sys.modules["olive.passes.pytorch.trt_utils"] = mock_trt_utils
+    with tempfile.TemporaryDirectory() as tempdir:
+        local_system = LocalSystem()
+        model_name = "hf-internal-testing/tiny-random-OPTForCausalLM"
+        task = "text-generation"
+        model_type = "opt"
+        input_model = PyTorchModel(hf_config={"model_name": model_name, "task": task})
+        original_submodules = list(
+            sparsegpt_utils.get_layer_submodules(
+                sparsegpt_utils.get_layers(input_model.load_model(), model_type)[0], submodule_types=[torch.nn.Linear]
+            ).keys()
+        )
+
+        dataset = {
+            "data_name": "ptb_text_only",
+            "subset": "penn_treebank",
+            "split": "train",
+            "input_cols": ["sentence"],
+            "component_kwargs": {"pre_process_data": {"seqlen": 100, "max_samples": 1, "random_seed": 42}},
+        }
+        data_config = huggingface_data_config_template(model_name=model_name, task=task, **dataset)
+        config = {
+            "data_config": data_config,
+        }
+
+        p = create_pass_from_dict(TorchTRTConversion, config, disable_search=True)
+        output_folder = str(Path(tempdir) / "sparse")
+
+        # execute
+        model = local_system.run_pass(p, input_model, None, output_folder)
+
+        pytorch_model = model.load_model()
+        layers = sparsegpt_utils.get_layers(pytorch_model, model_type)
+        for layer in layers:
+            for submodule_name in original_submodules:
+                # check that the submodule is replaced with MockTRTLinearLayer
+                assert isinstance(sparsegpt_utils._get_attr(layer, submodule_name), MockTRTLinearLayer)
+    # cleanup
+    del sys.modules["olive.passes.pytorch.trt_utils"]


### PR DESCRIPTION
## Describe your changes
This PR adds `TorchTRTConversion` pass which converts `nn.Linear` modules in transformer layers to `TRTModule` from `torch-tensorrt`. `torch-tensorrt` is an extension to `torch` where TensorRT engines can be used like normal `nn.Module`. 

We require this conversion to take advantage of `2:4` sparsity. 

~~I have not added unit test for the pass since the pass requires GPU and we don't have GPU support for ci tests yet. I will add a unit test in a follow up PR that uses aml system to run the pass and evaluation on GPU.~~

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
Add `TorchTRTConversion` pass. 

## (Optional) Issue link
