### PR TITLE
🗺️ Align hf dataset label with model output

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -129,7 +129,7 @@ case insensitive.
                 "batch_size": 1  # the batch size of the dataloader
                 "component_kwargs": {
                     "pre_process_data": {
-                        "remap_labels": true # whether to align the dataset labels to model
+                        "align_labels": true # whether to align the dataset labels with huggingface model config(label2id), more details in https://huggingface.co/docs/datasets/nlp_process#align
                         "model_config_path": "model_config.json" # model config used to process dataset, if not set, it will use the model name to fetch config from huggingface hub.
                     }
                 }

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -127,6 +127,12 @@ case insensitive.
                 "input_cols": ["sentence1", "sentence2"],  # the input columns of the dataset
                 "label_cols": ["label"],  # the label columns of the dataset
                 "batch_size": 1  # the batch size of the dataloader
+                "component_kwargs": {
+                    "pre_process_data": {
+                        "remap_labels": true # whether to align the dataset labels to model
+                        "model_config_path": "model_config.json" # model config used to process dataset, if not set, it will use the model name to fetch config from huggingface hub.
+                    }
+                }
             }
             ```
             For cases where you do not want to use the huggingface model but want to use the huggingface dataset, you can provide `dataset` config only like above.

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -60,7 +60,7 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, max_sa
     Returns:
         object: Pre-processed data.
     """
-    from transformers import AutoTokenizer
+    from transformers import AutoConfig, AutoTokenizer
 
     def _tokenizer_and_align_labels(examples):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -75,6 +75,12 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, max_sa
         tokenized_inputs["label"] = examples[label_cols[0]]
         # huggingface dataset api limit to return dict and arrow table
         return tokenized_inputs
+
+    model_config_path = kwargs.pop("model_config_path", None)
+    if kwargs.pop("remap_labels", False):
+        model_hf_config = AutoConfig.from_pretrained(model_config_path or model_name)
+        if model_hf_config and model_hf_config.label2id:
+            _dataset = _dataset.align_labels_with_mapping(model_hf_config.label2id, label_cols[0])
 
     tokenized_datasets = _huggingface_pre_process_helper(
         _dataset, model_name, input_cols, label_cols, _tokenizer_and_align_labels, **kwargs

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -77,7 +77,10 @@ def huggingface_pre_process(_dataset, model_name, input_cols, label_cols, max_sa
         return tokenized_inputs
 
     model_config_path = kwargs.pop("model_config_path", None)
-    if kwargs.pop("remap_labels", False):
+    # TODO: add the complete data operation mapping like:
+    # align_labels -> align_labels_with_mapping
+    # Also to support customized operation arguments from users
+    if kwargs.pop("align_labels", False):
         model_hf_config = AutoConfig.from_pretrained(model_config_path or model_name)
         if model_hf_config and model_hf_config.label2id:
             _dataset = _dataset.align_labels_with_mapping(model_hf_config.label2id, label_cols[0])

--- a/olive/data/template.py
+++ b/olive/data/template.py
@@ -47,6 +47,15 @@ def huggingface_data_config_template(model_name, task, **kwargs) -> DataConfig:
         and other arguments in
             - olive.data.component.load_dataset.huggingface_dataset
             - olive.data.component.pre_process_data.huggingface_pre_process
+                - `remap_labels`: true | false, whether to remap the labels with huggingface model config
+                - `model_config_path`: str, path to the model config file
+                - others is used for huggingface tokenizer
+                e.g.:
+                "component_kwargs": {
+                    "pre_process_data": {
+                        "remap_labels": true
+                    }
+                }
     """
     return DataConfig(
         name="huggingface_data_config_template",

--- a/olive/data/template.py
+++ b/olive/data/template.py
@@ -47,13 +47,14 @@ def huggingface_data_config_template(model_name, task, **kwargs) -> DataConfig:
         and other arguments in
             - olive.data.component.load_dataset.huggingface_dataset
             - olive.data.component.pre_process_data.huggingface_pre_process
-                - `remap_labels`: true | false, whether to remap the labels with huggingface model config
+                - `align_labels`: true | false, whether to align the dataset labels with huggingface model config
+                more details in https://huggingface.co/docs/datasets/nlp_process#align
                 - `model_config_path`: str, path to the model config file
                 - others is used for huggingface tokenizer
                 e.g.:
                 "component_kwargs": {
                     "pre_process_data": {
-                        "remap_labels": true
+                        "align_labels": true
                     }
                 }
     """

--- a/test/unit_test/workflows/mock_data/only_transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/only_transformer_dataset.json
@@ -13,7 +13,12 @@
                     "split": "validation",
                     "input_cols": ["sentence1", "sentence2"],
                     "label_cols": ["label"],
-                    "batch_size": 1
+                    "batch_size": 1,
+                    "component_kwargs": {
+                        "pre_process_data": {
+                            "remap_labels": true
+                        }
+                    }
                 }
             },
             "io_config" : {

--- a/test/unit_test/workflows/mock_data/only_transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/only_transformer_dataset.json
@@ -16,7 +16,7 @@
                     "batch_size": 1,
                     "component_kwargs": {
                         "pre_process_data": {
-                            "remap_labels": true
+                            "align_labels": true
                         }
                     }
                 }


### PR DESCRIPTION
## Describe your changes
In some cases, the model output label is mismatched with original huggingface dataset.
E.g. the deberta-base-mnli output id2label is:
<img width="406" alt="image" src="https://github.com/microsoft/Olive/assets/13343117/34946271-eab8-4a21-b4ce-d69c0d3a2e8c">
But the dataset label is:
<img width="305" alt="image" src="https://github.com/microsoft/Olive/assets/13343117/a93a04fe-80a6-4d7a-b5c6-87daed911d35">

This PR is used to fill this gap.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
