### PR TITLE
Bugfix: Correct context length for text-gen dataset

### DIFF
--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -168,7 +168,7 @@ def text_gen_corpus_pre_process(_dataset, tokenizer, all_kwargs):
             # no randomization, just use contiguous blocks of tokens
             if args.corpus_strategy == TextGenCorpusStrategy.JOIN_SLIDING_WINDOW:
                 # we use the stride as both the step between sequences and the context size
-                step, context = args.stride, args.stride
+                step, context = args.stride, seqlen - args.stride
             else:
                 # JOIN corpus_strategy
                 # text is split into non-overlapping sequences and there is no context


### PR DESCRIPTION
## Describe your changes
`context` was computed incorrectly after the PR https://github.com/microsoft/Olive/pull/545. Fixed in this PR. 
The above PR changed the indexing from `:-context` to `:context`. So we need use the `seqlen - stride` instead of `stride` to get the correct length.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
