### PR TITLE
Add `ConfigWithExtraArgs`

### DIFF
--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from pydantic import BaseModel, create_model, validator
+from pydantic import BaseModel, Field, create_model, root_validator, validator
 
 from olive.common.utils import hash_function, hash_object
 
@@ -149,6 +149,52 @@ class ConfigDictBase(ConfigBase):
 
     def __len__(self):
         return len(self.__root__) if self.__root__ else 0
+
+
+class ConfigWithExtraArgs(ConfigBase):
+    """
+    Config class that automatically gathers all values not defined in the class fields into a dict Field
+    called `extra_args`
+    """
+
+    extra_args: Dict = Field(
+        None,
+        description=(
+            "Dictionary of extra arguments that are not defined in the class fields. Values can be provided in two"
+            " ways: 1. As a dict value to `extra_args` key. 2. As keyword arguments to the class constructor. Any"
+            " values provided as keyword arguments will be added to the `extra_args` dict. `extra_args` values take"
+            " precedence over keyword arguments if the same key is provided in both."
+        ),
+    )
+
+    @root_validator(pre=True)
+    def gather_extra_args(cls, values):
+        other_fields = set()
+        for field in cls.__fields__.values():
+            for name in (field.name, field.alias):
+                if name != "extra_args":
+                    other_fields.add(name)
+
+        extra_args = values.pop("extra_args", {})
+        # ensure that extra_args does not contain any field names
+        for name in list(extra_args):  # need a copy of the keys since we are mutating the dict
+            if name in other_fields:
+                logger.warning(
+                    f"'{name}' provided to 'extra_args' is already defined in the class fields. Please provide the"
+                    " value directly to the field. Ignoring."
+                )
+                del extra_args[name]
+        # put any values provided as keyword arguments into extra_args
+        for name in list(values):  # need a copy of the keys since we are mutating the dict
+            if name in other_fields:
+                continue
+            if name in extra_args:
+                # extra_args takes precedence over keyword arguments
+                logger.warning(f"kwarg '{name}' is already defined in 'extra_args'. Ignoring.")
+            else:
+                extra_args[name] = values.pop(name)
+        values["extra_args"] = extra_args or None
+        return values
 
 
 class ParamCategory(str, Enum):

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -13,7 +13,7 @@ import transformers
 from pydantic import Field, validator
 from transformers import AutoConfig, AutoModel, AutoTokenizer
 
-from olive.common.config_utils import ConfigBase
+from olive.common.config_utils import ConfigBase, ConfigWithExtraArgs
 from olive.model.hf_mappings import MODELS_TO_MAX_LENGTH_MAPPING, TASK_TO_FEATURE
 from olive.model.model_config import IOConfig
 
@@ -27,7 +27,7 @@ class HFComponent(ConfigBase):
     dummy_inputs_func: Union[str, Callable]
 
 
-class HFModelLoadingArgs(ConfigBase):
+class HFModelLoadingArgs(ConfigWithExtraArgs):
     """
     Arguments to pass to the `from_pretrained` method of the model class.
 
@@ -78,8 +78,8 @@ class HFModelLoadingArgs(ConfigBase):
     extra_args: Dict = Field(
         None,
         description=(
-            "Other kwargs to pass to the .from_pretrained method of the model class. Parameters already specified in"
-            " the config will be ignored. Please refer to the docstring of"
+            "Other kwargs to pass to the .from_pretrained method of the model class. Values can be provided directly to"
+            " this field as a dict or as keyword arguments to the config. Please refer to the docstring of"
             " `transformers.PreTrainedModel.from_pretrained` for more details on the supported parameters. Eg."
             " {'use_safetensors': True}"
         ),
@@ -118,18 +118,6 @@ class HFModelLoadingArgs(ConfigBase):
                 " validation"
             )
             return v
-
-    @validator("extra_args", pre=True)
-    def validate_extra_args(cls, v, values):
-        # remove args that are already specified in the config
-        args_to_del = []
-        for k, v in v.items():
-            if k in values:
-                logger.warning(f"extra_arg {k} is already specified in the config. Ignoring it")
-                args_to_del.append(k)
-        for k in args_to_del:
-            del v[k]
-        return v
 
     def get_loading_args(self):
         loading_args = {}


### PR DESCRIPTION
## Describe your changes
This PR adds a new config base class called `ConfigWithExtraArgs` where the config values not defined in the class fields are collected in a field called `extra_args`. This behaves similar to `**kwargs` in functionality. It is useful for config classes where we expose some parameters but still want to accept extra arguments. The child classes can add their own validators on `extra_args` if needed.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
