### PR TITLE
Disable qualcomm linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,8 @@ autodoc_pydantic_settings_member_order = "bysource"  # is groupwise and alphabet
 # we could enable it when the issue is fixed
 linkcheck_anchors = False
 linkcheck_ignore = [
+    # TODO(trajep): remove this when the issue is fixed
+    r"https://developer.qualcomm.com/*",
     # TODO(jambayk): remove this when the issue is fixed
     r"https://www.intel.com/*",
 ]


### PR DESCRIPTION
## Describe your changes
Reverting the qualcomm linkcheck change in https://github.com/microsoft/Olive/pull/682. 
Some of the qualcomm link checks are still flaky.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
