### PR TITLE
ConfigWithExtraArgs: Handle cases where extra_args is provided as None

### DIFF
--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -175,7 +175,7 @@ class ConfigWithExtraArgs(ConfigBase):
                 if name != "extra_args":
                     other_fields.add(name)
 
-        extra_args = values.pop("extra_args") or {}
+        extra_args = values.pop("extra_args", {}) or {}
         # ensure that extra_args does not contain any field names
         for name in list(extra_args):  # need a copy of the keys since we are mutating the dict
             if name in other_fields:

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -175,7 +175,7 @@ class ConfigWithExtraArgs(ConfigBase):
                 if name != "extra_args":
                     other_fields.add(name)
 
-        extra_args = values.pop("extra_args", {})
+        extra_args = values.pop("extra_args") or {}
         # ensure that extra_args does not contain any field names
         for name in list(extra_args):  # need a copy of the keys since we are mutating the dict
             if name in other_fields:
@@ -193,7 +193,8 @@ class ConfigWithExtraArgs(ConfigBase):
                 logger.warning(f"kwarg '{name}' is already defined in 'extra_args'. Ignoring.")
             else:
                 extra_args[name] = values.pop(name)
-        values["extra_args"] = extra_args or None
+        if extra_args:
+            values["extra_args"] = extra_args
         return values
 
 


### PR DESCRIPTION
## Describe your changes
This is a follow up to https://github.com/microsoft/Olive/pull/534. The `gather_extra_args` validator did not consider the case where the value could be provided as None explicitly in the config (such as after serialization). In which case `values.pop("extra_args", {})` returns `None` which is not iterable. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
