### PR TITLE
🎏 Flag to identify model cannot be load by hf even if hf_config is not None

### DIFF
--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -212,7 +212,6 @@ class HFConfig(ConfigBase):
     # feature is optional if task is specified and don't need past
     # else, provide feature such as "causal-lm-with-past"
     feature: str = None
-    # TODO: remove model_class and only use task
     model_class: str = None
     components: List[HFComponent] = None
     dataset: Dict[str, Any] = None
@@ -302,7 +301,7 @@ def load_huggingface_model_from_model_class(model_class: str, name: str, **kwarg
     return huggingface_model_loader(model_class)(name, **kwargs)
 
 
-# patched version of transforrmers.onnx.features.supported_features_mapping
+# patched version of transformers.onnx.features.supported_features_mapping
 # to support additional models in olive
 def patched_supported_features_mapping(*supported_features: str, onnx_config_cls: str = None) -> Dict[str, Callable]:
     """

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -14,7 +14,7 @@ from olive.common.config_utils import ConfigBase, ParamCategory, validate_config
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.config import DataConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
-from olive.model import CompositeOnnxModel, DistributedOnnxModel, OliveModel, PyTorchModel
+from olive.model import CompositeOnnxModel, DistributedOnnxModel, OliveModel
 from olive.passes.pass_config import (
     PassConfigBase,
     PassConfigParam,
@@ -399,8 +399,7 @@ class Pass(ABC):
             return self.inherit_hf_config_from_input_model(model, output_model)
 
     def inherit_hf_config_from_input_model(self, input_model: OliveModel, output_model: OliveModel) -> OliveModel:
-        # TODO: handle the case with local model path and huggingface model config for torch model
-        if hasattr(output_model, "hf_config") and not isinstance(output_model, PyTorchModel):
+        if hasattr(output_model, "hf_config"):
             # not all models have hf_config
             # Do not inherit hf_config from input model if output_model is PyTorchModel for time being.
             if not output_model.hf_config and getattr(input_model, "hf_config", None):

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -141,7 +141,11 @@ class OrtTransformersOptimization(Pass):
         for key in get_external_data_config():
             del run_config[key]
 
-        if model.hf_config:
+        if run_config["model_type"] and run_config["num_heads"] and run_config["hidden_size"]:
+            logger.debug("Skip searching for model_type, num_heads, and hidden_size as they are already set.")
+        elif not model.hf_config:
+            logger.debug("Skip searching for model_type, num_heads, and hidden_size as hf_config is not available.")
+        elif model.hf_config:
             model_config = model.hf_config.load_model_config().to_dict()
             input_model_type = model_config.get("model_type", "")
             _model_type = MODEL_TYPE_MAPPING.get(input_model_type, input_model_type)

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -183,4 +183,4 @@ class TorchTRTConversion(Pass):
         # save save entire model to output_model_path
         output_model_path = Path(output_model_path).with_suffix(".pt")
         torch.save(pytorch_model, output_model_path)
-        return PyTorchModel(model_path=output_model_path)
+        return PyTorchModel(model_path=output_model_path, is_complete_hf_folder=False)

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -88,6 +88,9 @@ def test_torch_trt_conversion_success(
         # execute
         model = local_system.run_pass(p, input_model, None, output_folder)
 
+        # assert that the model is not complete huggingface model which is pass-specific
+        assert model.is_complete_hf_folder is False
+
         pytorch_model = model.load_model()
         layers = sparsegpt_utils.get_layers(pytorch_model, model_type)
         for layer in layers:


### PR DESCRIPTION
## Describe your changes

For torch model, if hf_config is not None, the loader will fall into huggingface model loader even if the model is local pytorch model(e.g, the output of TensorRTConversion).

Then we add a flag to identify model cannot be load by hf even if hf_config is not None. This flag is set by pass specifically. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
