### PR TITLE
`Pass._requires_data_config` -> `Pass._data_configs()`

### DIFF
--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -12,7 +12,7 @@ from olive.evaluator.metric_config import get_user_config_properties_from_metric
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec
 from olive.model import ONNXModel
 from olive.passes import Pass
-from olive.passes.pass_config import ParamCategory, PassConfigParam
+from olive.passes.pass_config import ParamCategory, PassConfigParam, PassDataConfigParam
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 logger = logging.getLogger(__name__)
@@ -267,7 +267,6 @@ class OrtPerfTuning(Pass):
     """Optimize ONNX Runtime inference settings."""
 
     _requires_user_script = True
-    _requires_data_config = True
 
     @staticmethod
     def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
@@ -340,6 +339,14 @@ class OrtPerfTuning(Pass):
                 default_value=None,
                 description="Extra customized session options during tuning process.",
             ),
+        }
+
+    @staticmethod
+    def _data_configs() -> Dict[str, PassDataConfigParam]:
+        return {
+            "data_config": PassDataConfigParam(
+                description="Data config for calibration, required if 'dataloader_func' is not provided."
+            )
         }
 
     def _run_for_config(

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -11,7 +11,7 @@ from olive.cache import get_local_path_from_root
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import OpenVINOModel
 from olive.passes import Pass
-from olive.passes.pass_config import ParamCategory, PassConfigParam
+from olive.passes.pass_config import ParamCategory, PassConfigParam, PassDataConfigParam
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 
@@ -22,7 +22,6 @@ class OpenVINOQuantization(Pass):
     """
 
     _requires_user_script = True
-    _requires_data_config = True
 
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
@@ -71,6 +70,14 @@ class OpenVINOQuantization(Pass):
             ),
         }
 
+    @staticmethod
+    def _data_configs() -> Dict[str, PassDataConfigParam]:
+        return {
+            "data_config": PassDataConfigParam(
+                description="Data config for calibration, required if 'dataloader_func' is not provided."
+            )
+        }
+
     def _run_for_config(
         self, model: OpenVINOModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> OpenVINOModel:
@@ -87,8 +94,8 @@ class OpenVINOQuantization(Pass):
             data_loader = self._user_module_loader.call_object(
                 config["dataloader_func"], data_dir, config["batch_size"]
             )
-        elif self._data_config:
-            common_dataloader = self._data_config.to_data_container().create_dataloader(data_root)
+        elif self._data_config_dict["data_config"]:
+            common_dataloader = self._data_config_dict["data_config"].to_data_container().create_dataloader(data_root)
             data_loader = self._create_dataloader(common_dataloader)
 
         metric = self._user_module_loader.load_object(config["metric_func"])

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -84,18 +84,17 @@ def get_user_script_config(
     return user_script_config
 
 
-def get_data_config(required: Optional[bool] = False):
-    data_config = {
-        "data_config": PassConfigParam(
-            type_=Union[DataConfig, str],
-            required=required,
-            description="""
-                Data config for calibration, required if quant_mode is 'static'.
-                If not provided, a default DataConfig will be used.
-            """,
-        )
+class PassDataConfigParam(ConfigBase):
+    required: bool = False
+    description: str = None
+    auto_insert: bool = True
+
+
+def pass_data_configs_to_params(data_configs: Dict[str, PassDataConfigParam]) -> Dict[str, PassConfigParam]:
+    return {
+        k: PassConfigParam(type_=Union[DataConfig, str], required=v.required, description=v.description)
+        for k, v in data_configs.items()
     }
-    return data_config
 
 
 class PassConfigBase(ConfigBase):


### PR DESCRIPTION
## Describe your changes
`Pass` has a class attribute `_requires_data_config` that we use to add a config parameter with type `DataConfig` and name `data_config`. We also use this in workflow run config validation to resolve string name references or auto insert input models. 

However, this functionality is limited. We can only add one `DataConfig` parameter with name `data_config` and single description. Currently, all of the passes are using the same parameter definition. 

In this PR, `_requires_data_config` is replaced with a static method `_data_configs` where we can define data config parameters with their own names and descriptions. We can also specify whether the parameters are required and if we should auto insert input model data configs. 
This will be especially useful in passes that do training (fine-tuning), etc where we need multiple data configs for train and validation. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
