### PR TITLE
⏮️ Preprocess for quant as true for bert model

### DIFF
--- a/.azure_pipelines/performance_check/configs/bert.json
+++ b/.azure_pipelines/performance_check/configs/bert.json
@@ -58,6 +58,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
+                "quant_preprocess": true,
                 "data_config": "__input_model_data_config__"
             }
         },

--- a/.azure_pipelines/performance_check/configs/deberta.json
+++ b/.azure_pipelines/performance_check/configs/deberta.json
@@ -64,6 +64,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
+                "quant_preprocess": true,
                 "data_config": "__input_model_data_config__"
             }
         },

--- a/.azure_pipelines/performance_check/configs/distilbert.json
+++ b/.azure_pipelines/performance_check/configs/distilbert.json
@@ -59,6 +59,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
+                "quant_preprocess": true,
                 "data_config": "__input_model_data_config__"
             }
         },

--- a/.azure_pipelines/performance_check/configs/roberta_large.json
+++ b/.azure_pipelines/performance_check/configs/roberta_large.json
@@ -63,6 +63,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
+                "quant_preprocess": true,
                 "data_config": "__input_model_data_config__"
             }
         },

--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -56,6 +56,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
+                "quant_preprocess": true,
                 "data_config": "__input_model_data_config__"
             }
         },

--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -57,6 +57,8 @@
             "type": "OnnxQuantization",
             "config": {
                 "quant_preprocess": true,
+                "per_channel": false,
+                "reduce_range": false,
                 "data_config": "__input_model_data_config__"
             }
         },

--- a/examples/bert/bert_ptq_cpu_aml.json
+++ b/examples/bert/bert_ptq_cpu_aml.json
@@ -64,6 +64,7 @@
         "quantization": {
             "type": "OnnxQuantization",
             "config": {
+                "quant_preprocess": true,
                 "data_config": "__input_model_data_config__"
             }
         },


### PR DESCRIPTION
## Describe your changes

Enable quantization preprocess by default for bert model, as we know that would avoid some bad samples from olive optimization for bert cases. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
