### PR TITLE
🆓 Release GPU memory for torch model evaluation

### DIFF
--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -698,9 +698,10 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
         targets = torch.cat(targets, dim=0)
         logits = torch.cat(logits, dim=0)
         # move model to cpu
-        # don't want model to be kept on gpu since model persists and takes up gpu memory
         if device:
             session.to("cpu")
+        # only move to cpu cannot release gpu memory, call cuda.empty_cache() to release gpu memory
+        torch.cuda.is_available() and torch.cuda.empty_cache()
         return OliveModelOutput(preds=preds, logits=logits), targets
 
     def _evaluate_accuracy(
@@ -770,7 +771,8 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
         # move model to cpu
         if device:
             session.to("cpu")
-
+        # only move to cpu cannot release gpu memory, call cuda.empty_cache() to release gpu memory
+        torch.cuda.is_available() and torch.cuda.empty_cache()
         return OliveEvaluator.compute_latency(metric, latencies)
 
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -701,7 +701,8 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
         if device:
             session.to("cpu")
         # only move to cpu cannot release gpu memory, call cuda.empty_cache() to release gpu memory
-        torch.cuda.is_available() and torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
         return OliveModelOutput(preds=preds, logits=logits), targets
 
     def _evaluate_accuracy(
@@ -772,7 +773,8 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
         if device:
             session.to("cpu")
         # only move to cpu cannot release gpu memory, call cuda.empty_cache() to release gpu memory
-        torch.cuda.is_available() and torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
         return OliveEvaluator.compute_latency(metric, latencies)
 
 

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -192,6 +192,8 @@ class OnnxConversion(Pass):
         # Reset to CPU so the resource consumed on GPU could be free.
         if device != "cpu":
             pytorch_model.to("cpu")
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
         # save the model to the output path and return the model
         return model_proto_to_olive_model(onnx_model, output_model_path, config)
 

--- a/olive/passes/pytorch/qlora.py
+++ b/olive/passes/pytorch/qlora.py
@@ -269,6 +269,9 @@ class QLoRA(Pass):
 
         # remove loaded model
         new_model.model = None
+        del pytorch_model
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
         # remove the device map since we don't want "auto" device map
         new_model.hf_config.model_loading_args.device_map = None
         # remove model_overwrites from model_attributes


### PR DESCRIPTION
## Describe your changes
In llamav2 tests, torch model occupied the gpu memory which leads to error when evaluate onnx model.

Release GPU memory for torch model evaluation
model.to("cpu") could not release gpu memory in time. Call torch.cuda.empty_cache() to cleanup.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
