### PR TITLE
use typevar for validate_config

### DIFF
--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -9,7 +9,7 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from types import FunctionType, MethodType
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel, Field, create_model, root_validator, validator
 
@@ -264,7 +264,7 @@ def create_config_class(
     default_config: Dict[str, ConfigParam],
     base: type = ConfigBase,
     validators: Dict[str, Callable] = None,
-):
+) -> Type[ConfigBase]:
     """
     Create a Pydantic model class from a configuration dictionary.
     """
@@ -293,12 +293,15 @@ def create_config_class(
     return create_model(class_name, **config, __base__=base, __validators__=validators)
 
 
+T = TypeVar("T", bound=ConfigBase)
+
+
 def validate_config(
     config: Union[Dict[str, Any], ConfigBase, None],
-    base_class: ConfigBase,
-    instance_class: Optional[ConfigBase] = None,
+    base_class: Type[T],
+    instance_class: Optional[Type[T]] = None,
     warn_unused_keys: bool = True,
-):
+) -> T:
     """
     Validate a config dictionary or object against a base class and instance class.
     instance class is a subclass of base class.

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -65,9 +65,9 @@ class OliveModel(ABC):
         self.composite_parent = None
         self.io_config = None
         # store resource paths
-        self.resource_paths = {}
+        self.resource_paths: Dict[str, ResourcePath] = {}
         # this is for storing local instances of resource paths
-        self.local_resource_paths = {}
+        self.local_resource_paths: Dict[str, ResourcePath] = {}
         resources = resources or {}
         resources["model_path"] = model_path
         for resource_name, resource_path in resources.items():

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -124,9 +124,7 @@ class Pass(ABC):
         return config
 
     @classmethod
-    def get_config_class(
-        cls, accelerator_spec: AcceleratorSpec, disable_search: Optional[bool] = False
-    ) -> Type[PassConfigBase]:
+    def get_config_class(cls, accelerator_spec: AcceleratorSpec, disable_search: Optional[bool] = False):
         """
         Get the configuration class for the pass.
         """


### PR DESCRIPTION
## Describe your changes
use typevar for validate_config so that typehints for the caller validate_config works in VSCode
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
