### PR TITLE
Enable ORT Python logging

### DIFF
--- a/olive/logging.py
+++ b/olive/logging.py
@@ -62,7 +62,7 @@ def set_ort_logger_severity(level):
     ort_logger = logging.getLogger("onnxruntime")
     ort_logger.setLevel(level_map[level])
     formatter = logging.Formatter(
-        "[%(asctime)s] [%(levelname)s] [onnxruntime-%(filename)s:%(lineno)d:%(funcName)s] %(message)s"
+        "[%(asctime)s] [%(levelname)s] [onnxruntime]-[%(filename)s:%(lineno)d:%(funcName)s] %(message)s"
     )
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setFormatter(formatter)

--- a/olive/logging.py
+++ b/olive/logging.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+import sys
 
 
 def set_verbosity(verbose):
@@ -43,3 +44,25 @@ def set_default_logger_severity(level):
 
     # set logger level
     set_verbosity(level_map[level])
+
+
+def set_ort_logger_severity(level):
+    """Set log level for onnxruntime package.
+
+    :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
+    """
+    # mapping from level to logging level
+    level_map = {0: logging.DEBUG, 1: logging.INFO, 2: logging.WARNING, 3: logging.ERROR, 4: logging.CRITICAL}
+
+    # check if level is valid
+    if level not in level_map:
+        raise ValueError(f"Invalid level {level}, should be one of {list(level_map.keys())}")
+
+    # set logger level
+    ort_logger = logging.getLogger("onnxruntime")
+    ort_logger.setLevel(level_map[level])
+    ort_logger.addHandler()
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
+    stream_handler = logging.StreamHandler(stream=sys.stdout)
+    stream_handler.setFormatter(formatter)
+    ort_logger.addHandler(stream_handler)

--- a/olive/logging.py
+++ b/olive/logging.py
@@ -61,8 +61,9 @@ def set_ort_logger_severity(level):
     # set logger level
     ort_logger = logging.getLogger("onnxruntime")
     ort_logger.setLevel(level_map[level])
-    ort_logger.addHandler()
-    formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
+    formatter = logging.Formatter(
+        "[%(asctime)s] [%(levelname)s] [onnxruntime-%(filename)s:%(lineno)d:%(funcName)s] %(message)s"
+    )
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setFormatter(formatter)
     ort_logger.addHandler(stream_handler)

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -445,6 +445,7 @@ class OnnxQuantization(Pass):
                 output_model_path=str(output_model_path),
                 auto_merge=True,
                 save_as_external_data=True,
+                verbose=3,  # set verbose to 3 to get more information about the preprocessing
             )
         except Exception as e:
             # TODO(jambayk): try with `skip_optimization = True`

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -13,7 +13,7 @@ from typing import List, Union
 import onnxruntime as ort
 
 from olive.hardware import Device
-from olive.logging import set_default_logger_severity, set_verbosity_info
+from olive.logging import set_default_logger_severity, set_ort_logger_severity, set_verbosity_info
 from olive.passes import Pass
 from olive.systems.common import SystemType
 from olive.workflows.run.config import RunConfig
@@ -143,6 +143,7 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
     # set ort log level
     set_default_logger_severity(config.engine.log_severity_level)
     ort.set_default_logger_severity(config.engine.ort_log_severity_level)
+    set_ort_logger_severity(config.engine.ort_log_severity_level)
 
     # input model
     input_model = config.input_model

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -144,6 +144,7 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
     set_default_logger_severity(config.engine.log_severity_level)
     # the ort_log_severity_level is used to control the C++ logging levels.
     # As the result, we use the Olive logger level to control the ORT Python logging level.
+    # TODO(myguo): do we need use another config to control the ORT Python logging?
     set_ort_logger_severity(config.engine.log_severity_level)
     ort.set_default_logger_severity(config.engine.ort_log_severity_level)
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -142,8 +142,10 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
 
     # set ort log level
     set_default_logger_severity(config.engine.log_severity_level)
+    # the ort_log_severity_level is used to control the C++ logging levels.
+    # As the result, we use the Olive logger level to control the ORT Python logging level.
+    set_ort_logger_severity(config.engine.log_severity_level)
     ort.set_default_logger_severity(config.engine.ort_log_severity_level)
-    set_ort_logger_severity(config.engine.ort_log_severity_level)
 
     # input model
     input_model = config.input_model


### PR DESCRIPTION
## Describe your changes
From the time being, all ORT Python logging is missing except the root logger. This PR enable it
Turn on quant_pre_process to detail logs and let the logging level control what should be shown.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
