### PR TITLE
Separate logging level for ort python logs

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -525,7 +525,10 @@ This is a dictionary that contains the information of the engine. The informatio
 - `log_severity_level: [int]` The log severity level of Olive. The options are `0` for `VERBOSE`, `1` for
     `INFO`, `2` for `WARNING`, `3` for `ERROR`, `4` for `FATAL`. The default value is `1` for `INFO`.
 
-- `ort_log_severity_level: [int]` The log severity level of ONNX Runtime. The options are `0` for `VERBOSE`, `1` for
+- `ort_log_severity_level: [int]` The log severity level of ONNX Runtime C++ logs. The options are `0` for `VERBOSE`, `1` for
+    `INFO`, `2` for `WARNING`, `3` for `ERROR`, `4` for `FATAL`. The default value is `3` for `ERROR`.
+
+- `ort_py_log_severity_level: [int]` The log severity level of ONNX Runtime Python logs. The options are `0` for `VERBOSE`, `1` for
     `INFO`, `2` for `WARNING`, `3` for `ERROR`, `4` for `FATAL`. The default value is `3` for `ERROR`.
 
 Please find the detailed config options from following table for each search algorithm:

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -542,10 +542,6 @@ class OnnxMatMul4Quantizer(Pass):
 
         from onnxruntime.quantization.matmul_4bits_quantizer import MatMul4BitsQuantizer
 
-        # MatMul4BitsQuantizer sets basicConfig to INFO and prints verbose logs as INFO, suppress them
-        # TODO(jambayk): Use the ort logging severity from the workflow if we expose it as environment variable
-        logging.getLogger("onnxruntime.quantization.matmul_4bits_quantizer").setLevel(logging.ERROR)
-
         output_model_path = ONNXModel.resolve_path(output_model_path)
 
         quant = MatMul4BitsQuantizer(

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -34,6 +34,7 @@ class RunEngineConfig(EngineConfig):
     packaging_config: PackagingConfig = None
     log_severity_level: int = 1
     ort_log_severity_level: int = 3
+    ort_py_log_severity_level: int = 3
 
     def create_engine(self):
         config = self.dict()
@@ -44,6 +45,7 @@ class RunEngineConfig(EngineConfig):
             "packaging_config",
             "log_severity_level",
             "ort_log_severity_level",
+            "ort_py_log_severity_level",
         ]
         for key in to_del:
             del config[key]

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -140,12 +140,12 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
     else:
         config = RunConfig.parse_obj(config)
 
-    # set ort log level
+    # set log level for olive
     set_default_logger_severity(config.engine.log_severity_level)
-    # the ort_log_severity_level is used to control the C++ logging levels.
-    # As the result, we use the Olive logger level to control the ORT Python logging level.
-    # TODO(myguo): do we need use another config to control the ORT Python logging?
-    set_ort_logger_severity(config.engine.log_severity_level)
+    # for onnxruntime
+    # ort_py_log_severity_level: python logging levels
+    # ort_log_severity_level: C++ logging levels
+    set_ort_logger_severity(config.engine.ort_py_log_severity_level)
     ort.set_default_logger_severity(config.engine.ort_log_severity_level)
 
     # input model


### PR DESCRIPTION
## Describe your changes
Add a new option called `ort_py_log_severity_level` for onnxruntime python logs. 

The levels used for onnxruntime python logs are not consistent across its modules. For example, MatMul4BitsQuantizer is very verbose at `INFO` level. 
Olive is not verbose at `INFO` level and only logs important high-level information. So, it is better to create a separate logging level control for ort python logs and set it at a higher default level. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
