### PR TITLE
🐛 Bugfix: metric.user_config is None when the entrypoint is not RunConfig

### DIFF
--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -145,7 +145,7 @@ class Metric(ConfigBase):
 
         return v
 
-    @validator("user_config", pre=True)
+    @validator("user_config", pre=True, always=True)
     def validate_user_config(cls, v, values):
         if "type" not in values:
             raise ValueError("Invalid type")

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -204,6 +204,7 @@ class OliveEvaluator(ABC):
 
     @staticmethod
     def get_user_config(framework: Framework, data_root: str, metric: Metric):
+        assert metric.user_config, "user_config is not specified in the metric config"
         user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
 
         post_processing_func = getattr(metric.user_config, "post_processing_func", None)

--- a/test/unit_test/evaluator/test_metric.py
+++ b/test/unit_test/evaluator/test_metric.py
@@ -66,4 +66,5 @@ class TestEvaluation:
 
         metrics = OliveEvaluatorConfig(metrics=metrics_config).metrics
         for metric in metrics:
+            assert metric.user_config, "user_config should not be None anytime"
             assert metric.name in ["accuracy", "hf_accuracy", "latency", "test"]


### PR DESCRIPTION
## Describe your changes
metric.user_config is None when the entrypoint is not RunConfig

Reproduce:
```python
from olive.data.template import huggingface_data_config_template
evaluation_config = {
    "metrics":[
        {
            "name": "accuracy",
            "type": "accuracy",
            "backend": "huggingface_metrics",
            "sub_types": [
                {"name": "accuracy", "priority": 1, "goal": {"type": "max-degradation", "value": 0.01}},
                {"name": "f1"}
            ],
            "data_config": huggingface_data_config_template(
                model_name="bert-base-uncased",
                task="text-classification",
                **{
                    "data_name":"glue",
                    "subset": "mrpc",
                    "split": "validation",
                    "input_cols": ["sentence1", "sentence2"],
                    "label_cols": ["label"],
                    "batch_size": 1
                }
            )
        },
        {
            "name": "latency",
            "type": "latency",
            "sub_types": [
                {"name": "avg", "priority": 2, "goal": {"type": "percent-min-improvement", "value": 20}},
                {"name": "max"},
                {"name": "min"}
            ],
            "data_config": huggingface_data_config_template(
                model_name="bert-base-uncased",
                task="text-classification",
                **{
                    "data_name":"glue",
                    "subset": "mrpc",
                    "split": "validation",
                    "input_cols": ["sentence1", "sentence2"],
                    "label_cols": ["label"],
                    "batch_size": 1
                }
            )
        }
    ]
}

from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR
from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
evaluation_config = OliveEvaluatorConfig.parse_obj(evaluation_config)
engine._evaluate_model(
    olive_model,
    model_id="bert",
    data_root=None,
    evaluator_config=evaluation_config,
    accelerator_spec=DEFAULT_CPU_ACCELERATOR,
)
```

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
