### PR TITLE
Move reusable code from `sparsegpt_utils` to common and hf utils

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -168,9 +168,9 @@ def get_attr(module, attr, fail_on_not_found=False):
     """
     Get attribute from module.
 
-    :param module: module to get attribute from
-    :param attr: attribute name, can be a string with dot notation. If empty, return modulenot
-    :param fail_on_not_found: if True, raise AttributeError if attribute is not found
+    :param module: module to get attribute from.
+    :param attr: attribute name, can be a string with dot notation. If empty, return module.
+    :param fail_on_not_found: if True, raise AttributeError if attribute is not found.
     :return: attribute
     """
     if not attr:
@@ -181,9 +181,9 @@ def get_attr(module, attr, fail_on_not_found=False):
     for a in attr:
         try:
             module = getattr(module, a)
-        except AttributeError:
+        except AttributeError as e:
             if fail_on_not_found:
-                raise AttributeError(f"Attribute {attr} not found.")
+                raise AttributeError(f"Attribute {attr} not found.") from e
             else:
                 return None
     return module

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -162,3 +162,27 @@ def tensor_data_to_device(data, device: str):
         return set(tensor_data_to_device(v, device) for v in data)
     else:
         return data
+
+
+def get_attr(module, attr, fail_on_not_found=False):
+    """Get attribute from module.
+
+    :param module: module to get attribute from
+    :param attr: attribute name, can be a string with dot notation. If empty, return modulenot
+    :param fail_on_not_found: if True, raise AttributeError if attribute is not found
+    :return: attribute
+    """
+    if not attr:
+        # return module if attr is empty
+        return module
+
+    attr = attr.split(".")
+    for a in attr:
+        try:
+            module = getattr(module, a)
+        except AttributeError:
+            if fail_on_not_found:
+                raise AttributeError(f"Attribute {attr} not found.")
+            else:
+                return None
+    return module

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -165,7 +165,8 @@ def tensor_data_to_device(data, device: str):
 
 
 def get_attr(module, attr, fail_on_not_found=False):
-    """Get attribute from module.
+    """
+    Get attribute from module.
 
     :param module: module to get attribute from
     :param attr: attribute name, can be a string with dot notation. If empty, return modulenot

--- a/olive/model/hf_mappings.py
+++ b/olive/model/hf_mappings.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+# mapping from task to feature
+TASK_TO_FEATURE = {
+    "automatic-speech-recognition": "speech2seq-lm",
+    "fill-mask": "masked-lm",
+    "image-classification": "image-classification",
+    "image-segmentation": "image-segmentation",
+    "image-to-text": "vision2seq-lm",
+    "multiple-choice": "multiple-choice",
+    "ner": "token-classification",
+    "object-detection": "object-detection",
+    "question-answering": "question-answering",
+    "sentiment-analysis": "sequence-classification",
+    "summarization": "seq2seq-lm",
+    "text2text-generation": "seq2seq-lm",
+    "text-classification": "sequence-classification",
+    "text-generation": "causal-lm",
+    "token-classification": "token-classification",
+    "translation": "seq2seq-lm",
+}
+
+# model_type -> name for layers
+MODELS_TO_LAYERS_MAPPING = {
+    "bloom": "transformer.h",
+    "gpt2": "transformer.h",
+    "gpt_neox": "gpt_neox.layers",
+    "llama": "model.layers",
+    "opt": "model.decoder.layers",
+}
+
+# model_type -> name for embedding, these are the modules before the first layer
+MODELS_TO_EMBEDDINGS_MAPPING = {
+    "bloom": ["transformer.word_embeddings", "transformer.word_embeddings_layernorm"],
+    "gpt2": ["transformer.wte", "transformer.wpe"],
+    "gpt_neox": ["gpt_neox.embed_in"],
+    "llama": ["model.embed_tokens"],
+    "opt": [
+        "model.decoder.embed_tokens",
+        "model.decoder.embed_positions",
+        "model.model.decoder.project_out",
+        "model.model.decoder.project_in",
+    ],
+}
+
+# model_type -> max length of the model, extracted from the config
+# will be int if not present in the config
+MODELS_TO_MAX_LENGTH_MAPPING = {
+    "__default__": "max_position_embeddings",
+    "bloom": 2048,
+    "gpt2": "n_positions",
+    "gpt_neox": "max_position_embeddings",
+    "llama": "max_position_embeddings",
+    "opt": "max_position_embeddings",
+}

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -45,7 +45,7 @@ class HFConfig(ConfigBase):
         return v
 
 
-def load_huggingface_model_from_task(task: str, name: str, kwargs: Dict[str, Any] = None):
+def load_huggingface_model_from_task(task: str, name: str):
     """Load huggingface model from task and name"""
     from transformers.pipelines import check_task
 
@@ -63,10 +63,9 @@ def load_huggingface_model_from_task(task: str, name: str, kwargs: Dict[str, Any
     class_tuple = class_tuple + model_class.get("pt", (AutoModel,))
 
     model = None
-    kwargs = kwargs or {}
     for model_class in class_tuple:
         try:
-            model = model_class.from_pretrained(name, **kwargs)
+            model = model_class.from_pretrained(name)
             logger.debug(f"Loaded model {model_class} with name_or_path {name}")
             return model
         except (OSError, ValueError):

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -22,7 +22,7 @@ from olive.passes.pytorch.sparsegpt_utils import (
     catch_layer_inputs,
     get_layer_submodules,
     get_layers,
-    layers_map,
+    supported_models,
     validate_min_max_layers,
 )
 
@@ -96,8 +96,8 @@ class SparseGPT(Pass):
     ) -> PyTorchModel:
         model_config = model.get_model_config()
         model_type = model_config.model_type
-        if model_type not in layers_map:
-            raise ValueError(f"Unsupported model type: {model_type}. Supported types: {layers_map.keys()}")
+        if model_type not in supported_models:
+            raise ValueError(f"Unsupported model type: {model_type}. Supported types: {supported_models}")
 
         # get sparsity mode and parameters
         if isinstance(config["sparsity"], float):

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -9,17 +9,17 @@ from typing import Any, Dict, List, Union
 import torch
 
 from olive.common.config_utils import validate_config
-from olive.common.utils import tensor_data_to_device
+from olive.common.utils import get_attr, tensor_data_to_device
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import PyTorchModel
+from olive.model.hf_utils import get_model_max_length
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
 from olive.passes.pytorch.sparsegpt_utils import (
-    _get_attr,
     get_layer_submodules,
     get_layers,
-    seqlens,
+    supported_models,
     validate_min_max_layers,
 )
 
@@ -83,8 +83,8 @@ class TorchTRTConversion(Pass):
 
         model_config = model.get_model_config()
         model_type = model_config.model_type
-        if model_type not in seqlens:
-            raise ValueError(f"Unsupported model type: {model_type}. Supported types: {seqlens.keys()}")
+        if model_type not in supported_models:
+            raise ValueError(f"Unsupported model type: {model_type}. Supported types: {supported_models}")
 
         if not torch.cuda.is_available():
             raise ValueError("TorchTRTConversion requires a GPU to run.")
@@ -95,7 +95,9 @@ class TorchTRTConversion(Pass):
         first_batch = data_config.to_data_container().get_first_batch(data_root_path=data_root)[0]
         first_batch = tensor_data_to_device(first_batch, device=device)
         batch_size = first_batch["input_ids"].shape[0]
-        seqlen = seqlens[model_type]
+        # get max sequence length
+        model_name = model.hf_config.model_name
+        seqlen = get_model_max_length(model_name, fail_on_not_found=True)
 
         # load model
         pytorch_model = model.load_model()
@@ -164,11 +166,7 @@ class TorchTRTConversion(Pass):
                 trt_module = compile_trt_model(info["submodules"][name], input, batch_size, seqlen)
                 # get parent module
                 parent_name = ".".join(name.split(".")[:-1])
-                parent_module = (
-                    _get_attr(layers[layer_index], ".".join(name.split(".")[:-1]))
-                    if parent_name
-                    else layers[layer_index]
-                )
+                parent_module = get_attr(layers[layer_index], parent_name)
                 # get submodule name
                 module_name = name.split(".")[-1]
                 # replace submodule with trt module

--- a/test/unit_test/common/test_get_attr.py
+++ b/test/unit_test/common/test_get_attr.py
@@ -1,0 +1,43 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import pytest
+
+from olive.common.utils import get_attr
+
+
+def test_attr_exists():
+    class A:
+        def __init__(self, b):
+            self.b = b
+
+    class B:
+        def __init__(self, c):
+            self.c = c
+
+    class C:
+        def __init__(self):
+            self.d = "hi"
+
+    c = C()
+    b = B(c)
+    a = A(b)
+
+    attrs = ["", "b", "b.c", "b.c.d"]
+    expected = [a, b, c, "hi"]
+    for attr, exp in zip(attrs, expected):
+        assert get_attr(a, attr) == exp
+
+
+def test_attr_no_exists():
+    a = "hi"
+
+    assert get_attr(a, "b") is None
+
+
+def test_attr_no_exists_raise():
+    a = "hi"
+
+    with pytest.raises(AttributeError):
+        get_attr(a, "b", fail_on_not_found=True)

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 import olive.passes.pytorch.sparsegpt_utils as sparsegpt_utils
+from olive.common.utils import get_attr
 from olive.data.template import huggingface_data_config_template
 from olive.model import PyTorchModel
 from olive.passes.olive_pass import create_pass_from_dict
@@ -92,6 +93,6 @@ def test_torch_trt_conversion_success(
         for layer in layers:
             for submodule_name in original_submodules:
                 # check that the submodule is replaced with MockTRTLinearLayer
-                assert isinstance(sparsegpt_utils._get_attr(layer, submodule_name), MockTRTLinearLayer)
+                assert isinstance(get_attr(layer, submodule_name), MockTRTLinearLayer)
     # cleanup
     del sys.modules["olive.passes.pytorch.trt_utils"]


### PR DESCRIPTION
## Describe your changes
`sparsegpt_utils` has some mappings and helper functions that are useful in other parts of Olive too. This PR refactors it and puts the reusable code into `olive.common.utils` and `olive.model.hf_utils`. 

Also cleaned up the imports in `hf_utils` by moving `transformers` imports to top of file. `transformers` is an olive requirement so we don't need to lazy import it unless it is a version specific import. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
