### PR TITLE
Pin `transformers` version in `phi` example

### DIFF
--- a/examples/phi/requirements.txt
+++ b/examples/phi/requirements.txt
@@ -1,3 +1,5 @@
 datasets
 einops
 sentencepiece
+# transformers >= 4.35.0 has breaking change for gradient checkpointing
+transformers==4.34.1


### PR DESCRIPTION
## Describe your changes
The latest version of transformers (>= 4.35.0) is not compatible with the model. PRs:  https://github.com/huggingface/transformers/pull/27020, https://github.com/huggingface/transformers/pull/27073 change the expected signature of `_set_gradient_checkpointing` which now doesn't match the model's https://huggingface.co/microsoft/phi-1_5/blob/main/modeling_mixformer_sequential.py#L802

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
