### PR TITLE
check whether the inference session is fallback after it is created

### DIFF
--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -32,6 +32,7 @@ from olive.evaluator.metric import (
     joint_metric_key,
 )
 from olive.evaluator.metric_backend import MetricBackend
+from olive.exception import OliveEvaluationException
 from olive.hardware import Device
 from olive.model import DistributedOnnxModel, OliveModel, ONNXModel, OpenVINOModel, PyTorchModel, SNPEModel
 from olive.model.model_config import is_io_config_static
@@ -327,6 +328,9 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             device=device,
             execution_providers=execution_providers,
         )
+
+        OnnxEvaluator.disable_ort_fallback(session, execution_providers)
+
         io_config = model.get_io_config()
 
         preds = []
@@ -388,6 +392,8 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             device=device,
             execution_providers=execution_providers,
         )
+        OnnxEvaluator.disable_ort_fallback(session, execution_providers)
+
         io_config = model.get_io_config()
 
         input_data, _ = next(iter(dataloader))
@@ -637,6 +643,17 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             return self._evaluate_distributed_latency(model, data_root, metric, device, execution_providers)
         else:
             raise TypeError(f"Cannot evaluate latency for model of type: {type(model)}")
+
+    @staticmethod
+    def disable_ort_fallback(session, execution_providers):
+        if execution_providers:
+            if session.get_providers() == execution_providers:
+                session.disable_fallback()
+            else:
+                raise OliveEvaluationException(
+                    f"The onnxruntime fallback happens. The original execution provider is {execution_providers}, but"
+                    f" the actual execution provider is {session.get_providers()}"
+                )
 
 
 class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -654,7 +654,8 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             else:
                 raise OliveEvaluationException(
                     f"The onnxruntime fallback happens. The original execution provider is {execution_providers}, but"
-                    f" the actual execution provider is {session.get_providers()}"
+                    f" the actual execution provider is {session.get_providers()}, and the"
+                    f" session._enable_fallback = {session._enable_fallback}"
                 )
 
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -649,14 +649,15 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         if execution_providers:
             assert isinstance(execution_providers, (str, list))
             execution_providers = [execution_providers] if isinstance(execution_providers, str) else execution_providers
-            if session.get_providers() == execution_providers:
-                session.disable_fallback()
+            session_providers = session.get_providers()
+            for ep in execution_providers:
+                if ep not in session_providers:
+                    raise OliveEvaluationException(
+                        f"The onnxruntime fallback happens. {ep} is not in the session providers {session_providers}."
+                        f" session._enable_fallback = {session._enable_fallback}"
+                    )
             else:
-                raise OliveEvaluationException(
-                    f"The onnxruntime fallback happens. The original execution provider is {execution_providers}, but"
-                    f" the actual execution provider is {session.get_providers()}, and the"
-                    f" session._enable_fallback = {session._enable_fallback}"
-                )
+                session.disable_fallback()
 
 
 class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -647,6 +647,8 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
     @staticmethod
     def disable_ort_fallback(session, execution_providers):
         if execution_providers:
+            assert isinstance(execution_providers, (str, list))
+            execution_providers = [execution_providers] if isinstance(execution_providers, str) else execution_providers
             if session.get_providers() == execution_providers:
                 session.disable_fallback()
             else:


### PR DESCRIPTION
## Describe your changes
From the time being, the ORT will automatically allow execution provider fallback. This behavior is not expected for Olive which targeted on the specific EP optimization. 

We explicitly check whether it is fallbacked or not. If yes, throw exception, otherwise, we will disable the fallback.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
