### PR TITLE
Fix bugs in how free dimension session options are set:

### DIFF
--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -207,17 +207,17 @@ def run_inference(
         sess_options.add_free_dimension_override_by_name("unet_hidden_batch", batch_size * 2)
         sess_options.add_free_dimension_override_by_name("unet_hidden_sequence", 77)
         sess_options.add_free_dimension_override_by_name("unet_text_embeds_batch", batch_size * 2)
-        sess_options.add_free_dimension_override_by_name("unet_text_embeds_size", image_size + 256)
+        sess_options.add_free_dimension_override_by_name("unet_text_embeds_size", 1280)
         sess_options.add_free_dimension_override_by_name("unet_time_ids_batch", batch_size * 2)
         sess_options.add_free_dimension_override_by_name("unet_time_ids_size", 6)
 
     if base_images is None:
         pipeline = ORTStableDiffusionXLPipeline.from_pretrained(
-            model_dir, provider="DmlExecutionProvider", sess_options=sess_options
+            model_dir, provider="DmlExecutionProvider", session_options=sess_options
         )
     else:
         pipeline = ORTStableDiffusionXLImg2ImgPipeline.from_pretrained(
-            model_dir, provider="DmlExecutionProvider", sess_options=sess_options
+            model_dir, provider="DmlExecutionProvider", session_options=sess_options
         )
 
     if interactive:

--- a/examples/directml/stable_diffusion_xl/user_script.py
+++ b/examples/directml/stable_diffusion_xl/user_script.py
@@ -83,12 +83,12 @@ def unet_inputs(batchsize, torch_dtype, is_conversion_inputs=False):
     if is_conversion_inputs:
         inputs["additional_inputs"] = {
             "added_cond_kwargs": {
-                "text_embeds": torch.rand((2 * batchsize, config.image_size + 256), dtype=torch_dtype),
+                "text_embeds": torch.rand((2 * batchsize, 1280), dtype=torch_dtype),
                 "time_ids": torch.rand((2 * batchsize, config.time_ids_size), dtype=torch_dtype),
             }
         }
     else:
-        inputs["text_embeds"] = torch.rand((2 * batchsize, config.image_size + 256), dtype=torch_dtype)
+        inputs["text_embeds"] = torch.rand((2 * batchsize, 1280), dtype=torch_dtype)
         inputs["time_ids"] = torch.rand((2 * batchsize, config.time_ids_size), dtype=torch_dtype)
 
     return inputs


### PR DESCRIPTION
## Describe your changes

- The “unet_text_embeds_size” free dimension should always be overridden with a value of 1280 irrespective of image resolution - this value is same as the text_encoder_2 hidden dimension for both SD-XL base and refiner model. Currently using a resolution other than 1024 results in error.
- With the optimum pipeline, the right keyword to pass session options is “session_options” and not “sess_options”. This change improves perf by 40% for 512x512 resolution and about 10% for 1024x1024 resolution.
