### PR TITLE
Add `to_hf_dataset` method to `olive.data.component.dataset.Dataset`

### DIFF
--- a/olive/data/component/dataset.py
+++ b/olive/data/component/dataset.py
@@ -77,7 +77,7 @@ class BaseDataset(Dataset):
             for col_name in self.label_cols[1:]:
                 # label_cols is a list but we only use the first element for now
                 # remove the other label columns
-                hf_dataset.remove_columns(col_name)
+                hf_dataset = hf_dataset.remove_columns(col_name)
             # rename the label column
             if self.label_cols[0] != label_name:
                 if label_name in hf_dataset.column_names:

--- a/test/unit_test/data_container/test_dataset.py
+++ b/test/unit_test/data_container/test_dataset.py
@@ -1,0 +1,69 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import pytest
+from datasets import Dataset as HFDataset
+
+from olive.data.component.dataset import BaseDataset, DummyDataset
+
+
+def get_dict_dataset(length=256, labels_name="labels", max_samples=None):
+    input_names = ["input_1", "input_2"]
+    data = []
+    for i in range(length):
+        data.append({input_names[0]: [i, i], input_names[1]: [i, i, i], labels_name: i})
+    return BaseDataset(data, ["labels"], max_samples)
+
+
+def get_dummy_dataset():
+    input_shapes = [[2], [3]]
+    input_names = ["input_1", "input_2"]
+    return DummyDataset(input_shapes, input_names)
+
+
+def get_hf_dataset():
+    length = 300
+    data = {"input_1": [], "input_2": [], "labels": []}
+    for i in range(length):
+        data["input_1"].append([i, i])
+        data["input_2"].append([i, i, i])
+        data["labels"].append(i)
+    hf_dataset = HFDataset.from_dict(data)
+    hf_dataset.set_format(type="torch", output_all_columns=True)
+    return BaseDataset(hf_dataset, ["labels"], max_samples=256)
+
+
+class TestDataset:
+    def test_base_dataset(self):
+        # default
+        dataset = get_dict_dataset()
+        assert len(dataset) == 256
+        assert dataset[0] == ({"input_1": [0, 0], "input_2": [0, 0, 0]}, 0)
+
+        # max_samples < length
+        dataset = get_dict_dataset(max_samples=200)
+        assert len(dataset) == 200
+
+        # max_samples > length
+        dataset = get_dict_dataset(max_samples=300)
+        assert len(dataset) == 256
+
+    @pytest.mark.parametrize("dataset_func", [get_dict_dataset, get_dummy_dataset, get_hf_dataset])
+    @pytest.mark.parametrize("label_name", [None, "labels", "label"])
+    def test_dataset_to_hf_dataset(self, dataset_func, label_name):
+        dataset = dataset_func()
+        hf_dataset = dataset.to_hf_dataset(label_name=label_name)
+        # assert the dataset is converted to HFDataset
+        assert isinstance(hf_dataset, HFDataset)
+        # assert length
+        assert len(hf_dataset) == 256
+        # ensure all input and label names are in the features
+        label_name = label_name or "labels"
+        for key in ["input_1", "input_2", label_name]:
+            assert key in hf_dataset.features
+        # assert shape of the first sample
+        assert hf_dataset["input_1"][0].shape == (2,)
+        assert hf_dataset["input_2"][0].shape == (3,)
+        assert hf_dataset[label_name][0].shape == ()


### PR DESCRIPTION
## Describe your changes
Add a method called `to_hf_dataset` which converts an olive Dataset to huggingface `datasets.Dataset`. This is useful if we want to use some huggingface related features such as `train_test_split` or easy indexing by feature/index. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
