### PR TITLE
Abstract common code in AzureMLSystem 

### DIFF
--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -50,7 +50,10 @@ class LocalSystem(OliveSystem):
         evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
         return evaluator.evaluate(model, data_root, metrics, device=device, execution_providers=execution_providers)
 
-    def get_supported_execution_providers(self):
+    def get_supported_execution_providers(self) -> List[str]:
+        """
+        Get the available execution providers.
+        """
         import onnxruntime as ort
 
         return ort.get_available_providers()


### PR DESCRIPTION
## Describe your changes
Get some of the code improvements from https://github.com/microsoft/Olive/pull/591. 
Duplicated code in AzureMLSystem for submitting and downloading aml jobs has been abstracted into a method `run_job`. 
Pipeline output is not hard-coded to "pipeline_output" anymore in `_create_step`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
