### PR TITLE
Option to provide kwargs to user_script functions

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -262,7 +262,7 @@ information of the evaluator contains following items:
 
         - `inference_settings: [Dict]` Inference settings for the different runtime.
 
-        - `dataloader_func: [str]` The name of the function provided by the user to load the data for the metric evaluation. The function should take the `data_dir`, `batch_size`, `model_framework`
+        - `dataloader_func: [str]` The name of the function provided by the user to load the data for the metric evaluation. The function should take the `data_dir`, `batch_size`, `model_framework` (provided as a keyword argument)
         as input and return the data loader. Not valid for `custom` type when `evaluate_func` is provided.
 
         - `post_processing_func: [str]` The name of the function provided by the user to post process the model output. The function should take the model output as input and return the post processed
@@ -275,7 +275,7 @@ information of the evaluator contains following items:
         metric result. Only valid for `custom` type when `evaluate_func` is not provided.
 
         - `func_kwargs: [Dict[str, Dict[str, Any]]]` Keyword arguments for the functions provided by the user. The key is the name of the function and the value is the keyword arguments for the function. The
-        functions must be able to take the keyword arguments either through the function signature or through `**kwargs`.
+        functions must be able to take the keyword arguments either through the function signature as keyword/positional parameters after the required positional parameters or through `**kwargs`.
 
     Note that for above `data_dir` config which is related to resource path, Olive supports local file, local folder or AML Datastore. Take AML Datastore as an example, Olive can parse the resource type automatically from `config dict`, or `url`. Please refer to our [Resnet](https://github.com/microsoft/Olive/tree/main/examples/resnet#resnet-optimization-with-ptq-on-cpu) example for more details.
     ```json

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -260,17 +260,22 @@ information of the evaluator contains following items:
 
         - `batch_size: [int]` The batch size for the metric evaluation.
 
-        - `dataloader_func: [str]` The name of the function provided by the user to load the data for the metric evaluation. The
-        function should take the `data_dir`, `batch_size`, `*args`, `**kwargs` as input and return the data loader. Only valid for `accuracy` and `latency`
-         type.
+        - `inference_settings: [Dict]` Inference settings for the different runtime.
 
-        - `inference_settings: [Dict]` Inference settings for the different runtime. Only valid for `accuracy` and `latency` type.
+        - `dataloader_func: [str]` The name of the function provided by the user to load the data for the metric evaluation. The function should take the `data_dir`, `batch_size`, `model_framework`
+        as input and return the data loader. Not valid for `custom` type when `evaluate_func` is provided.
 
-        - `post_processing_func: [str]` The name of the function provided by the user to post process the model output. The function
-        should take the model output and return the post processed output. Only valid for `accuracy` type.
+        - `post_processing_func: [str]` The name of the function provided by the user to post process the model output. The function should take the model output as input and return the post processed
+        output. Only valid for `accuracy` type or `custom` type when `evaluate_func` is not provided.
 
-        - `evaluate_func: [str]` The name of the function provided by the user to evaluate the model. The function should take the
-        model, `data_dir` and `batch_size` as input and return the evaluation result. Only valid for `custom` type.
+        - `evaluate_func: [str]` The name of the function provided by the user to evaluate the model. The function should take the model, `data_dir`, `batch_size`, `device`, `execution_providers` as input
+        and return the evaluation result. Only valid for `custom` type.
+
+        - `metric_func: [str]` The name of the function provided by the user to compute metric from the model output. The function should take the post processed output and target as input and return the
+        metric result. Only valid for `custom` type when `evaluate_func` is not provided.
+
+        - `func_kwargs: [Dict[Dict[str, Any]]]` Keyword arguments for the functions provided by the user. The key is the name of the function and the value is the keyword arguments for the function. The
+        functions must be able to take the keyword arguments either through the function signature or through `**kwargs`.
 
     Note that for above `data_dir` config which is related to resource path, Olive supports local file, local folder or AML Datastore. Take AML Datastore as an example, Olive can parse the resource type automatically from `config dict`, or `url`. Please refer to our [Resnet](https://github.com/microsoft/Olive/tree/main/examples/resnet#resnet-optimization-with-ptq-on-cpu) example for more details.
     ```json

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -274,7 +274,7 @@ information of the evaluator contains following items:
         - `metric_func: [str]` The name of the function provided by the user to compute metric from the model output. The function should take the post processed output and target as input and return the
         metric result. Only valid for `custom` type when `evaluate_func` is not provided.
 
-        - `func_kwargs: [Dict[Dict[str, Any]]]` Keyword arguments for the functions provided by the user. The key is the name of the function and the value is the keyword arguments for the function. The
+        - `func_kwargs: [Dict[str, Dict[str, Any]]]` Keyword arguments for the functions provided by the user. The key is the name of the function and the value is the keyword arguments for the function. The
         functions must be able to take the keyword arguments either through the function signature or through `**kwargs`.
 
     Note that for above `data_dir` config which is related to resource path, Olive supports local file, local folder or AML Datastore. Take AML Datastore as an example, Olive can parse the resource type automatically from `config dict`, or `url`. Please refer to our [Resnet](https://github.com/microsoft/Olive/tree/main/examples/resnet#resnet-optimization-with-ptq-on-cpu) example for more details.

--- a/examples/llama2/.gitignore
+++ b/examples/llama2/.gitignore
@@ -1,3 +1,2 @@
 llama2_cpu*
 llama2_gpu*
-user_script_*.py

--- a/examples/llama2/llama2_template.json
+++ b/examples/llama2/llama2_template.json
@@ -6,7 +6,7 @@
             "io_config": "get_merged_decoder_with_past_io_config",
             "dummy_inputs_func": "get_merged_decoder_with_past_dummy_inputs",
             "hf_config": {
-                "model_name": "meta-llama/Llama-2-7b-hf",
+                "model_name": "<model_name_placeholder>",
                 "model_class": "LlamaForCausalLM"
             }
         }
@@ -26,6 +26,11 @@
                     "user_config": {
                         "user_script": "user_script.py",
                         "dataloader_func": "dataloader_func_for_merged",
+                        "func_kwargs": {
+                            "dataloader_func": {
+                                "model_id": "<model_name_placeholder>"
+                            }
+                        },
                         "batch_size": 2,
                         "io_bind": true
                     }
@@ -46,6 +51,11 @@
                     "user_config": {
                         "user_script": "user_script.py",
                         "dataloader_func": "dataloader_func_for_merged_gqa",
+                        "func_kwargs": {
+                            "dataloader_func": {
+                                "model_id": "<model_name_placeholder>"
+                            }
+                        },
                         "batch_size": 2,
                         "io_bind": true
                     }
@@ -129,6 +139,6 @@
         },
         "evaluator": "merged_evaluator",
         "cache_dir": "cache",
-        "output_dir": "models/llama2-7b"
+        "output_dir": "<output_dir_placeholder>"
     }
 }

--- a/examples/llama2/user_script.py
+++ b/examples/llama2/user_script.py
@@ -237,9 +237,8 @@ class RandomDataLoader:
 
 def dataloader_func_for_merged(data_dir, batch_size, *args, **kwargs):
     """Return data loader for input PyTorch model and ONNX models with past_key_values."""
-    model_id = "meta-llama/Llama-2-7b-hf"
-    seq_length, past_seq_length = 8, 0
-    max_seq_length = 2048
+    model_id = kwargs["model_id"]
+    seq_length, past_seq_length, max_seq_length = 8, 0, 2048
     model_framework = kwargs.get("model_framework", Framework.PYTORCH)
     return RandomDataLoader(
         model_id, batch_size, seq_length, past_seq_length, max_seq_length, model_framework=model_framework
@@ -248,9 +247,8 @@ def dataloader_func_for_merged(data_dir, batch_size, *args, **kwargs):
 
 def dataloader_func_for_merged_gqa(data_dir, batch_size, *args, **kwargs):
     """Return data loader for ONNX model + FP16 + GQA."""
-    model_id = "meta-llama/Llama-2-7b-hf"
-    seq_length, past_seq_length = 8, 0
-    max_seq_length = 2048
+    model_id = kwargs["model_id"]
+    seq_length, past_seq_length, max_seq_length = 8, 0, 2048
     model_framework = kwargs.get("model_framework", Framework.PYTORCH)
     return RandomDataLoader(
         model_id,

--- a/examples/llama2/user_script.py
+++ b/examples/llama2/user_script.py
@@ -269,14 +269,14 @@ def dataloader_func_for_merged_gqa(data_dir, batch_size, *args, **kwargs):
 
 def inc_cali_dataloader_func(data_dir, batch_size, *args, **kwargs):
     return QuantKVDataLoader(
-        hf_model_id="meta-llama/Llama-2-7b-hf",
+        hf_model_id=kwargs["model_id"],
         dataset_name="NeelNanda/pile-10k",
     )
 
 
 def inc_cali_merged_dataloader_func(data_dir, batch_size, *args, **kwargs):
     return QuantKVDataLoader(
-        hf_model_id="meta-llama/Llama-2-7b-hf",
+        hf_model_id=kwargs["model_id"],
         dataset_name="NeelNanda/pile-10k",
         merged=True,
     )

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Callable, List, Union
+from typing import Any, Callable, Dict, List, Union
 
 from pydantic import validator
 
@@ -21,6 +21,7 @@ _common_user_config = {
     "inference_settings": ConfigParam(type_=dict),
     "data_dir": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS, category=ParamCategory.DATA),
     "dataloader_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
+    "func_kwargs": ConfigParam(type_=Dict[Dict[str, Any]]),
     "batch_size": ConfigParam(type_=int, default_value=1),
     "input_names": ConfigParam(type_=List),
     "input_shapes": ConfigParam(type_=List),
@@ -37,6 +38,7 @@ _type_to_user_config = {
         "post_processing_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
     },
     "custom": {
+        "post_processing_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
         "evaluate_func": ConfigParam(type_=Union[Callable, str], required=False, category=ParamCategory.OBJECT),
         "metric_func": ConfigParam(type_=Union[Callable, str], required=False, category=ParamCategory.OBJECT),
     },

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -21,7 +21,7 @@ _common_user_config = {
     "inference_settings": ConfigParam(type_=dict),
     "data_dir": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS, category=ParamCategory.DATA),
     "dataloader_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
-    "func_kwargs": ConfigParam(type_=Dict[Dict[str, Any]]),
+    "func_kwargs": ConfigParam(type_=Dict[str, Dict[str, Any]]),
     "batch_size": ConfigParam(type_=int, default_value=1),
     "input_names": ConfigParam(type_=List),
     "input_shapes": ConfigParam(type_=List),

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -161,6 +161,10 @@ _inc_static_dataloader_config = {
             required if approach is 'static' and data_config is None.
         """,
     ),
+    "dataloader_func_kwargs": PassConfigParam(
+        type_=Dict[str, Any],
+        description="Keyword arguments for dataloader_func.",
+    ),
     "data_config": PassConfigParam(
         type_=Union[DataConfig, Dict],
         description="""
@@ -503,6 +507,7 @@ class IncQuantization(Pass):
             "data_dir",
             "batch_size",
             "dataloader_func",
+            "dataloader_func_kwargs",
             "tuning_criterion",
             "data_config",
             "metric",
@@ -530,7 +535,11 @@ class IncQuantization(Pass):
             if self._user_module_loader:
                 data_dir = get_local_path_from_root(data_root, config["data_dir"])
                 inc_calib_dataloader = self._user_module_loader.call_object(
-                    config["dataloader_func"], data_dir, config["batch_size"], model_path=model.model_path
+                    config["dataloader_func"],
+                    data_dir,
+                    config["batch_size"],
+                    model_path=model.model_path,
+                    **(config["dataloader_func_kwargs"] or {}),
                 )
             elif config["data_config"]:
                 data_config = validate_config(config["data_config"], DataConfig)

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -74,6 +74,8 @@ def tune_onnx_model(model, data_root, config):
     for eval_config in get_user_config_properties_from_metric_type(MetricType.LATENCY):
         if eval_config in config_dict:
             latency_user_config[eval_config] = config_dict.get(eval_config)
+    if config_dict.get("dataloader_func_kwargs"):
+        latency_user_config["func_kwargs"] = {"dataloader_func": config_dict.get("dataloader_func_kwargs")}
     latency_sub_types = [{"name": LatencySubType.AVG}]
     latency_metric_config = {
         "name": "latency",
@@ -81,7 +83,6 @@ def tune_onnx_model(model, data_root, config):
         "sub_types": latency_sub_types,
         "user_config": latency_user_config,
         "data_config": config_dict.get("data_config"),
-        "func_kwargs": {"dataloader_func": config_dict.get("dataloader_func_kwargs")},
     }
     latency_metric = Metric(**latency_metric_config)
 

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -81,6 +81,7 @@ def tune_onnx_model(model, data_root, config):
         "sub_types": latency_sub_types,
         "user_config": latency_user_config,
         "data_config": config_dict.get("data_config"),
+        "func_kwargs": {"dataloader_func": config_dict.get("dataloader_func_kwargs")},
     }
     latency_metric = Metric(**latency_metric_config)
 
@@ -291,6 +292,10 @@ class OrtPerfTuning(Pass):
                 type_=Union[Callable, str],
                 category=ParamCategory.OBJECT,
                 description="Dataloader function to load data from given data_dir with given batch size.",
+            ),
+            "dataloader_func_kwargs": PassConfigParam(
+                type_=Dict[str, Any],
+                description="Keyword arguments for dataloader_func.",
             ),
             "batch_size": PassConfigParam(type_=int, description="Batch size for inference."),
             "data_config": PassConfigParam(

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -162,6 +162,10 @@ _static_dataloader_config = {
             required if quant_mode is 'static' and data_config is None.
         """,
     ),
+    "dataloader_func_kwargs": PassConfigParam(
+        type_=Dict[str, Any],
+        description="Keyword arguments for dataloader_func.",
+    ),
     "data_config": PassConfigParam(
         type_=Union[DataConfig, Dict],
         description="""
@@ -401,6 +405,7 @@ class OnnxQuantization(Pass):
                     config["dataloader_func"],
                     data_dir,
                     config["batch_size"],
+                    **(config["dataloader_func_kwargs"] or {}),
                 )
             elif config["data_config"]:
                 data_config = validate_config(config["data_config"], DataConfig)

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -50,6 +50,10 @@ vai_q_onnx_quantization_config = {
             required'
         """,
     ),
+    "dataloader_func_kwargs": PassConfigParam(
+        type_=Dict[str, Any],
+        description="Keyword arguments for dataloader_func.",
+    ),
     "weight_type": PassConfigParam(
         type_=str,
         default_value="QInt8",
@@ -304,6 +308,7 @@ class VitisAIQuantization(Pass):
             "data_dir",
             "batch_size",
             "dataloader_func",
+            "dataloader_func_kwargs",
         ]
         to_delete += list(get_external_data_config().keys())
 
@@ -340,6 +345,7 @@ class VitisAIQuantization(Pass):
                 config["dataloader_func"],
                 data_dir,
                 config["batch_size"],
+                **(config["dataloader_func_kwargs"] or {}),
             )
         elif self._data_config:
             dataloader = self._data_config.to_data_container().create_calibration_dataloader(data_root)

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -44,6 +44,10 @@ class OpenVINOQuantization(Pass):
                     "Function/function name to generate dataloader for calibration, required if data_config is None."
                 ),
             ),
+            "dataloader_func_kwargs": PassConfigParam(
+                type_=Dict[str, Any],
+                description="Keyword arguments for dataloader_func.",
+            ),
             "data_dir": PassConfigParam(
                 type_=OLIVE_RESOURCE_ANNOTATIONS,
                 category=ParamCategory.DATA,
@@ -98,7 +102,7 @@ class OpenVINOQuantization(Pass):
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
             data_loader = self._user_module_loader.call_object(
-                config["dataloader_func"], data_dir, config["batch_size"]
+                config["dataloader_func"], data_dir, config["batch_size"], **(config["dataloader_func_kwargs"] or {})
             )
         elif config["data_config"]:
             data_config = validate_config(config["data_config"], DataConfig)
@@ -128,6 +132,7 @@ class OpenVINOQuantization(Pass):
 
         class _OVDataloader(DataLoader):
             def __init__(self, dataloader):
+                # pylint: disable=super-init-not-called
                 self.data = []
                 self.labels = []
                 for data_k, label in dataloader:

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -45,6 +45,10 @@ class SNPEQuantization(Pass):
                     " object. Required if data_config is None."
                 ),
             ),
+            "dataloader_func_kwargs": PassConfigParam(
+                type_=Dict[str, Any],
+                description="Keyword arguments for dataloader_func.",
+            ),
             "data_config": PassConfigParam(
                 type_=Union[DataConfig, Dict],
                 required=True,
@@ -90,7 +94,9 @@ class SNPEQuantization(Pass):
 
         if config["dataloader_func"]:
             data_dir = get_local_path_from_root(data_root, config["data_dir"])
-            dataloader = self._user_module_loader.call_object(config["dataloader_func"], data_dir)
+            dataloader = self._user_module_loader.call_object(
+                config["dataloader_func"], data_dir, **(config["dataloader_func_kwargs"] or {})
+            )
         elif config["data_config"]:
             data_config = validate_config(config["data_config"], DataConfig)
             dataloader = data_config.to_data_container().create_dataloader(data_root)

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -2,8 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
-from test.unit_test.utils import get_onnx_model
+from test.unit_test.utils import create_dataloader, get_onnx_model
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +13,12 @@ from olive.passes.onnx import OrtPerfTuning
 
 @pytest.mark.parametrize(
     "config",
-    [{"input_names": ["input"], "input_shapes": [[1, 1]]}, {}],
+    [
+        {"input_names": ["input"], "input_shapes": [[1, 1]]},
+        {},
+        {"dataloader_func": create_dataloader},
+        {"dataloader_func": create_dataloader, "dataloader_func_kwargs": {"dummy_kwarg": 1}},
+    ],
 )
 def test_ort_perf_tuning_pass(config, tmp_path):
     # setup
@@ -45,10 +49,9 @@ def test_ort_perf_tuning_with_customized_configs(mock_run, config):
 
     # assert
     if "providers_list" not in config:
-        assert mock_run.call_args.args[2]["providers_list"] == ["CPUExecutionProvider"], (
-            "providers_list is not set correctly as ['CPUExecutionProvider'] by default when"
-            " user does not specify it"
-        )
+        assert mock_run.call_args.args[2]["providers_list"] == [
+            "CPUExecutionProvider"
+        ], "providers_list is not set correctly as ['CPUExecutionProvider'] by default when user does not specify it"
     if "device" not in config:
         assert (
             mock_run.call_args.args[2]["device"] == "cpu"

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from test.unit_test.utils import get_accuracy_metric, get_custom_eval, get_latency_metric
+from test.unit_test.utils import get_accuracy_metric, get_custom_metric, get_latency_metric
 from typing import ClassVar, List
 from unittest.mock import MagicMock, patch
 
@@ -50,7 +50,7 @@ class TestLocalSystem:
         (get_latency_metric(LatencySubType.P95)),
         (get_latency_metric(LatencySubType.P99)),
         (get_latency_metric(LatencySubType.P999)),
-        (get_custom_eval()),
+        (get_custom_metric()),
     ]
 
     @pytest.mark.parametrize(

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -171,24 +171,18 @@ def get_accuracy_metric(*acc_subtype, random_dataloader=True, user_config=None, 
     )
 
 
-def get_custom_eval():
+def get_custom_metric(user_config=None):
     user_script_path = str(Path(__file__).absolute().parent / "assets" / "user_script.py")
     return Metric(
         name="custom",
         type=MetricType.CUSTOM,
         sub_types=[{"name": "custom"}],
-        user_config={"evaluate_func": "eval_func", "user_script": user_script_path, "need_inference": False},
+        user_config=user_config or {"evaluate_func": "eval_func", "user_script": user_script_path},
     )
 
 
-def get_custom_metric():
-    custom_metric = get_custom_eval()
-    custom_metric.user_config.metric_func = "metric_func"
-    return custom_metric
-
-
 def get_custom_metric_no_eval():
-    custom_metric = get_custom_eval()
+    custom_metric = get_custom_metric()
     custom_metric.user_config.evaluate_func = None
     return custom_metric
 


### PR DESCRIPTION
## Describe your changes
This PR makes the user script functions such as `dataloader_func` more flexible by allowing the user to provide `kwargs` for the functions. 
- In MetricConfig, the kwargs are provided as a dict of dicts. the outer dict is indexed by the name of the function param and the inner dict contains the kwargs for that func. 
- In passes, a new param called `dataloader_func_kwargs` is added to be used with the `dataloader_func` param. 

Docs have been updated to reflect the current state of the functions and their uses.
`llama` example has been updated to use kwargs for the `model_id` instead of hard-coding the values into the user_script. Now, the same user script works for all models. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Format your code by running `pre-commit run --all-files`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

Users can now provide `kwargs` to user script functions such as `dataloader_func` and `evaluate_func`. 

## (Optional) Issue link
