### PR TITLE
Bugfix: Insert `input_model` data_config and don't overwrite custom hf data_configs

### DIFF
--- a/examples/open_llama/open_llama_sparsegpt_gpu.json
+++ b/examples/open_llama/open_llama_sparsegpt_gpu.json
@@ -13,8 +13,6 @@
             "name": "c4_train",
             "type": "HuggingfaceContainer",
             "params_config": {
-                "model_name": "openlm-research/open_llama_3b",
-                "task": "text-generation",
                 "data_name": "allenai/c4",
                 "subset": "allenai--c4",
                 "split": "train",
@@ -34,8 +32,6 @@
             "name": "wikitext2_test",
             "type": "HuggingfaceContainer",
             "params_config": {
-                "model_name": "openlm-research/open_llama_3b",
-                "task": "text-generation",
                 "data_name": "wikitext",
                 "subset": "wikitext-2-raw-v1",
                 "split": "test",

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from olive.workflows.run.config import RunConfig
+from olive.workflows.run.config import INPUT_MODEL_DATA_CONFIG_NAME, RunConfig
 
 
 class TestRunConfig:
@@ -129,3 +129,66 @@ class TestRunConfig:
 
         cfg = RunConfig.parse_obj(user_script_config)
         assert cfg.engine.target.config.accelerators == ["GPU"]
+
+
+class TestDataConfigValidation:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.template = {
+            "input_model": {
+                "type": "PyTorchModel",
+                "config": {
+                    "hf_config": {
+                        "model_name": "dummy_model",
+                        "task": "dummy_task",
+                        "dataset": {"name": "dumy_dataset"},
+                    }
+                },
+            },
+            "data_configs": {
+                "dummy_data_config2": {
+                    "name": "dummy_data_config2",
+                    "type": "HuggingfaceContainer",
+                    "params_config": {
+                        "model_name": "dummy_model2",
+                        "task": "dummy_task2",
+                        "dataset_name": "dumy_dataset2",
+                    },
+                }
+            },
+            "passes": {"tuning": {"type": "OrtPerfTuning"}},
+            "engine": {"evaluate_input_model": False},
+        }
+
+    @pytest.mark.parametrize(
+        "model_name,task,expected_model_name,expected_task",
+        [
+            ("dummy_model2", "dummy_task2", "dummy_model2", "dummy_task2"),  # no auto insert
+            ("dummy_model2", None, "dummy_model2", "dummy_task"),  # auto insert task
+            (None, "dummy_task2", "dummy_model", "dummy_task2"),  # auto insert model_name
+            (None, None, "dummy_model", "dummy_task"),  # auto insert model_name and task
+        ],
+    )
+    def test_auto_insert_model_name_and_task(self, model_name, task, expected_model_name, expected_task):
+        config_dict = self.template.copy()
+        config_dict["data_configs"]["dummy_data_config2"]["params_config"] = {
+            "model_name": model_name,
+            "task": task,
+            "dataset_name": "dummy_dataset2",
+        }
+
+        run_config = RunConfig.parse_obj(config_dict)
+        assert run_config.data_configs["dummy_data_config2"].params_config["model_name"] == expected_model_name
+        assert run_config.data_configs["dummy_data_config2"].params_config["task"] == expected_task
+
+    @pytest.mark.parametrize(
+        "data_config,expected_name",
+        [(None, INPUT_MODEL_DATA_CONFIG_NAME), ("dummy_data_config2", "dummy_data_config2")],
+    )
+    def test_str_to_data_config(self, data_config, expected_name):
+        config_dict = self.template.copy()
+        config_dict["passes"]["tuning"]["config"] = {"data_config": data_config}
+
+        run_config = RunConfig.parse_obj(config_dict)
+        # print(run_config.passes["tuning"])
+        assert run_config.passes["tuning"].config["data_config"].name == expected_name


### PR DESCRIPTION
## Describe your changes
Previously, `RunConfigs.data_configs` had some default configs. We remove the default configs and only insert a data config for the input model if it has `hf_config.dataset`. 

There was also a bug where all HF container data configs were being overwritten by the input model's dataset. But we don't want to do this. This has been fixed by only updating the `model_name` and `task` of the user provided hf data_configs if not already present. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
