### PR TITLE
Fix rocm ep name

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -41,7 +41,7 @@ def get_package_name_from_ep(execution_provider):
         "CPUExecutionProvider": ("onnxruntime", "ort-nightly"),
         "CUDAExecutionProvider": ("onnxruntime-gpu", "ort-nightly-gpu"),
         "TensorrtExecutionProvider": ("onnxruntime-gpu", "ort-nightly-gpu"),
-        "RocmExecutionProvider": ("onnxruntime-gpu", "ort-nightly-gpu"),
+        "ROCMExecutionProvider": ("onnxruntime-gpu", "ort-nightly-gpu"),
         "OpenVINOExecutionProvider": ("onnxruntime-openvino", None),
         "DmlExecutionProvider": ("onnxruntime-directml", "ort-nightly-directml"),
     }

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -56,7 +56,7 @@ class AcceleratorLookup:
         "gpu": [
             "DmlExecutionProvider",
             "CUDAExecutionProvider",
-            "ROCmExecutionProvider",
+            "ROCMExecutionProvider",
             "TensorrtExecutionProvider",
             "CPUExecutionProvider",
             "OpenVINOExecutionProvider",


### PR DESCRIPTION
## Describe your changes
As described in https://github.com/microsoft/Olive/issues/667, the name for rocm ep has a typo. onnxruntime uses `ROCMExecutionProvider` as the name. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
