### PR TITLE
Text-gen: Optional attn mask. Loading args for hf model config. QLoRA: Update loading args 

### DIFF
--- a/examples/open_llama/open_llama_qlora_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_tinycodes.json
@@ -19,7 +19,7 @@
                 }
             },
             "params_config": {
-                "dataset_name": "nampdn-ai/tiny-codes",
+                "data_name": "nampdn-ai/tiny-codes",
                 "split": "train",
                 "component_kwargs": {
                     "load_dataset": {

--- a/examples/open_llama/qlora_user_script.py
+++ b/examples/open_llama/qlora_user_script.py
@@ -11,6 +11,6 @@ from olive.data.registry import Registry
 
 # TODO(jambayk): remove custom dataset component once default dataset component supports filter, tokens and split
 @Registry.register_dataset()
-def load_tiny_code_dataset(dataset_name: str, split: str, language: str, token: Union[bool, str] = True):
-    dataset = load_dataset(dataset_name, split=split, token=token)
+def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
+    dataset = load_dataset(data_name, split=split, token=token)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -416,7 +416,7 @@ def text_gen_pair_pre_process(dataset, tokenizer, all_kwargs):
             # skip short sequences if drop_short_sequences is True
             continue
         if args.pad_to_max_len:
-            if not tokenizer.pad_token_id:
+            if tokenizer.pad_token_id is None:
                 raise ValueError("Tokenizer does not have a pad token")
             # add padding to max_len
             input_ids = torch.nn.functional.pad(

--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -206,6 +206,7 @@ class TextGenPairParams(TextGenParams):
             raise ValueError(
                 "pad_to_max_len is True but use_attention_mask is False. Attention mask is required for padding!"
             )
+        return v
 
 
 def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -226,7 +226,8 @@ class HFConfig(ConfigBase):
     def load_model_config(self, model_path: str = None):
         """Load model config from model_path or model_name."""
         model_name_or_path = model_path or self.model_name
-        return get_hf_model_config(model_name_or_path)
+        loading_args = self.model_loading_args.get_loading_args() if self.model_loading_args else {}
+        return get_hf_model_config(model_name_or_path, **loading_args)
 
 
 def load_huggingface_model_from_task(task: str, name: str, **kwargs):
@@ -275,9 +276,9 @@ def huggingface_model_loader(model_loader):
     return model_loader.from_pretrained
 
 
-def get_hf_model_config(model_name: str):
+def get_hf_model_config(model_name: str, **kwargs):
     """Get HF Config for the given model name."""
-    return AutoConfig.from_pretrained(model_name)
+    return AutoConfig.from_pretrained(model_name, **kwargs)
 
 
 def load_huggingface_model_from_model_class(model_class: str, name: str, **kwargs):

--- a/olive/passes/pytorch/qlora.py
+++ b/olive/passes/pytorch/qlora.py
@@ -269,7 +269,7 @@ class QLoRA(Pass):
         new_model.model = None
         # remove the device map since we don't want "auto" device map
         new_model.hf_config.model_loading_args.device_map = None
-        # remove model_overwrites from model_attributes
+        # remove model_overwrites from model_attributes since new config will be created
         if new_model.model_attributes:
             for k in QLoRA.model_overwrites:
                 if k in new_model.model_attributes:

--- a/olive/passes/pytorch/qlora.py
+++ b/olive/passes/pytorch/qlora.py
@@ -122,6 +122,8 @@ class QLoRA(Pass):
     This pass only supports PyTorchModel with hf_config.
     """
 
+    # these are the attributes of the model (in hf_config) that will be overwritten by the pass
+    # values from the input model will be ignored and new values will be set based on the pass config
     model_overwrites: ClassVar[tuple] = ("torch_dtype", "device_map", "quantization_method", "quantization_config")
 
     @staticmethod
@@ -272,8 +274,7 @@ class QLoRA(Pass):
         # remove model_overwrites from model_attributes since new config will be created
         if new_model.model_attributes:
             for k in QLoRA.model_overwrites:
-                if k in new_model.model_attributes:
-                    del new_model.model_attributes[k]
+                new_model.model_attributes.pop(k, None)
 
         # set adapter_path
         new_model.set_resource("adapter_path", adapter_path)

--- a/olive/passes/pytorch/qlora.py
+++ b/olive/passes/pytorch/qlora.py
@@ -271,7 +271,7 @@ class QLoRA(Pass):
         new_model.model = None
         # remove the device map since we don't want "auto" device map
         new_model.hf_config.model_loading_args.device_map = None
-        # remove model_overwrites from model_attributes since new config will be created
+        # remove model_overwrites from model_attributes
         if new_model.model_attributes:
             for k in QLoRA.model_overwrites:
                 new_model.model_attributes.pop(k, None)

--- a/olive/passes/pytorch/qlora.py
+++ b/olive/passes/pytorch/qlora.py
@@ -347,7 +347,7 @@ class QLoRA(Pass):
         # TODO(jambayk): Do this in a better way since the embedding size might become unoptimal
         # (not a multiple of 64, etc) perhaps use eos_token as pad_token, but need to ensure the actual eos_token
         # at the end of the sequence is not masked (both in attention mask and loss calculation)
-        if not tokenizer.pad_token_id:
+        if tokenizer.pad_token_id is None:
             cls.smart_tokenizer_and_embedding_resize(
                 special_tokens_dict={"pad_token": DEFAULT_PAD_TOKEN}, tokenizer=tokenizer, model=pytorch_model
             )

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -152,7 +152,7 @@ class TestDataConfigValidation:
                     "params_config": {
                         "model_name": "dummy_model2",
                         "task": "dummy_task2",
-                        "dataset_name": "dummy_dataset2",
+                        "data_name": "dummy_dataset2",
                     },
                 }
             },
@@ -174,7 +174,7 @@ class TestDataConfigValidation:
         config_dict["data_configs"]["dummy_data_config2"]["params_config"] = {
             "model_name": model_name,
             "task": task,
-            "dataset_name": "dummy_dataset2",
+            "data_name": "dummy_dataset2",
         }
 
         run_config = RunConfig.parse_obj(config_dict)


### PR DESCRIPTION
## Describe your changes
Some enhancements to the QLoRA pass and related components. 

Example use case scenario is for fine-tuning [microsoft/phi-1_5](https://huggingface.co/microsoft/phi-1_5). In order to load the model and config for this model non-interactively, we have to pass `trust_remote_code=True` to `model_loading_args`. However, the QLoRA pass and `get_hf_model_config` both ignore it.
There are also cases where we have to provide `token` for models like [meta-llama/Llama-2-7b](https://huggingface.co/meta-llama/Llama-2-7b). 
Both components have been updated to use the model_loading_args correctly. 

`microsoft/phi-1_5` gives a warning about `attention_mask` during training. Text-gen preprocessing is updated to make `attention_mask` optional (opt out if needed). 

Bug Fix: Check `pad_token_id` for `None` since `not pad_token_id` is `True` for `pad_token_id == 0`. 

Renamed `dataset_name` to `data_name` in qlora example to use consistent naming. 



## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
