### PR TITLE
📁 Fill Perf Tuning default config with accelerator spec

### DIFF
--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+
 import copy
 import itertools
 import logging
@@ -277,6 +278,9 @@ class OrtPerfTuning(Pass):
 
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        device = accelerator_spec.accelerator_type
+        execution_provider = accelerator_spec.execution_provider
+
         return {
             "data_dir": PassConfigParam(
                 type_=OLIVE_RESOURCE_ANNOTATIONS,
@@ -303,7 +307,7 @@ class OrtPerfTuning(Pass):
                 type_=list, default_value=None, description="Input types list for ONNX model."
             ),
             "device": PassConfigParam(
-                type_=str, default_value="cpu", description="Device selected for tuning process."
+                type_=str, default_value=device, description="Device selected for tuning process."
             ),
             "cpu_cores": PassConfigParam(
                 type_=int, default_value=None, description="CPU cores used for thread tuning."
@@ -320,7 +324,7 @@ class OrtPerfTuning(Pass):
             ),
             "providers_list": PassConfigParam(
                 type_=list,
-                default_value=None,
+                default_value=[execution_provider],
                 description="Execution providers framework list to execute the ONNX models.",
             ),
             "execution_mode_list": PassConfigParam(
@@ -348,14 +352,6 @@ class OrtPerfTuning(Pass):
     def _run_for_config(
         self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModel:
-        # TODO(trajep): remove this when we have a concrete investigation on the backcompat issue
-        if not config.get("providers_list"):
-            # add the provider to the config if user doesn't provide the execution providers
-            config["providers_list"] = [self.accelerator_spec.execution_provider]
-
-        if not config.get("device"):
-            config["device"] = self.accelerator_spec.accelerator_type
-
         config = self._config_class(**config)
         # TODO(jambayk): decide on whether to ignore the output_model_path
         # if we want to ignore it, we can just return the model

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -31,6 +31,7 @@ def test_ort_perf_tuning_pass(config, tmp_path):
     "config",
     [
         {},
+        {"input_names": ["input"], "input_shapes": [[1, 1]]},
         {"providers_list": ["CPUExecutionProvider", "CUDAExecutionProvider"], "device": "gpu"},
     ],
 )

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+
 from test.unit_test.utils import get_onnx_model
 from unittest.mock import patch
 
@@ -11,12 +12,26 @@ from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OrtPerfTuning
 
 
-@pytest.mark.parametrize("config", [{"input_names": ["input"], "input_shapes": [[1, 1]]}, {}])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"input_names": ["input"], "input_shapes": [[1, 1]]},
+        {"providers_list": ["CPUExecutionProvider", "CUDAExecutionProvider"], "device": "gpu"},
+        {},
+    ],
+)
 def test_ort_perf_tuning_pass(config, tmp_path):
     # setup
     input_model = get_onnx_model()
     p = create_pass_from_dict(OrtPerfTuning, config, disable_search=True)
     output_folder = str(tmp_path / "onnx")
+
+    # check config
+    # pylint: disable=protected-access
+    assert p._config["device"] is not None
+    assert p._config["providers_list"] is not None
+    for k, v in config.items():
+        assert p._config[k] == v, f"{k} is not set correctly as {v}"
 
     # execute
     p.run(input_model, None, output_folder)


### PR DESCRIPTION
## Describe your changes
This pull request includes changes to improve testing and mocking in `test/unit_test/passes/onnx/test_perf_tuning.py` and add support for specifying device and execution provider in the default configuration of the ONNX pass in `olive/passes/onnx/perf_tuning.py`.

Testing improvements:

* <a href="diffhunk://#diff-3c4b1c200e2ac992cd17d17e72a48402d7376e0dcc11d3c4a3728d630ec48097L14-R35">`test/unit_test/passes/onnx/test_perf_tuning.py`</a>: Added additional test cases and import statements to improve testing and mocking. <a href="diffhunk://#diff-3c4b1c200e2ac992cd17d17e72a48402d7376e0dcc11d3c4a3728d630ec48097L14-R35">[1]</a> <a href="diffhunk://#diff-3c4b1c200e2ac992cd17d17e72a48402d7376e0dcc11d3c4a3728d630ec48097R5">[2]</a>

Pass improvements:

* <a href="diffhunk://#diff-01a5090bdcf3c820e5075bea71814779996751d98719a0b2f0c92c77445b7760R281-R283">`olive/passes/onnx/perf_tuning.py`</a>: Added support for specifying device and execution provider in the default configuration of the ONNX pass, and removed redundant code for setting default values. <a href="diffhunk://#diff-01a5090bdcf3c820e5075bea71814779996751d98719a0b2f0c92c77445b7760R281-R283">[1]</a> <a href="diffhunk://#diff-01a5090bdcf3c820e5075bea71814779996751d98719a0b2f0c92c77445b7760L306-R310">[2]</a> <a href="diffhunk://#diff-01a5090bdcf3c820e5075bea71814779996751d98719a0b2f0c92c77445b7760R5">[3]</a> <a href="diffhunk://#diff-01a5090bdcf3c820e5075bea71814779996751d98719a0b2f0c92c77445b7760L323-R327">[4]</a> <a href="diffhunk://#diff-01a5090bdcf3c820e5075bea71814779996751d98719a0b2f0c92c77445b7760L351-L358">[5]</a>

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Format your code by running `pre-commit run --all-files`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
