### PR TITLE
refactor engine run for each accelerator

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -340,7 +340,7 @@ class Engine:
                     # for evaluate input model only, return the evaluation results
                     # TODO: need check whether the evaluation results are valid since it will only evaluate input model
                     # once and use the same evaluation results for all accelerators
-                    return run_result
+                    outputs[accelerator_spec] = run_result
                 elif self.no_search:
                     output, model_ids = run_result
                     if output:
@@ -351,6 +351,10 @@ class Engine:
                 else:
                     outputs[accelerator_spec] = run_result
                     pf_footprints[accelerator_spec] = run_result
+
+        if not self.passes:
+            # no passes registered, return the evaluation results
+            return outputs
 
         for accelerator_spec in self.footprints.keys():
             logger.info(f"Run history for {accelerator_spec}:")


### PR DESCRIPTION
## Describe your changes
Move the engine run for each accelerator to a dedicated method since it introduce a lot of indent in Python, which is hard to maintain. 

BTW, during the refactoring process, I found : 
https://github.com/microsoft/Olive/pull/419 introduce a behavior which is not consistent with original one. 
If there is no pass only the first accelerator will be used for evaluation input model. Not sure it is a bug. 


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
