### PR TITLE
CI: Fail `PublishTestResults` when any test failed, Fix failing tests

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -67,6 +67,7 @@ jobs:
       inputs:
         testResultsFiles: '**/*TestOlive*.xml'
         testRunTitle: '$(Build.BuildNumber)[$(Agent.JobName)]'
+        failTaskOnFailedTests: true
       displayName: Upload pipeline run test results
 
     - script: git clean -dfX

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -77,7 +77,6 @@ jobs:
 
             coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml $(Build.SourcesDirectory)/test/$(testType)
             coverage xml
-
         displayName: Test Olive
         env:
           OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -106,6 +106,7 @@ jobs:
       inputs:
         testResultsFiles: '**/*TestOlive*.xml'
         testRunTitle: '$(Build.BuildNumber)[$(Agent.JobName)]'
+        failTaskOnFailedTests: true
       displayName: Upload pipeline run test results
 
     - task: PublishCodeCoverageResults@1

--- a/test/unit_test/snpe/test_adb_run.py
+++ b/test/unit_test/snpe/test_adb_run.py
@@ -27,7 +27,7 @@ def test_run_adb_command(mock_run_subprocess, mock_which, android_target):
     mock_which.side_effect = lambda x, path: x
     stdout, stderr = run_adb_command("version", android_target)
     mock_run_subprocess.assert_called_once_with(
-        f"adb -s {android_target} version".split(), capture_output=True, env=None, cwd=None
+        f"adb -s {android_target} version".split(), capture_output=True, env=None, cwd=None, check=False
     )
     assert stdout == "stdout"
     assert stderr == "stderr"
@@ -56,5 +56,6 @@ def test_run_snpe_command():
             capture_output=True,
             env=env,
             cwd=None,
+            check=False,
         )
         assert stdout.strip() == "stdout"

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -237,7 +237,7 @@ class TestPythonEnvironmentSystem:
         ]
         for i in range(num_batches):
             assert (output_dir / f"output_{i}.npy").exists()
-            assert np.load(output_dir / f"output_{i}.npy") == dummy_output
+            assert np.array_equal(np.load(output_dir / f"output_{i}.npy"), dummy_output)
 
     @pytest.mark.parametrize("io_bind", [True, False])
     @patch("olive.systems.python_environment.inference_runner.get_ort_inference_session")


### PR DESCRIPTION
## Describe your changes
Because of the `coverage run` command used to run unit and integrations tests, the `Test Olive` steps doesn't fail even when some tests fail. So we were not catching them. 

Set `failOnStandardError=True` for `PublishTestResults` tasks so that the test results task catches any failing tests. You can see this working as expected in this [test run](https://dev.azure.com/aiinfra/PublicPackages/_build/results?buildId=360973&view=results).

Also fixes failing tests caused by the recent lint related changes.  

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
