### PR TITLE
Add `model_loading_args`, `load_model` and `load_model_config` to `HFConfig`

### DIFF
--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -3,10 +3,12 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from copy import deepcopy
 from functools import partial
 from itertools import chain
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import torch
 import transformers
 from pydantic import validator
 from transformers import AutoConfig, AutoModel, AutoTokenizer
@@ -25,6 +27,137 @@ class HFComponent(ConfigBase):
     dummy_inputs_func: Union[str, Callable]
 
 
+class HFModelLoadingArgs(ConfigBase):
+    """
+    Arguments to pass to the `from_pretrained` method of the model class.
+
+    Refer to https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L2074
+    """
+
+    # load model under a specific torch dtype
+    torch_dtype: str = None
+    # A map that specifies where each submodule should go. Refer to link in class docstring
+    # str suffices for torch.dtype, otherwise serializer won't recognize it
+    device_map: Union[int, str, Dict[str, Union[int, str]]] = None
+    # A dictionary device identifier to maximum memory
+    max_memory: Dict = None
+    # quant method to use (transformers.QuantizationMethod), e.g. "bitsandbytes", "gptq"
+    # must be provided if quantization_config is provided
+    quantization_method: str = None
+    # A dictionary of configuration parameters for quantization
+    quantization_config: Dict = None
+    # other kwargs
+    extra_args: Dict = None
+
+    @validator("torch_dtype", pre=True)
+    def validate_torch_dtype(cls, v):
+        if isinstance(v, torch.dtype):
+            v = str(v).replace("torch.", "")
+        return v
+
+    @validator("device_map", pre=True)
+    def validate_device_map(cls, v):
+        if isinstance(v, torch.device):
+            v = cls.device_to_str(v)
+        elif isinstance(v, dict):
+            v = {k: cls.device_to_str(v) for k, v in v.items()}
+        return v
+
+    @validator("quantization_config", pre=True, always=True)
+    def validate_quantization_config(cls, v, values):
+        if "quantization_method" not in values:
+            # to ensure we don't get a KeyError
+            raise ValueError("Invalid quantization_config")
+        if (values["quantization_method"] and not v) or (not values["quantization_method"] and v):
+            raise ValueError("quantization_config and quantization_method must be provided together")
+        if not v:
+            return v
+
+        try:
+            return cls.dict_to_quantization_config(values["quantization_method"], v).to_dict()
+        except ImportError:
+            # we don't want to fail since the pass target might have the correct transformers version
+            logger.warning(
+                f"Could not import the config class for quantization method {values['quantization_method']}. Skipping "
+                " validation"
+            )
+            return v
+
+    def get_loading_args(self):
+        loading_args = {}
+        # copy args that can be directly copied
+        direct_copy_args = ["device_map", "max_memory"]
+        for arg in direct_copy_args:
+            if getattr(self, arg):
+                loading_args[arg] = deepcopy(getattr(self, arg))
+        # convert torch dtype to torch.dtype or "auto"
+        if self.torch_dtype:
+            loading_args["torch_dtype"] = self.get_torch_dtype()
+        # convert quantization_config to the config class
+        quantization_config = self.get_quantization_config()
+        if quantization_config:
+            loading_args["quantization_config"] = quantization_config
+        # add extra args
+        if self.extra_args:
+            loading_args.update(deepcopy(self.extra_args))
+        return loading_args
+
+    def get_torch_dtype(self):
+        v = self.torch_dtype
+        if isinstance(v, str) and v != "auto":
+            # get rid of torch. prefix, this might have been added when serializing
+            v = v.replace("torch.", "")
+            try:
+                return getattr(torch, v)
+            except AttributeError as e:
+                raise ValueError(f"Invalid torch dtype {v}") from e
+        return v
+
+    def get_quantization_config(self):
+        if not self.quantization_method or not self.quantization_config:
+            return None
+        return self.dict_to_quantization_config(self.quantization_method, self.quantization_config)
+
+    @staticmethod
+    def device_to_str(device):
+        if isinstance(device, torch.device):
+            device = str(device)
+        return device
+
+    @staticmethod
+    def dict_to_quantization_config(quantization_method, config_dict):
+        method_to_class_name = {"bitsandbytes": "BitsAndBytesConfig", "gptq": "GPTQConfig"}
+        method_to_min_version = {
+            # bitsandbytes exists from 4.27.0, but 4bit quantization is only supported from 4.30.0
+            "bitsandbytes": "4.30.0",
+            "gptq": "4.32.0",
+        }
+        if quantization_method not in method_to_class_name:
+            raise ValueError(
+                f"Unsupported quantization method {quantization_method}. Supported methods are"
+                f" {list(method_to_class_name.keys())}"
+            )
+
+        try:
+            config_cls = getattr(transformers, method_to_class_name[quantization_method])
+        except AttributeError as e:
+            raise ImportError(
+                f"Quantization method {quantization_method} is not supported in transformers version"
+                f" {transformers.__version__}. Recommended transformers version is"
+                f" {method_to_min_version[quantization_method]} or above"
+            ) from e
+
+        # return unused kwargs doesn't work in catching unused args in config_dict
+        # they just call config_cls(**config_dict), extras get absorbed in **kwargs
+        config = config_cls.from_dict(config_dict, return_unused_kwargs=False)
+        # we will do a manual check to see if there are unused kwargs
+        # this works since config_cls is created as a dataclass
+        extras = set(config_dict.keys()) - set(config.__dict__.keys())
+        if extras:
+            logger.warning(f"Unused kwargs in quantization_config: {extras}. Ignoring them")
+        return config
+
+
 class HFConfig(ConfigBase):
     model_name: str = None
     task: str = None
@@ -36,6 +169,7 @@ class HFConfig(ConfigBase):
     components: List[HFComponent] = None
     config: Dict[str, Any] = None
     dataset: Dict[str, Any] = None
+    model_loading_args: HFModelLoadingArgs = None
 
     @validator("model_class", always=True)
     def task_or_model_class_required(cls, v, values):
@@ -44,8 +178,25 @@ class HFConfig(ConfigBase):
                 raise ValueError("Either task or model_class must be specified")
         return v
 
+    def load_model(self, model_path: str = None):
+        """Load model from model_path or model_name"""
+        # TODO: handle self.config, probably need to pass it as part of loading_args
+        model_name_or_path = model_path or self.model_name
+        loading_args = self.model_loading_args.get_loading_args() if self.model_loading_args else {}
+        if self.task:
+            model = load_huggingface_model_from_task(self.task, model_name_or_path, loading_args)
+        elif self.model_class:
+            model = load_huggingface_model_from_model_class(self.model_class, model_name_or_path, loading_args)
+        return model
 
-def load_huggingface_model_from_task(task: str, name: str):
+    def load_model_config(self, model_path: str = None):
+        """Load model config from model_path or model_name"""
+        # TODO: handle self.config, probably need to pass it as kwargs
+        model_name_or_path = model_path or self.model_name
+        return get_hf_model_config(model_name_or_path)
+
+
+def load_huggingface_model_from_task(task: str, name: str, kwargs: Dict[str, Any] = None):
     """Load huggingface model from task and name"""
     from transformers.pipelines import check_task
 
@@ -63,9 +214,10 @@ def load_huggingface_model_from_task(task: str, name: str):
     class_tuple = class_tuple + model_class.get("pt", (AutoModel,))
 
     model = None
+    kwargs = kwargs or {}
     for model_class in class_tuple:
         try:
-            model = model_class.from_pretrained(name)
+            model = model_class.from_pretrained(name, **kwargs)
             logger.debug(f"Loaded model {model_class} with name_or_path {name}")
             return model
         except (OSError, ValueError):
@@ -98,11 +250,12 @@ def get_hf_model_config(model_name: str):
     return AutoConfig.from_pretrained(model_name)
 
 
-def load_huggingface_model_from_model_class(model_class: str, name: str):
+def load_huggingface_model_from_model_class(model_class: str, name: str, kwargs: Dict[str, Any] = None):
     """
     Load huggingface model from model_loader and name
     """
-    return huggingface_model_loader(model_class)(name)
+    kwargs = kwargs or {}
+    return huggingface_model_loader(model_class)(name, **kwargs)
 
 
 # patched version of transforrmers.onnx.features.supported_features_mapping

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -4,9 +4,13 @@
 # --------------------------------------------------------------------------
 import pytest
 import torch
+import transformers
+from packaging import version
+from pydantic import ValidationError
 from transformers.onnx import OnnxConfig
 
 from olive.model.hf_utils import (
+    HFModelLoadingArgs,
     get_onnx_config,
     load_huggingface_model_from_model_class,
     load_huggingface_model_from_task,
@@ -40,3 +44,85 @@ def test_load_huggingface_model_from_model_class():
 def test_get_onnx_config(model_name, task, feature):
     onnx_config = get_onnx_config(model_name, task, feature)
     assert isinstance(onnx_config, OnnxConfig)
+
+
+class TestHFModelLoadingArgs:
+    @pytest.mark.parametrize(
+        "input,inner,output",
+        [
+            ("auto", "auto", "auto"),
+            (torch.float32, "float32", torch.float32),
+            ("float32", "float32", torch.float32),
+            ("torch.float32", "torch.float32", torch.float32),
+        ],
+    )
+    def test_torch_dtype(self, input, inner, output):
+        args = HFModelLoadingArgs(torch_dtype=input)
+        assert args.torch_dtype == inner
+        assert args.get_torch_dtype() == output
+
+    @pytest.mark.parametrize(
+        "input,inner",
+        [
+            ("auto", "auto"),
+            (1, 1),
+            ("1", 1),
+            ("cuda:0", "cuda:0"),
+            (torch.device(0), "cuda:0"),
+            (torch.device("cuda:0"), "cuda:0"),
+        ],
+    )
+    def test_device_map(self, input, inner):
+        args = HFModelLoadingArgs(device_map=input)
+        assert args.device_map == inner
+
+        args = HFModelLoadingArgs(device_map={"": input})
+        assert args.device_map == {"": inner}
+
+    @pytest.mark.parametrize(
+        "quantization_method,quantization_config,valid",
+        [
+            ("bitsandbyte", None, False),
+            (None, None, True),
+            (None, {"load_in_8bit": True}, False),
+            ("dummy", {"load_in_8bit": True}, False),
+            ("bitsandbytes", {"load_in_8bit": True}, True),
+        ],
+    )
+    def test_quant(self, quantization_method, quantization_config, valid):
+        if not valid:
+            with pytest.raises(ValidationError):
+                args = HFModelLoadingArgs(
+                    quantization_method=quantization_method, quantization_config=quantization_config
+                )
+
+        else:
+            args = HFModelLoadingArgs(quantization_method=quantization_method, quantization_config=quantization_config)
+            if quantization_method is None:
+                return
+
+            # check quantization method and config
+            assert args.quantization_method == quantization_method
+            assert isinstance(args.quantization_config, dict)
+            for k, v in quantization_config.items():
+                # assumes there are no unused keys in quantization_config
+                assert args.quantization_config[k] == v
+
+    # There is dependency conflict between transformers>=4.27.0 and azureml-evaluate-mlflow
+    # TODO: remove this skip when the dependency conflict is resolved
+    @pytest.mark.skipif(
+        version.parse(transformers.__version__) < version.parse("4.27.0"), reason="requires transformers>=4.27.0"
+    )
+    def test_get_quantization_config(self):
+        from transformers import BitsAndBytesConfig
+
+        quanntization_method = "bitsandbytes"
+        quantization_config = {"load_in_8bit": True}
+        args = HFModelLoadingArgs(quantization_method=quanntization_method, quantization_config=quantization_config)
+        config = args.get_quantization_config()
+
+        assert isinstance(config, BitsAndBytesConfig)
+        for k, v in quantization_config.items():
+            assert getattr(config, k) == v
+        for k in args.quantization_config:
+            assert hasattr(config, k)

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -66,7 +66,6 @@ class TestHFModelLoadingArgs:
         [
             ("auto", "auto"),
             (1, 1),
-            ("1", 1),
             ("cuda:0", "cuda:0"),
             (torch.device(0), "cuda:0"),
             (torch.device("cuda:0"), "cuda:0"),

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import mlflow
 import pandas as pd
 import pytest
+import torch
 import transformers
 from azureml.evaluate import mlflow as aml_mlflow
 
@@ -75,6 +76,7 @@ class TestPyTorchHFModel(unittest.TestCase):
         self.task = "text-classification"
         self.model_class = "BertForSequenceClassification"
         self.model_name = "Intel/bert-base-uncased-mrpc"
+        self.torch_dtype = "float16"
 
     def test_hf_config_task(self):
         self.setup()
@@ -91,6 +93,19 @@ class TestPyTorchHFModel(unittest.TestCase):
 
         pytorch_model = olive_model.load_model()
         assert isinstance(pytorch_model, transformers.BertForSequenceClassification)
+
+    def test_hf_model_loading_args(self):
+        self.setup()
+
+        olive_model = PyTorchModel(
+            hf_config={
+                "task": self.task,
+                "model_name": self.model_name,
+                "model_loading_args": {"torch_dtype": self.torch_dtype},
+            }
+        )
+        pytorch_model = olive_model.load_model()
+        assert pytorch_model.dtype == getattr(torch, self.torch_dtype)
 
 
 class TestPytorchDummyInput:


### PR DESCRIPTION
## Describe your changes
Add a new field called `model_loading_args` to `HFConfig`. `transformers.PreTrainedConfig.from_pretrained` method can take many other keyword arguments. One such argument is `device_map` which can be used to load a large model to multiple gpus. This can be useful when evaluating accuracy metrics such as perplexity for large LLMs. 

New passes like QLoRA needs to save a hf model with quantization_config. The model is quantized during loading. 

Also added `load_model` and `load_model_config` methods to `HFConfig`. This way, we can use the hf_config directly instead of keep loading logic outside of it. I think we can also handle the point I brought up in [this discussion](https://github.com/microsoft/Olive/pull/518#discussion_r1309159989) in https://github.com/microsoft/Olive/pull/518 by expanding on these methods.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
