### PR TITLE
Remove `Pass._requires_data_config`, resolve using `endswith`, don't auto-insert input model dataset

### DIFF
--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -59,7 +59,8 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "enable_cuda_graph": true
+                "enable_cuda_graph": true,
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
             }
         }
     },

--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -60,7 +60,7 @@
             "type": "OrtPerfTuning",
             "config": {
                 "enable_cuda_graph": true,
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         }
     },

--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -59,13 +59,13 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         }
     },

--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -57,10 +57,16 @@
             }
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         }
     },
     "engine": {

--- a/examples/bert/bert_ptq_cpu_aml.json
+++ b/examples/bert/bert_ptq_cpu_aml.json
@@ -65,10 +65,16 @@
             }
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         }
     },
     "engine": {

--- a/examples/bert/bert_ptq_cpu_aml.json
+++ b/examples/bert/bert_ptq_cpu_aml.json
@@ -67,13 +67,13 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         }
     },

--- a/examples/bert/bert_trt_gpu.json
+++ b/examples/bert/bert_trt_gpu.json
@@ -51,7 +51,8 @@
             "type": "OrtPerfTuning",
             "config": {
                 "trt_fp16_enable": true,
-                "io_bind": true
+                "io_bind": true,
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
             }
 
         }

--- a/examples/bert/bert_trt_gpu.json
+++ b/examples/bert/bert_trt_gpu.json
@@ -52,7 +52,7 @@
             "config": {
                 "trt_fp16_enable": true,
                 "io_bind": true,
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
 
         }

--- a/olive/data/constants.py
+++ b/olive/data/constants.py
@@ -5,8 +5,6 @@
 
 from enum import Enum
 
-DEFAULT_HF_DATA_CONTAINER_NAME = "_default_huggingface_dc"
-
 
 class DataComponentType(Enum):
     """

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -78,11 +78,12 @@ class Pass(ABC):
         if self._requires_user_script:
             self._user_module_loader = UserModuleLoader(self._config["user_script"], self._config["script_dir"])
 
+        self._data_configs = {}
         for k, v in self._config.items():
             if v is None or not k.endswith("data_config"):
                 continue
             # convert data_config to DataConfig
-            self._config[k] = v if isinstance(v, DataConfig) else DataConfig(**v)
+            self._data_configs[k] = v if isinstance(v, DataConfig) else DataConfig(**v)
 
         self._fixed_params = {}
         self._search_space = {}

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -78,13 +78,6 @@ class Pass(ABC):
         if self._requires_user_script:
             self._user_module_loader = UserModuleLoader(self._config["user_script"], self._config["script_dir"])
 
-        self._data_configs = {}
-        for k, v in self._config.items():
-            if v is None or not k.endswith("data_config"):
-                continue
-            # convert data_config to DataConfig
-            self._data_configs[k] = v if isinstance(v, DataConfig) else DataConfig(**v)
-
         self._fixed_params = {}
         self._search_space = {}
         for k, v in self._config.items():

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -78,11 +78,11 @@ class Pass(ABC):
         if self._requires_user_script:
             self._user_module_loader = UserModuleLoader(self._config["user_script"], self._config["script_dir"])
 
-        self._data_configs = {}
         for k, v in self._config.items():
             if v is None or not k.endswith("data_config"):
                 continue
-            self._data_configs[k] = v if isinstance(v, DataConfig) else DataConfig(**v)
+            # convert data_config to DataConfig
+            self._config[k] = v if isinstance(v, DataConfig) else DataConfig(**v)
 
         self._fixed_params = {}
         self._search_space = {}

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -452,9 +452,9 @@ class IncQuantization(Pass):
                     data_dir,
                     config["batch_size"],
                 )
-            elif self._data_configs["data_config"]:
+            elif config["data_config"]:
                 inc_calib_dataloader = (
-                    self._data_configs["data_config"].to_data_container().create_calibration_dataloader(data_root)
+                    config["data_config"].to_data_container().create_calibration_dataloader(data_root)
                 )
 
         q_model = quantization.fit(

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 from olive.cache import get_local_path_from_root
+from olive.common.config_utils import validate_config
 from olive.data.config import DataConfig
 from olive.evaluator.metric import Metric, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
@@ -452,10 +453,9 @@ class IncQuantization(Pass):
                     data_dir,
                     config["batch_size"],
                 )
-            elif self._data_configs["data_config"]:
-                inc_calib_dataloader = (
-                    self._data_configs["data_config"].to_data_container().create_calibration_dataloader(data_root)
-                )
+            elif config["data_config"]:
+                data_config = validate_config(config["data_config"], DataConfig)
+                inc_calib_dataloader = data_config.to_data_container().create_calibration_dataloader(data_root)
 
         q_model = quantization.fit(
             model.model_path, ptq_config, calib_dataloader=inc_calib_dataloader, eval_func=eval_func

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -452,9 +452,9 @@ class IncQuantization(Pass):
                     data_dir,
                     config["batch_size"],
                 )
-            elif config["data_config"]:
+            elif self._data_configs["data_config"]:
                 inc_calib_dataloader = (
-                    config["data_config"].to_data_container().create_calibration_dataloader(data_root)
+                    self._data_configs["data_config"].to_data_container().create_calibration_dataloader(data_root)
                 )
 
         q_model = quantization.fit(

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -124,7 +124,7 @@ _inc_static_dataloader_config = {
         category=ParamCategory.DATA,
         description="""
             Path to the directory containing the dataset.
-            For local data, it is required if quant_mode is 'static' and dataloader_func is provided.
+            For local data, it is required if approach is 'static' and dataloader_func is provided.
         """,
     ),
     "batch_size": PassConfigParam(
@@ -140,13 +140,13 @@ _inc_static_dataloader_config = {
         category=ParamCategory.OBJECT,
         description="""
             Function/function name to generate dataloader for calibration,
-            required if quant_mode is 'static' and data_config is None.
+            required if approach is 'static' and data_config is None.
         """,
     ),
     "data_config": PassConfigParam(
         type_=Union[DataConfig, Dict],
         description="""
-            Data config for calibration, required if quant_mode is 'static' and
+            Data config for calibration, required if approach is 'static' and
             dataloader_func is None.
         """,
     ),

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 from typing import Any, Callable, Dict, Union
 
+from olive.data.config import DataConfig
 from olive.evaluator.metric import LatencySubType, Metric, MetricType, joint_metric_key
 from olive.evaluator.metric_config import get_user_config_properties_from_metric_type
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec
@@ -267,7 +268,6 @@ class OrtPerfTuning(Pass):
     """Optimize ONNX Runtime inference settings."""
 
     _requires_user_script = True
-    _requires_data_config = True
 
     @staticmethod
     def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
@@ -290,6 +290,10 @@ class OrtPerfTuning(Pass):
                 description="Dataloader function to load data from given data_dir with given batch size.",
             ),
             "batch_size": PassConfigParam(type_=int, description="Batch size for inference."),
+            "data_config": PassConfigParam(
+                type_=Union[DataConfig, Dict],
+                description="Data config to load data for computing latency.",
+            ),
             "input_names": PassConfigParam(
                 type_=list, default_value=None, description="Input names list for ONNX model."
             ),

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -12,6 +12,7 @@ import onnx
 from packaging import version
 
 from olive.cache import get_local_path_from_root
+from olive.common.config_utils import validate_config
 from olive.common.utils import hash_string
 from olive.data.config import DataConfig
 from olive.exception import OlivePassException
@@ -396,10 +397,9 @@ class OnnxQuantization(Pass):
                     data_dir,
                     config["batch_size"],
                 )
-            elif self._data_configs["data_config"]:
-                dataloader = (
-                    self._data_configs["data_config"].to_data_container().create_calibration_dataloader(data_root)
-                )
+            elif config["data_config"]:
+                data_config = validate_config(config["data_config"], DataConfig)
+                dataloader = data_config.to_data_container().create_calibration_dataloader(data_root)
             try:
                 quantize_static(
                     model_input=model.model_path,

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -396,10 +396,8 @@ class OnnxQuantization(Pass):
                     data_dir,
                     config["batch_size"],
                 )
-            elif self._data_configs["data_config"]:
-                dataloader = (
-                    self._data_configs["data_config"].to_data_container().create_calibration_dataloader(data_root)
-                )
+            elif config["data_config"]:
+                dataloader = config["data_config"].to_data_container().create_calibration_dataloader(data_root)
             try:
                 quantize_static(
                     model_input=model.model_path,

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -396,8 +396,10 @@ class OnnxQuantization(Pass):
                     data_dir,
                     config["batch_size"],
                 )
-            elif config["data_config"]:
-                dataloader = config["data_config"].to_data_container().create_calibration_dataloader(data_root)
+            elif self._data_configs["data_config"]:
+                dataloader = (
+                    self._data_configs["data_config"].to_data_container().create_calibration_dataloader(data_root)
+                )
             try:
                 quantize_static(
                     model_input=model.model_path,

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -97,8 +97,8 @@ class OpenVINOQuantization(Pass):
             data_loader = self._user_module_loader.call_object(
                 config["dataloader_func"], data_dir, config["batch_size"]
             )
-        elif config["data_config"]:
-            common_dataloader = config["data_config"].to_data_container().create_dataloader(data_root)
+        elif self._data_configs["data_config"]:
+            common_dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
             data_loader = self._create_dataloader(common_dataloader)
 
         metric = self._user_module_loader.load_object(config["metric_func"])

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -58,7 +58,7 @@ class OpenVINOQuantization(Pass):
             ),
             "data_config": PassConfigParam(
                 type_=Union[DataConfig, Dict],
-                description="Data config calibration",
+                description="Data config for calibration.",
             ),
             "metric_func": PassConfigParam(
                 type_=Union[Callable, str],
@@ -97,8 +97,8 @@ class OpenVINOQuantization(Pass):
             data_loader = self._user_module_loader.call_object(
                 config["dataloader_func"], data_dir, config["batch_size"]
             )
-        elif self._data_configs["data_config"]:
-            common_dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
+        elif config["data_config"]:
+            common_dataloader = config["data_config"].to_data_container().create_dataloader(data_root)
             data_loader = self._create_dataloader(common_dataloader)
 
         metric = self._user_module_loader.load_object(config["metric_func"])

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Union
 import numpy as np
 
 from olive.cache import get_local_path_from_root
+from olive.common.config_utils import validate_config
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import OpenVINOModel
@@ -97,8 +98,9 @@ class OpenVINOQuantization(Pass):
             data_loader = self._user_module_loader.call_object(
                 config["dataloader_func"], data_dir, config["batch_size"]
             )
-        elif self._data_configs["data_config"]:
-            common_dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
+        elif config["data_config"]:
+            data_config = validate_config(config["data_config"], DataConfig)
+            common_dataloader = data_config.to_data_container().create_dataloader(data_root)
             data_loader = self._create_dataloader(common_dataloader)
 
         metric = self._user_module_loader.load_object(config["metric_func"])

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -9,7 +9,6 @@ from typing import Callable, Dict, Optional, Type, Union
 from pydantic import create_model, validator
 
 from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, validate_object, validate_resource_path
-from olive.data.config import DataConfig
 from olive.strategy.search_parameter import SearchParameter, json_to_search_parameter
 
 
@@ -82,20 +81,6 @@ def get_user_script_config(
         ),
     }
     return user_script_config
-
-
-def get_data_config(required: Optional[bool] = False):
-    data_config = {
-        "data_config": PassConfigParam(
-            type_=Union[DataConfig, str],
-            required=required,
-            description="""
-                Data config for calibration, required if quant_mode is 'static'.
-                If not provided, a default DataConfig will be used.
-            """,
-        )
-    }
-    return data_config
 
 
 class PassConfigBase(ConfigBase):

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Union
 
 import torch
 
+from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import PyTorchModel
 from olive.passes import Pass
@@ -35,8 +36,6 @@ class SparseGPT(Pass):
     This pass only supports PyTorchModel with hf_config. The transformers model type
     must be one of [bloom, gpt2, gpt_neox, llama, opt].
     """
-
-    _requires_data_config = True
 
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
@@ -80,6 +79,14 @@ class SparseGPT(Pass):
                     " will use cuda if available. Does not affect the final model."
                 ),
             ),
+            "data_config": PassConfigParam(
+                type_=Union[DataConfig, Dict],
+                required=True,
+                description=(
+                    "Data config to use for pruning weights. All samples in the data are expected to be of the"
+                    " same length, most likely the max sequence length of the model."
+                ),
+            ),
         }
 
     @torch.no_grad()
@@ -107,8 +114,7 @@ class SparseGPT(Pass):
         logger.debug(f"Running SparseGPT on {device} with model_type: {model_type}, mode: {mode}, sparsity: {sparsity}")
 
         # load_data
-        assert config["data_config"] is not None, "Data config is required for SparseGPT pass."
-        dataloader = self._data_config.to_data_container().create_dataloader(data_root)
+        dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
         logger.debug(f"Data loaded. Number of batches: {len(dataloader)}")
 
         # load model

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -114,7 +114,7 @@ class SparseGPT(Pass):
         logger.debug(f"Running SparseGPT on {device} with model_type: {model_type}, mode: {mode}, sparsity: {sparsity}")
 
         # load_data
-        dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
+        dataloader = config["data_config"].to_data_container().create_dataloader(data_root)
         logger.debug(f"Data loaded. Number of batches: {len(dataloader)}")
 
         # load model

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -114,7 +114,7 @@ class SparseGPT(Pass):
         logger.debug(f"Running SparseGPT on {device} with model_type: {model_type}, mode: {mode}, sparsity: {sparsity}")
 
         # load_data
-        dataloader = config["data_config"].to_data_container().create_dataloader(data_root)
+        dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
         logger.debug(f"Data loaded. Number of batches: {len(dataloader)}")
 
         # load model

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Union
 
 import torch
 
+from olive.common.config_utils import validate_config
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import PyTorchModel
@@ -114,7 +115,8 @@ class SparseGPT(Pass):
         logger.debug(f"Running SparseGPT on {device} with model_type: {model_type}, mode: {mode}, sparsity: {sparsity}")
 
         # load_data
-        dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
+        data_config = validate_config(config["data_config"], DataConfig)
+        dataloader = data_config.to_data_container().create_dataloader(data_root)
         logger.debug(f"Data loaded. Number of batches: {len(dataloader)}")
 
         # load model

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -90,7 +90,7 @@ class TorchTRTConversion(Pass):
         device = "cuda"
 
         # load_data
-        first_batch = self._data_configs["data_config"].to_data_container().get_first_batch(data_root_path=data_root)[0]
+        first_batch = config["data_config"].to_data_container().get_first_batch(data_root_path=data_root)[0]
         first_batch = tensor_data_to_device(first_batch, device=device)
         batch_size = first_batch["input_ids"].shape[0]
         seqlen = seqlens[model_type]

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Union
 
 import torch
 
+from olive.common.config_utils import validate_config
 from olive.common.utils import tensor_data_to_device
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec, Device
@@ -90,7 +91,8 @@ class TorchTRTConversion(Pass):
         device = "cuda"
 
         # load_data
-        first_batch = self._data_configs["data_config"].to_data_container().get_first_batch(data_root_path=data_root)[0]
+        data_config = validate_config(config["data_config"], DataConfig)
+        first_batch = data_config.to_data_container().get_first_batch(data_root_path=data_root)[0]
         first_batch = tensor_data_to_device(first_batch, device=device)
         batch_size = first_batch["input_ids"].shape[0]
         seqlen = seqlens[model_type]

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -90,7 +90,7 @@ class TorchTRTConversion(Pass):
         device = "cuda"
 
         # load_data
-        first_batch = config["data_config"].to_data_container().get_first_batch(data_root_path=data_root)[0]
+        first_batch = self._data_configs["data_config"].to_data_container().get_first_batch(data_root_path=data_root)[0]
         first_batch = tensor_data_to_device(first_batch, device=device)
         batch_size = first_batch["input_ids"].shape[0]
         seqlen = seqlens[model_type]

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
 from olive.cache import get_local_path_from_root
+from olive.common.config_utils import validate_config
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import SNPEModel
@@ -88,8 +89,9 @@ class SNPEQuantization(Pass):
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
-        elif self._data_configs["data_config"]:
-            dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
+        elif config["data_config"]:
+            data_config = validate_config(config["data_config"], DataConfig)
+            dataloader = data_config.to_data_container().create_dataloader(data_root)
 
         # convert dataloader to SNPEDataLoader if it is not already
         if not isinstance(dataloader, SNPEDataLoader):

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -88,8 +88,8 @@ class SNPEQuantization(Pass):
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
-        elif self._data_configs["data_config"]:
-            dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
+        elif config["data_config"]:
+            dataloader = config["data_config"].to_data_container().create_dataloader(data_root)
 
         # convert dataloader to SNPEDataLoader if it is not already
         if not isinstance(dataloader, SNPEDataLoader):

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -88,8 +88,8 @@ class SNPEQuantization(Pass):
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
-        elif config["data_config"]:
-            dataloader = config["data_config"].to_data_container().create_dataloader(data_root)
+        elif self._data_configs["data_config"]:
+            dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
 
         # convert dataloader to SNPEDataLoader if it is not already
         if not isinstance(dataloader, SNPEDataLoader):

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
 from olive.cache import get_local_path_from_root
+from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import SNPEModel
 from olive.passes.olive_pass import Pass
@@ -23,7 +24,6 @@ class SNPEQuantization(Pass):
     """
 
     _requires_user_script = True
-    _requires_data_config = True
 
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
@@ -43,6 +43,11 @@ class SNPEQuantization(Pass):
                     " directory as an argument and return a olive.snpe.SNPEDataLoader or torch.data.DataLoader-like"
                     " object. Required if data_config is None."
                 ),
+            ),
+            "data_config": PassConfigParam(
+                type_=Union[DataConfig, Dict],
+                required=True,
+                description="Data config for quantization, required if dataloader_func is None",
             ),
             "use_enhanced_quantizer": PassConfigParam(
                 type_=bool,
@@ -83,8 +88,8 @@ class SNPEQuantization(Pass):
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
-        elif self._data_config:
-            dataloader = self._data_config.to_data_container().create_dataloader(data_root)
+        elif self._data_configs["data_config"]:
+            dataloader = self._data_configs["data_config"].to_data_container().create_dataloader(data_root)
 
         # convert dataloader to SNPEDataLoader if it is not already
         if not isinstance(dataloader, SNPEDataLoader):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -50,7 +50,7 @@ class RunEngineConfig(EngineConfig):
         return Engine(config)
 
 
-INPUT_MODEL_DATA_CONFIG = "INPUT_MODEL_DATA_CONFIG"
+INPUT_MODEL_DATA_CONFIG = "__input_model_data_config__"
 
 
 class RunConfig(ConfigBase):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -50,7 +50,7 @@ class RunEngineConfig(EngineConfig):
         return Engine(config)
 
 
-INPUT_MODEL_DATA_CONFIG_NAME = "olive_input_model_data_config"
+INPUT_MODEL_DATA_CONFIG = "INPUT_MODEL_DATA_CONFIG"
 
 
 class RunConfig(ConfigBase):
@@ -87,15 +87,15 @@ class RunConfig(ConfigBase):
             # if data_configs is None, create an empty dict
             v = {}
 
-        if INPUT_MODEL_DATA_CONFIG_NAME in v:
-            raise ValueError(f"Data config name {INPUT_MODEL_DATA_CONFIG_NAME} is reserved. Please use another name.")
+        if INPUT_MODEL_DATA_CONFIG in v:
+            raise ValueError(f"Data config name {INPUT_MODEL_DATA_CONFIG} is reserved. Please use another name.")
 
         # insert input model hf data config if present
         hf_config = values["input_model"].dict()["config"].get("hf_config", {})
         hf_config_dataset = hf_config.get("dataset", None)
         if hf_config_dataset:
-            v[INPUT_MODEL_DATA_CONFIG_NAME] = {
-                "name": INPUT_MODEL_DATA_CONFIG_NAME,
+            v[INPUT_MODEL_DATA_CONFIG] = {
+                "name": INPUT_MODEL_DATA_CONFIG,
                 "type": HuggingfaceContainer.__name__,
                 "params_config": {
                     "model_name": hf_config.get("model_name", None),
@@ -115,7 +115,7 @@ class RunConfig(ConfigBase):
         if isinstance(v, DataConfig):
             v = v.dict()
 
-        if v["name"] == INPUT_MODEL_DATA_CONFIG_NAME:
+        if v["name"] == INPUT_MODEL_DATA_CONFIG:
             # skip validation for input model data config
             return v
 
@@ -170,11 +170,16 @@ class RunConfig(ConfigBase):
 
         v["disable_search"] = disable_search
         pass_cls = Pass.registry.get(v["type"].lower(), None)
-        if pass_cls and pass_cls.requires_data_config():
-            v["config"] = _resolve_data_config(v.get("config", {}), values, "data_config")
-
-            if not v["config"]:
+        if pass_cls:
+            if not v.get("config"):
                 return v
+
+            for param_name in v["config"]:
+                if param_name.endswith("data_config"):
+                    # we won't auto insert the input model data config for pass
+                    # user must explicitly set the data config to INPUT_MODEL_DATA_CONFIG if needed
+                    v["config"] = _resolve_data_config(v["config"], values, param_name, auto_insert=False)
+
             data_dir_config = v["config"].get("data_dir", None)
             if isinstance(data_dir_config, dict):
                 if _have_aml_client(data_dir_config, values):
@@ -239,12 +244,12 @@ def _resolve_system(v, values, system_alias):
     return v
 
 
-def _resolve_data_config(v, values, data_config_alias):
+def _resolve_data_config(v, values, data_config_alias, auto_insert=True):
     # get the value for data_config_alias in v
     data_container_config = v.get(data_config_alias, None)
     # auto insert input model data config if data_container_config is None
-    if not data_container_config and INPUT_MODEL_DATA_CONFIG_NAME in values["data_configs"]:
-        v[data_config_alias] = INPUT_MODEL_DATA_CONFIG_NAME
+    if not data_container_config and INPUT_MODEL_DATA_CONFIG in values["data_configs"] and auto_insert:
+        v[data_config_alias] = INPUT_MODEL_DATA_CONFIG
     # resolve data_config_alias to data config
     return _resolve_config_str(v, values, data_config_alias, component_name="data_configs")
 

--- a/test/unit_test/workflows/mock_data/ner_task_dataset.json
+++ b/test/unit_test/workflows/mock_data/ner_task_dataset.json
@@ -60,10 +60,16 @@
             }
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         }
     },
     "engine": {

--- a/test/unit_test/workflows/mock_data/ner_task_dataset.json
+++ b/test/unit_test/workflows/mock_data/ner_task_dataset.json
@@ -62,13 +62,13 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         }
     },

--- a/test/unit_test/workflows/mock_data/only_transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/only_transformer_dataset.json
@@ -98,7 +98,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {

--- a/test/unit_test/workflows/mock_data/only_transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/only_transformer_dataset.json
@@ -96,7 +96,10 @@
             }
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",

--- a/test/unit_test/workflows/mock_data/text_generation_dataset.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset.json
@@ -37,13 +37,13 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         }
     },

--- a/test/unit_test/workflows/mock_data/text_generation_dataset.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset.json
@@ -35,10 +35,16 @@
             "type": "OnnxConversion"
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         }
     },
     "engine": {

--- a/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
@@ -39,10 +39,16 @@
             "type": "OnnxConversion"
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
-            "type": "OrtPerfTuning"
+            "type": "OrtPerfTuning",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         }
     },
     "engine": {

--- a/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
@@ -41,13 +41,13 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         }
     },

--- a/test/unit_test/workflows/mock_data/transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/transformer_dataset.json
@@ -69,7 +69,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "data_config": "INPUT_MODEL_DATA_CONFIG"
+                "data_config": "__input_model_data_config__"
             }
         },
         "perf_tuning": {

--- a/test/unit_test/workflows/mock_data/transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/transformer_dataset.json
@@ -67,7 +67,10 @@
             "config": {"model_type": "bert"}
         },
         "quantization": {
-            "type": "OnnxQuantization"
+            "type": "OnnxQuantization",
+            "config": {
+                "data_config": "INPUT_MODEL_DATA_CONFIG"
+            }
         },
         "perf_tuning": {
             "type": "OrtPerfTuning",

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -9,7 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
-from olive.workflows.run.config import INPUT_MODEL_DATA_CONFIG_NAME, RunConfig
+from olive.data.config import DataConfig
+from olive.workflows.run.config import INPUT_MODEL_DATA_CONFIG, RunConfig
 
 
 class TestRunConfig:
@@ -182,13 +183,16 @@ class TestDataConfigValidation:
         assert run_config.data_configs["dummy_data_config2"].params_config["task"] == expected_task
 
     @pytest.mark.parametrize(
-        "data_config,expected_name",
-        [(None, INPUT_MODEL_DATA_CONFIG_NAME), ("dummy_data_config2", "dummy_data_config2")],
+        "data_config_str",
+        [None, INPUT_MODEL_DATA_CONFIG, "dummy_data_config2"],
     )
-    def test_str_to_data_config(self, data_config, expected_name):
+    def test_str_to_data_config(self, data_config_str):
         config_dict = self.template.copy()
-        config_dict["passes"]["tuning"]["config"] = {"data_config": data_config}
+        config_dict["passes"]["tuning"]["config"] = {"data_config": data_config_str}
 
         run_config = RunConfig.parse_obj(config_dict)
-        # print(run_config.passes["tuning"])
-        assert run_config.passes["tuning"].config["data_config"].name == expected_name
+        pass_data_config = run_config.passes["tuning"].config["data_config"]
+        if data_config_str is None:
+            assert pass_data_config is None
+        else:
+            assert isinstance(pass_data_config, DataConfig) and pass_data_config.name == data_config_str


### PR DESCRIPTION
## Describe your changes
This PR is an update to [#506](https://github.com/microsoft/Olive/pull/505) with changes discussed offline. 

`Pass` has a class attribute `_requires_data_config` that we use to add a config parameter with type `DataConfig` and name `data_config`. We also use this in workflow run config validation to resolve string name references or auto insert input models. 

However, this functionality is limited. We can only add one `DataConfig` parameter with name `data_config` and single description. Currently, all of the passes are using the same parameter definition. 

We remove `_requires_user_config` class attribute from passes. DataConfig parameters must be defined along with other parameters in `_default_config`. Parameter names ending in `default_config` are reserved for such parameters. We use this to find and resolve DataConfig parameters in run config validation. 

Auto-insertion of the input model (if it's a pytorch model with hf_config.dataset) data config in pass configs is removed. This behavior only applies to a subset of pytorch input models and might be unexpected to the user. If the user wants to use the input model's data config, they can do so by assigning the value for the parameter as `INPUT_MODEL_DATA_CONFIG`. After this, it behaves like any other string name resolution. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
