### PR TITLE
Optional `evaluate_input_model` in no-search mode

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -392,7 +392,12 @@ class Engine:
         self.footprints[accelerator_spec].record(model_id=input_model_id)
 
         try:
-            if evaluate_input_model:
+            if evaluate_input_model and self.no_search and not self.evaluator_config:
+                logger.debug(
+                    "evaluate_input_model is True but no evaluator provided in no-search mode. Skipping input model"
+                    " evaluation."
+                )
+            elif evaluate_input_model:
                 prefix_output_name = (
                     f"{output_name}_{accelerator_spec}_" if output_name is not None else f"{accelerator_spec}"
                 )


### PR DESCRIPTION
## Describe your changes
In `no-search` mode, the `evaluate_input_model=True` case is only used if an evaluator is provided. Otherwise, it requires the user to explicitly set `evaluate_input_model=False`. 
Now the input model evaluation behavior is the same as for the output model: evaluate if evaluator provided. 
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
