### PR TITLE
Fix test_python_environment_system to correctly use `assert_called_once_with`

### DIFF
--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -38,7 +38,7 @@ def mocked_torch_zeros(*args, **kwargs):
 # replace device in kwargs with "cpu"
 @patch("torch.zeros", side_effect=mocked_torch_zeros)
 def test_torch_trt_conversion_success(
-    mock_is_cuda_available, mock_tensor_data_to_device, mock_module_to, mock_torch_zeros
+    mock_torch_zeros, mock_torch_nn_module_to, mock_tensor_data_to_device, mock_torch_cuda_is_available
 ):
     # setup
     # mock trt utils since we don't have tensorrt and torch-tensorrt installed


### PR DESCRIPTION
## Describe your changes
Also corrected the order of paths in the torch_trt_conversion test. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
