### PR TITLE
Enable Intel® Neural Compressor 4-bits weight-only quantization and add related example

### DIFF
--- a/examples/open_llama/README.md
+++ b/examples/open_llama/README.md
@@ -6,6 +6,7 @@ This folder contains examples of Open LLaMA workflow.
 This workflow also demonstrates how to use:
 - Huggingface `transformers` to load model from [model hub](https://huggingface.co/models).
 - Huggingface `optimum` to convert and merge generative models [optimum](https://huggingface.co/docs/optimum/index).
+- Intel® Neural Compressor `neural-compressor` to compress model with 4-bits weight-only quantization ([WOQ](https://github.com/intel/neural-compressor/blob/master/docs/source/quantization_weight_only.md)).
 
 This example config file [open_llama_config.json](open_llama_config.json) is meant to be a starting point for optimizing Open LLaMA for target hardware. One can add additional passes as well as set different options for Transformer Optimization pass as per need. See [Olive documentation](https://microsoft.github.io/Olive/) for more information on optimizations passes available.
 
@@ -97,6 +98,126 @@ This workflow optimizes Open Llama model on Azure ML compute, and evaluate outpu
 This example config file is [open_llama_arc.json](open_llama_arc.json).
 
 Requirements file: [requirements-arc.txt](requirements-arc.txt)
+
+### Compress Open Llama Model with Intel® Neural Compressor 4-bits Weight-only Quantization
+This workflow compresses Open Llama model with 4-bits weight-only quantization using Intel® Neural Compressor, and evaluate accuracy and perplexity on [lambada_openai](https://huggingface.co/datasets/EleutherAI/lambada_openai) datasets.
+
+This example config file is [open_llama_inc_woq.json](open_llama_inc_woq.json).
+
+Requirements file: [requirements-woq.txt](requirements-arc.txt)
+
+#### Prerequisites
+
+To use Intel® Neural Compressor 4-bits weight-only quantization, please install `neural-compressor>=2.3`. Weight-only quantization in Intel® Neural Compressor is still under development. We encourage you to use the master branch to access the latest features. Please check the link of [installing neural-compressor from source](https://github.com/intel/neural-compressor/blob/master/docs/source/installation_guide.md#install-from-source-1)
+
+#### Run 4-bits weight-only quantization
+
+4-bits weight-only quantization supports two algorithms:
+- Round-to-nearest (RTN) is the most straightforward way to quantize weight using scale maps.
+- GPTQ algorithm provides more accurate quantization but requires more computational resources.
+
+To compress model with 4-bits weight-only quantization, you may need
+1. set `approach` to `weight_only`, and set `algorithm` to `GPTQ` or `RTN` in `weight_only_config`.
+```json
+"quantization": {
+    "type": "IncStaticQuantization",
+    "config": {
+        "user_script": "user_script.py",
+        "approach": "weight_only",
+        "weight_only_config":{
+            "algorithm": "RTN"
+        }
+    }
+}
+```
+2. if `GPTQ` algorithm is used, you need to provide a calibration dataloader, which outputs input data and label.
+```json
+"quantization": {
+    "type": "IncStaticQuantization",
+    "config": {
+        "user_script": "user_script.py",
+        "approach": "weight_only",
+        "weight_only_config":{
+            "algorithm": "GPTQ"
+        }
+    },
+    "dataloader_func": "calib_dataloader",
+}
+```
+```python
+class CalibDataloader:
+    def __init__(self, batch_size, **kwargs):
+        self.batch_size = batch_size
+        self.dataset = []
+        # operations to add (input_data, label) pairs into self.dataset
+
+    def __iter__(self):
+        for input_data, label in self.dataset:
+            yield input_data, label
+```
+
+#### Validated results
+
+The following table shows the accuracy and perplexity results of Open Llama models evaluated on lambada_openai task. `GPTQ W4G32Asym` in the configuration column means GPTQ algorithm is used for 4-bits weight only quantization, setting group_size=32 and scheme=asym.
+
+<table class="tg">
+<thead>
+  <tr>
+    <th rowspan="2">Model name</th>
+    <th rowspan="2">Configuration</th>
+    <th colspan="2">Lambada_openai</th>
+    <th rowspan="2">Accuracy Ratio<br>[WOQ/FP32]</th>
+  </tr>
+  <tr>
+    <th>Accuracy</th>
+    <th>Perplexity</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td rowspan="2">openlm-research/open_llama_3b</td>
+    <td>FP32</td>
+    <td>0.6637</td>
+    <td>4.8496</td>
+    <td>/</td>
+  </tr>
+  <tr>
+    <td>GPTQ<br>W4G32Asym</td>
+    <td>0.6579</td>
+    <td>4.9773</td>
+    <td>99.13%</td>
+  </tr>
+  <tr>
+    <td rowspan="2">openlm-research/open_llama_7b</td>
+    <td>FP32</td>
+    <td>0.7044</td>
+    <td>3.9716</td>
+    <td>/</td>
+  </tr>
+  <tr>
+    <td>GPTQ<br>W4G32Sym</td>
+    <td>0.7017</td>
+    <td>4.1320</td>
+    <td>99.62%</td>
+  </tr>
+  <tr>
+    <td rowspan="2">openlm-research/open_llama_13b</td>
+    <td>FP32</td>
+    <td>0.7213</td>
+    <td>3.5728</td>
+    <td>/</td>
+  </tr>
+  <tr>
+    <td>RTN<br>W4G32Sym</td>
+    <td>0.7174</td>
+    <td>3.7322</td>
+    <td>99.36%</td>
+  </tr>
+</tbody>
+</table>
+
+> Note: The above results are obtained using onnxruntime built from source code with the `sub_byte_quant_zp` branch, which enables support for the `MatMulWithQuantWeight` op. Weight-only quantization in Intel® Neural Compressor is still under development. We encourage you to use the master branch to access the latest features.
+
 
 ## How to run
 ### Pip requirements

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -57,23 +57,23 @@
             "config": {
                 "user_script": "user_script.py",
                 "approach": "weight_only",
-		"weight_only_config":{
-		    "bits": 4,
-		    "algorithm": "GPTQ"
-		},
-		"dataloader_func": "calib_dataloader",
+        "weight_only_config":{
+            "bits": 4,
+            "algorithm": "GPTQ"
+        },
+        "dataloader_func": "calib_dataloader",
                 "calibration_sampling_size": [8],
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }
         },
-	"merge": {
+    "merge": {
             "type": "OptimumMerging",
-	    "config": {
-		"save_as_external_data": true,
-		"all_tensors_to_one_file": true
-	    }
-	}
+        "config": {
+        "save_as_external_data": true,
+        "all_tensors_to_one_file": true
+        }
+    }
     },
     "engine": {
         "evaluator": "common_evaluator",

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -1,0 +1,84 @@
+{
+    "input_model":{
+        "type": "OptimumModel",
+        "config": {
+            "model_path": "openlm-research/open_llama_3b",
+            "model_components": ["decoder_model.onnx", "decoder_with_past_model.onnx"],
+            "hf_config": {
+                "model_class": "LlamaForCausalLM"
+            }
+        }
+    },
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "custom",
+                    "sub_types": [
+                        {"name": "accuracy_custom", "higher_is_better": true}
+                    ],
+                    "user_config":{
+                        "user_script": "user_script.py",
+                        "evaluate_func": "eval_accuracy",
+                        "batch_size": 64
+                    }
+                }
+            ]
+        }
+    },
+    "passes": {
+        "convert": {
+            "type": "OptimumConversion",
+            "config": {
+                "target_opset": 14,
+                "save_as_external_data": true,
+                "all_tensors_to_one_file": true
+            }
+        },
+        "optimize": {
+            "type": "OrtTransformersOptimization",
+            "config": {
+                "model_type": "gpt2",
+                "use_gpu": false,
+                "keep_io_types": true,
+                "num_heads": 32,
+                "hidden_size": 4096,
+                "optimization_options": {
+                    "use_multi_head_attention": false
+                },
+                "save_as_external_data": true,
+                "all_tensors_to_one_file": true
+            }
+        },
+        "quantization": {
+            "type": "IncStaticQuantization",
+            "disable_search": true,
+            "config": {
+                "user_script": "user_script.py",
+                "approach": "weight_only",
+		"weight_only_config":{
+		    "bits": 4,
+		    "algorithm": "GPTQ"
+		},
+		"dataloader_func": "calib_dataloader",
+                "calibration_sampling_size": [8],
+                "save_as_external_data": true,
+                "all_tensors_to_one_file": true
+            }
+        },
+	"merge": {
+            "type": "OptimumMerging",
+	    "config": {
+		"save_as_external_data": true,
+		"all_tensors_to_one_file": true
+	    }
+	}
+    },
+    "engine": {
+        "evaluator": "common_evaluator",
+        "cache_dir": "cache",
+        "output_name": "ollama",
+        "output_dir": "footprints"
+    }
+}

--- a/examples/open_llama/requirements-woq.txt
+++ b/examples/open_llama/requirements-woq.txt
@@ -1,0 +1,7 @@
+datasets
+# TODO: remove commit hash once update
+git+https://github.com/EleutherAI/lm-evaluation-harness.git@83dbfbf6070324f3e5872f63e49d49ff7ef4c9b3
+intel-extension-for-transformers>=1.2
+neural-compressor>=2.3
+onnxruntime
+sentencepiece

--- a/examples/open_llama/user_script.py
+++ b/examples/open_llama/user_script.py
@@ -2,10 +2,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import random
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
 import torch
-from transformers import AutoConfig
+from datasets import load_dataset
+from transformers import AutoConfig, LlamaTokenizer
 
 from olive.constants import Framework
+from olive.model import OliveModel
 
 model_id = "openlm-research/open_llama_3b"
 config = AutoConfig.from_pretrained(model_id)
@@ -55,3 +62,91 @@ def dummy_inputs(batch_size, torch_dtype, model_framework=Framework.PYTORCH):
 def dataloader_func(data_dir, batch_size, *args, **kwargs):
     model_framework = kwargs.get("model_framework", Framework.PYTORCH)
     return RandomDataLoader(dummy_inputs, batch_size, torch.float16, model_framework)
+
+
+def tokenize_function(examples):
+    tokenizer = LlamaTokenizer.from_pretrained(model_id)
+    return tokenizer(examples["text"])
+
+
+class PileDataloader:
+    def __init__(self, model_path, batch_size=1, seqlen=2048, sub_folder="train"):
+        random.seed(0)
+        self.seqlen = seqlen
+        self.batch_size = batch_size
+        self.dataset = load_dataset("NeelNanda/pile-10k", split=sub_folder)
+        self.dataset = self.dataset.map(tokenize_function, batched=True)
+        self.dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
+        self.sess = None
+        if not model_path.endswith("decoder_model.onnx"):
+            for item in Path(model_path).parent.parent.glob("**/decoder_model.onnx"):
+                decoder_model_path = item.resolve()
+                break
+            self.sess = ort.InferenceSession(decoder_model_path)
+
+    def __iter__(self):
+        try:
+            while True:
+                while True:
+                    i = random.randint(0, len(self.dataset) - 1)
+                    trainenc = self.dataset[i]
+                    if trainenc["input_ids"].shape[0] > self.seqlen:
+                        break
+                i = random.randint(0, trainenc["input_ids"].shape[0] - self.seqlen - 1)
+                j = i + self.seqlen
+                inp = trainenc["input_ids"][i:j].unsqueeze(0)
+                mask = torch.ones(inp.shape)
+                if self.sess is None:
+                    yield {
+                        "input_ids": inp.detach().cpu().numpy().astype("int64"),
+                        "attention_mask": mask.detach().cpu().numpy().astype("int64"),
+                    }, 0
+                else:
+                    outputs = self.sess.run(
+                        None,
+                        {
+                            "input_ids": inp[:, :-1].detach().cpu().numpy().astype("int64"),
+                            "attention_mask": mask[:, :-1].detach().cpu().numpy().astype("int64"),
+                        },
+                    )
+                    ort_input = {}
+                    ort_input["input_ids"] = inp[:, -1].unsqueeze(0).detach().cpu().numpy().astype("int64")
+                    for layer_index in range(config.num_hidden_layers):
+                        ort_input[f"past_key_values.{layer_index}.key"] = outputs[layer_index * 2 + 1]
+                        ort_input[f"past_key_values.{layer_index}.value"] = outputs[layer_index * 2 + 2]
+
+                    ort_input["attention_mask"] = np.zeros(
+                        [self.batch_size, ort_input["past_key_values.0.key"].shape[2] + 1], dtype="int64"
+                    )
+                    yield ort_input, 0
+
+        except StopIteration:
+            return
+
+
+def calib_dataloader(data_dir, batch_size=1, *args, **kwargs):
+    model_path = kwargs.pop("model_path")
+    return PileDataloader(model_path, batch_size=batch_size)
+
+
+def eval_accuracy(model: OliveModel, data_dir, batch_size, device, execution_providers):
+    from intel_extension_for_transformers.llm.evaluation.lm_eval import evaluate
+
+    if model.framework == Framework.PYTORCH:
+        results = evaluate(
+            model="hf-causal",
+            model_args="pretrained=" + model.model_path + ",tokenizer=" + model_id + ",dtype=float32",
+            batch_size=batch_size,
+            tasks=["lambada_openai"],
+        )
+    elif model.framework == Framework.ONNX:
+        output_config_file = Path(model.model_path).resolve().parent / "config.json"
+        config.to_json_file(output_config_file, use_diff=False)
+        results = evaluate(
+            model="hf-causal",
+            model_args="pretrained=" + str(Path(model.model_path).resolve().parent) + ",tokenizer=" + model_id,
+            batch_size=batch_size,
+            tasks=["lambada_openai"],
+            model_format="onnx",
+        )
+    return results["results"]["lambada_openai"]["acc"]


### PR DESCRIPTION
## Describe your changes

Support 4-bits weight-only quantization with  Intel® Neural Compressor and add related example.

As large language models (LLMs) become more prevalent, there is a growing need for new and improved quantization methods that can meet the computational demands of these modern architectures while maintaining the accuracy. Compared to normal quantization like W8A8, weight only quantization (WOQ) is probably a better trade-off to balance the performance and the accuracy.

Two weight only algorithms are provided in this PR. Round-to-nearest (RTN) is the most straightforward way to quantize weight using scale maps. GPTQ algorithm provides more accurate quantization but requires more computational resources.

More detials please refer to this [link](https://github.com/intel/neural-compressor/blob/master/docs/source/quantization_weight_only.md)

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
