### PR TITLE
Update `fp16` related parameters in `OrtTransformersOptimization`

### DIFF
--- a/examples/directml/stable_diffusion/config_safety_checker.json
+++ b/examples/directml/stable_diffusion/config_safety_checker.json
@@ -74,12 +74,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion/config_text_encoder.json
+++ b/examples/directml/stable_diffusion/config_text_encoder.json
@@ -71,12 +71,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion/config_text_encoder_2.json
@@ -71,12 +71,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -78,12 +78,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion/config_vae_decoder.json
@@ -71,12 +71,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion/config_vae_encoder.json
@@ -71,12 +71,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion_xl/config_text_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder.json
@@ -104,12 +104,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
@@ -144,12 +144,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion_xl/config_unet.json
+++ b/examples/directml/stable_diffusion_xl/config_unet.json
@@ -80,12 +80,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion_xl/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_decoder.json
@@ -74,10 +74,7 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
                 "force_fp32_ops": ["RandomNormalLike"],
                 "force_fp32_nodes": [
@@ -101,7 +98,10 @@
                     "GroupNorm_28",
                     "/decoder/conv_out/Conv",
                     "graph_output_cast0"
-                ]
+                ],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },

--- a/examples/directml/stable_diffusion_xl/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_encoder.json
@@ -74,12 +74,12 @@
                     "enable_packed_qkv": true,
                     "enable_packed_kv": true,
                     "enable_bias_add": false,
-                    "group_norm_channels_last": false,
-                    "force_fp16_inputs": {
-                        "GroupNorm": [0, 1, 2]
-                    }
+                    "group_norm_channels_last": false
                 },
-                "force_fp32_ops": ["RandomNormalLike"]
+                "force_fp32_ops": ["RandomNormalLike"],
+                "force_fp16_inputs": {
+                    "GroupNorm": [0, 1, 2]
+                }
             }
         }
     },


### PR DESCRIPTION
## Describe your changes
Update the description of the `fp16` related arguments in `OrtTransformersOptimization` pass to describe their relation to the `fp16` flag. 
The parameter orders have been updated to group the related parameters together. 

`force_fp16_inputs` has been moved from `optimization_options` into the pass config params. It is not part of `optimization_options` which are used for FusionOptions. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
