### PR TITLE
raise the known failure exceptions when do perf-tuning

### DIFF
--- a/examples/bert/conda.yaml
+++ b/examples/bert/conda.yaml
@@ -7,6 +7,7 @@ dependencies:
   - pip:
       - datasets
       - evaluate
+      - psutil
       - scipy
       - scikit-learn
       - tabulate

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -20,7 +20,7 @@ from olive.engine.packaging.packaging_config import PackagingConfig
 from olive.engine.packaging.packaging_generator import generate_output_artifacts
 from olive.evaluator.metric import Metric, MetricResult, joint_metric_key
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
-from olive.exception import OlivePassError
+from olive.exception import EXCEPTIONS_TO_RAISE, OlivePassError
 from olive.hardware import AcceleratorLookup, AcceleratorSpec, Device
 from olive.model import ModelConfig
 from olive.passes.olive_pass import Pass
@@ -31,8 +31,6 @@ from olive.systems.olive_system import OliveSystem
 from olive.systems.utils import create_new_system_with_cache
 
 logger = logging.getLogger(__name__)
-
-EXCEPTIONS_TO_RAISE = (AssertionError, AttributeError, ImportError, TypeError, ValueError)
 
 
 class Engine:

--- a/olive/exception/__init__.py
+++ b/olive/exception/__init__.py
@@ -12,3 +12,6 @@ class OlivePassError(OliveError):
 
 class OliveEvaluationError(OliveError):
     """Base class for Olive evaluation exceptions."""
+
+
+EXCEPTIONS_TO_RAISE = (AssertionError, AttributeError, ImportError, TypeError, ValueError)

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, Union
 from olive.data.config import DataConfig
 from olive.evaluator.metric import LatencySubType, Metric, MetricType, joint_metric_key
 from olive.evaluator.metric_config import get_user_config_properties_from_metric_type
+from olive.exception import EXCEPTIONS_TO_RAISE
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec
 from olive.model import ONNXModel
 from olive.passes import Pass
@@ -151,6 +152,8 @@ def threads_num_tuning(model, data_root, latency_metric, config, tuning_combo):
             for intra in config.intra_thread_num_list:
                 test_params["session_options"]["intra_op_num_threads"] = intra
                 threads_num_binary_search(model, data_root, latency_metric, config, test_params, tuning_results)
+    except EXCEPTIONS_TO_RAISE:
+        raise
     except Exception:
         logger.error("Optimization failed for tuning combo %s", tuning_combo, exc_info=True)
 

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -404,7 +404,7 @@ class TestEngine:
 
             with pytest.raises(ValueError) as exc_info:
                 engine.initialize()
-                assert str(exc_info.value) == "ValueError: invalid literal for int() with base 10: '435d'"
+            assert str(exc_info.value) == "invalid literal for int() with base 10: '435d'"
 
     @patch("olive.systems.local.LocalSystem")
     @patch("onnxruntime.get_available_providers")

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -40,4 +40,19 @@ def test_ort_perf_tuning_pass_with_dynamic_shapes(mock_get_io_config, tmp_path):
     with pytest.raises(TypeError) as e:
         # execute
         p.run(input_model, None, output_folder)
-        assert "ones() received an invalid combination of arguments" in str(e.value)
+    assert "ones() received an invalid combination of arguments" in str(e.value)
+
+
+@patch("olive.passes.onnx.perf_tuning.threads_num_binary_search")
+def test_ort_perf_tuning_pass_with_import_error(mock_threads_num_binary_search, tmp_path):
+    mock_threads_num_binary_search.side_effect = ModuleNotFoundError("test")
+
+    input_model = get_onnx_model()
+    p = create_pass_from_dict(OrtPerfTuning, {}, disable_search=True)
+    output_folder = str(tmp_path / "onnx")
+
+    with pytest.raises(ModuleNotFoundError) as e:
+        # execute
+        p.run(input_model, None, output_folder)
+
+    assert "test" in str(e.value)

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -55,7 +55,7 @@ class TestRunConfig:
         user_script_config.pop("azureml_client")
         with pytest.raises(ValueError) as e:
             RunConfig.parse_obj(user_script_config)
-            assert str(e.value) == "AzureML client config is required for AzureML system"
+        assert "AzureML client config is required for AzureML system" in str(e.value)
 
     @pytest.fixture
     def mock_aml_credentials(self):


### PR DESCRIPTION
## Describe your changes
In perf-tuning, if the exception is known as ImportModuleError, we need not retry the next step. And we need throw the exception like in engine.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
