### PR TITLE
Drop python 3.7, Fix `onnxruntime` dependency setup, Whisper: Add EP and FAQ

### DIFF
--- a/.azure_pipelines/formatting.yaml
+++ b/.azure_pipelines/formatting.yaml
@@ -10,10 +10,10 @@ jobs:
   - job: Pylint
     strategy:
       matrix:
-        Python37:
-          python.version: "3.7"
         Python38:
           python.version: "3.8"
+        Python39:
+          python.version: "3.9"
 
     steps:
       - task: UsePythonVersion@0

--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -128,3 +128,16 @@ python test_transcription.py --config whisper_cpu_int8.json
 
 `--task` Optional. Whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate'). Default is `transcribe`. Only used
 when `--multilingual` is provided to `prepare_whisper_configs.py`
+
+## FAQ
+The following are some common issues that may be encountered when running this example.
+1. `INVALID_GRAPH / Error Node (BeamSearch_node) has input size 12 not in range [min=5, max=10]` or similar error when running inference using the optimized model.
+This is likely due to:
+    - Mismatch between the versions of onnxruntime used to run the optimization workflow and the inference. To fix this, please use the same version of
+    onnxruntime for both.
+    - Mismatch between the versions of onnxruntime used in a previously cached run and the currently installed version. To fix this, please delete the `cache` folder
+    and run the workflow again.
+
+2. Whenever you install a new version of onnxruntime (such as ort-nightly), you may need to delete the `cache` folder and run the workflow again. This is because the cache doesn't
+distinguish between different versions of onnxruntime and will use the cached models from a previous run. There might be incompatibilities between the cached models and the new
+version of onnxruntime.

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -31,6 +31,10 @@ SUPPORTED_WORKFLOWS = {
     ("gpu", "fp16"): ["conversion", "transformers_optimization", "mixed_precision", "insert_beam_search", "prepost"],
     ("gpu", "int8"): ["conversion", "onnx_dynamic_quantization", "insert_beam_search", "prepost"],
 }
+DEVICE_TO_EP = {
+    "cpu": "CPUExecutionProvider",
+    "gpu": "CUDAExecutionProvider",
+}
 
 
 def get_args(raw_args):
@@ -88,6 +92,9 @@ def main(raw_args=None):
         # set output name
         config["engine"]["output_name"] = f"whisper_{device}_{precision}"
         config["engine"]["packaging_config"]["name"] = f"whisper_{device}_{precision}"
+
+        # set ep
+        config["engine"]["execution_providers"] = [DEVICE_TO_EP[device]]
 
         # set device for system
         config["systems"]["local_system"]["config"]["accelerators"] = [device]

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import onnxruntime as ort
 
 from olive.evaluator.olive_evaluator import OnnxEvaluator
+from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModel
 
 sys.path.append(str(Path(__file__).parent / "code"))
@@ -65,9 +66,16 @@ def main(raw_args=None):
     if not multilingual and not (args.language == "english" and args.task == "transcribe"):
         print("Model is not multilingual but custom language/task provided. Will ignore custom language/task.")
 
+    # get device and ep
+    device = config["systems"]["local_system"]["config"]["accelerators"][0]
+    ep = config["engine"]["execution_providers"][0]
+    accelerator_spec = AcceleratorSpec(accelerator_type=device, execution_provider=ep)
+
     # load output model json
     output_model_json_path = Path(config["engine"]["output_dir"])
-    for model_json in output_model_json_path.glob(f"**/{config['engine']['output_name']}_cpu-cpu_model.json"):
+    for model_json in output_model_json_path.glob(
+        f"**/{config['engine']['output_name']}_{accelerator_spec}_model.json"
+    ):
         output_model_json = json.load(open(model_json, "r"))
         break
 
@@ -93,13 +101,8 @@ def main(raw_args=None):
         task=args.task,
     )
 
-    # get device and ep
-    device = config["systems"]["local_system"]["config"]["accelerators"][0]
-    ep = config["engine"]["execution_providers"]
-    print(f"Using device: {device}, ep: {ep}")
-
     # create inference session
-    session = olive_model.prepare_session(None, device, ep)
+    session = olive_model.prepare_session(None, device, [ep])
 
     # get output
     input, _ = dataset[0]

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -93,8 +93,13 @@ def main(raw_args=None):
         task=args.task,
     )
 
+    # get device and ep
+    device = config["systems"]["local_system"]["config"]["accelerators"][0]
+    ep = config["engine"]["execution_providers"]
+    print(f"Using device: {device}, ep: {ep}")
+
     # create inference session
-    session = olive_model.prepare_session(None, "cpu")
+    session = olive_model.prepare_session(None, device, ep)
 
     # get output
     input, _ = dataset[0]

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -106,6 +106,7 @@
         "target": "local_system",
         "evaluator": "common_evaluator",
         "evaluate_input_model": false,
+        "execution_providers": "<place_holder>",
         "clean_cache": false,
         "cache_dir": "cache",
         "output_dir": "models",

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -117,9 +117,11 @@ def dependency_setup(config):
             check_local_ort_installation(package)
         else:
             try:
-                __import__(package)
+                # use importlib_metadata to check if package is installed
+                # better than __import__ since the package name can be different from the import name
+                importlib_metadata.distribution(package)
                 logger.info(f"{package} is already installed.")
-            except ImportError:
+            except importlib_metadata.PackageNotFoundError:
                 logger.info(f"Installing {package}...")
                 subprocess.check_call(["python", "-m", "pip", "install", "{}".format(package)])
                 logger.info(f"Successfully installed {package}.")

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -219,18 +219,19 @@ def check_local_ort_installation(package_name: str):
         logger.info(f"{local_ort_packages[0]} is already installed.")
         return
 
-    # uninstall all ort packages
-    logger.info("There are one or more onnxruntime packages installed in your environment.")
-    uninstall_command = ["python", "-m", "pip", "uninstall", "-y"] + local_ort_packages
-    uninstall_command = " ".join(uninstall_command)
-    logger.info(f"Please run '{uninstall_command}' to uninstall all existing onnxruntime packages.")
-
-    # install the package
-    logger.info(f"Then install {package_name} by running 'python -m pip install {package_name}'.")
-    logger.info(
+    # instruction to user
+    messages = [
+        "There are one or more onnxruntime packages installed in your environment!",
+        "Please run the following commands:",
+    ]
+    uninstall_command = "python -m pip uninstall -y " + " ".join(local_ort_packages)
+    messages.append(f"Uninstall all existing onnxruntime packages: '{uninstall_command}'")
+    messages.append(f"Install {package_name}: 'python -m pip install {package_name}'")
+    messages.append(
         "You can also instead install the corresponding nightly version following the instructions at"
         " https://onnxruntime.ai/docs/install/#inference-install-table-for-all-languages"
     )
+    logger.warning("\n".join(messages))
 
 
 def get_local_ort_packages() -> List[str]:

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -195,9 +195,11 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
 
 
 def check_local_ort_installation(ep_mapping: Dict[str, str], package_name: str):
-    # check if onnxruntime is installed
+    # Don't need try except since olive itself cannot be imported and run without onnxruntime
+    # there are onnxruntime imports in many places
     import onnxruntime as ort
 
+    # check for expected ep as a heuristic to see if the correct ort package is installed
     if ep_mapping[package_name] in ort.get_available_providers():
         logger.info(f"onnxruntime installation has {ep_mapping[package_name]} as expected.")
         return

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     url="https://microsoft.github.io/Olive/",
     download_url="https://github.com/microsoft/Olive/tags",
     packages=find_packages(exclude=("test", "examples*")),
+    python_requires=">=3.8.0",
     install_requires=requirements,
     extras_require=EXTRAS,
     include_package_data=True,


### PR DESCRIPTION
## Describe your changes
Officially drop python 3.7 since it has already reached end of life. Most olive dependencies have already dropped python 3.7 support so olive was probably incompatible with it. 

`onnxruntime` packages are distributed using different names but they are all installed under the same `onnxruntime` namespace.
So, we cannot check if the required package is installed using the `try: __import__` method. This PR uses `importlib.metadata` to check the local ort installations and log the required steps needed. We don't want to uninstall packages ourselves so we will just log the command for the user to run. 

Addresses the original issue in https://github.com/microsoft/Olive/issues/557 

Also update Whisper example to provide and use accelerator+ep correctly.
Added FAQ for common issues like https://github.com/microsoft/Olive/issues/508

Update: Also fixes https://github.com/microsoft/Olive/issues/571

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
