### PR TITLE
Bugfix: `deepcopy` default values in DataConfig

### DIFF
--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import copy
 import logging
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Union
 
@@ -68,12 +68,16 @@ class DataConfig(ConfigBase):
         self._update_default_component_type()
         self._update_default_component()
         for k, v in self.default_components.items():
+            # do deepcopies here since we don't want to update the default_components
             if k not in self.components:
-                self.components[k] = v
+                # v is a DataComponentConfig object, so we deepcopy it
+                self.components[k] = deepcopy(v)
             else:
+                # both are strings, so we don't need to deepcopy
                 self.components[k].type = self.components[k].type or v.type
                 self.components[k].name = self.components[k].name or v.name
-                self.components[k].params = self.components[k].params or v.params
+                # v.params is a dict, so we deepcopy it
+                self.components[k].params = self.components[k].params or deepcopy(v.params)
 
     def _update_default_component_type(self):
         """
@@ -81,7 +85,7 @@ class DataConfig(ConfigBase):
         """
         dc_cls = Registry.get_container(self.type)
         # deepcopy dc_cls.default_components_type since we don't want to update dc_cls.default_components_type
-        self.default_components_type = copy.deepcopy(dc_cls.default_components_type) or {}
+        self.default_components_type = deepcopy(dc_cls.default_components_type) or {}
         # 1. update default_components_type with task_type for huggingface case
         self._update_default_component_type_with_task_type(dc_cls)
         # 2. update default_components_type with DefaultDataComponentCombos


### PR DESCRIPTION
## Describe your changes
In `DataConfig.update_components`, we assign values for `components` from `default_components`. However, these are assigned by reference for objects and the default components get updated when we update components. 

We can see this behavior in the follow code snippet:
```python
from olive.data.config import DataConfig 

dc_dict = {
    "name": "wikitext2_test",
    "type": "HuggingfaceContainer",
    "params_config": {
        "model_name": "gpt2",
        "task": "text-generation",
        "data_name": "wikitext",
        "subset": "wikitext-2-raw-v1",
        "split": "test",
        "input_cols": ["text"],
        "seqlen": 2048
    }
}

dc = DataConfig(**dc_dict)
dc_json = dc.to_json()

dc2 = DataConfig(**dc_json)
dc2_json = dc2.to_json()

import json
json.dump(dc_json, open("dc.json", "w"), indent=4)
json.dump(dc2_json, open("dc2.json", "w"), indent=4)
```

`dc.json` and `dc2.json` are not the same. 
![bug](https://github.com/microsoft/Olive/assets/94929125/dbeaec7b-9e6c-4c6a-9c32-3a734f88f0a2)
This is not expected behavior since the they should be the same. 

This PR fixes it by deepcopying objects when getting from default components. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
