### PR TITLE
Assert that `dataloader_func` or `data_config` is present if required

### DIFF
--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -419,6 +419,10 @@ class IncQuantization(Pass):
         # start with a copy of the config
         run_config = deepcopy(config)
         is_static = run_config["approach"] == "static"
+        if is_static:
+            assert (
+                config["dataloader_func"] or config["data_config"]
+            ), "dataloader_func or data_config is required for static quantization."
 
         output_model_path = ONNXModel.resolve_path(output_model_path)
 

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -310,6 +310,10 @@ class OnnxQuantization(Pass):
         # start with a copy of the config
         run_config = deepcopy(config)
         is_static = run_config["quant_mode"] == "static"
+        if is_static:
+            assert (
+                config["dataloader_func"] or config["data_config"]
+            ), "dataloader_func or data_config is required for static quantization."
 
         output_model_path = ONNXModel.resolve_path(output_model_path)
 

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -48,7 +48,7 @@ class OpenVINOQuantization(Pass):
                 type_=OLIVE_RESOURCE_ANNOTATIONS,
                 category=ParamCategory.DATA,
                 description=(
-                    "Path to the directory containing the dataset. For local data, it is required if  dataloader_func"
+                    "Path to the directory containing the dataset. For local data, it is required if dataloader_func"
                     " is provided."
                 ),
             ),
@@ -59,7 +59,7 @@ class OpenVINOQuantization(Pass):
             ),
             "data_config": PassConfigParam(
                 type_=Union[DataConfig, Dict],
-                description="Data config for calibration.",
+                description="Data config for calibration, required if dataloader_func is None.",
             ),
             "metric_func": PassConfigParam(
                 type_=Union[Callable, str],
@@ -89,6 +89,8 @@ class OpenVINOQuantization(Pass):
             from openvino.tools.pot import IEEngine, compress_model_weights, create_pipeline, save_model
         except ImportError:
             raise ImportError("Please install olive-ai[openvino] to use OpenVINO model")
+
+        assert config["dataloader_func"] or config["data_config"], "dataloader_func or data_config is required."
 
         # output model always has ov_model name stem
         model_name = "ov_model"

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -86,6 +86,8 @@ class SNPEQuantization(Pass):
         if Path(output_model_path).suffix != ".dlc":
             output_model_path += ".dlc"
 
+        assert config["dataloader_func"] or config["data_config"], "dataloader_func or data_config is required."
+
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
             dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -525,6 +525,7 @@ class TestEngine:
         if is_search:
             options = {
                 "cache_dir": tmpdir,
+                "clean_cache": True,
                 "search_strategy": {
                     "execution_order": "joint",
                     "search_algorithm": "random",

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -520,7 +520,6 @@ class TestEngine:
         temp_dir = tempfile.TemporaryDirectory()
         output_dir = Path(temp_dir.name)
 
-        print(tmpdir)
         # setup
         if is_search:
             options = {


### PR DESCRIPTION
## Describe your changes
Some passes support both `dataloader_func` and `data_config`. We don't set them to required but most of the time, one is required. Check for this in the pass run so that the error is caught early and is clear to the user.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
