### PR TITLE
fix model to_json bug since the resource is just string now

### DIFF
--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -118,8 +118,6 @@ class OliveModel(ABC):
         assert resource_name in self.resource_paths, f"{resource_name} is not a valid resource name."
         resource = self.resource_paths[resource_name]
         assert resource is None or isinstance(resource, str)
-        if resource and isinstance(resource, ResourcePath):
-            resource = resource.get_path()
         return resource
 
     @abstractmethod

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -25,13 +25,7 @@ from olive.constants import Framework, ModelFileFormat
 from olive.hardware import AcceleratorLookup, Device
 from olive.model.hf_utils import HFConfig, get_hf_model_dummy_input, huggingface_model_loader
 from olive.model.model_config import IOConfig
-from olive.resource_path import (
-    OLIVE_RESOURCE_ANNOTATIONS,
-    ResourcePath,
-    ResourcePathConfig,
-    ResourceType,
-    create_resource_path,
-)
+from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS, ResourcePath, ResourcePathConfig, create_resource_path
 from olive.snpe import SNPEDevice, SNPEInferenceSession, SNPESessionOptions
 from olive.snpe.tools.dev import get_dlc_metrics
 
@@ -735,7 +729,7 @@ class PyTorchModel(OliveModel):
         # the original config has them as serialized ResourcePath
         for resource_name in ["script_dir", "model_script"]:
             if self.resource_paths[resource_name]:
-                config["config"][resource_name] = self.resource_paths[resource_name].get_path()
+                config["config"][resource_name] = self.get_resource(resource_name)
         return serialize_to_json(config, check_object)
 
 

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -517,7 +517,6 @@ class PyTorchModel(OliveModel):
             hf_model_config.update(model_attr)
             self.model_attributes = hf_model_config
 
-
         # ensure that script_dirs are local folder
         script_dir_resource = create_resource_path(self.script_dir)
         if script_dir_resource:

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -66,7 +66,7 @@ class OliveModel(ABC):
         self.model_attributes = model_attributes
         self.io_config = None
         # store resource paths
-        self.resource_paths: Dict[str, ResourcePath] = {}
+        self.resource_paths: Dict[str, str] = {}
         resources = {}
         resources["model_path"] = model_path
         self.add_resources(resources)
@@ -117,6 +117,7 @@ class OliveModel(ABC):
         """
         assert resource_name in self.resource_paths, f"{resource_name} is not a valid resource name."
         resource = self.resource_paths[resource_name]
+        assert resource is None or isinstance(resource, str)
         if resource and isinstance(resource, ResourcePath):
             resource = resource.get_path()
         return resource

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -195,3 +195,15 @@ class TestPytorchDummyInput:
 
         get_hf_model_dummy_input.assert_called_once_with(self.model_name, self.task, None)
         assert dummy_inputs == 1
+
+
+class TestPyTorchModel:
+    def test_model_to_json(self, tmp_path):
+        script_dir = tmp_path / "model"
+        script_dir.mkdir(exist_ok=True)
+        model = PyTorchModel(model_path="test_path", script_dir=script_dir)
+        model.set_resource("model_script", "model_script")
+        model_json = model.to_json()
+        assert model_json["config"]["model_path"] == "test_path"
+        assert model_json["config"]["script_dir"] == str(script_dir)
+        assert model_json["config"]["model_script"] == "model_script"


### PR DESCRIPTION
## Describe your changes
PyTorchModel.to_json  will call resource.get_path. This would not work since the resource is just string now. The PR just to fix the bug.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
