### PR TITLE
🐛 Test fix for mlflow packing

### DIFF
--- a/test/unit_test/engine/packaging/test_packaging_generator.py
+++ b/test/unit_test/engine/packaging/test_packaging_generator.py
@@ -132,7 +132,7 @@ def test_generate_zipfile_artifacts_mlflow():
     engine = Engine(options)
     engine.register(OnnxConversion)
 
-    input_model = get_pytorch_model()
+    input_model_config = get_pytorch_model_config()
 
     packaging_config = PackagingConfig()
     packaging_config.type = PackagingType.Zipfile
@@ -144,7 +144,10 @@ def test_generate_zipfile_artifacts_mlflow():
 
     # execute
     engine.run(
-        input_model=input_model, packaging_config=packaging_config, output_dir=output_dir, evaluate_input_model=False
+        input_model_config=input_model_config,
+        packaging_config=packaging_config,
+        output_dir=output_dir,
+        evaluate_input_model=False,
     )
 
     # assert


### PR DESCRIPTION
## Describe your changes
After the PR #561, we use input_model_config as engine input. But the change #564 is merged without the right config in tests. This PR is used to fix that.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
