### PR TITLE
Add `adapter_path` to `PyTorchModel`

### DIFF
--- a/olive/cache.py
+++ b/olive/cache.py
@@ -230,20 +230,33 @@ def save_model(
         logger.warning(f"Saving models of type '{model_json['type']}' is not supported yet.")
         return
 
-    model_path = model_json["config"]["model_path"]
-    if model_path:
-        # create resource path
-        model_resource_path = create_resource_path(model_path)
+    model_type = model_json["type"].lower()
+    for path_name in ["model_path", "adapter_path"]:
+        if path_name == "adapter_path" and model_type != "pytorchmodel":
+            # the adapter path is only relevant for PyTorch models
+            continue
+        if not model_json["config"][path_name]:
+            # Nothing to do if the path is empty
+            continue
 
+        resource_path = create_resource_path(model_json["config"][path_name])
         # get cached resource path if not local or string name
-        if not (model_resource_path.is_local_resource() or model_resource_path.is_string_name()):
-            model_resource_path = download_resource(model_resource_path, cache_dir)
+        if not (resource_path.is_local_resource() or resource_path.is_string_name()):
+            resource_path = download_resource(resource_path, cache_dir)
+
+        if model_type == "pytorchmodel":
+            # for PyTorch models, we will use output_dir/output_name as the save directory
+            # it will have model and adapter children
+            save_dir = (output_dir / output_name).with_suffix("")
+            save_name = path_name.replace("_path", "")
+        else:
+            save_dir = output_dir
+            save_name = output_name
 
         # save model to output directory
-        model_path = model_resource_path.save_to_dir(output_dir, output_name, overwrite)
+        model_json["config"][path_name] = resource_path.save_to_dir(save_dir, save_name, overwrite)
 
     # save model json
-    model_json["config"]["model_path"] = model_path
     with open(output_dir / f"{output_name}.json", "w") as f:
         json.dump(model_json, f, indent=4)
 

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -21,8 +21,9 @@ from olive.evaluator.metric import Metric, MetricResult, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.exception import OlivePassException
 from olive.hardware import AcceleratorLookup, AcceleratorSpec, Device
-from olive.model import ModelConfig, OliveModel
+from olive.model import ModelConfig, OliveModel, PyTorchModel
 from olive.passes.olive_pass import Pass
+from olive.resource_path import ResourcePath
 from olive.strategy.search_strategy import SearchStrategy
 from olive.systems.common import SystemType
 from olive.systems.local import LocalSystem
@@ -812,25 +813,32 @@ class Engine:
 
     def _prepare_non_local_model(self, model: OliveModel) -> OliveModel:
         """
-        Prepare models with non-local model path for local run by downloading the model resource to cache
+        Prepare models with non-local model path for local run by downloading the model resources to cache
         """
         model_resource_path = model.model_resource_path
-        if (
-            model_resource_path is None
-            or model_resource_path.is_local_resource()
-            or model_resource_path.is_string_name()
-        ):
-            logger.debug("Model path is None, local or string name. No need to prepare")
-            return model
+        downloaded_model_resource_path = self._download_non_local_resource(model_resource_path)
+        if downloaded_model_resource_path:
+            # set local model resource path
+            model.set_local_model_path(downloaded_model_resource_path)
 
-        # download and cache the model resource
-        logger.debug("Downloading non local model resource to cache")
-        local_model_resource_path = cache_utils.download_resource(model_resource_path, self._config.cache_dir)
-
-        # set local model resource path
-        model.set_local_model_path(local_model_resource_path)
+        if isinstance(model, PyTorchModel):
+            adapter_resource_path = model.adapter_resource_path
+            downloaded_adapter_resource_path = self._download_non_local_resource(adapter_resource_path)
+            if downloaded_adapter_resource_path:
+                # set local adapter resource path
+                model.set_local_adapter_path(downloaded_adapter_resource_path)
 
         return model
+
+    def _download_non_local_resource(self, resource_path: ResourcePath) -> ResourcePath:
+        """
+        Download non local resource to cache
+        """
+        if resource_path is None or resource_path.is_local_resource() or resource_path.is_string_name():
+            return None
+        else:
+            # download and cache the resource
+            return cache_utils.download_resource(resource_path, self._config.cache_dir)
 
     def _init_input_model(self, input_model: OliveModel):
         """

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -70,6 +70,10 @@ class ResourcePath(AutoConfigClass):
         """Return True if the resource is a string name."""
         return self.type == ResourceType.StringName
 
+    def is_local_resource_or_string_name(self) -> bool:
+        """Return True if the resource is a local resource or a string name."""
+        return self.is_local_resource() or self.is_string_name()
+
     def to_json(self):
         json_data = {"type": self.type, "config": self.config.to_json()}
         return serialize_to_json(json_data)
@@ -146,6 +150,33 @@ def create_resource_path(
 
     logger.debug(f"Resource path {resource_path} is inferred to be of type {type}.")
     return ResourcePathConfig(type=type, config={config_key: resource_path}).create_resource_path()
+
+
+def resolve_local_resource(resource_path: ResourcePath, local_resource_path: ResourcePath) -> str:
+    """
+    Get a local instance of the resource
+    If the resource is already a local resource, return the path of the resource.
+    Otherwise, check if the resource is already saved to the local resource path.
+    If it is, return the path of the resource. Otherwise, return None.
+    It is the caller's responsibility to save the resource to the local resource path and
+    handle unsaved resources.
+
+    :param resource_path: A resource path.
+    :param local_resource_path: Resource path of the local resource.
+    :return: Path of the local resource.
+    """
+    if not resource_path:
+        return None
+
+    # return local path if resource_path is local or string name
+    if resource_path.is_local_resource_or_string_name():
+        return resource_path.get_path()
+
+    # return local path if resource_path is already saved to local_resource_path
+    if not local_resource_path or not local_resource_path.is_local_resource_or_string_name():
+        # local_resource_path is not specified or is not a local resource or a string name
+        return None
+    return local_resource_path.get_path()
 
 
 def _overwrite_helper(new_path: Union[Path, str], overwrite: bool):

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -11,7 +11,7 @@ from olive.hardware import AcceleratorSpec
 from olive.model import ModelConfig
 from olive.systems.local import LocalSystem
 from olive.systems.olive_system import OliveSystem
-from olive.systems.utils import get_model_config, parse_common_args
+from olive.systems.utils import get_common_args
 
 
 def parse_metric_args(raw_args):
@@ -45,7 +45,7 @@ def create_metric(metric_config, metric_args):
 
 
 def main(raw_args=None):
-    common_args, extra_args = parse_common_args(raw_args)
+    model_config, pipeline_output, extra_args = get_common_args(raw_args)
     metric_args, extra_args = parse_metric_args(extra_args)
     accelerator_args = parse_accelerator_args(extra_args)
 
@@ -55,7 +55,6 @@ def main(raw_args=None):
     metric = create_metric(metric_config, metric_args)
 
     # load model
-    model_config = get_model_config(common_args)
     model = ModelConfig.from_json(model_config).create_model()
 
     with open(accelerator_args.accelerator_config) as f:
@@ -68,7 +67,7 @@ def main(raw_args=None):
     metric_result = target.evaluate_model(model, None, [metric], accelerator_spec)
 
     # save metric result json
-    with open(Path(common_args.pipeline_output) / "metric_result.json", "w") as f:
+    with open(Path(pipeline_output) / "metric_result.json", "w") as f:
         f.write(metric_result.json())
 
 

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -13,11 +13,11 @@ from packaging import version
 
 from olive.common.config_utils import ParamCategory
 from olive.hardware import AcceleratorSpec
-from olive.model import ModelConfig, PyTorchModel
+from olive.model import ModelConfig
 from olive.passes import REGISTRY as PASS_REGISTRY
 from olive.passes import FullPassConfig
 from olive.resource_path import create_resource_path
-from olive.systems.utils import get_model_config, parse_common_args
+from olive.systems.utils import get_common_args
 
 
 def parse_pass_config_arg(raw_args):
@@ -49,7 +49,8 @@ def parse_pass_args(pass_type, accelerator_spec, raw_args):
 def create_pass(pass_config, pass_args):
     for key, value in vars(pass_args).items():
         if value is not None:
-            key = key.replace("pass_", "")
+            # remove the pass_ prefix, the 1 is to only replace the first occurrence
+            key = key.replace("pass_", "", 1)
             pass_config["config"][key] = value
 
     p = FullPassConfig.from_json(pass_config).create_pass()
@@ -57,7 +58,7 @@ def create_pass(pass_config, pass_args):
 
 
 def main(raw_args=None):
-    common_args, extra_args = parse_common_args(raw_args)
+    input_model_config, pipeline_output, extra_args = get_common_args(raw_args)
     pass_config_arg, extra_args = parse_pass_config_arg(extra_args)
 
     # pass config
@@ -74,30 +75,30 @@ def main(raw_args=None):
 
         # Some passes create temporary files in the same directory as the model
         # original directory for model path is read only, so we need to copy the model to a temp directory
-        if common_args.model_path is not None:
+        input_model_path = input_model_config["config"]["model_path"]
+        if input_model_path is not None:
             tmp_dir = tempfile.TemporaryDirectory()
-            old_path = Path(common_args.model_path).resolve()
+            old_path = Path(input_model_path).resolve()
             new_path = Path(tmp_dir.name).resolve() / old_path.name
             if old_path.is_file():
                 shutil.copy(old_path, new_path)
             else:
                 new_path.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(old_path, new_path, dirs_exist_ok=True)
-            common_args.model_path = str(new_path)
+            input_model_config["config"]["model_path"] = str(new_path)
 
     # pass specific args
     accelerator_spec = AcceleratorSpec(pass_config_arg.pass_accelerator_type, pass_config_arg.pass_execution_provider)
     pass_args = parse_pass_args(pass_type, accelerator_spec, extra_args)
 
     # load input_model
-    input_model_config = get_model_config(common_args)
     input_model = ModelConfig.from_json(input_model_config).create_model()
 
     # load pass
     p = create_pass(pass_config, pass_args)
 
     # output model path
-    output_model_path = str(Path(common_args.pipeline_output) / "output_model")
+    output_model_path = str(Path(pipeline_output) / "output_model")
 
     # run pass
     output_model = p.run(input_model, None, output_model_path)
@@ -109,38 +110,40 @@ def main(raw_args=None):
     if input_model_config["config"].get("hf_config"):
         model_json["config"]["hf_config"] = input_model_config["config"]["hf_config"]
 
-    for path_name in ["model_path", "adapter_path"]:
-        if path_name == "adapter_path" and not isinstance(output_model, PyTorchModel):
-            # only PyTorchModel has adapter_path
-            continue
-        # this will help us set the same value as input model, no need to keep a copy
-        model_json[f"same_{path_name}_as_input"] = False
-        # create a resource path from the path
-        path_resource = create_resource_path(model_json["config"][path_name])
-        if not path_resource or path_resource.is_string_name():
+    # Replace local paths with relative paths
+    # keep track of the resource names that are relative paths
+    # during download in aml system, the relative paths will be resolved to the pipeline output
+    model_json["resource_names"] = []
+    # keep track of the resource names that are the same as the input model
+    model_json["same_resources_as_input"] = []
+    for resource_name, resource_path in output_model.resource_paths.items():
+        resource_path = create_resource_path(resource_path)  # just in case
+        if not resource_path or resource_path.is_string_name():
             # nothing to do if the path is None or a string name
             continue
-        if getattr(input_model, path_name, None) == getattr(output_model, path_name, None):
+        # check if the path is the same as the input model's path
+        resource_path_str = resource_path.get_path()
+        # input model might not have the resource, e.g. pytorch model -> onnx model
+        input_resource_path = create_resource_path(input_model.resource_paths.get(resource_name))
+        input_resource_path_str = input_resource_path.get_path() if input_resource_path else None
+        if input_resource_path_str == resource_path_str:
             # if the path is the same as the input path, set the path to None
-            # and set same_path_as_input to True
-            # Note: we getattr here since `model.model_path` for ONNXModel might not be same as
-            # model_resource_path if it's a folder
-            # so it's safer to check the property of the model
-            model_json["config"][path_name] = None
-            model_json[f"same_{path_name}_as_input"] = True
+            # and add the resource name to the same_resources_as_input list
+            model_json["config"][resource_name] = None
+            model_json["same_resources_as_input"].append(resource_name)
             continue
         # need to ensure that the path is a local resource
-        assert path_resource.is_local_resource(), f"Expected local resource, got {path_resource.type}"
-        path_str = path_resource.get_path()
+        assert resource_path.is_local_resource(), f"Expected local resource, got {resource_path.type}"
         # if the model is a local file or folder, set the model path to be relative to the pipeline output
         # the aml system will resolve the relative path to the pipeline output during download
-        relative_path = str(Path(path_str).relative_to(Path(common_args.pipeline_output)))
-        path_json = path_resource.to_json()
+        relative_path = str(Path(resource_path_str).relative_to(Path(pipeline_output)))
+        path_json = resource_path.to_json()
         path_json["config"]["path"] = relative_path
-        model_json["config"][path_name] = path_json
+        model_json["config"][resource_name] = path_json
+        model_json["resource_names"].append(resource_name)
 
     # save model json
-    with open(Path(common_args.pipeline_output) / "output_model_config.json", "w") as f:
+    with open(Path(pipeline_output) / "output_model_config.json", "w") as f:
         json.dump(model_json, f, indent=4)
 
 

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -396,12 +396,6 @@ class AzureMLSystem(OliveSystem):
             if path_name == "adapter_path" and model_type != "pytorchmodel":
                 # only PyTorchModel has adapter_path
                 continue
-            if (
-                model_json["config"][path_name] is None
-                or model_json["config"][path_name]["type"] == ResourceType.StringName
-            ):
-                # nothing to do if the path is None or a string name
-                continue
             same_as_input = model_json.pop(f"same_{path_name}_as_input")
             if same_as_input:
                 # get the resource path from the input model
@@ -410,6 +404,12 @@ class AzureMLSystem(OliveSystem):
                 model_json["config"][path_name] = getattr(
                     input_model, path_name.replace("_path", "_resource_path"), None
                 )
+                continue
+            if (
+                model_json["config"][path_name] is None
+                or model_json["config"][path_name]["type"] == ResourceType.StringName
+            ):
+                # nothing to do if the path is None or a string name
                 continue
             # can only be local file or folder
             resource_type = model_json["config"][path_name]["type"]

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -50,6 +50,7 @@ RESOURCE_TYPE_TO_ASSET_TYPE = {
 
 
 def get_asset_type_from_resource_path(resource_path: ResourcePath):
+    resource_path = create_resource_path(resource_path)  # just in case
     if not resource_path:
         # this is a placeholder for optional input
         return AssetTypes.URI_FILE
@@ -149,17 +150,19 @@ class AzureMLSystem(OliveSystem):
 
             return self._load_model(model, output_model_path, pipeline_output_path)
 
-    def _create_model_inputs(self, model_path_type: AssetTypes, adapter_path_type: AssetTypes):
-        return {
-            "model_config": Input(type=AssetTypes.URI_FILE),
-            "model_path": Input(type=model_path_type, optional=True),
-            "adapter_path": Input(type=adapter_path_type, optional=True),
-            "model_script": Input(type=AssetTypes.URI_FILE, optional=True),
-            "model_script_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
-        }
+    def _create_model_inputs(self, model_resource_paths: Dict[str, ResourcePath]):
+        inputs = {"model_config": Input(type=AssetTypes.URI_FILE)}
+        # loop through all the model resource paths
+        # create an input for each one using the resource type, with the name model_<resource_name>
+        for path_name, resource_path in model_resource_paths.items():
+            inputs[f"model_{path_name}"] = Input(type=get_asset_type_from_resource_path(resource_path), optional=True)
+        return inputs
 
     def _create_args_from_resource_path(self, rp: OLIVE_RESOURCE_ANNOTATIONS):
         model_resource_path = create_resource_path(rp)
+        if not model_resource_path:
+            # no argument for this resource, placeholder for optional input
+            return None
         asset_type = get_asset_type_from_resource_path(model_resource_path)
 
         if model_resource_path.type == ResourceType.AzureMLDatastore:
@@ -213,41 +216,25 @@ class AzureMLSystem(OliveSystem):
 
         return None
 
-    def _create_model_args(self, model_json: dict, tmp_dir: Path):
-        model_script = None
-        if model_json["config"].get("model_script"):
-            model_script = Input(type=AssetTypes.URI_FILE, path=model_json["config"]["model_script"])
-            model_json["config"]["model_script"] = None
+    def _create_model_args(self, model_json: dict, model_resource_paths: Dict[str, ResourcePath], tmp_dir: Path):
+        args = {}
+        # keep track of resource names in model_json that are uploaded/mounted
+        model_json["resource_names"] = []
 
-        model_script_dir = None
-        if model_json["config"].get("script_dir"):
-            model_script_dir = Input(type=AssetTypes.URI_FOLDER, path=model_json["config"]["script_dir"])
-            model_json["config"]["script_dir"] = None
+        for resource_name, resource_path in model_resource_paths.items():
+            arg = self._create_args_from_resource_path(resource_path)
+            if arg:
+                model_json["config"][resource_name] = None
+                model_json["resource_names"].append(resource_name)
+            args[f"model_{resource_name}"] = arg
 
-        model_path = None
-        if model_json["config"].get("model_path"):
-            model_path = self._create_args_from_resource_path(model_json["config"]["model_path"])
-            if model_path:
-                model_json["config"]["model_path"] = None
-
-        adapter_path = None
-        if model_json["config"].get("adapter_path"):
-            adapter_path = self._create_args_from_resource_path(model_json["config"]["adapter_path"])
-            if adapter_path:
-                model_json["config"]["adapter_path"] = None
-
+        # save the model json to a file
         model_config_path = tmp_dir / "model_config.json"
         with model_config_path.open("w") as f:
             json.dump(model_json, f, sort_keys=True, indent=4)
-        model_config = Input(type=AssetTypes.URI_FILE, path=model_config_path)
+        args["model_config"] = Input(type=AssetTypes.URI_FILE, path=model_config_path)
 
-        return {
-            "model_config": model_config,
-            "model_path": model_path,
-            "adapter_path": adapter_path,
-            "model_script": model_script,
-            "model_script_dir": model_script_dir,
-        }
+        return args
 
     def _create_pass_inputs(self, pass_path_params: List[Tuple[str, bool, ParamCategory]]):
         inputs = {"pass_config": Input(type=AssetTypes.URI_FILE)}
@@ -336,14 +323,9 @@ class AzureMLSystem(OliveSystem):
             "pass_accelerator_type": pass_config["accelerator"]["accelerator_type"],
             "pass_execution_provider": pass_config["accelerator"]["execution_provider"],
         }
-        model_resource_path = model.model_resource_path
-        adapter_resource_path = getattr(model, "adapter_resource_path", None)
         # prepare inputs
         inputs = {
-            **self._create_model_inputs(
-                get_asset_type_from_resource_path(model_resource_path),
-                get_asset_type_from_resource_path(adapter_resource_path),
-            ),
+            **self._create_model_inputs(model.resource_paths),
             **self._create_pass_inputs(pass_path_params),
             **accelerator_info,
         }
@@ -369,7 +351,7 @@ class AzureMLSystem(OliveSystem):
 
         # input argument values
         args = {
-            **self._create_model_args(model_json, tmp_dir),
+            **self._create_model_args(model_json, model.resource_paths, tmp_dir),
             **self._create_pass_args(pass_config, pass_path_params, data_root, tmp_dir),
             **accelerator_info,
         }
@@ -390,49 +372,38 @@ class AzureMLSystem(OliveSystem):
         with model_json_path.open("r") as f:
             model_json = json.load(f)
 
-        model_type = model_json["type"].lower()
-        # resolve model and adapter path
-        for path_name in ["model_path", "adapter_path"]:
-            if path_name == "adapter_path" and model_type != "pytorchmodel":
-                # only PyTorchModel has adapter_path
-                continue
-            same_as_input = model_json.pop(f"same_{path_name}_as_input")
-            if same_as_input:
-                # get the resource path from the input model
-                # note: config has it as `model_path`, `adapter_path` but they are actually stored as
-                # `model_resource_path`, `adapter_resource_path` in the model object
-                model_json["config"][path_name] = getattr(
-                    input_model, path_name.replace("_path", "_resource_path"), None
-                )
-                continue
-            if (
-                model_json["config"][path_name] is None
-                or model_json["config"][path_name]["type"] == ResourceType.StringName
-            ):
-                # nothing to do if the path is None or a string name
-                continue
+        # set the resources that are the same as the input model
+        same_resources_as_input = model_json.pop("same_resources_as_input")
+        for resource_name in same_resources_as_input:
+            # get the resource path from the input model
+            # do direct indexing to catch errors, should never happen
+            model_json["config"][resource_name] = input_model.resource_paths[resource_name]
+        # resolve resource names that are relative paths and save them to the output folder
+        relative_resource_names = model_json.pop("resource_names")
+        for resource_name in relative_resource_names:
+            resource_json = model_json["config"][resource_name]
             # can only be local file or folder
-            resource_type = model_json["config"][path_name]["type"]
+            resource_type = resource_json["type"]
             assert resource_type in LOCAL_RESOURCE_TYPES, f"Expected local file or folder, got {resource_type}"
             # to be safe when downloading we will use the whole of output_model_path as a directory
-            # and create subfolders for model and adapter
+            # and create subfolders for each resource
             # this is fine since the engine calls the system with a unique output_model_path which is a folder
             output_dir = Path(output_model_path).with_suffix("")
-            output_name = path_name.replace("_path", "")
+            output_name = resource_name.replace("_path", "")
             # if the model is downloaded from job, we need to copy it to the output folder
             # get the downloaded model path
-            downloaded_path = pipeline_output_path / model_json["config"][path_name]["config"]["path"]
+            downloaded_path = pipeline_output_path / resource_json["config"]["path"]
             # create a resource path object for the downloaded path
-            downloaded_resource_path = deepcopy(model_json["config"][path_name])
+            downloaded_resource_path = deepcopy(resource_json)
             downloaded_resource_path["config"]["path"] = str(downloaded_path)
             downloaded_resource_path = create_resource_path(downloaded_resource_path)
             # save the downloaded model to the output folder
             output_path = downloaded_resource_path.save_to_dir(output_dir, output_name, True)
             # create a resource path object for the output model
-            output_resource_path = deepcopy(model_json["config"][path_name])
+            output_resource_path = deepcopy(resource_json)
             output_resource_path["config"]["path"] = str(output_path)
             output_resource_path = create_resource_path(output_resource_path)
-            model_json["config"][path_name] = output_resource_path
+            model_json["config"][resource_name] = output_resource_path
 
         return ModelConfig(**model_json).create_model()
 
@@ -531,14 +502,11 @@ class AzureMLSystem(OliveSystem):
         model_json = model.to_json(check_object=True)
 
         # model args
-        model_args = self._create_model_args(model_json, tmp_dir)
+        model_args = self._create_model_args(model_json, model.resource_paths, tmp_dir)
 
         accelerator_config_path: Path = tmp_dir / "accelerator.json"
         with accelerator_config_path.open("w") as f:
             json.dump(accelerator.to_json(), f, sort_keys=True)
-
-        model_resource_path = model.model_resource_path
-        adapter_resource_path = getattr(model, "adapter_resource_path", None)
 
         @pipeline
         def evaluate_pipeline():
@@ -550,8 +518,7 @@ class AzureMLSystem(OliveSystem):
                     metric_tmp_dir,
                     metric,
                     model_args,
-                    model_resource_path,
-                    adapter_resource_path,
+                    model.resource_paths,
                     accelerator_config_path,
                 )
                 outputs[metric.name] = metric_component.outputs.pipeline_output
@@ -568,8 +535,7 @@ class AzureMLSystem(OliveSystem):
         tmp_dir: Path,
         metric: Metric,
         model_args: Dict[str, Input],
-        model_resource_path: ResourcePath,
-        adapter_resource_path: ResourcePath,
+        model_resource_paths: Dict[str, ResourcePath],
         accelerator_config_path: str,
     ):
         metric_json = metric.to_json(check_object=True)
@@ -591,10 +557,7 @@ class AzureMLSystem(OliveSystem):
 
         # prepare inputs
         inputs = {
-            **self._create_model_inputs(
-                get_asset_type_from_resource_path(model_resource_path),
-                get_asset_type_from_resource_path(adapter_resource_path),
-            ),
+            **self._create_model_inputs(model_resource_paths),
             **self._create_metric_inputs(),
             **{"accelerator_config": Input(type=AssetTypes.URI_FILE)},
         }

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -114,12 +114,10 @@ class DockerSystem(OliveSystem):
             volumes_list.append(dev_mount_str)
 
         model_copy = copy.deepcopy(model)
-        model_mount_path = None
-        if model_copy.model_path:
-            model_mount_path, model_mount_str_list = docker_utils.create_model_mount(
-                model=model_copy, container_root_path=container_root_path
-            )
-            volumes_list += model_mount_str_list
+        model_mounts, model_mount_str_list = docker_utils.create_model_mount(
+            model=model_copy, container_root_path=container_root_path
+        )
+        volumes_list += model_mount_str_list
 
         metrics_copy = copy.deepcopy(metrics)
         volumes_list = docker_utils.create_metric_volumes_list(
@@ -134,7 +132,7 @@ class DockerSystem(OliveSystem):
             model=model_copy,
             metrics=metrics_copy,
             container_root_path=container_root_path,
-            model_mount_path=model_mount_path,
+            model_mounts=model_mounts,
         )
         volumes_list.append(config_file_mount_str)
 
@@ -148,7 +146,6 @@ class DockerSystem(OliveSystem):
 
         eval_command = docker_utils.create_evaluate_command(
             eval_script_path=eval_file_mount_path,
-            model_path=model_mount_path,
             config_path=config_mount_path,
             output_path=output_mount_path,
             output_name=eval_output_name,

--- a/olive/systems/docker/eval.py
+++ b/olive/systems/docker/eval.py
@@ -14,14 +14,12 @@ from olive.model import ModelConfig
 logger = logging.getLogger(__name__)
 
 
-def evaluate_entry(config, model_path, output_path, output_name):
+def evaluate_entry(config, output_path, output_name):
     with open(config, "r") as f:
         config_json = json.load(f)
     evaluator_config = OliveEvaluatorConfig(metrics=config_json["metrics"])
     model_json = config_json["model"]
 
-    if model_path != "None":
-        model_json["config"]["model_path"] = model_path
     model = ModelConfig.from_json(model_json).create_model()
 
     evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
@@ -35,8 +33,8 @@ def evaluate_entry(config, model_path, output_path, output_name):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
+    # no need to get model_path since it's already updated in config file
     parser.add_argument("--config", type=str, help="evaluation config")
-    parser.add_argument("--model_path", help="The input directory.")
     parser.add_argument("--output_path", help="Path of output model")
     parser.add_argument("--output_name", help="Name of output json file")
 
@@ -44,4 +42,4 @@ if __name__ == "__main__":
     logger = logging.getLogger("module")
     logger.info("command line arguments: ", sys.argv)
 
-    evaluate_entry(args.config, args.model_path, args.output_path, args.output_name)
+    evaluate_entry(args.config, args.output_path, args.output_name)

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -9,18 +9,19 @@ from pathlib import Path
 from typing import List
 
 from olive.cache import get_local_path_from_root
-from olive.constants import Framework
 from olive.evaluator.metric import Metric
-from olive.model import OliveModel
+from olive.model import OliveModel, PyTorchModel
+from olive.resource_path import ResourcePath, create_resource_path
 
 logger = logging.getLogger(__name__)
 
 
 def create_config_file(
-    tempdir, model: OliveModel, metrics: List[Metric], container_root_path: Path, model_mount_path: str
+    tempdir, model: OliveModel, metrics: List[Metric], container_root_path: Path, model_mounts: dict
 ):
     model_json = model.to_json(check_object=True)
-    model_json["config"]["model_path"] = model_mount_path
+    for k, v in model_mounts.items():
+        model_json["config"][k] = v
 
     config_file_path = Path(tempdir) / "config.json"
     data = {"metrics": [k.dict() for k in metrics], "model": model_json}
@@ -33,12 +34,10 @@ def create_config_file(
     return config_mount_path, config_file_mount_str
 
 
-def create_evaluate_command(
-    eval_script_path: str, model_path: str, config_path: str, output_path: str, output_name: str
-):
+def create_evaluate_command(eval_script_path: str, config_path: str, output_path: str, output_name: str):
+    # no need to pass model_path since it's already updated in config file
     parameters = [
         f"--config {config_path}",
-        f"--model_path {model_path}",
         f"--output_path {output_path}",
         f"--output_name {output_name}",
     ]
@@ -84,26 +83,60 @@ def create_metric_volumes_list(
     return mount_list
 
 
-def create_model_mount(model: OliveModel, container_root_path: Path):
-    model_resource_path = None
-    if not model.model_resource_path:
-        model_resource_path = None
-    elif model.model_resource_path.is_local_resource() or model.model_resource_path.is_string_name():
-        model_resource_path = model.model_resource_path
+def create_resource_path_mount(
+    resource_path: ResourcePath, local_resource_path: ResourcePath, container_root_path: Path
+) -> (str, str):
+    # no need to mount if resource path is None or string name
+    if not resource_path or resource_path.is_string_name():
+        return None, None
+    # the resource we want to mount should be local resource
+    relevant_resource_path = None
+    if resource_path.is_local_resource():
+        relevant_resource_path = resource_path
     else:
-        assert model.local_model_path, "local model path not set"
-        model_resource_path = model.local_model_path
-    model_path = model_resource_path.get_path()
-    model_mount_path = str(container_root_path / Path(model_path).name)
-    model_mount_str = f"{str(Path(model_path).resolve())}:{model_mount_path}"
-    model_mount_str_list = [model_mount_str]
+        assert local_resource_path, "local resource path not set"
+        relevant_resource_path = local_resource_path
+    relevant_path = relevant_resource_path.get_path()
 
-    if model.framework == Framework.PYTORCH:
+    mount_path = str(container_root_path / Path(relevant_path).name)
+    mount_str = f"{str(Path(relevant_path).resolve())}:{mount_path}"
+    return mount_path, mount_str
+
+
+def create_model_mount(model: OliveModel, container_root_path: Path):
+    mounts = {}
+    mount_strs = []
+
+    # mount model resource path
+    model_path_mount_path, model_path_mount_str = create_resource_path_mount(
+        resource_path=model.model_resource_path,
+        local_resource_path=model.local_model_path,
+        container_root_path=container_root_path,
+    )
+    if model_path_mount_path:
+        mounts["model_path"] = model_path_mount_path
+        mount_strs.append(model_path_mount_str)
+
+    if isinstance(model, PyTorchModel):
+        adapter_path_mount_path, adapter_path_mount_str = create_resource_path_mount(
+            resource_path=model.adapter_resource_path,
+            local_resource_path=model.local_adapter_path,
+            container_root_path=container_root_path,
+        )
+        if adapter_path_mount_path:
+            mounts["adapter_path"] = adapter_path_mount_path
+            mount_strs.append(adapter_path_mount_str)
+
         if model.script_dir:
-            script_dir_mount = f"{model.script_dir}:{container_root_path}"
-            model.script_dir = container_root_path
-            model_mount_str_list.append(script_dir_mount)
-    return model_mount_path, model_mount_str_list
+            script_dir_mount_path, script_dir_mount_str = create_resource_path_mount(
+                resource_path=create_resource_path(model.script_dir),
+                local_resource_path=None,
+                container_root_path=container_root_path,
+            )
+            if script_dir_mount_path:
+                mounts["script_dir"] = script_dir_mount_path
+                mount_strs.append(script_dir_mount_str)
+    return mounts, mount_strs
 
 
 def create_eval_script_mount(container_root_path: Path):

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -7,28 +7,47 @@ import json
 
 
 def parse_common_args(raw_args):
-    parser = argparse.ArgumentParser("Olive model args")
+    """Parse common args"""
+    parser = argparse.ArgumentParser("Olive common args")
 
     # model args
-    parser.add_argument("--model_config", type=str, help="model config", required=True)
-    parser.add_argument("--model_path", type=str, help="model path")
-    parser.add_argument("--adapter_path", type=str, help="adapter path")
-    parser.add_argument("--model_script", type=str, help="model script")
-    parser.add_argument("--model_script_dir", type=str, help="model script dir")
+    parser.add_argument("--model_config", type=str, help="Path to model config json", required=True)
 
     # pipeline output arg
-    # model output args
     parser.add_argument("--pipeline_output", type=str, help="pipeline output path", required=True)
 
     return parser.parse_known_args(raw_args)
 
 
-def get_model_config(common_args):
+def parse_model_resources(model_resource_names, raw_args):
+    """Parse model resources. These are the resources that were uploaded with the job."""
+    parser = argparse.ArgumentParser("Model resources")
+
+    # parse model resources
+    for resource_name in model_resource_names:
+        # will keep as required since only uploaded resources should be in this list
+        parser.add_argument(f"--model_{resource_name}", type=str, required=True)
+
+    return parser.parse_known_args(raw_args)
+
+
+def get_common_args(raw_args):
+    """
+    Returns the model_config json with the model resource paths filled in, the pipeline output path, and any
+    extra args that were not parsed.
+    """
+    common_args, extra_args = parse_common_args(raw_args)
+
+    # load model json
     with open(common_args.model_config) as f:
         model_json = json.load(f)
+    # model json has a list of model resource names
+    model_resource_names = model_json.pop("resource_names")
+    model_resource_args, extra_args = parse_model_resources(model_resource_names, extra_args)
 
-    for key, value in common_args.__dict__.items():
-        if value and key in model_json["config"]:
-            model_json["config"][key] = value
+    for key, value in vars(model_resource_args).items():
+        # remove the model_ prefix, the 1 is to only replace the first occurrence
+        key = key.replace("model_", "", 1)
+        model_json["config"][key] = value
 
-    return model_json
+    return model_json, common_args.pipeline_output, extra_args

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -12,6 +12,7 @@ def parse_common_args(raw_args):
     # model args
     parser.add_argument("--model_config", type=str, help="model config", required=True)
     parser.add_argument("--model_path", type=str, help="model path")
+    parser.add_argument("--adapter_path", type=str, help="adapter path")
     parser.add_argument("--model_script", type=str, help="model script")
     parser.add_argument("--model_script_dir", type=str, help="model script dir")
 

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -49,15 +49,6 @@ def test_aml_model_pass_run():
         assert Path(onnx_model.model_path).is_file()
 
 
-def test_aml_model_download():
-    pytorch_model = get_pytorch_model()
-    tmp_dir = tempfile.TemporaryDirectory()
-    tmp_dir_path = Path(tmp_dir.name).resolve()
-
-    download_path, _ = pytorch_model.download_model(tmp_dir_path)
-    assert Path(download_path).is_file()
-
-
 def get_pytorch_model():
     workspace_config = get_olive_workspace_config()
     azureml_client_config = AzureMLClientConfig(**workspace_config)

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -54,7 +54,7 @@ def test_aml_model_download():
     tmp_dir = tempfile.TemporaryDirectory()
     tmp_dir_path = Path(tmp_dir.name).resolve()
 
-    download_path = pytorch_model.download_model(tmp_dir_path)
+    download_path, _ = pytorch_model.download_model(tmp_dir_path)
     assert Path(download_path).is_file()
 
 

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -150,9 +150,9 @@ class TestDockerSystem:
         eval_file_mount_str = "eval_file_mount_str"
         self.mock_create_eval_script_mount.return_value = [eval_file_mount_path, eval_file_mount_str]
 
-        model_mount_path = "model_mount_path"
+        model_mounts = {"model_path": "model_mount_path"}
         model_mount_str_list = ["model_mount_str_list"]
-        self.mock_create_model_mount.return_value = [model_mount_path, model_mount_str_list]
+        self.mock_create_model_mount.return_value = [model_mounts, model_mount_str_list]
 
         volumes_list = ["volumes_list"]
         self.mock_create_metric_volumes_list.return_value = volumes_list
@@ -185,10 +185,12 @@ class TestDockerSystem:
             self.mock_create_model_mount.called_once_with(mock_copy, container_root_path)
             vol_list = [eval_file_mount_str] + model_mount_str_list
             self.mock_create_metric_volumes_list.called_once_with(data_root, mock_copy, container_root_path, vol_list)
-            self.mock_create_config_file.called_once_with(tempdir, mock_copy, mock_copy, container_root_path)
+            self.mock_create_config_file.called_once_with(
+                tempdir, mock_copy, mock_copy, container_root_path, model_mounts
+            )
             self.mock_create_output_mount.called_once_with(tempdir, eval_output_path, container_root_path)
             self.mock_create_evaluate_command.called_once_with(
-                eval_file_mount_path, model_mount_path, config_mount_path, output_mount_path, eval_output_name
+                eval_file_mount_path, config_mount_path, output_mount_path, eval_output_name
             )
             self.mock_create_run_command.called_once_with(docker_system.run_params)
             volumes_list.append(config_file_mount_str)

--- a/test/unit_test/test_cache.py
+++ b/test/unit_test/test_cache.py
@@ -81,16 +81,19 @@ class TestCache:
             model_folder = model_cache_dir / model_path
             model_folder.mkdir(parents=True, exist_ok=True)
             model_p = str(model_folder)
+            # create a dummy .onnx file in the folder
+            onnx_file = model_folder / "dummy.onnx"
+            onnx_file.touch()
         else:
             model_p = str(model_cache_dir / model_path)
-            open(model_p, "w")
+            Path(model_p).touch()
 
         # cache model to cache_dir
         model_id = "0"
         model_cache_dir = cache_dir / "models"
         model_cache_dir.mkdir(parents=True, exist_ok=True)
         model_cache_file_path = str((model_cache_dir / f"{model_id}_p(･◡･)p.json").resolve())
-        model_json = {"type": "onnx", "config": {"model_path": model_p}}
+        model_json = {"type": "onnxmodel", "config": {"model_path": model_p}}
         json.dump(model_json, open(model_cache_file_path, "w"))
 
         # output model to output_dir


### PR DESCRIPTION
## Describe your changes
Some pytorch models such as huggingface models might have adapters, such as LoRA weights (https://huggingface.co/docs/peft/conceptual_guides/lora). This PR adds `adapter_path` to `PyTorchModel` which will be used to add the adapters to the model during load. Currently, we only support hugging face `peft` adapters. 

`adapter_path` can be a resource path like `model_path`. 

Updated the cache, docker system and azureml systems to handle adapter_path correctly. Refactored some of the code for `model_path` into helper methods so that we can reuse them for handling different resource path attributes. For now, we only have `model_path` and `adaptor_path`.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
