### PR TITLE
Move model preparation logic out of model itself

### DIFF
--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -4,6 +4,12 @@ OliveModels
 =================================
 The following models are available in Olive.
 
+.. _model_config:
+
+Model Configuration
+-------------------
+.. autoclass:: olive.model.ModelConfig
+
 .. _onnx_model:
 
 ONNX Model

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -20,17 +20,21 @@ Start by creating an instance of an OliveModel to represent the model to be opti
 model can be loaded from file or using a model loader function. For a complete of available models and their initialization options, refer to [OliveModels api reference](models).
 
 ```python
-from olive.models import PytorchModel
+from olive.models import Modelconfig
 
-input_model = PyTorchModel(
-    model_path="resnet.pt",
-    io_config={
-        "input_names": ["input"],
-        "input_shapes": [[1, 3, 32, 32]],
-        "output_names": ["output"],
-        "dynamic_axes": {"input": {0: "batch_size"}, "output": {0: "batch_size"}}
+config = {
+    "type": "PyTorchModel",
+    "config": {
+        "model_path": "resnet.pt",
+        "io_config": {
+            "input_names": ["input"],
+            "input_shapes": [[1, 3, 32, 32]],
+            "output_names": ["output"],
+            "dynamic_axes": {"input": {0: "batch_size"}, "output": {0: "batch_size"}},
+        }
     }
-)
+}
+input_model = ModelConfig.parse_obj(config)
 ```
 
 ## Host and Target Systems

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -235,10 +235,9 @@ def save_model(
         return
 
     # create model object so that we can get the resource paths
-    model = ModelConfig.from_json(model_json).create_model()
-    resource_path_names = list(model.resource_paths.keys())
-    for resource_name in resource_path_names:
-        resource_path = create_resource_path(model_json["config"][resource_name])
+    model_config: ModelConfig = ModelConfig.from_json(model_json)
+    resource_paths = model_config.get_resource_paths()
+    for resource_name, resource_path in resource_paths.items():
         if not resource_path or resource_path.is_string_name():
             # Nothing to do if the path is empty or a string name
             continue
@@ -246,7 +245,7 @@ def save_model(
         if not resource_path.is_local_resource():
             resource_path = download_resource(resource_path, cache_dir)
         # if there are multiple resource paths, we will save them to a subdirectory of output_dir/output_name
-        if len(resource_path_names) > 1:
+        if len(resource_paths) > 1:
             save_dir = (output_dir / output_name).with_suffix("")
             save_name = resource_name.replace("_path", "")
         else:

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -22,8 +22,9 @@ from olive.evaluator.metric import Metric, MetricResult, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.exception import OlivePassException
 from olive.hardware import AcceleratorLookup, AcceleratorSpec, Device
-from olive.model import ModelConfig, OliveModel
+from olive.model import ModelConfig
 from olive.passes.olive_pass import Pass
+from olive.resource_path import create_resource_path
 from olive.strategy.search_strategy import SearchStrategy
 from olive.systems.common import SystemType
 from olive.systems.local import LocalSystem
@@ -288,7 +289,7 @@ class Engine:
 
     def run(
         self,
-        input_model: OliveModel,
+        input_model_config: ModelConfig,
         data_root: str = None,
         packaging_config: Optional[PackagingConfig] = None,
         output_dir: str = None,
@@ -299,7 +300,7 @@ class Engine:
         Run all the registered Olive passes on the input model and produce one or more candidate models.
 
         Args:
-            input_model: input Olive model
+            input_model_config: input Olive model configuration
             packaging_config: packaging configuration, if packaging_config is provided, the output
                 model will be packaged into a zip file.
             output_dir: output directory for the output model
@@ -332,61 +333,59 @@ class Engine:
                 # generate search space and initialize the passes for each hardware accelerator
                 self.setup_passes(accelerator_spec)
 
-                # hash the input model
-                input_model_id = self._init_input_model(input_model)
-                self.footprints[accelerator_spec].record(model_id=input_model_id)
+            # hash the input model
+            input_model_id = self._init_input_model(input_model_config)
+            self.footprints[accelerator_spec].record(model_id=input_model_id)
 
-                try:
-                    if evaluate_input_model:
-                        prefix_output_name = (
-                            f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}"
-                        )
-                        assert (
-                            self.evaluator_config is not None
-                        ), "evaluate_input_model is True but no evaluator provided"
-                        results = self._evaluate_model(
-                            input_model, input_model_id, data_root, self.evaluator_config, accelerator_spec
-                        )
-                        logger.info(f"Input model evaluation results: {results}")
-                        result_name = f"{prefix_output_name}_input_model_metrics"
-                        results_path = output_dir / f"{result_name}.json"
-                        with open(results_path, "w") as f:
-                            json.dump(results.to_json(), f, indent=4)
-                        logger.info(f"Saved evaluation results of input model to {results_path}")
-                        outputs[accelerator_spec] = results
-                        if not self.passes:
-                            logger.debug("No passes registered, return input model evaluation results.")
-                            return outputs
+            try:
+                if evaluate_input_model:
+                    prefix_output_name = (
+                        f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}"
+                    )
+                    assert self.evaluator_config is not None, "evaluate_input_model is True but no evaluator provided"
+                    results = self._evaluate_model(
+                        input_model_config, input_model_id, data_root, self.evaluator_config, accelerator_spec
+                    )
+                    logger.info(f"Input model evaluation results: {results}")
+                    result_name = f"{prefix_output_name}_input_model_metrics"
+                    results_path = output_dir / f"{result_name}.json"
+                    with open(results_path, "w") as f:
+                        json.dump(results.to_json(), f, indent=4)
+                    logger.info(f"Saved evaluation results of input model to {results_path}")
+                    outputs[accelerator_spec] = results
+                    if not self.passes:
+                        logger.debug("No passes registered, return input model evaluation results.")
+                        return outputs
 
-                    if self.no_search:
-                        output, model_ids = self.run_no_search(
-                            input_model,
-                            input_model_id,
-                            data_root,
-                            accelerator_spec,
-                            output_dir,
-                            output_name,
+                if self.no_search:
+                    output, model_ids = self.run_no_search(
+                        input_model_config,
+                        input_model_id,
+                        data_root,
+                        accelerator_spec,
+                        output_dir,
+                        output_name,
+                    )
+                    if output:
+                        outputs[accelerator_spec] = output
+                        pf_footprints[accelerator_spec] = self.footprints[accelerator_spec].get_footprints_by_model_ids(
+                            model_ids
                         )
-                        if output:
-                            outputs[accelerator_spec] = output
-                            pf_footprints[accelerator_spec] = self.footprints[
-                                accelerator_spec
-                            ].get_footprints_by_model_ids(model_ids)
-                    else:
-                        footprint = self.run_search(
-                            input_model,
-                            input_model_id,
-                            data_root,
-                            accelerator_spec,
-                            output_dir,
-                            output_name,
-                        )
-                        outputs[accelerator_spec] = footprint
-                        pf_footprints[accelerator_spec] = footprint
-                except EXCEPTIONS_TO_RAISE:
-                    raise
-                except Exception as e:
-                    logger.warning(f"Failed to run Olive on {accelerator_spec}: {e}", exc_info=True)
+                else:
+                    footprint = self.run_search(
+                        input_model_config,
+                        input_model_id,
+                        data_root,
+                        accelerator_spec,
+                        output_dir,
+                        output_name,
+                    )
+                    outputs[accelerator_spec] = footprint
+                    pf_footprints[accelerator_spec] = footprint
+            except EXCEPTIONS_TO_RAISE:
+                raise
+            except Exception as e:
+                logger.warning(f"Failed to run Olive on {accelerator_spec}: {e}", exc_info=True)
 
         for accelerator_spec in self.footprints.keys():
             logger.info(f"Run history for {accelerator_spec}:")
@@ -431,7 +430,7 @@ class Engine:
 
     def run_no_search(
         self,
-        input_model: OliveModel,
+        input_model_config: ModelConfig,
         input_model_id: str,
         data_root: str,
         accelerator_spec: AcceleratorSpec,
@@ -456,7 +455,7 @@ class Engine:
             objective_dict = {"dummy": {"higher_is_better": True, "goal": 0}}
         else:
             objective_dict = self.resolve_objectives(
-                input_model, input_model_id, data_root, evaluator_config.metrics, accelerator_spec
+                input_model_config, input_model_id, data_root, evaluator_config.metrics, accelerator_spec
             )
 
         # initialize the search strategy
@@ -481,9 +480,9 @@ class Engine:
             # get the model id of the first input model
             model_id = next_step["model_id"]
             if model_id == input_model_id:
-                model = input_model
+                model_config = input_model_config
             else:
-                model = self._load_model(model_id)
+                model_config = self._load_model(model_id)
 
             logger.debug(f"Step no search with search point {next_step['search_point']} ...")
 
@@ -492,7 +491,7 @@ class Engine:
                 should_prune,
                 signal,
                 model_ids,
-            ) = self._run_passes(next_step["passes"], model, model_id, data_root, accelerator_spec)
+            ) = self._run_passes(next_step["passes"], model_config, model_id, data_root, accelerator_spec)
             pass_flow = self.pass_flows[iter_num - 1]
 
             if should_prune:
@@ -548,7 +547,7 @@ class Engine:
 
     def run_search(
         self,
-        input_model: OliveModel,
+        input_model_config: ModelConfig,
         input_model_id: str,
         data_root: str,
         accelerator_spec: AcceleratorSpec,
@@ -568,7 +567,7 @@ class Engine:
             raise ValueError("No evaluator provided for the last pass")
         else:
             objective_dict = self.resolve_objectives(
-                input_model, input_model_id, data_root, evaluator_config.metrics, accelerator_spec
+                input_model_config, input_model_id, data_root, evaluator_config.metrics, accelerator_spec
             )
 
         # initialize the search strategy
@@ -591,15 +590,15 @@ class Engine:
             # get the model id of the first input model
             model_id = next_step["model_id"]
             if model_id == input_model_id:
-                model = input_model
+                model_config = input_model_config
             else:
-                model = self._load_model(model_id)
+                model_config = self._load_model(model_id)
 
             logger.debug(f"Step {iter_num} with search point {next_step['search_point']} ...")
 
             # run all the passes in the step
             should_prune, signal, model_ids = self._run_passes(
-                next_step["passes"], model, model_id, data_root, accelerator_spec
+                next_step["passes"], model_config, model_id, data_root, accelerator_spec
             )
 
             # record feedback signal
@@ -652,7 +651,7 @@ class Engine:
 
     def resolve_objectives(
         self,
-        input_model: OliveModel,
+        input_model_config: ModelConfig,
         input_model_id: str,
         data_root: str,
         metrics: List[Metric],
@@ -663,7 +662,7 @@ class Engine:
 
         {objective_name: {"higher_is_better": bool, "goal": float}}
         """
-        goals = self.resolve_goals(input_model, input_model_id, data_root, metrics, accelerator_spec)
+        goals = self.resolve_goals(input_model_config, input_model_id, data_root, metrics, accelerator_spec)
         objective_dict = {}
         for metric in metrics:
             for sub_type in metric.sub_types:
@@ -681,7 +680,7 @@ class Engine:
 
     def resolve_goals(
         self,
-        input_model: OliveModel,
+        input_model_config: ModelConfig,
         input_model_id: str,
         data_root: str,
         metrics: List[Metric],
@@ -713,7 +712,7 @@ class Engine:
                     assert self.evaluator_config is not None, "Default evaluator must be provided to resolve goals"
                     logger.debug("Computing baseline for metrics ...")
                     baseline = self._evaluate_model(
-                        input_model, input_model_id, data_root, self.evaluator_config, accelerator_spec
+                        input_model_config, input_model_id, data_root, self.evaluator_config, accelerator_spec
                     )
                     _evaluated = True
                     break
@@ -783,7 +782,7 @@ class Engine:
         """
         return self._model_cache_path / f"{model_id}.json"
 
-    def _cache_model(self, model: Union[OliveModel, str], model_id: str, check_object: bool = True):
+    def _cache_model(self, model: Union[ModelConfig, str], model_id: str, check_object: bool = True):
         """
         Cache the model in the cache directory.
         """
@@ -799,7 +798,7 @@ class Engine:
         except Exception as e:
             logger.error(f"Failed to cache model: {e}", exc_info=True)
 
-    def _load_model(self, model_id: str) -> Union[OliveModel, str]:
+    def _load_model(self, model_id: str) -> Union[ModelConfig, str]:
         """
         Load the model from the cache directory.
         """
@@ -814,31 +813,34 @@ class Engine:
         if model_json == {}:
             return FAILED_CONFIG
 
-        model = ModelConfig.from_json(model_json).create_model()
+        model = ModelConfig.from_json(model_json)
         return model
 
-    def _prepare_non_local_model(self, model: OliveModel) -> OliveModel:
+    def _prepare_non_local_model(self, model_config: ModelConfig) -> ModelConfig:
         """
         Prepare models with non-local model path for local run by downloading the model resources to cache
         """
-        for resource_name, resource_path in model.resource_paths.items():
+        resource_keys = model_config.get_resource_keys()
+        for resource_name in resource_keys:
+            resource_path = model_config.config.get(resource_name)
+            resource_path = create_resource_path(resource_path)
             if not resource_path or resource_path.is_local_resource_or_string_name():
                 continue
             downloaded_resource_path = cache_utils.download_resource(resource_path, self._config.cache_dir)
             if downloaded_resource_path:
                 # set local resource path
-                model.set_local_resource(resource_name, downloaded_resource_path)
+                model_config.config[resource_name] = downloaded_resource_path
 
-        return model
+        return model_config
 
-    def _init_input_model(self, input_model: OliveModel):
+    def _init_input_model(self, input_model_config: ModelConfig):
         """
         Initialize the input model.
         """
-        model_hash = hash_dict(input_model.to_json())
+        model_hash = hash_dict(input_model_config.to_json())
 
         # cache the model
-        self._cache_model(input_model, model_hash, check_object=False)
+        self._cache_model(input_model_config, model_hash, check_object=False)
 
         return model_hash
 
@@ -909,7 +911,7 @@ class Engine:
     def _run_passes(
         self,
         passes: List[Tuple[str, Dict[str, Any]]],
-        model: OliveModel,
+        model_config: ModelConfig,
         model_id: str,
         data_root: str,
         accelerator_spec: AcceleratorSpec,
@@ -922,8 +924,10 @@ class Engine:
         # run all the passes in the step
         model_ids = []
         for pass_id, pass_search_point in passes:
-            model, model_id = self._run_pass(pass_id, pass_search_point, model, model_id, data_root, accelerator_spec)
-            if model in PRUNED_CONFIGS:
+            model_config, model_id = self._run_pass(
+                pass_id, pass_search_point, model_config, model_id, data_root, accelerator_spec
+            )
+            if model_config in PRUNED_CONFIGS:
                 should_prune = True
                 logger.debug("Pruned")
                 break
@@ -936,7 +940,7 @@ class Engine:
                 # skip evaluation if no search and no evaluator
                 signal = None
             else:
-                signal = self._evaluate_model(model, model_id, data_root, evaluator_config, accelerator_spec)
+                signal = self._evaluate_model(model_config, model_id, data_root, evaluator_config, accelerator_spec)
             logger.debug(f"Signal: {signal}")
         else:
             signal = None
@@ -948,7 +952,7 @@ class Engine:
         self,
         pass_id: str,
         pass_search_point: Dict[str, Any],
-        input_model: OliveModel,
+        input_model_config: ModelConfig,
         input_model_id: str,
         data_root: str,
         accelerator_spec: AcceleratorSpec,
@@ -966,12 +970,12 @@ class Engine:
         # check whether the config is valid
         if not p.validate_search_point(pass_search_point, accelerator_spec, with_fixed_value=True):
             logger.debug("Invalid search point, prune")
-            output_model = INVALID_CONFIG
+            output_model_config = INVALID_CONFIG
             # no need to record in footprint since there was no run and thus no valid/failed model
             # invalid configs are also not cached since the same config can be valid for other accelerator specs
             # a pass can be accelerator agnostic but still have accelerator specific invalid configs
             # this helps reusing cached models for different accelerator specs
-            return output_model, None
+            return output_model_config, None
 
         # load run from cache if it exists
         run_accel = None if p.is_accelerator_agnostic(accelerator_spec) else accelerator_spec
@@ -979,19 +983,21 @@ class Engine:
         output_model_id = run_cache.get("output_model_id", None)
         if output_model_id is not None:
             logger.debug("Loading model from cache ...")
-            output_model = self._load_model(output_model_id)
-            if output_model is not None:
+            output_model_config = self._load_model(output_model_id)
+            if output_model_config is not None:
                 # footprint model and run
                 self.footprints[accelerator_spec].record(
                     model_id=output_model_id,
-                    model_config=output_model.to_json() if output_model != FAILED_CONFIG else {"is_pruned": True},
+                    model_config=output_model_config.to_json()
+                    if output_model_config != FAILED_CONFIG
+                    else {"is_pruned": True},
                     parent_model_id=input_model_id,
                     from_pass=pass_name,
                     pass_run_config=pass_config,
                     start_time=run_cache.get("run_start_time", 0),
                     end_time=run_cache.get("run_end_time", 0),
                 )
-                return output_model, output_model_id
+                return output_model_config, output_model_id
 
         # new model id
         input_model_number = input_model_id.split("_")[0]
@@ -1014,18 +1020,19 @@ class Engine:
         # run pass
         host = self.host_for_pass(pass_id)
         if host.system_type != SystemType.AzureML:
-            input_model = self._prepare_non_local_model(input_model)
+            input_model_config = self._prepare_non_local_model(input_model_config)
+
         run_start_time = datetime.now().timestamp()
         try:
-            output_model = host.run_pass(p, input_model, data_root, output_model_path, pass_search_point)
+            output_model_config = host.run_pass(p, input_model_config, data_root, output_model_path, pass_search_point)
         except OlivePassException as e:
             logger.error(f"Pass run_pass failed: {e}", exc_info=True)
-            output_model = FAILED_CONFIG
+            output_model_config = FAILED_CONFIG
         except EXCEPTIONS_TO_RAISE:
             # Don't catch these errors since most of time, it is caused by the user errors and need not retry.
             raise
         except Exception:
-            output_model = FAILED_CONFIG
+            output_model_config = FAILED_CONFIG
             # TODO: from the time being, we need to catch all exceptions to make the
             #      search process robust. We need rethrow the exception only when
             #      it is not pass specific. For example, for olive bugs and user errors
@@ -1035,7 +1042,7 @@ class Engine:
 
         run_end_time = datetime.now().timestamp()
         # cache model
-        self._cache_model(output_model, output_model_id)
+        self._cache_model(output_model_config, output_model_id)
 
         # cache run
         self._cache_run(
@@ -1045,14 +1052,14 @@ class Engine:
         # footprint model and run
         self.footprints[accelerator_spec].record(
             model_id=output_model_id,
-            model_config=output_model.to_json() if output_model != FAILED_CONFIG else {"is_pruned": True},
+            model_config=output_model_config.to_json() if output_model_config != FAILED_CONFIG else {"is_pruned": True},
             parent_model_id=input_model_id,
             from_pass=pass_name,
             pass_run_config=pass_config,
             start_time=run_start_time,
             end_time=run_end_time,
         )
-        return output_model, output_model_id
+        return output_model_config, output_model_id
 
     def get_evaluation_json_path(self, model_id: str):
         """
@@ -1096,7 +1103,7 @@ class Engine:
 
     def _evaluate_model(
         self,
-        model: OliveModel,
+        model: ModelConfig,
         model_id: str,
         data_root: str,
         evaluator_config: OliveEvaluatorConfig,

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -24,7 +24,6 @@ from olive.exception import OlivePassException
 from olive.hardware import AcceleratorLookup, AcceleratorSpec, Device
 from olive.model import ModelConfig
 from olive.passes.olive_pass import Pass
-from olive.resource_path import create_resource_path
 from olive.strategy.search_strategy import SearchStrategy
 from olive.systems.common import SystemType
 from olive.systems.local import LocalSystem
@@ -822,10 +821,9 @@ class Engine:
         """
         Prepare models with non-local model path for local run by downloading the model resources to cache
         """
-        resource_keys = model_config.get_resource_keys()
-        for resource_name in resource_keys:
-            resource_path = model_config.config.get(resource_name)
-            resource_path = create_resource_path(resource_path)
+        # TODO: maybe we can move this method into OliveSystem?
+        resource_paths = model_config.get_resource_paths()
+        for resource_name, resource_path in resource_paths.items():
             if not resource_path or resource_path.is_local_resource_or_string_name():
                 continue
             downloaded_resource_path = cache_utils.download_resource(resource_path, self._config.cache_dir)

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -299,8 +299,7 @@ class ONNXModel(ONNXModelBase):
     @property
     def model_path(self) -> str:
         model_path = super().model_path
-        if model_path and Path(model_path).is_dir():
-            model_path = self.get_onnx_file_path(model_path, self.onnx_file_name)
+        model_path = self.get_onnx_file_path(model_path, self.onnx_file_name) if model_path else None
         return model_path
 
     @staticmethod

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -516,9 +516,8 @@ class PyTorchModel(OliveModel):
         # ensure that model_script and script_dirs are local
         for resource_name in ["script_dir", "model_script"]:
             if self.resource_paths[resource_name]:
-                assert self.resource_paths[
-                    resource_name
-                ].is_local_resource(), f"{resource_name} must be local file or directory."
+                relavant_path = create_resource_path(self.resource_paths[resource_name])
+                assert relavant_path.is_local_resource(), f"{resource_name} must be local file or directory."
 
         # io config for conversion to onnx
         self.io_config = validate_config(io_config, IOConfig).dict() if io_config else None

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -833,8 +833,9 @@ class OpenVINOModel(OliveModel):
             model_attributes=model_attributes,
         )
         # check if the model files (xml, bin) are in the same directory
-        if self.resource_paths["model_path"].is_local_resource():
-            _ = self.model_config
+        model_path = create_resource_path(self.resource_paths["model_path"])
+        assert model_path.is_local_resource(), "OpenVINO model_path must be local file or directory."
+        _ = self.model_config
 
     @property
     def model_config(self) -> Dict[str, str]:

--- a/olive/passes/pytorch/qlora.py
+++ b/olive/passes/pytorch/qlora.py
@@ -328,7 +328,7 @@ class QLoRA(Pass):
                 "bnb_4bit_quant_type": config.quant_type,
             },
         )
-        if new_model.get_local_resource("adapter_path"):
+        if new_model.get_resource("adapter_path"):
             logger.warning(
                 "Input model has adapter_path. Ignoring. QLoRA will save the adapter weights to its own adapter_path."
             )

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -152,33 +152,6 @@ def create_resource_path(
     return ResourcePathConfig(type=type, config={config_key: resource_path}).create_resource_path()
 
 
-def resolve_local_resource(resource_path: ResourcePath, local_resource_path: ResourcePath) -> str:
-    """
-    Get a local instance of the resource
-    If the resource is already a local resource, return the path of the resource.
-    Otherwise, check if the resource is already saved to the local resource path.
-    If it is, return the path of the resource. Otherwise, return None.
-    It is the caller's responsibility to save the resource to the local resource path and
-    handle unsaved resources.
-
-    :param resource_path: A resource path.
-    :param local_resource_path: Resource path of the local resource.
-    :return: Path of the local resource.
-    """
-    if not resource_path:
-        return None
-
-    # return local path if resource_path is local or string name
-    if resource_path.is_local_resource_or_string_name():
-        return resource_path.get_path()
-
-    # return local path if resource_path is already saved to local_resource_path
-    if not local_resource_path or not local_resource_path.is_local_resource_or_string_name():
-        # local_resource_path is not specified or is not a local resource or a string name
-        return None
-    return local_resource_path.get_path()
-
-
 def _overwrite_helper(new_path: Union[Path, str], overwrite: bool):
     new_path = Path(new_path).resolve()
 

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -54,8 +54,8 @@ def main(raw_args=None):
         metric_config = json.load(f)
     metric = create_metric(metric_config, metric_args)
 
-    # load model
-    model = ModelConfig.from_json(model_config).create_model()
+    # load model config
+    model_config = ModelConfig.from_json(model_config)
 
     with open(accelerator_args.accelerator_config) as f:
         accelerator_config = json.load(f)
@@ -64,7 +64,7 @@ def main(raw_args=None):
     target: OliveSystem = LocalSystem()
 
     # metric result
-    metric_result = target.evaluate_model(model, None, [metric], accelerator_spec)
+    metric_result = target.evaluate_model(model_config, None, [metric], accelerator_spec)
 
     # save metric result json
     with open(Path(pipeline_output) / "metric_result.json", "w") as f:

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -75,7 +75,7 @@ def main(raw_args=None):
 
         # Some passes create temporary files in the same directory as the model
         # original directory for model path is read only, so we need to copy the model to a temp directory
-        input_model_path = input_model_config["config"]["model_path"]
+        input_model_path = input_model_config["config"].get("model_path")
         if input_model_path is not None:
             tmp_dir = tempfile.TemporaryDirectory()
             old_path = Path(input_model_path).resolve()

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -471,9 +471,9 @@ class AzureMLSystem(OliveSystem):
     def evaluate_model(
         self, model_config: ModelConfig, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
     ) -> MetricResult:
-        if model_config.type == "SNPEModel":
+        if model_config.type.lower() == "SNPEModel".lower():
             raise NotImplementedError("SNPE model does not support azureml evaluation")
-        if model_config.type == "OpenVINOModel":
+        if model_config.type.lower() == "OpenVINOModel".lower():
             raise NotImplementedError("OpenVINO model does not support azureml evaluation")
 
         with tempfile.TemporaryDirectory() as tempdir:

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -92,13 +92,15 @@ def create_model_mount(model_config: ModelConfig, container_root_path: Path):
     mount_strs = []
     resource_paths = model_config.get_resource_paths()
     for resource_name, resource_path in resource_paths.items():
+        # if the resource path is None or string name, we need not to mount it
+        if not resource_path or resource_path.is_string_name():
+            continue
+
         relevant_path = resource_path.get_path()
         resource_path_mount_path = str(container_root_path / Path(relevant_path).name)
         resource_path_mount_str = f"{str(Path(relevant_path).resolve())}:{resource_path_mount_path}"
-        if resource_path_mount_path:
-            # if the resource path is not None or string name, we need to mount it
-            mounts[resource_name] = resource_path_mount_path
-            mount_strs.append(resource_path_mount_str)
+        mounts[resource_name] = resource_path_mount_path
+        mount_strs.append(resource_path_mount_str)
     return mounts, mount_strs
 
 

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -11,16 +11,15 @@ from typing import List
 from olive.cache import get_local_path_from_root
 from olive.evaluator.metric import Metric
 from olive.hardware.accelerator import AcceleratorSpec
-from olive.model import OliveModel
-from olive.resource_path import ResourcePath
+from olive.model import ModelConfig
 
 logger = logging.getLogger(__name__)
 
 
 def create_config_file(
-    tempdir, model: OliveModel, metrics: List[Metric], container_root_path: Path, model_mounts: dict
+    tempdir, model_config: ModelConfig, metrics: List[Metric], container_root_path: Path, model_mounts: dict
 ):
-    model_json = model.to_json(check_object=True)
+    model_json = model_config.to_json(check_object=True)
     for k, v in model_mounts.items():
         model_json["config"][k] = v
 
@@ -88,36 +87,14 @@ def create_metric_volumes_list(
     return mount_list
 
 
-def create_resource_path_mount(
-    resource_path: ResourcePath, local_resource_path: ResourcePath, container_root_path: Path
-) -> (str, str):
-    # no need to mount if resource path is None or string name
-    if not resource_path or resource_path.is_string_name():
-        return None, None
-    # the resource we want to mount should be local resource
-    relevant_resource_path = None
-    if resource_path.is_local_resource():
-        relevant_resource_path = resource_path
-    else:
-        assert local_resource_path and local_resource_path.is_local_resource(), "local resource path not set"
-        relevant_resource_path = local_resource_path
-    relevant_path = relevant_resource_path.get_path()
-
-    mount_path = str(container_root_path / Path(relevant_path).name)
-    mount_str = f"{str(Path(relevant_path).resolve())}:{mount_path}"
-    return mount_path, mount_str
-
-
-def create_model_mount(model: OliveModel, container_root_path: Path):
+def create_model_mount(model_config: ModelConfig, container_root_path: Path):
     mounts = {}
     mount_strs = []
-    for resource_name, resource_path in model.resource_paths.items():
-        local_resource_path = model.local_resource_paths[resource_name]
-        resource_path_mount_path, resource_path_mount_str = create_resource_path_mount(
-            resource_path=resource_path,
-            local_resource_path=local_resource_path,
-            container_root_path=container_root_path,
-        )
+    resource_paths = model_config.get_resource_paths()
+    for resource_name, resource_path in resource_paths.items():
+        relevant_path = resource_path.get_path()
+        resource_path_mount_path = str(container_root_path / Path(relevant_path).name)
+        resource_path_mount_str = f"{str(Path(relevant_path).resolve())}:{resource_path_mount_path}"
         if resource_path_mount_path:
             # if the resource path is not None or string name, we need to mount it
             mounts[resource_name] = resource_path_mount_path

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -40,7 +40,7 @@ class LocalSystem(OliveSystem):
         """
         Evaluate the model
         """
-        if model_config.type == "CompositeOnnxModel":
+        if model_config.type.lower() == "CompositeOnnxModel".lower():
             raise NotImplementedError()
 
         device = accelerator.accelerator_type if accelerator else Device.CPU

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from olive.evaluator.metric import Metric, MetricResult
 from olive.hardware.accelerator import AcceleratorSpec
-from olive.model import OliveModel
+from olive.model import ModelConfig
 from olive.passes.olive_pass import Pass
 from olive.systems.common import SystemType
 
@@ -26,11 +26,11 @@ class OliveSystem(ABC):
     def run_pass(
         self,
         the_pass: Pass,
-        model: OliveModel,
+        model_config: ModelConfig,
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
-    ) -> OliveModel:
+    ) -> ModelConfig:
         """
         Run the pass on the model at a specific point in the search space.
         """
@@ -38,7 +38,7 @@ class OliveSystem(ABC):
 
     @abstractmethod
     def evaluate_model(
-        self, model: OliveModel, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
+        self, model_config: ModelConfig, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
     ) -> MetricResult:
         """
         Evaluate the model

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -125,7 +125,7 @@ class PythonEnvironmentSystem(OliveSystem):
 
             with open(output_model_json_path, "r") as f:
                 model_json = json.load(f)
-                output_model = ModelConfig.from_json(model_json).create_model()
+                output_model = ModelConfig.from_json(model_json)
 
         return output_model
 
@@ -135,7 +135,7 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         Evaluate the model
         """
-        if not model_config.type == "ONNXModel":
+        if not model_config.type.lower() == "ONNXModel".lower():
             raise ValueError("PythonEnvironmentSystem can only evaluate ONNXModel.")
 
         # check if custom metric is present

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -26,7 +26,7 @@ from olive.evaluator.metric import (
 )
 from olive.evaluator.olive_evaluator import OliveEvaluator, OliveModelOutput, OnnxEvaluator
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec, Device
-from olive.model import ModelConfig, OliveModel, ONNXModel
+from olive.model import ModelConfig, ONNXModel
 from olive.passes.olive_pass import Pass
 from olive.systems.common import SystemType
 from olive.systems.olive_system import OliveSystem
@@ -93,7 +93,7 @@ class PythonEnvironmentSystem(OliveSystem):
         """
         Run the pass on the model at a specific point in the search space.
         """
-        model_config = model.to_json()
+        model_config_json = model_config.to_json()
         pass_config = the_pass.to_json()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -103,7 +103,7 @@ class PythonEnvironmentSystem(OliveSystem):
             output_model_json_path = tmp_dir_path / "output_model.json"
 
             with model_json_path.open("w") as f:
-                json.dump(model_config, f, indent=4)
+                json.dump(model_config_json, f, indent=4)
             with pass_json_path.open("w") as f:
                 json.dump(pass_config, f, indent=4)
 

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -85,11 +85,11 @@ class PythonEnvironmentSystem(OliveSystem):
     def run_pass(
         self,
         the_pass: Pass,
-        model: OliveModel,
+        model_config: ModelConfig,
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
-    ) -> OliveModel:
+    ) -> ModelConfig:
         """
         Run the pass on the model at a specific point in the search space.
         """
@@ -130,18 +130,19 @@ class PythonEnvironmentSystem(OliveSystem):
         return output_model
 
     def evaluate_model(
-        self, model: OliveModel, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
+        self, model_config: ModelConfig, data_root: str, metrics: List[Metric], accelerator: AcceleratorSpec
     ) -> MetricResult:
         """
         Evaluate the model
         """
-        if not isinstance(model, ONNXModel):
+        if not model_config.type == "ONNXModel":
             raise ValueError("PythonEnvironmentSystem can only evaluate ONNXModel.")
 
         # check if custom metric is present
         if any(metric.type == MetricType.CUSTOM for metric in metrics):
             raise ValueError("PythonEnvironmentSystem does not support custom metrics.")
 
+        model = model_config.create_model()
         metrics_res = {}
         for original_metric in metrics:
             metric = OliveEvaluator.generate_metric_user_config_with_model_io(original_metric, model)

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -138,7 +138,7 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
     ort.set_default_logger_severity(config.engine.ort_log_severity_level)
 
     # input model
-    input_model = config.input_model.create_model()
+    input_model = config.input_model
 
     # Azure ML Client
     if config.azureml_client:

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -10,6 +10,7 @@ from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.model import ModelConfig
 from olive.passes import OnnxConversion
 from olive.passes.olive_pass import create_pass_from_dict
+from olive.resource_path import ResourcePath
 from olive.systems.azureml import AzureMLDockerConfig, AzureMLSystem
 
 
@@ -46,7 +47,10 @@ def test_aml_model_pass_run():
         onnx_model_file = str(Path(tempdir) / "model.onnx")
         onnx_conversion_pass = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
         onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model_config, None, onnx_model_file)
-        assert Path(onnx_model.config["model_path"]).is_file()
+        model_path = onnx_model.config["model_path"]
+        if isinstance(model_path, ResourcePath):
+            model_path = model_path.get_path()
+        assert Path(model_path).is_file()
 
 
 def get_pytorch_model():

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from test.integ_test.utils import get_olive_workspace_config
 
 from olive.azureml.azureml_client import AzureMLClientConfig
-from olive.model import PyTorchModel
+from olive.model import ModelConfig
 from olive.passes import OnnxConversion
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.systems.azureml import AzureMLDockerConfig, AzureMLSystem
@@ -34,7 +34,7 @@ def test_aml_model_pass_run():
 
     # ------------------------------------------------------------------
     # Input model
-    pytorch_model = get_pytorch_model()
+    pytorch_model_config = get_pytorch_model()
 
     # ------------------------------------------------------------------
     # Onnx conversion pass
@@ -45,27 +45,31 @@ def test_aml_model_pass_run():
     with tempfile.TemporaryDirectory() as tempdir:
         onnx_model_file = str(Path(tempdir) / "model.onnx")
         onnx_conversion_pass = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
-        onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model, None, onnx_model_file)
+        onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model_config, None, onnx_model_file)
         assert Path(onnx_model.model_path).is_file()
 
 
 def get_pytorch_model():
     workspace_config = get_olive_workspace_config()
     azureml_client_config = AzureMLClientConfig(**workspace_config)
-    pytorch_model = PyTorchModel(
-        model_path={
-            "type": "azureml_model",
-            "config": {
-                "azureml_client": azureml_client_config,
-                "name": "bert_glue",
-                "version": 10,
+    model_config = {
+        "type": "PyTorchModel",
+        "config": {
+            "model_path": {
+                "type": "azureml_model",
+                "config": {
+                    "azureml_client": azureml_client_config,
+                    "name": "bert_glue",
+                    "version": 10,
+                },
+            },
+            "io_config": {
+                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+                "input_shapes": [[1, 128], [1, 128], [1, 128]],
+                "input_types": ["int64", "int64", "int64"],
+                "output_names": ["output"],
             },
         },
-        io_config={
-            "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-            "input_shapes": [[1, 128], [1, 128], [1, 128]],
-            "input_types": ["int64", "int64", "int64"],
-            "output_names": ["output"],
-        },
-    )
-    return pytorch_model
+    }
+
+    return ModelConfig.parse_obj(model_config)

--- a/test/integ_test/aml_model_test/test_aml_model.py
+++ b/test/integ_test/aml_model_test/test_aml_model.py
@@ -46,7 +46,7 @@ def test_aml_model_pass_run():
         onnx_model_file = str(Path(tempdir) / "model.onnx")
         onnx_conversion_pass = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
         onnx_model = aml_system.run_pass(onnx_conversion_pass, pytorch_model_config, None, onnx_model_file)
-        assert Path(onnx_model.model_path).is_file()
+        assert Path(onnx_model.config["model_path"]).is_file()
 
 
 def get_pytorch_model():

--- a/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
+++ b/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
@@ -18,7 +18,7 @@ import pytest
 
 from olive.evaluator.metric import joint_metric_key
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
-from olive.model import ONNXModel, PyTorchModel
+from olive.model import ModelConfig
 
 
 class TestAMLEvaluation:
@@ -31,20 +31,20 @@ class TestAMLEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE = [
-        (PyTorchModel, get_pytorch_model(), get_accuracy_metric(), 0.99),
-        (PyTorchModel, get_pytorch_model(), get_latency_metric(), 0.001),
-        (ONNXModel, get_onnx_model(), get_accuracy_metric(), 0.99),
-        (ONNXModel, get_onnx_model(), get_latency_metric(), 0.001),
+        ("PyTorchModel", get_pytorch_model(), get_accuracy_metric(), 0.99),
+        ("PyTorchModel", get_pytorch_model(), get_latency_metric(), 0.001),
+        ("ONNXModel", get_onnx_model(), get_accuracy_metric(), 0.99),
+        ("ONNXModel", get_onnx_model(), get_latency_metric(), 0.001),
     ]
 
     @pytest.mark.parametrize(
-        "model_cls,model_path,metric,expected_res",
+        "model_type,model_path,metric,expected_res",
         EVALUATION_TEST_CASE,
     )
-    def test_evaluate_model(self, model_cls, model_path, metric, expected_res):
+    def test_evaluate_model(self, model_type, model_path, metric, expected_res):
         aml_target = get_aml_target()
-        olive_model = model_cls(model_path=model_path)
-        actual_res = aml_target.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
+        config = ModelConfig.parse_obj({"type": model_type, "config": {"model_path": model_path}})
+        actual_res = aml_target.evaluate_model(config, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/integ_test/evaluator/local_eval/test_local_evaluation.py
+++ b/test/integ_test/evaluator/local_eval/test_local_evaluation.py
@@ -21,7 +21,7 @@ import pytest
 
 from olive.evaluator.metric import joint_metric_key
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
-from olive.model import ONNXModel, OpenVINOModel, PyTorchModel
+from olive.model import ModelConfig
 from olive.systems.local import LocalSystem
 
 
@@ -33,23 +33,23 @@ class TestLocalEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE = [
-        (PyTorchModel, get_pytorch_model(), get_accuracy_metric(post_process), 0.99),
-        (PyTorchModel, get_pytorch_model(), get_latency_metric(), 0.001),
-        (PyTorchModel, get_huggingface_model(), get_hf_accuracy_metric(), 0.1),
-        (PyTorchModel, get_huggingface_model(), get_hf_latency_metric(), 0.001),
-        (ONNXModel, get_onnx_model(), get_accuracy_metric(post_process), 0.99),
-        (ONNXModel, get_onnx_model(), get_latency_metric(), 0.001),
-        (OpenVINOModel, get_openvino_model(), get_accuracy_metric(openvino_post_process), 0.99),
-        (OpenVINOModel, get_openvino_model(), get_latency_metric(), 0.001),
+        ("PyTorchModel", get_pytorch_model(), get_accuracy_metric(post_process), 0.99),
+        ("PyTorchModel", get_pytorch_model(), get_latency_metric(), 0.001),
+        ("PyTorchModel", get_huggingface_model(), get_hf_accuracy_metric(), 0.1),
+        ("PyTorchModel", get_huggingface_model(), get_hf_latency_metric(), 0.001),
+        ("ONNXModel", get_onnx_model(), get_accuracy_metric(post_process), 0.99),
+        ("ONNXModel", get_onnx_model(), get_latency_metric(), 0.001),
+        ("OpenVINOModel", get_openvino_model(), get_accuracy_metric(openvino_post_process), 0.99),
+        ("OpenVINOModel", get_openvino_model(), get_latency_metric(), 0.001),
     ]
 
     @pytest.mark.parametrize(
-        "model_cls,model_config,metric,expected_res",
+        "type,model_config,metric,expected_res",
         EVALUATION_TEST_CASE,
     )
-    def test_evaluate_model(self, model_cls, model_config, metric, expected_res):
-        olive_model = model_cls(**model_config)
-        actual_res = LocalSystem().evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
+    def test_evaluate_model(self, type, model_config, metric, expected_res):
+        model_conf = ModelConfig.parse_obj({"type": type, "config": model_config})
+        actual_res = LocalSystem().evaluate_model(model_conf, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/multiple_ep/test_aml_system.py
+++ b/test/multiple_ep/test_aml_system.py
@@ -12,7 +12,7 @@ from olive.engine import Engine
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import Device
 from olive.hardware.accelerator import AcceleratorSpec
-from olive.model import ONNXModel
+from olive.model import ModelConfig
 from olive.passes.onnx import OrtPerfTuning
 
 
@@ -41,7 +41,9 @@ class TestOliveAzureMLSystem:
 
         self.execution_providers = ["CPUExecutionProvider", "OpenVINOExecutionProvider"]
         download_models()
-        self.input_model = ONNXModel(model_path=get_onnx_model())
+        self.input_model_config = ModelConfig.parse_obj(
+            {"type": "ONNXModel", "config": {"model_path": get_onnx_model()}}
+        )
         download_data()
 
     def test_run_pass_evaluate(self):
@@ -55,7 +57,7 @@ class TestOliveAzureMLSystem:
         options = {"execution_providers": self.execution_providers}
         engine = Engine(options, target=self.system, host=self.system, evaluator_config=evaluator_config)
         engine.register(OrtPerfTuning)
-        output = engine.run(self.input_model, output_dir=output_dir)
+        output = engine.run(self.input_model_config, output_dir=output_dir)
         cpu_res = output[AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="CPUExecutionProvider")]
         openvino_res = output[
             AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -11,7 +11,7 @@ from olive.engine import Engine
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import Device
 from olive.hardware.accelerator import AcceleratorSpec
-from olive.model import ONNXModel
+from olive.model import ModelConfig
 from olive.passes.onnx import OrtPerfTuning
 
 
@@ -27,7 +27,9 @@ class TestOliveManagedDockerSystem:
         self.system = DockerSystem(accelerators=["cpu"], olive_managed_env=True, is_dev=True)
         self.execution_providers = ["CPUExecutionProvider", "OpenVINOExecutionProvider"]
         download_models()
-        self.input_model = ONNXModel(model_path=get_onnx_model())
+        self.input_model_config = ModelConfig.parse_obj(
+            {"type": "ONNXModel", "config": {"model_path": get_onnx_model()}}
+        )
         download_data()
 
     def test_run_pass_evaluate(self):
@@ -41,7 +43,7 @@ class TestOliveManagedDockerSystem:
         options = {"execution_providers": self.execution_providers}
         engine = Engine(options, target=self.system, evaluator_config=evaluator_config)
         engine.register(OrtPerfTuning)
-        output = engine.run(self.input_model, output_dir=output_dir)
+        output = engine.run(self.input_model_config, output_dir=output_dir)
         cpu_res = output[AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="CPUExecutionProvider")]
         openvino_res = output[
             AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")

--- a/test/multiple_ep/test_python_env_system.py
+++ b/test/multiple_ep/test_python_env_system.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import platform
 import tempfile
-from test.unit_test.utils import create_onnx_model_file, get_latency_metric, get_onnx_model
+from test.unit_test.utils import create_onnx_model_file, get_latency_metric, get_onnx_model_config
 
 import pytest
 
@@ -21,7 +21,7 @@ class TestOliveManagedPythonEnvironmentSystem:
     @pytest.fixture(autouse=True)
     def setup(self):
         create_onnx_model_file()
-        self.input_model = get_onnx_model()
+        self.input_model_config = get_onnx_model_config()
 
     @pytest.mark.skip(reason="No machine to test DML execution provider")
     def test_run_pass_evaluate_windows(self):
@@ -39,7 +39,7 @@ class TestOliveManagedPythonEnvironmentSystem:
         options = {"execution_providers": self.execution_providers}
         engine = Engine(options, target=self.system, host=self.system, evaluator_config=evaluator_config)
         engine.register(OrtPerfTuning)
-        output = engine.run(self.input_model, output_dir=output_dir, evaluate_input_model=True)
+        output = engine.run(self.input_model_config, output_dir=output_dir, evaluate_input_model=True)
         dml_res = output[AcceleratorSpec(accelerator_type=Device.GPU, execution_provider="DmlExecutionProvider")]
         openvino_res = output[
             AcceleratorSpec(accelerator_type=Device.GPU, execution_provider="OpenVINOExecutionProvider")
@@ -63,7 +63,7 @@ class TestOliveManagedPythonEnvironmentSystem:
         options = {"execution_providers": self.execution_providers}
         engine = Engine(options, target=self.system, host=self.system, evaluator_config=evaluator_config)
         engine.register(OrtPerfTuning)
-        output = engine.run(self.input_model, output_dir=output_dir, evaluate_input_model=True)
+        output = engine.run(self.input_model_config, output_dir=output_dir, evaluate_input_model=True)
         cpu_res = output[AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="CPUExecutionProvider")]
         openvino_res = output[
             AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")

--- a/test/unit_test/engine/packaging/test_packaging_generator.py
+++ b/test/unit_test/engine/packaging/test_packaging_generator.py
@@ -6,7 +6,7 @@ import json
 import tempfile
 import zipfile
 from pathlib import Path
-from test.unit_test.utils import get_accuracy_metric, get_pytorch_model
+from test.unit_test.utils import get_accuracy_metric, get_pytorch_model_config
 from unittest.mock import patch
 
 import onnx
@@ -45,7 +45,7 @@ def test_generate_zipfile_artifacts(mock_sys_getsizeof, save_as_external_data, m
     engine = Engine(options, evaluator_config=evaluator_config)
     engine.register(OnnxConversion, {"save_as_external_data": save_as_external_data})
 
-    input_model = get_pytorch_model()
+    input_model_config = get_pytorch_model_config()
 
     packaging_config = PackagingConfig()
     packaging_config.type = PackagingType.Zipfile
@@ -55,7 +55,9 @@ def test_generate_zipfile_artifacts(mock_sys_getsizeof, save_as_external_data, m
     output_dir = Path(tempdir.name) / "outputs"
 
     # execute
-    engine.run(input_model=input_model, data_root=None, packaging_config=packaging_config, output_dir=output_dir)
+    engine.run(
+        input_model_config=input_model_config, data_root=None, packaging_config=packaging_config, output_dir=output_dir
+    )
 
     # assert
     artifacts_path = output_dir / "OutputModels.zip"
@@ -93,7 +95,7 @@ def test_generate_zipfile_artifacts_no_search():
     engine = Engine(options)
     engine.register(OnnxConversion)
 
-    input_model = get_pytorch_model()
+    input_model_config = get_pytorch_model_config()
 
     packaging_config = PackagingConfig()
     packaging_config.type = PackagingType.Zipfile
@@ -104,7 +106,10 @@ def test_generate_zipfile_artifacts_no_search():
 
     # execute
     engine.run(
-        input_model=input_model, packaging_config=packaging_config, output_dir=output_dir, evaluate_input_model=False
+        input_model_config=input_model_config,
+        packaging_config=packaging_config,
+        output_dir=output_dir,
+        evaluate_input_model=False,
     )
 
     # assert

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -8,10 +8,9 @@ import tempfile
 from pathlib import Path
 from test.unit_test.utils import (
     get_accuracy_metric,
-    get_onnx_model,
+    get_onnx_model_config,
     get_onnxconversion_pass,
-    get_pytorch_model,
-    pytorch_model_loader,
+    get_pytorch_model_config,
 )
 from unittest.mock import patch
 
@@ -22,7 +21,6 @@ from olive.engine import Engine
 from olive.evaluator.metric import AccuracySubType, MetricResult, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
-from olive.model import PyTorchModel
 from olive.passes.onnx import OnnxConversion, OnnxDynamicQuantization, OnnxStaticQuantization
 from olive.systems.common import SystemType
 from olive.systems.local import LocalSystem
@@ -78,7 +76,7 @@ class TestEngine:
     def test_register_no_search_fail(self, tmpdir):
         name = "OnnxDynamicQuantization"
         # setup
-        pytorch_model = get_pytorch_model()
+        model_config = get_pytorch_model_config()
 
         options = {
             "cache_dir": tmpdir,
@@ -90,15 +88,15 @@ class TestEngine:
         # execute
         engine.register(OnnxDynamicQuantization)
         with pytest.raises(ValueError) as exc_info:
-            engine.run(pytorch_model)
+            engine.run(model_config)
 
         assert str(exc_info.value) == f"Search strategy is None but pass {name} has search space"
 
     @patch("olive.systems.local.LocalSystem")
     def test_run(self, mock_local_system, tmpdir):
         # setup
-        pytorch_model = get_pytorch_model()
-        input_model_id = hash_dict(pytorch_model.to_json())
+        model_config = get_pytorch_model_config()
+        input_model_id = hash_dict(model_config.to_json())
         p, pass_config = get_onnxconversion_pass(ignore_pass_config=False)
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
@@ -113,7 +111,6 @@ class TestEngine:
             },
             "clean_evaluation_cache": True,
         }
-        onnx_model = get_onnx_model()
         metric_result_dict = {
             joint_metric_key(metric.name, sub_metric.name): {
                 "value": 0.998,
@@ -122,7 +119,8 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
-        mock_local_system.run_pass.return_value = onnx_model
+        onnx_model_config = get_onnx_model_config()
+        mock_local_system.run_pass.return_value = onnx_model_config
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
         mock_local_system.olive_managed_env = False
@@ -145,7 +143,7 @@ class TestEngine:
         # execute
         temp_dir = tempfile.TemporaryDirectory()
         output_dir = Path(temp_dir.name)
-        actual_res = engine.run(pytorch_model, output_dir=output_dir)
+        actual_res = engine.run(model_config, output_dir=output_dir)
         accelerator_spec = DEFAULT_CPU_ACCELERATOR
         actual_res = actual_res[accelerator_spec]
 
@@ -167,12 +165,14 @@ class TestEngine:
         assert engine.get_model_json_path(actual_res.nodes[model_id].model_id).exists()
         mock_local_system.run_pass.assert_called_once()
         mock_local_system.evaluate_model.call_count == 2
-        mock_local_system.evaluate_model.assert_called_with(onnx_model, None, [metric], accelerator_spec)
+        mock_local_system.evaluate_model.assert_called_with(
+            onnx_model_config.to_json(), None, [metric], accelerator_spec
+        )
 
     @patch("olive.systems.local.LocalSystem")
     def test_run_no_search(self, mock_local_system, tmpdir):
         # setup
-        pytorch_model = get_pytorch_model()
+        model_config = get_pytorch_model_config()
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
         options = {
@@ -183,7 +183,6 @@ class TestEngine:
             "search_strategy": None,
             "clean_evaluation_cache": True,
         }
-        onnx_model = get_onnx_model()
         metric_result_dict = {
             joint_metric_key(metric.name, sub_metric.name): {
                 "value": 0.998,
@@ -192,7 +191,8 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
-        mock_local_system.run_pass.return_value = onnx_model
+        onnx_model_config = get_onnx_model_config()
+        mock_local_system.run_pass.return_value = onnx_model_config
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
         mock_local_system.olive_managed_env = False
@@ -207,13 +207,13 @@ class TestEngine:
 
         accelerator_spec = DEFAULT_CPU_ACCELERATOR
         output_prefix = f"{accelerator_spec}"
-        expected_res = {"model": onnx_model.to_json(), "metrics": MetricResult.parse_obj(metric_result_dict)}
+        expected_res = {"model": onnx_model_config.to_json(), "metrics": MetricResult.parse_obj(metric_result_dict)}
         expected_res["model"]["config"]["model_path"] = str(
             Path(expected_output_dir / f"{output_prefix}_model.onnx").resolve()
         )
 
         # execute
-        actual_res = engine.run(pytorch_model, output_dir=output_dir)
+        actual_res = engine.run(model_config, output_dir=output_dir)
         actual_res = actual_res[accelerator_spec][tuple(engine.pass_flows[0])]
 
         assert expected_res == actual_res
@@ -247,12 +247,13 @@ class TestEngine:
             }
             engine = Engine(options, evaluator_config=evaluator_config, host=system, target=system)
             engine.register(OnnxConversion, clean_run_cache=True)
-            model = PyTorchModel(model_loader=pytorch_model_loader, model_path=None)
+
+            model_config = get_pytorch_model_config()
 
             # execute
             temp_dir = tempfile.TemporaryDirectory()
             output_dir = Path(temp_dir.name)
-            engine.run(model, output_dir=output_dir)
+            engine.run(model_config, output_dir=output_dir)
 
             # assert
             assert "Exception: test" in caplog.text
@@ -262,7 +263,7 @@ class TestEngine:
     @patch("olive.systems.local.LocalSystem")
     def test_run_evaluate_input_model(self, mock_local_system, tmpdir):
         # setup
-        pytorch_model = get_pytorch_model()
+        model_config = get_pytorch_model_config()
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
         options = {
@@ -271,7 +272,6 @@ class TestEngine:
             "search_strategy": None,
             "clean_evaluation_cache": True,
         }
-        onnx_model = get_onnx_model()
         metric_result_dict = {
             joint_metric_key(metric.name, sub_metric.name): {
                 "value": 0.998,
@@ -280,7 +280,7 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
-        mock_local_system.run_pass.return_value = onnx_model
+        mock_local_system.run_pass.return_value = get_onnx_model_config()
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
         mock_local_system.olive_managed_env = False
@@ -295,7 +295,7 @@ class TestEngine:
         expected_res = MetricResult.parse_obj(metric_result_dict)
 
         # execute
-        actual_res = engine.run(pytorch_model, output_dir=output_dir, evaluate_input_model=True)
+        actual_res = engine.run(model_config, output_dir=output_dir, evaluate_input_model=True)
         accelerator_spec = DEFAULT_CPU_ACCELERATOR
         actual_res = actual_res[accelerator_spec][tuple(engine.pass_flows[0])]["metrics"]
 
@@ -307,7 +307,7 @@ class TestEngine:
     @patch("olive.systems.local.LocalSystem")
     def test_run_no_pass(self, mock_local_system, tmpdir):
         # setup
-        pytorch_model = get_pytorch_model()
+        model_config = get_pytorch_model_config()
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
         options = {
@@ -337,7 +337,7 @@ class TestEngine:
         expected_res = MetricResult.parse_obj(metric_result_dict)
 
         # execute
-        actual_res = engine.run(pytorch_model, output_dir=output_dir, evaluate_input_model=True)
+        actual_res = engine.run(model_config, output_dir=output_dir, evaluate_input_model=True)
         accelerator_spec = DEFAULT_CPU_ACCELERATOR
         actual_res = actual_res[accelerator_spec]
 
@@ -412,7 +412,7 @@ class TestEngine:
             "QNNExecutionProvider",
         ]
         mock_get_available_providers.return_value = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-        mock_local_system.run_pass.return_value = get_onnx_model()
+        mock_local_system.run_pass.return_value = get_onnx_model_config()
         mock_local_system.olive_managed_env = False
         metric_result_dict = {
             joint_metric_key(metric.name, sub_metric.name): {
@@ -429,11 +429,10 @@ class TestEngine:
         assert "QNNExecutionProvider" in caplog.text
         engine.register(OnnxConversion, clean_run_cache=True)
 
-        pytorch_model = get_pytorch_model()
-
+        model_config = get_pytorch_model_config()
         temp_dir = tempfile.TemporaryDirectory()
         output_dir = Path(temp_dir.name)
-        _ = engine.run(pytorch_model, output_dir=output_dir)
+        _ = engine.run(model_config, output_dir=output_dir)
 
         mock_local_system.run_pass.assert_called_once()
 
@@ -459,7 +458,7 @@ class TestEngine:
             "CPUExecutionProvider",
         ]
         mock_get_available_providers.return_value = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-        mock_local_system.run_pass.return_value = get_onnx_model()
+        mock_local_system.run_pass.return_value = get_onnx_model_config()
         mock_local_system.olive_managed_env = False
         metric_result_dict = {
             joint_metric_key(metric.name, sub_metric.name): {
@@ -474,8 +473,7 @@ class TestEngine:
         engine = Engine(options, host=mock_local_system, target=mock_local_system, evaluator_config=evaluator_config)
         engine.register(OnnxConversion, clean_run_cache=True)
 
-        pytorch_model = get_pytorch_model()
-
+        model_config = get_pytorch_model_config()
         temp_dir = tempfile.TemporaryDirectory()
         output_dir = Path(temp_dir.name)
 
@@ -483,7 +481,7 @@ class TestEngine:
             "olive.passes.onnx.conversion.OnnxConversion.is_accelerator_agnostic"
         ) as is_accelerator_agnostic_mock:
             is_accelerator_agnostic_mock.return_value = False
-            _ = engine.run(pytorch_model, output_dir=output_dir)
+            _ = engine.run(model_config, output_dir=output_dir)
             mock_local_system.run_pass.call_count == 2
 
     def test_pass_value_error(self, caplog, tmpdir):
@@ -506,13 +504,12 @@ class TestEngine:
             }
             engine = Engine(options, evaluator_config=evaluator_config, host=system, target=system)
             engine.register(OnnxConversion, clean_run_cache=True)
-            model = PyTorchModel(model_loader=pytorch_model_loader, model_path=None)
-
+            model_config = get_pytorch_model_config()
             # execute
             temp_dir = tempfile.TemporaryDirectory()
             output_dir = Path(temp_dir.name)
             with pytest.raises(ValueError):
-                engine.run(model, output_dir=output_dir)
+                engine.run(model_config, output_dir=output_dir)
 
     @pytest.mark.parametrize("is_search", [True, False])
     def test_pass_quantization_error(self, is_search, caplog, tmpdir):
@@ -521,7 +518,7 @@ class TestEngine:
         logger = logging.getLogger("olive")
         logger.propagate = True
 
-        onnx_model = get_onnx_model()
+        onnx_model_config = get_onnx_model_config()
         # output model to output_dir
         temp_dir = tempfile.TemporaryDirectory()
         output_dir = Path(temp_dir.name)
@@ -542,7 +539,7 @@ class TestEngine:
             engine.register(OnnxStaticQuantization, {"dataloader_func": lambda x, y: None})
             with patch("onnxruntime.quantization.quantize_static") as mock_quantize_static:
                 mock_quantize_static.side_effect = AttributeError("test")
-                actual_res = engine.run(onnx_model, data_root=None, output_dir=output_dir)
+                actual_res = engine.run(onnx_model_config, data_root=None, output_dir=output_dir)
                 pf = actual_res[DEFAULT_CPU_ACCELERATOR]
                 assert not pf.nodes, "Expect empty dict when quantization fails"
         else:
@@ -555,7 +552,9 @@ class TestEngine:
             engine.register(OnnxDynamicQuantization, disable_search=True)
             with patch("onnxruntime.quantization.quantize_dynamic") as mock_quantize_dynamic:
                 mock_quantize_dynamic.side_effect = AttributeError("test")
-                actual_res = engine.run(onnx_model, data_root=None, output_dir=output_dir, evaluate_input_model=False)
+                actual_res = engine.run(
+                    onnx_model_config, data_root=None, output_dir=output_dir, evaluate_input_model=False
+                )
                 for pass_flow in engine.pass_flows:
                     assert not actual_res[DEFAULT_CPU_ACCELERATOR][
                         tuple(pass_flow)

--- a/test/unit_test/evaluator/test_metric_backend.py
+++ b/test/unit_test/evaluator/test_metric_backend.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from test.unit_test.utils import get_accuracy_metric, get_onnx_model, get_pytorch_model
+from test.unit_test.utils import get_accuracy_metric, get_onnx_model_config, get_pytorch_model_config
 from unittest.mock import patch
 
 import pytest
@@ -41,15 +41,23 @@ class TestMetricBackend:
             assert v.value == 0.999
 
     HF_ACCURACY_TEST_CASE = [
-        (get_pytorch_model(), get_accuracy_metric("accuracy", "f1", backend="huggingface_metrics"), 0.99),
-        (get_onnx_model(), get_accuracy_metric("accuracy", "f1", backend="huggingface_metrics"), 0.99),
+        (
+            get_pytorch_model_config(),
+            get_accuracy_metric("accuracy", "f1", backend="huggingface_metrics"),
+            0.99,
+        ),
+        (
+            get_onnx_model_config(),
+            get_accuracy_metric("accuracy", "f1", backend="huggingface_metrics"),
+            0.99,
+        ),
     ]
 
     @pytest.mark.parametrize(
-        "olive_model,metric,expected_res",
+        "model_config,metric,expected_res",
         HF_ACCURACY_TEST_CASE,
     )
-    def test_evaluate_backend(self, olive_model, metric, expected_res):
+    def test_evaluate_backend(self, model_config, metric, expected_res):
         from olive.evaluator.metric_backend import HuggingfaceMetrics
 
         with patch.object(HuggingfaceMetrics, "measure_sub_metric") as mock_measure:
@@ -57,7 +65,7 @@ class TestMetricBackend:
             system = LocalSystem()
 
             # execute
-            actual_res = system.evaluate_model(olive_model, None, [metric], DEFAULT_CPU_ACCELERATOR)
+            actual_res = system.evaluate_model(model_config, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
             # assert
             mock_measure.call_count == len(metric.sub_types)

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -27,70 +27,70 @@ class TestOliveEvaluator:
     ACCURACY_TEST_CASE = [
         (
             PyTorchEvaluator(),
-            get_pytorch_model(),
+            get_pytorch_model,
             get_accuracy_metric(AccuracySubType.ACCURACY_SCORE),
             "olive.evaluator.accuracy.AccuracyScore",
             0.99,
         ),
         (
             PyTorchEvaluator(),
-            get_pytorch_model(),
+            get_pytorch_model,
             get_accuracy_metric(AccuracySubType.F1_SCORE),
             "olive.evaluator.accuracy.F1Score",
             0.99,
         ),
         (
             PyTorchEvaluator(),
-            get_pytorch_model(),
+            get_pytorch_model,
             get_accuracy_metric(AccuracySubType.PRECISION),
             "olive.evaluator.accuracy.Precision",
             0.99,
         ),
         (
             PyTorchEvaluator(),
-            get_pytorch_model(),
+            get_pytorch_model,
             get_accuracy_metric(AccuracySubType.RECALL),
             "olive.evaluator.accuracy.Recall",
             0.99,
         ),
         (
             PyTorchEvaluator(),
-            get_pytorch_model(),
+            get_pytorch_model,
             get_accuracy_metric(AccuracySubType.AUROC),
             "olive.evaluator.accuracy.AUROC",
             0.99,
         ),
         (
             OnnxEvaluator(),
-            get_onnx_model(),
+            get_onnx_model,
             get_accuracy_metric(AccuracySubType.ACCURACY_SCORE),
             "olive.evaluator.accuracy.AccuracyScore",
             0.99,
         ),
         (
             OnnxEvaluator(),
-            get_onnx_model(),
+            get_onnx_model,
             get_accuracy_metric(AccuracySubType.F1_SCORE),
             "olive.evaluator.accuracy.F1Score",
             0.99,
         ),
         (
             OnnxEvaluator(),
-            get_onnx_model(),
+            get_onnx_model,
             get_accuracy_metric(AccuracySubType.PRECISION),
             "olive.evaluator.accuracy.Precision",
             0.99,
         ),
         (
             OnnxEvaluator(),
-            get_onnx_model(),
+            get_onnx_model,
             get_accuracy_metric(AccuracySubType.RECALL),
             "olive.evaluator.accuracy.Recall",
             0.99,
         ),
         (
             OnnxEvaluator(),
-            get_onnx_model(),
+            get_onnx_model,
             get_accuracy_metric(AccuracySubType.AUROC),
             "olive.evaluator.accuracy.AUROC",
             0.99,
@@ -98,14 +98,15 @@ class TestOliveEvaluator:
     ]
 
     @pytest.mark.parametrize(
-        "evaluator, olive_model,metric,acc_subtype,expected_res",
+        "evaluator,model_loader,metric,acc_subtype,expected_res",
         ACCURACY_TEST_CASE,
     )
-    def test_evaluate_accuracy(self, evaluator, olive_model, metric, acc_subtype, expected_res):
+    def test_evaluate_accuracy(self, evaluator, model_loader, metric, acc_subtype, expected_res):
         # setup
         with patch(f"{acc_subtype}.measure") as mock_acc:
             mock_acc.return_value = expected_res
 
+            olive_model = model_loader()
             # execute
             actual_res = evaluator.evaluate(olive_model, None, [metric])
 
@@ -115,31 +116,32 @@ class TestOliveEvaluator:
                 assert expected_res == actual_res.get_value(metric.name, sub_type.name)
 
     LATENCY_TEST_CASE = [
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.AVG, LatencySubType.MAX), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.MAX), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.MIN), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.P50), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.P75), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.P90), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.P95), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.P99), 10),
-        (PyTorchEvaluator(), get_pytorch_model(), get_latency_metric(LatencySubType.P999), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.AVG), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.MAX), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.MIN), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.P50), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.P75), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.P90), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.P95), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.P99), 10),
-        (OnnxEvaluator(), get_onnx_model(), get_latency_metric(LatencySubType.P999), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.AVG, LatencySubType.MAX), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.MAX), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.MIN), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.P50), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.P75), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.P90), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.P95), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.P99), 10),
+        (PyTorchEvaluator(), get_pytorch_model, get_latency_metric(LatencySubType.P999), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.AVG), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.MAX), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.MIN), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.P50), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.P75), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.P90), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.P95), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.P99), 10),
+        (OnnxEvaluator(), get_onnx_model, get_latency_metric(LatencySubType.P999), 10),
     ]
 
     @pytest.mark.parametrize(
-        "evaluator,olive_model,metric,expected_res",
+        "evaluator,model_loader,metric,expected_res",
         LATENCY_TEST_CASE,
     )
-    def test_evaluate_latency(self, evaluator, olive_model, metric, expected_res):
+    def test_evaluate_latency(self, evaluator, model_loader, metric, expected_res):
+        olive_model = model_loader()
         # execute
         actual_res = evaluator.evaluate(olive_model, None, [metric])
 
@@ -148,17 +150,18 @@ class TestOliveEvaluator:
             assert expected_res > actual_res.get_value(metric.name, sub_type.name)
 
     CUSTOM_TEST_CASE = [
-        (PyTorchEvaluator(), get_pytorch_model(), get_custom_eval(), 0.382715310),
-        (OnnxEvaluator(), get_onnx_model(), get_custom_eval(), 0.382715310),
-        (SNPEEvaluator(), get_mock_snpe_model(), get_custom_eval(), 0.382715310),
-        (OpenVINOEvaluator(), get_mock_openvino_model(), get_custom_eval(), 0.382715310),
+        (PyTorchEvaluator(), get_pytorch_model, get_custom_eval(), 0.382715310),
+        (OnnxEvaluator(), get_onnx_model, get_custom_eval(), 0.382715310),
+        (SNPEEvaluator(), get_mock_snpe_model, get_custom_eval(), 0.382715310),
+        (OpenVINOEvaluator(), get_mock_openvino_model, get_custom_eval(), 0.382715310),
     ]
 
     @pytest.mark.parametrize(
-        "evaluator,olive_model,metric,expected_res",
+        "evaluator,model_laader,metric,expected_res",
         CUSTOM_TEST_CASE,
     )
-    def test_evaluate_custom(self, evaluator, olive_model, metric, expected_res):
+    def test_evaluate_custom(self, evaluator, model_laader, metric, expected_res):
+        olive_model = model_laader()
         # execute
         actual_res = evaluator.evaluate(olive_model, None, [metric])
 

--- a/test/unit_test/passes/pytorch/test_qlora.py
+++ b/test/unit_test/passes/pytorch/test_qlora.py
@@ -58,4 +58,4 @@ def test_qlora(patched_model_loading_args, patched_find_all_linear_names, tmp_pa
 
     # execute
     out = p.run(input_model, None, output_folder)
-    assert Path(out.get_local_resource("adapter_path")).exists()
+    assert Path(out.get_resource("adapter_path")).exists()

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -16,7 +16,7 @@ from olive.data.config import DataComponentConfig, DataConfig
 from olive.data.registry import Registry
 from olive.evaluator.metric import Metric, MetricType
 from olive.evaluator.metric_config import MetricGoal
-from olive.model import ONNXModel, OptimumModel, PyTorchModel
+from olive.model import ModelConfig, ONNXModel, OptimumModel, PyTorchModel
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OnnxConversion, OnnxDynamicQuantization
 
@@ -62,6 +62,17 @@ def pytorch_model_loader(model_path):
     return DummyModel().eval()
 
 
+def get_pytorch_model_config():
+    config = {
+        "type": "PyTorchModel",
+        "config": {
+            "model_loader": pytorch_model_loader,
+            "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+        },
+    }
+    return ModelConfig.parse_obj(config)
+
+
 def get_pytorch_model():
     return PyTorchModel(
         model_loader=pytorch_model_loader,
@@ -105,6 +116,10 @@ def create_onnx_model_file():
     torch.onnx.export(
         pytorch_model, dummy_input, ONNX_MODEL_PATH, opset_version=10, input_names=["input"], output_names=["output"]
     )
+
+
+def get_onnx_model_config():
+    return ModelConfig.parse_obj({"type": "ONNXModel", "config": {"model_path": str(ONNX_MODEL_PATH)}})
 
 
 def get_onnx_model():


### PR DESCRIPTION
## Describe your changes
From the time being, the OliveModel is used in Olive to prepare the optimization. It should use model config instead of model itself. For example, if the model is hosted in AML, Engine need create the model instance for run. later, it will need manually set the download model path to model instance. This kind of behavior hinder the lifecycle of the model. In case of remote model path scenario, we cannot call any model path related method in constructor. Such as https://github.com/microsoft/Olive/pull/542#discussion_r1320161984.

In this PR, I split the responsibility of model itself and model preparation to different place. The assumption is whenever the model instance is created, the model path should already be downloaded and can directly access.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
