### PR TITLE
🐛 Aml mlflow fix

### DIFF
--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -551,7 +551,10 @@ class PyTorchModel(OliveModel):
 
         with open(os.path.join(self.model_path, "MLmodel"), "r") as fp:
             mlflow_data = yaml.safe_load(fp)
-            hf_pretrained_class = mlflow_data["flavors"]["hftransformers"]["hf_pretrained_class"]
+            # default flavor name from azureml.evaluate.mlflow>=0.0.14
+            # TODO: let user specify flavor name
+            flavors_name = "hftransformersv2"
+            hf_pretrained_class = mlflow_data["flavors"][flavors_name]["hf_pretrained_class"]
 
         model_loader = huggingface_model_loader(hf_pretrained_class)
         loaded_model = model_loader(tmp_dir_path)

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -558,7 +558,7 @@ class PyTorchModel(OliveModel):
             flavors_names = ["hftransformersv2", "hftransformers"]
             for flavors_name in flavors_names:
                 if flavors_name in mlflow_data.get("flavors", {}):
-                    hf_pretrained_class = mlflow_data["flavors"][flavors_name].get("hf_pretrained_class", None)
+                    hf_pretrained_class = mlflow_data["flavors"].get(flavors_name, {}).get("hf_pretrained_class", None)
                     break
             if not hf_pretrained_class:
                 raise ValueError(

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -554,17 +554,23 @@ class PyTorchModel(OliveModel):
             # default flavor is "hftransformersv2" from azureml.evaluate.mlflow>=0.0.8
             # "hftransformers" from azureml.evaluate.mlflow<0.0.8
             # TODO: let user specify flavor name if needed
+            # TODO: to support other flavors in mlflow not only hftransformers
             hf_pretrained_class = None
-            flavors_names = ["hftransformersv2", "hftransformers"]
-            for flavors_name in flavors_names:
-                if flavors_name in mlflow_data.get("flavors", {}):
-                    hf_pretrained_class = mlflow_data["flavors"].get(flavors_name, {}).get("hf_pretrained_class", None)
-                    break
-            if not hf_pretrained_class:
+            flavors = mlflow_data.get("flavors", {})
+            if not flavors:
                 raise ValueError(
-                    "Invalid MLFlow model format. Please make sure the saved model"
-                    " format is same with mlflow.transformers.save_model,"
+                    "Invalid MLFlow model format. Please make sure the input model"
+                    " format is same with the result of mlflow.transformers.save_model,"
                     " or aml_mlflow.hftransformers.save_model from azureml.evaluate.mlflow"
+                )
+
+            if "hftransformersv2" in flavors:
+                hf_pretrained_class = flavors["hftransformersv2"].get("hf_pretrained_class", "AutoModel")
+            elif "hftransformers" in flavors:
+                hf_pretrained_class = flavors["hftransformers"].get("hf_pretrained_class", "AutoModel")
+            else:
+                raise ValueError(
+                    "Unsupported MLFlow model flavor. Currently only support hftransformersv2/hftransformers."
                 )
 
         model_loader = huggingface_model_loader(hf_pretrained_class)

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -551,10 +551,14 @@ class PyTorchModel(OliveModel):
 
         with open(os.path.join(self.model_path, "MLmodel"), "r") as fp:
             mlflow_data = yaml.safe_load(fp)
-            # default flavor name from azureml.evaluate.mlflow>=0.0.14
-            # TODO: let user specify flavor name
-            flavors_name = "hftransformersv2"
-            hf_pretrained_class = mlflow_data["flavors"][flavors_name]["hf_pretrained_class"]
+            # default flavor is "hftransformersv2" name from azureml.evaluate.mlflow>=0.0.8
+            # "hftransformers" is the name from azureml.evaluate.mlflow<0.0.8
+            # TODO: let user specify flavor name if needed
+            flavors_names = ["hftransformersv2", "hftransformers"]
+            for flavors_name in flavors_names:
+                if flavors_name in mlflow_data["flavors"]:
+                    hf_pretrained_class = mlflow_data["flavors"][flavors_name]["hf_pretrained_class"]
+                    break
 
         model_loader = huggingface_model_loader(hf_pretrained_class)
         loaded_model = model_loader(tmp_dir_path)

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -16,11 +16,7 @@ pytorch_lightning
 tabulate
 torchvision
 datasets
-azureml-evaluate-mlflow
-mlflow
-# newest version mlflow-skinny==2.4.0 is not compatible with the test
-# issue: https://github.com/mlflow/mlflow/issues/8629
-mlflow-skinny==2.3.2
+azureml-evaluate-mlflow>=0.0.14
 evaluate
 sentencepiece
 protobuf==3.20.3

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -16,7 +16,7 @@ pytorch_lightning
 tabulate
 torchvision
 datasets
-azureml-evaluate-mlflow>=0.0.14
+azureml-evaluate-mlflow
 evaluate
 sentencepiece
 protobuf==3.20.3

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -16,7 +16,8 @@ pytorch_lightning
 tabulate
 torchvision
 datasets
-azureml-evaluate-mlflow
+# azureml-evaluate-mlflow>=0.0.14 will pin mlflow/mlflow-skinny to 2.3.1
+azureml-evaluate-mlflow>=0.0.14
 evaluate
 sentencepiece
 protobuf==3.20.3


### PR DESCRIPTION
## Describe your changes
For version azureml-evaluate-mlflow<=0.0.7, the default flaver name for huggingface transformers model is `hftransformer`.
But after that(>=0.08, currently the latest one is 0.0.25), the default name goes to `hftransformerv2`.

Also when it >=0.0.14, the version of mlflow[-skinny] will be forced to 2.3.1.

This PR used to reduce the version range for azureml-evaluate-mlflow and mlflow which is strong rely on mlflow[-skinny]==2.3.1.
If not, the pip resolver is always try to go through all the version and raise the following error:
![image](https://github.com/microsoft/Olive/assets/13343117/79f7d041-8b67-4d36-839c-e6851070a432)


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
