### PR TITLE
🐛 Distinguish pass instance with name not cls name

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -443,10 +443,10 @@ class Engine:
             p = pass_cls(accelerator_spec, pass_cfg, config["disable_search"])
             self.register_pass(
                 p,
+                name=name,
                 host=config["host"],
                 evaluator_config=config["evaluator"],
                 output_name=config["output_name"],
-                name=name,
             )
 
         # list of passes starting from the first pass with non-empty search space


### PR DESCRIPTION
## Describe your changes

This PR is used fix following issue where the same pass with different config appears in one olive run config.
https://github.com/microsoft/Olive/issues/573

[Root Cause]: 
Olive uses the pass's class name as key to identify the pass instance. When there are passes with same pass_class, the first one defined in olive run config will be picked always.
https://github.com/microsoft/Olive/blob/main/olive/engine/engine.py#L436

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
