### PR TITLE
New pass to patch model with unsupported ArgMax operator inputs

### DIFF
--- a/examples/switch/config.json
+++ b/examples/switch/config.json
@@ -3,7 +3,7 @@
     "input_model":{
         "type": "OnnxModel",
         "config": {
-            "model_path": "model_4n_2l_8e.onnx"
+            "model_path": "model.onnx"
         }
     },
     "passes": {

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -888,6 +888,8 @@ class OpenVINOModel(OliveModel):
 
 
 class DistributedOnnxModel(ONNXModelBase):
+    resource_keys: ClassVar[list] = ["model_filepaths"]
+
     EXECUTION_PROVIDERS: ClassVar[dict] = {
         "cpu": ["CPUExecutionProvider"],
         "gpu": ["CUDAExecutionProvider", "CPUExecutionProvider"],

--- a/olive/passes/onnx/moe_experts_distributor.py
+++ b/olive/passes/onnx/moe_experts_distributor.py
@@ -43,6 +43,7 @@ _expert_pattern = [
 
 
 def _dump_graph(node: Message, filepath: str):
+    Path(filepath).parent.mkdir(parents=True, exist_ok=True)
     with open(filepath, "w") as strm:  # noqa: PTH123
         json.dump(MessageToDict(node), fp=strm, indent=2, sort_keys=True, separators=_json_separators)
         strm.flush()

--- a/olive/passes/onnx/patch_argmax_operator.py
+++ b/olive/passes/onnx/patch_argmax_operator.py
@@ -1,0 +1,98 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+from typing import Any, Dict
+
+from google.protobuf.message import Message
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import ONNXModel
+from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
+from olive.passes.pass_config import PassConfigParam
+
+logger = logging.getLogger(__name__)
+
+
+class OrtPatchArgMaxOperator(Pass):
+    """Insert a Cast operator ahead of ArgMax if input tensor type is of unsupported type."""
+
+    @staticmethod
+    def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        config = {}
+        config.update(get_external_data_config())
+        return config
+
+    @staticmethod
+    def _create_node_name(nodes: Dict[str, Message], op_type: str, prefix_a: str, prefix_b: str):
+        prefix: str = ""
+        last_slash: int = -1
+        for i in range(min(len(prefix_a), len(prefix_b))):
+            if prefix_a[i] == prefix_b[i]:
+                prefix += prefix_a[i]
+                if prefix_a[i] == "/":
+                    last_slash = i
+            else:
+                break
+
+        if last_slash > 0:
+            prefix = prefix[: last_slash + 1]
+
+        if not prefix.endswith("/"):
+            prefix += "/"
+        prefix += op_type
+
+        suffix: int = 0
+        node_name: str = prefix
+        while True:
+            if node_name not in nodes:
+                return node_name
+
+            node_name = f"{prefix}_{suffix}"
+            suffix += 1
+
+    def _run_for_config(
+        self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModel:
+        import onnx
+        from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+        from onnxruntime.transformers.onnx_model import OnnxModel
+
+        o_model = OnnxModel(model.load_model())
+        o_model.topological_sort()
+
+        s_model = OnnxModel(
+            SymbolicShapeInference.infer_shapes(
+                o_model.model,
+                auto_merge=True,
+                guess_output_rank=True,
+                # verbose=1,
+            )
+        )
+
+        o_nodes_by_name = {n.name: n for n in o_model.nodes()}
+        s_value_info_by_name = {v.name: v for v in s_model.model.graph.value_info}
+        s_value_info_by_name.update({n.name: n for n in s_model.model.graph.input})
+
+        for s_argmax_node in s_model.get_nodes_by_op_type("ArgMax"):
+            s_value_info = s_value_info_by_name[s_argmax_node.input[0]]
+            if s_value_info.type.tensor_type.HasField("elem_type") and (
+                s_value_info.type.tensor_type.elem_type == onnx.TensorProto.INT64
+            ):
+
+                cast_node_name = OrtPatchArgMaxOperator._create_node_name(
+                    o_nodes_by_name, "Cast", s_argmax_node.input[0], s_argmax_node.name
+                )
+                cast_output_name = cast_node_name + "_output_0"
+                cast_node = onnx.helper.make_node(
+                    "Cast", [s_argmax_node.input[0]], [cast_output_name], name=cast_node_name, to=onnx.TensorProto.INT32
+                )
+
+                o_argmax_node = o_nodes_by_name[s_argmax_node.name]
+                o_argmax_node.input[0] = cast_output_name
+                o_model.add_node(cast_node)
+                o_nodes_by_name[cast_node_name] = cast_node
+
+        return model_proto_to_olive_model(o_model.model, output_model_path, config)

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -121,7 +121,8 @@ def create_resource_path(
         return None
     if isinstance(resource_path, ResourcePath):
         return resource_path
-
+    if isinstance(resource_path, list):
+        return [create_resource_path(rp) for rp in resource_path]
     if isinstance(resource_path, (ResourcePathConfig, dict)):
         resource_path_config = validate_config(resource_path, ResourcePathConfig)
         return resource_path_config.create_resource_path()

--- a/test/unit_test/passes/onnx/test_patch_argmax_operator.py
+++ b/test/unit_test/passes/onnx/test_patch_argmax_operator.py
@@ -1,0 +1,90 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from pathlib import Path
+from typing import Any, Dict
+
+from onnx import TensorProto, helper
+
+from olive.model import ONNXModel
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.common import model_proto_to_olive_model
+from olive.passes.onnx.patch_argmax_operator import OrtPatchArgMaxOperator
+
+
+def _make_model(data_type: TensorProto.DataType, filepath: str, config: Dict[str, Any]) -> ONNXModel:
+    X = helper.make_tensor_value_info("X", data_type, [None, None])  # noqa: N806
+    Y = helper.make_tensor_value_info("Y", data_type, [None])  # noqa: N806
+    node_def = helper.make_node("ArgMax", ["X"], ["Y"], domain="com.microsoft")
+    graph_def = helper.make_graph(
+        [node_def],
+        "g",
+        [X],
+        [Y],
+    )
+    opset_imports = [
+        helper.make_operatorsetid("", 18),
+        helper.make_operatorsetid("com.microsoft", 1),
+    ]
+    model = helper.make_model(
+        graph_def,
+        producer_name="From test_patch_argmax_operator.py",
+        opset_imports=opset_imports,
+    )
+
+    return model_proto_to_olive_model(model, filepath, config)
+
+
+def test_patch_argmax_operator_pass_does_insert(tmp_path):
+    config = {"save_as_external_data": False, "all_tensors_to_one_file": False, "external_data_name": False}
+
+    m = _make_model(TensorProto.INT64, str(tmp_path / "input.onnx"), config)
+    p = create_pass_from_dict(OrtPatchArgMaxOperator, config, disable_search=True)
+
+    # execute
+    actual_model = p.run(m, None, str(tmp_path / "onnx"))
+    assert Path(actual_model.model_path).exists()
+
+    actual_model = actual_model.load_model()
+    assert len(actual_model.graph.node) == 2
+
+    argmax_op_count = 0
+    cast_op_count = 0
+    others_op_count = 0
+    for node in actual_model.graph.node:
+        if node.op_type == "ArgMax":
+            argmax_op_count += 1
+        elif node.op_type == "Cast":
+            cast_op_count += 1
+        else:
+            others_op_count += 1
+
+    assert argmax_op_count == 1
+    assert cast_op_count == 1
+    assert others_op_count == 0
+
+
+def test_patch_argmax_operator_pass_no_insert(tmp_path):
+    config = {"save_as_external_data": False, "all_tensors_to_one_file": False, "external_data_name": False}
+
+    m = _make_model(TensorProto.INT32, str(tmp_path / "input.onnx"), config)
+    p = create_pass_from_dict(OrtPatchArgMaxOperator, config, disable_search=True)
+
+    # execute
+    actual_model = p.run(m, None, str(tmp_path / "onnx"))
+    assert Path(actual_model.model_path).exists()
+
+    actual_model = actual_model.load_model()
+    assert len(actual_model.graph.node) == 1
+
+    argmax_op_count = 0
+    others_op_count = 0
+    for node in actual_model.graph.node:
+        if node.op_type == "ArgMax":
+            argmax_op_count += 1
+        else:
+            others_op_count += 1
+
+    assert argmax_op_count == 1
+    assert others_op_count == 0


### PR DESCRIPTION
## Describe your changes

New pass to patch model with unsupported ArgMax operator inputs

ArgMax doesn't support TensorProto.INT64 type as input. Insert a Cast
operator ahead of ArgMax to make the model usuable for inferencing.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
