### PR TITLE
Train original resnet for min 1 epoch

### DIFF
--- a/examples/resnet/prepare_model_data.py
+++ b/examples/resnet/prepare_model_data.py
@@ -19,7 +19,7 @@ from torchvision.models import ResNet50_Weights, resnet50
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--num_epochs", type=int, default=0)
+    parser.add_argument("--num_epochs", type=int, default=1)
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Describe your changes
The default value for `num_epochs` in `prepare_model_data.py` is `0` so we are using a random model. The accuracy numbers and goals are meaningless for this. This also causes the resnet test to be flaky since the original accuracy ~10% and doen't have much freedom for movement.

Train it for atleast 1 epoch so that we are testing for a good model. 

 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
