### PR TITLE
Don't warn for repeated data component registration

### DIFF
--- a/olive/data/registry.py
+++ b/olive/data/registry.py
@@ -39,7 +39,9 @@ class Registry:
         def decorator(component):
             component_name = name if name is not None else component.__name__
             if component_name in cls._REGISTRY[sub_type.value]:
-                logger.warning(
+                # don't want to warn here since user script is loaded everytime data config is initialized
+                # there is nothing user can do to fix this warning
+                logger.debug(
                     f"Component {component_name} already registered in {sub_type.value}, will override the old one."
                 )
             cls._REGISTRY[sub_type.value][component_name] = component


### PR DESCRIPTION
## Describe your changes
Data component registration warns if a component has already been registered. However, this warning gets triggered every time a data config is initialized. This happens many times since data configs get converted to dict/json and back to object many times. 
There is nothing the user can do to prevent this so it should not be a warning. Changed to debug. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
