### PR TITLE
Don't copy the model for onnxruntime after 1.16.0

### DIFF
--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -70,7 +70,7 @@ def main(raw_args=None):
         # * https://github.com/microsoft/onnxruntime/pull/16531
         # * https://github.com/microsoft/onnxruntime/pull/16716
         # * https://github.com/microsoft/onnxruntime/pull/16912
-        # So, in 1.16.0 afterwords, we don't need to copy the model to a temp directory
+        # So, in 1.16.0 afterwards, we don't need to copy the model to a temp directory
 
         # Some passes create temporary files in the same directory as the model
         # original directory for model path is read only, so we need to copy the model to a temp directory


### PR DESCRIPTION
## Describe your changes
 In onnxruntime, the following PRs will make the optimize_model save external data in the temporary folder
  * https://github.com/microsoft/onnxruntime/pull/16531
  * https://github.com/microsoft/onnxruntime/pull/16716
  * https://github.com/microsoft/onnxruntime/pull/16912
 So, in 1.16.0 afterwards, we don't need to copy the model to a temp directory

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
