### PR TITLE
Implement `get_supported_execution_providers` for all systems

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -122,6 +122,7 @@ class Engine:
             elif self.target.system_type == SystemType.Docker:
                 # for docker system we default use CPUExecutionProvider
                 execution_providers = ["CPUExecutionProvider"]
+        logger.debug(f"Initial execution providers: {execution_providers}")
 
         self.execution_providers = execution_providers
 
@@ -139,6 +140,7 @@ class Engine:
                     f"from given execution providers {self.execution_providers}."
                 )
                 accelerators = inferred_accelerators
+        logger.debug(f"Initial accelerators: {accelerators}")
 
         ep_to_process = set(self.execution_providers)
         # Flatten the accelerators to list of AcceleratorSpec
@@ -159,9 +161,12 @@ class Engine:
             supported_eps = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(
                 device, available_eps
             )
+            logger.debug(f"Supported execution providers for device {device}: {supported_eps}")
             for ep in ep_to_process.copy():
                 if ep == "CPUExecutionProvider" and device != "cpu" and is_cpu_available:
-                    logger.info("ignore the CPUExecutionProvider for non-cpu device")
+                    logger.info(
+                        "Ignore the CPUExecutionProvider for non-cpu device since cpu accelerator is also present."
+                    )
                 elif ep in supported_eps:
                     self.accelerator_specs.append(AcceleratorSpec(device, ep))
                     ep_to_process.remove(ep)
@@ -172,6 +177,9 @@ class Engine:
             f"Given execution providers: {self.execution_providers}. "
             f"Current accelerators: {accelerators}."
             f"Supported execution providers: {AcceleratorLookup.EXECUTION_PROVIDERS}."
+        )
+        logger.info(
+            f"Running workflow on accelerator specs: {','.join([str(spec) for spec in self.accelerator_specs])}"
         )
         if ep_to_process:
             logger.warning(

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -121,7 +121,7 @@ class AcceleratorLookup:
                     if len(accelerators[idx]) > 1:
                         logger.warning(
                             f"Execution provider {ep} is mapped to multiple accelerators {accelerators[idx]}. "
-                            "Olive cannot infer the device which may cause unexpected behavior"
+                            "Olive cannot infer the device which may cause unexpected behavior. "
                             "Please specify the accelerator in the accelerator configs"
                         )
                         is_unique_inferring = False

--- a/olive/systems/available_eps_runner.py
+++ b/olive/systems/available_eps_runner.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import argparse
-import pickle
+import json
 from pathlib import Path
 
 import onnxruntime as ort
@@ -11,7 +11,9 @@ import onnxruntime as ort
 
 def get_args(raw_args):
     parser = argparse.ArgumentParser(description="Get available execution providers")
-    parser.add_argument("--output_path", type=str, required=True)
+    parser.add_argument(
+        "--output_path", type=str, required=True, help="Path of directory to save the available eps json."
+    )
 
     return parser.parse_args(raw_args)
 
@@ -22,10 +24,9 @@ def main(raw_args=None):
     # get available execution providers
     available_eps = ort.get_available_providers()
 
-    # save to pickle
-    output_path = Path(args.output_path)
-    with output_path.open("wb") as f:
-        pickle.dump(available_eps, f)
+    # save available execution providers to file
+    output_json_path = Path(args.output_path) / "available_eps.json"
+    json.dump(available_eps, open(output_json_path, "w"), indent=4)
 
 
 if __name__ == "__main__":

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -55,6 +55,7 @@ def create_available_eps_command(available_eps_runner_path: str, output_path: st
 
 def create_run_command(run_params: dict):
     run_params = run_params or {}
+
     run_command_dict = {}
     for k, v in run_params.items():
         run_command_dict[k.replace("-", "_")] = v

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -50,7 +50,10 @@ class LocalSystem(OliveSystem):
         evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
         return evaluator.evaluate(model, data_root, metrics, device=device, execution_providers=execution_providers)
 
-    def get_supported_execution_providers(self):
+    def get_supported_execution_providers(self) -> List[str]:
+        """
+        Get the available execution providers.
+        """
         import onnxruntime as ort
 
         return ort.get_available_providers()

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -23,6 +23,13 @@ class OliveSystem(ABC):
         self.olive_managed_env = olive_managed_env
 
     @abstractmethod
+    def get_supported_execution_providers(self) -> List[str]:
+        """
+        Get the available execution providers.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def run_pass(
         self,
         the_pass: Pass,

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -80,6 +80,7 @@ class PythonEnvironmentSystem(OliveSystem):
         # path to inference script
         self.inference_path = Path(__file__).parent.resolve() / "inference_runner.py"
         self.pass_path = Path(__file__).parent.resolve() / "pass_runner.py"
+        self.available_eps_path = Path(__file__).parent.parent.resolve() / "available_eps_runner.py"
         self.device = self.accelerators[0] if self.accelerators else Device.CPU
 
     def run_pass(
@@ -299,17 +300,17 @@ class PythonEnvironmentSystem(OliveSystem):
             return self.available_eps
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            available_eps_path = Path(__file__).parent.resolve() / "available_eps.py"
-            output_path = Path(temp_dir).resolve() / "available_eps.pb"
+            output_path = Path(temp_dir).resolve()
             run_subprocess(
-                f"python {available_eps_path} --output_path {output_path}",
+                f"python {self.available_eps_path} --output_path {output_path}",
                 env=self.environ,
                 check=True,
             )
-            with output_path.open("rb") as f:
-                available_eps = pickle.load(f)
-            self.available_eps = available_eps
-            return available_eps
+            available_eps_json_path = output_path / "available_eps.json"
+            with open(available_eps_json_path, "r") as f:
+                self.available_eps = json.load(f)
+
+            return self.available_eps
 
     def get_execution_providers(self) -> List[str]:
         """

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -14,6 +14,7 @@ from test.unit_test.utils import (
 )
 from unittest.mock import patch
 
+import onnxruntime as ort
 import pytest
 
 from olive.common.utils import hash_dict
@@ -120,7 +121,7 @@ class TestEngine:
             for sub_metric in metric.sub_types
         }
         onnx_model_config = get_onnx_model_config()
-        mock_local_system.system_type = SystemType.Local
+        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
         mock_local_system.run_pass.return_value = onnx_model_config
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.get_supported_execution_providers.return_value = [
@@ -197,7 +198,7 @@ class TestEngine:
             for sub_metric in metric.sub_types
         }
         onnx_model_config = get_onnx_model_config()
-        mock_local_system.system_type = SystemType.Local
+        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
         mock_local_system.run_pass.return_value = onnx_model_config
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
@@ -288,6 +289,7 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
+        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
         mock_local_system.run_pass.return_value = get_onnx_model_config()
         mock_local_system.get_supported_execution_providers.return_value = ["CPUExecutionProvider"]
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
@@ -334,6 +336,7 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
+        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
         mock_local_system.olive_managed_env = False

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -14,7 +14,6 @@ from test.unit_test.utils import (
 )
 from unittest.mock import patch
 
-import onnxruntime as ort
 import pytest
 
 from olive.common.utils import hash_dict
@@ -121,7 +120,7 @@ class TestEngine:
             for sub_metric in metric.sub_types
         }
         onnx_model_config = get_onnx_model_config()
-        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
+        mock_local_system.system_type = SystemType.Local
         mock_local_system.run_pass.return_value = onnx_model_config
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.get_supported_execution_providers.return_value = [
@@ -198,7 +197,7 @@ class TestEngine:
             for sub_metric in metric.sub_types
         }
         onnx_model_config = get_onnx_model_config()
-        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
+        mock_local_system.system_type = SystemType.Local
         mock_local_system.run_pass.return_value = onnx_model_config
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
@@ -289,7 +288,6 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
-        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
         mock_local_system.run_pass.return_value = get_onnx_model_config()
         mock_local_system.get_supported_execution_providers.return_value = ["CPUExecutionProvider"]
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
@@ -336,7 +334,6 @@ class TestEngine:
             }
             for sub_metric in metric.sub_types
         }
-        mock_local_system.get_supported_execution_providers.return_value = ort.get_available_providers()
         mock_local_system.evaluate_model.return_value = MetricResult.parse_obj(metric_result_dict)
         mock_local_system.accelerators = ["CPU"]
         mock_local_system.olive_managed_env = False

--- a/test/unit_test/systems/docker/output_local_path/available_eps.json
+++ b/test/unit_test/systems/docker/output_local_path/available_eps.json
@@ -1,0 +1,1 @@
+["DummyExecutionProvider"]

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -17,7 +17,6 @@ from olive.evaluator.metric import AccuracySubType, LatencySubType, MetricResult
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.systems.local import LocalSystem
 from olive.systems.python_environment import PythonEnvironmentSystem
-from olive.systems.python_environment.available_eps import main as available_eps_main
 from olive.systems.python_environment.inference_runner import main as inference_runner_main
 from olive.systems.python_environment.is_valid_ep import main as is_valid_ep_main
 
@@ -147,23 +146,6 @@ class TestPythonEnvironmentSystem:
         assert actual_res[LatencySubType.AVG].value == expected_res
         assert len(mock_compute_latency.call_args.args[1]) == metric_config.repeat_test_num
         assert all([latency > 0 for latency in mock_compute_latency.call_args.args[1]])
-
-    @patch("onnxruntime.get_available_providers")
-    def test_available_eps_script(self, mock_get_providers, tmp_path):
-        mock_get_providers.return_value = ["CPUExecutionProvider"]
-        output_path = tmp_path / "available_eps.pkl"
-
-        # command
-        args = ["--output_path", str(output_path)]
-
-        # execute
-        available_eps_main(args)
-
-        # assert
-        assert output_path.exists()
-        mock_get_providers.assert_called_once()
-        with open(output_path, "rb") as f:
-            assert pickle.load(f) == ["CPUExecutionProvider"]
 
     @pytest.mark.parametrize("valid", [True, False])
     @patch("olive.systems.python_environment.is_valid_ep.get_ort_inference_session")

--- a/test/unit_test/systems/test_available_eps_runner.py
+++ b/test/unit_test/systems/test_available_eps_runner.py
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import json
+from unittest.mock import patch
+
+from olive.systems.available_eps_runner import main as available_eps_main
+
+
+@patch("onnxruntime.get_available_providers")
+def test_available_eps_script(mock_get_providers, tmp_path):
+    dummy_eps = ["DummyExecutionProvider"]
+    mock_get_providers.return_value = dummy_eps
+
+    # command
+    args = ["--output_path", str(tmp_path)]
+
+    # execute
+    available_eps_main(args)
+
+    # assert
+    available_eps_json_path = tmp_path / "available_eps.json"
+    assert available_eps_json_path.exists()
+    mock_get_providers.assert_called_once()
+    with open(available_eps_json_path, "r") as f:
+        assert json.load(f) == dummy_eps


### PR DESCRIPTION
## Describe your changes
Implement `get_supported_execution_providers` method for all systems so that for non-managed systems. 
Olive engine doesn't use this method for remote systems but this method might be useful in the system or for debugging purposes where users want to check the available providers in their remote systems.

Added some debug logs during the resolution of accelerator specs.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
