### PR TITLE
🥋 Unify engine run returning

### DIFF
--- a/examples/test/test_bert_cuda_gpu.py
+++ b/examples/test/test_bert_cuda_gpu.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
-from utils import check_search_output, patch_config
+from utils import check_output, patch_config
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -32,4 +32,4 @@ def test_bert(search_algorithm, execution_order, system, olive_json, enable_cuda
     olive_config["passes"]["perf_tuning"]["config"]["enable_cuda_graph"] = enable_cuda_graph
 
     footprint = olive_run(olive_config)
-    check_search_output(footprint)
+    check_output(footprint)

--- a/examples/test/test_bert_ptq_cpu.py
+++ b/examples/test/test_bert_ptq_cpu.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
-from utils import check_search_output, patch_config
+from utils import check_output, patch_config
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -30,4 +30,4 @@ def test_bert(search_algorithm, execution_order, system, olive_json):
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
 
     footprint = olive_run(olive_config)
-    check_search_output(footprint)
+    check_output(footprint)

--- a/examples/test/test_bert_ptq_cpu_aml.py
+++ b/examples/test/test_bert_ptq_cpu_aml.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
-from utils import check_no_search_output, check_search_output, patch_config
+from utils import check_output, patch_config
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -38,4 +38,4 @@ def test_bert(olive_test_knob):
 
     olive_config = patch_config(*olive_test_knob)
     output = olive_run(olive_config)
-    check_no_search_output(output) if not olive_test_knob[1] else check_search_output(output)
+    check_output(output)

--- a/examples/test/test_bert_ptq_cpu_docker.py
+++ b/examples/test/test_bert_ptq_cpu_docker.py
@@ -7,7 +7,7 @@ import platform
 from pathlib import Path
 
 import pytest
-from utils import check_search_output, patch_config
+from utils import check_output, patch_config
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -33,4 +33,4 @@ def test_bert(search_algorithm, execution_order, system, olive_json):
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
 
     footprint = olive_run(olive_config)
-    check_search_output(footprint)
+    check_output(footprint)

--- a/examples/test/test_cifar10_openvino_intel_hw.py
+++ b/examples/test/test_cifar10_openvino_intel_hw.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from utils import check_search_output
+from utils import check_output
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -22,4 +22,4 @@ def test_cifar10():
     import cifar10
 
     metrics = cifar10.main()
-    check_search_output(metrics)
+    check_output(metrics)

--- a/examples/test/test_resnet_ptq_cpu.py
+++ b/examples/test/test_resnet_ptq_cpu.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
-from utils import check_search_output, patch_config
+from utils import check_output, patch_config
 
 from olive.common.utils import retry_func, run_subprocess
 
@@ -37,4 +37,4 @@ def test_resnet(search_algorithm, execution_order, system, olive_json):
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
 
     footprint = olive_run(olive_config)
-    check_search_output(footprint)
+    check_output(footprint)

--- a/examples/test/test_resnet_qat.py
+++ b/examples/test/test_resnet_qat.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
-from utils import check_search_output, patch_config
+from utils import check_output, patch_config
 
 from olive.common.utils import retry_func, run_subprocess
 
@@ -38,4 +38,4 @@ def test_resnet(search_algorithm, execution_order, system, olive_json):
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
 
     footprint = olive_run(olive_config)
-    check_search_output(footprint)
+    check_output(footprint)

--- a/examples/test/test_resnet_vitis_ai_ptq_cpu.py
+++ b/examples/test/test_resnet_vitis_ai_ptq_cpu.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
-from utils import check_search_output, patch_config
+from utils import check_output, patch_config
 
 from olive.common.utils import retry_func, run_subprocess
 
@@ -37,4 +37,4 @@ def test_resnet(search_algorithm, execution_order, system, olive_json):
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
 
     footprint = olive_run(olive_config)
-    check_search_output(footprint)
+    check_output(footprint)

--- a/examples/test/test_whisper.py
+++ b/examples/test/test_whisper.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from utils import check_no_search_output
+from utils import check_output
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -43,7 +43,7 @@ def test_whisper(device_precision):
 
     # test workflow
     result = olive_run(olive_config)
-    check_no_search_output(result)
+    check_output(result)
 
     # test transcription
     from test_transcription import main as test_transcription

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -6,24 +6,13 @@ import json
 import os
 
 
-def check_search_output(footprints):
+def check_output(footprints):
     """Check if the search output is valid."""
     assert footprints, "footprints is empty. The search must have failed for all accelerator specs."
     for footprint in footprints.values():
         assert footprint.nodes
         for v in footprint.nodes.values():
             assert all([metric_result.value > 0 for metric_result in v.metrics.value.values()])
-
-
-def check_no_search_output(outputs):
-    assert outputs, "outputs is empty. The run must have failed for all accelerator specs."
-    # k:v => accelerator_spec: pass_flow_output
-    for pass_flow_output in outputs.values():
-        # k:v => pass_flow: output
-        for output in pass_flow_output.values():
-            output_metrics = output["metrics"]
-            for item in output_metrics.values():
-                assert item.value > 0
 
 
 def patch_config(config_json_path: str, search_algorithm: str, execution_order: str, system: str, is_gpu: bool = False):

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -7,7 +7,6 @@ import logging
 import time
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
@@ -549,7 +548,7 @@ class Engine:
                     json.dump(signal.to_json(), f, indent=4)
 
         output_model_ids = list(output_models.keys())
-        fp_outputs = deepcopy(self.footprints[accelerator_spec].create_footprints_by_model_ids(output_model_ids))
+        fp_outputs = self.footprints[accelerator_spec].create_footprints_by_model_ids(output_model_ids)
         # update the output model config
         for model_id, model_config in output_models.items():
             fp_outputs.nodes[model_id].model_config = model_config

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -619,14 +619,14 @@ class Engine:
 
         self.footprints[accelerator_spec].to_file(output_dir / f"{prefix_output_name}footprints.json")
 
-        return self.get_pareto_frontier_footprints(
+        return self.create_pareto_frontier_footprints(
             accelerator_spec, output_model_num, objective_dict, output_dir, prefix_output_name
         )
 
-    def get_pareto_frontier_footprints(
+    def create_pareto_frontier_footprints(
         self, accelerator_spec, output_model_num, objective_dict, output_dir, prefix_output_name
     ):
-        pf_footprints = self.footprints[accelerator_spec].get_pareto_frontier()
+        pf_footprints = self.footprints[accelerator_spec].create_pareto_frontier()
         if output_model_num is None or len(pf_footprints.nodes) <= output_model_num:
             logger.info(f"Output all {len(pf_footprints.nodes)} models")
         else:

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -5,6 +5,7 @@
 
 import logging
 from collections import OrderedDict, defaultdict, namedtuple
+from copy import deepcopy
 from typing import DefaultDict, Dict
 
 from olive.common.config_utils import ConfigBase, config_json_dumps, config_json_loads
@@ -58,8 +59,8 @@ class Footprint:
         objective_dict: Dict = None,
         is_marked_pareto_frontier: bool = False,
     ):
-        self.nodes = nodes or OrderedDict()
-        self.objective_dict = objective_dict or {}
+        self.nodes = deepcopy(nodes) or OrderedDict()
+        self.objective_dict = deepcopy(objective_dict) or {}
         self.is_marked_pareto_frontier = is_marked_pareto_frontier
 
     def metric_numbers(self):

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -59,8 +59,8 @@ class Footprint:
         objective_dict: Dict = None,
         is_marked_pareto_frontier: bool = False,
     ):
-        self.nodes = deepcopy(nodes) or OrderedDict()
-        self.objective_dict = deepcopy(objective_dict) or {}
+        self.nodes = nodes or OrderedDict()
+        self.objective_dict = objective_dict or {}
         self.is_marked_pareto_frontier = is_marked_pareto_frontier
 
     def metric_numbers(self):
@@ -157,17 +157,19 @@ class Footprint:
     def create_footprints_by_model_ids(self, model_ids):
         nodes = OrderedDict()
         for model_id in model_ids:
-            nodes[model_id] = self.nodes[model_id]
-        return Footprint(nodes=nodes, objective_dict=self.objective_dict, is_marked_pareto_frontier=True)
+            nodes[model_id] = deepcopy(self.nodes[model_id])
+        return Footprint(nodes=nodes, objective_dict=deepcopy(self.objective_dict), is_marked_pareto_frontier=True)
 
-    def get_pareto_frontier(self):
+    def create_pareto_frontier(self):
         self.mark_pareto_frontier()
         rls = {k: v for k, v in self.nodes.items() if v.is_pareto_frontier}
         for _, v in rls.items():
             logger.info(f"pareto frontier points: {v.model_id} \n{v.metrics.value}")
 
         # restructure the pareto frontier points to instance of Footprints node for further analysis
-        return Footprint(nodes=rls, objective_dict=self.objective_dict, is_marked_pareto_frontier=True)
+        return Footprint(
+            nodes=deepcopy(rls), objective_dict=deepcopy(self.objective_dict), is_marked_pareto_frontier=True
+        )
 
     def update_nodes(self, nodes):
         node_dict = OrderedDict()

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -153,7 +153,7 @@ class Footprint:
             self.nodes[k].is_pareto_frontier = cmp_flag
         self.is_marked_pareto_frontier = True
 
-    def get_footprints_by_model_ids(self, model_ids):
+    def create_footprints_by_model_ids(self, model_ids):
         nodes = OrderedDict()
         for model_id in model_ids:
             nodes[model_id] = self.nodes[model_id]

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -158,7 +158,7 @@ class Footprint:
         nodes = OrderedDict()
         for model_id in model_ids:
             nodes[model_id] = deepcopy(self.nodes[model_id])
-        return Footprint(nodes=nodes, objective_dict=deepcopy(self.objective_dict), is_marked_pareto_frontier=True)
+        return Footprint(nodes=nodes, objective_dict=deepcopy(self.objective_dict))
 
     def create_pareto_frontier(self):
         self.mark_pareto_frontier()

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -10,7 +10,7 @@ import pytest
 from olive.engine import Engine
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import Device
-from olive.hardware.accelerator import AcceleratorSpec
+from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
 from olive.model import ModelConfig
 from olive.passes.onnx import OrtPerfTuning
 
@@ -44,9 +44,11 @@ class TestOliveManagedDockerSystem:
         engine = Engine(options, target=self.system, evaluator_config=evaluator_config)
         engine.register(OrtPerfTuning)
         output = engine.run(self.input_model_config, output_dir=output_dir)
-        cpu_res = output[AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="CPUExecutionProvider")]
-        openvino_res = output[
-            AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")
-        ]
-        assert cpu_res[tuple(engine.pass_flows[0])]["metrics"]["latency-avg"]
-        assert openvino_res[tuple(engine.pass_flows[0])]["metrics"]["latency-avg"]
+        cpu_res = list(output[DEFAULT_CPU_ACCELERATOR].nodes.values())[0]
+        openvino_res = list(
+            output[
+                AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")
+            ].nodes.values()
+        )[0]
+        assert cpu_res.metrics.value.__root__
+        assert openvino_res.metrics.value.__root__

--- a/test/multiple_ep/test_python_env_system.py
+++ b/test/multiple_ep/test_python_env_system.py
@@ -12,7 +12,7 @@ from olive.engine import Engine
 from olive.evaluator.metric import LatencySubType
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import Device
-from olive.hardware.accelerator import AcceleratorSpec
+from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
 from olive.passes.onnx import OrtPerfTuning
 from olive.systems.python_environment import PythonEnvironmentSystem
 
@@ -64,9 +64,11 @@ class TestOliveManagedPythonEnvironmentSystem:
         engine = Engine(options, target=self.system, host=self.system, evaluator_config=evaluator_config)
         engine.register(OrtPerfTuning)
         output = engine.run(self.input_model_config, output_dir=output_dir, evaluate_input_model=True)
-        cpu_res = output[AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="CPUExecutionProvider")]
-        openvino_res = output[
-            AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")
-        ]
-        assert cpu_res[tuple(engine.pass_flows[0])]["metrics"]["latency-avg"]
-        assert openvino_res[tuple(engine.pass_flows[0])]["metrics"]["latency-avg"]
+        cpu_res = list(output[DEFAULT_CPU_ACCELERATOR].nodes.values())[0]
+        openvino_res = list(
+            output[
+                AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="OpenVINOExecutionProvider")
+            ].nodes.values()
+        )[0]
+        assert cpu_res.metrics.value.__root__
+        assert openvino_res.metrics.value.__root__

--- a/test/unit_test/engine/test_footprint.py
+++ b/test/unit_test/engine/test_footprint.py
@@ -18,6 +18,12 @@ class TestFootprint:
         self.fp = Footprint.from_file(self.footprint_file)
         self.input_node = {k: v for k, v in self.fp.nodes.items() if v.parent_model_id is None}
 
+    def test_init(self):
+        new_fp = Footprint(nodes=self.fp.nodes, objective_dict=self.fp.objective_dict)
+        assert len(new_fp.nodes) == len(self.fp.nodes)
+        assert new_fp.nodes == self.fp.nodes
+        assert new_fp.nodes is not self.fp.nodes
+
     def test_file_dump(self):
         with tempfile.TemporaryDirectory() as tempdir:
             self.fp.to_file(Path(tempdir) / "footprint.json")

--- a/test/unit_test/engine/test_footprint.py
+++ b/test/unit_test/engine/test_footprint.py
@@ -18,11 +18,13 @@ class TestFootprint:
         self.fp = Footprint.from_file(self.footprint_file)
         self.input_node = {k: v for k, v in self.fp.nodes.items() if v.parent_model_id is None}
 
-    def test_init(self):
-        new_fp = Footprint(nodes=self.fp.nodes, objective_dict=self.fp.objective_dict)
+    def test_create_from_model_ids(self):
+        new_fp = self.fp.create_footprints_by_model_ids(self.fp.nodes.keys())
         assert len(new_fp.nodes) == len(self.fp.nodes)
         assert new_fp.nodes == self.fp.nodes
         assert new_fp.nodes is not self.fp.nodes
+        assert new_fp.objective_dict == self.fp.objective_dict
+        assert new_fp.objective_dict is not self.fp.objective_dict
 
     def test_file_dump(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -36,7 +38,7 @@ class TestFootprint:
         assert len(fp2.nodes) == 3
 
     def test_pareto_frontier(self):
-        pareto_frontier_fp = self.fp.get_pareto_frontier()
+        pareto_frontier_fp = self.fp.create_pareto_frontier()
         assert isinstance(pareto_frontier_fp, Footprint)
         assert len(pareto_frontier_fp.nodes) == 2
         assert all([v.is_pareto_frontier for v in pareto_frontier_fp.nodes.values()])


### PR DESCRIPTION
## Describe your changes

This PR is used to unify the returning of `run_no_search` and `run_search` with olive footprints.

More discussions here: https://github.com/microsoft/Olive/pull/572

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
