### PR TITLE
🎲 Be able to choose the NO. gpu to run

### DIFF
--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -41,7 +41,7 @@ PyTorch Model
 .. autoclass:: olive.model.PyTorchModel
 
 DistributedPyTorchModel Model
---------------
+-----------------------------
 .. autoclass:: olive.model.DistributedPyTorchModel
 
 .. _snpe_model:

--- a/docs/source/tutorials/configure_metrics.rst
+++ b/docs/source/tutorials/configure_metrics.rst
@@ -160,7 +160,7 @@ for :code:`"user_script.py"`.
 Here is an example of the :code:`"eval_accuracy"` function in :code:`"user_script.py"`:
 In your :code:`"user_script.py"`, you need to define a function that takes in an Olive model, the data directory, and the batch size, and returns a metric value::
 
-        def eval_accuracy(model, data_dir, batch_size, device, execution_providers):
+        def eval_accuracy(model, data_dir, batch_size, device, device_id, execution_providers):
             # load data
             # evaluate model
             # return metric value

--- a/docs/source/tutorials/configure_systems.rst
+++ b/docs/source/tutorials/configure_systems.rst
@@ -35,6 +35,11 @@ Local System
 
 Please refer to :ref:`local_system_config` for more details on the config options.
 
+.. note::
+
+    If you decide to use gpu accelerators, you can set the value of :code:`"accelerators"` as :code:`["gpu"]` to use default gpu device-0 or :code:`["cuda:1"]` to use default gpu device-1 as `torch` did.
+
+
 AzureML System
 ---------------
 

--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -78,6 +78,7 @@
         "evaluator": "common_evaluator",
         "execution_providers": ["CUDAExecutionProvider"],
         "cache_dir": "cache",
+        "clean_cache": true,
         "output_dir" : "models/bert_cuda"
     }
 }

--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -190,11 +190,13 @@ def inc_glue_calibration_reader(data_dir, batch_size, *args, **kwargs):
 # -------------------------------------------------------------------------
 
 
-def eval_accuracy(model: OliveModel, data_dir, batch_size, device, execution_providers):
+def eval_accuracy(model: OliveModel, data_dir, batch_size, device, device_id, execution_providers):
     dataloader = create_dataloader(data_dir, batch_size)
     preds = []
     target = []
-    sess = model.prepare_session(inference_settings=None, device=device, execution_providers=execution_providers)
+    sess = model.prepare_session(
+        inference_settings=None, device=device, rank=device_id, execution_providers=execution_providers
+    )
     if model.framework == Framework.ONNX:
         input_names = [i.name for i in sess.get_inputs()]
         output_names = [o.name for o in sess.get_outputs()]

--- a/examples/llama2/requirements.txt
+++ b/examples/llama2/requirements.txt
@@ -1,6 +1,6 @@
-git+https://github.com/huggingface/optimum.git
-transformers>=4.33.2
-onnx>=1.14.0
 datasets>=2.8.0
+git+https://github.com/huggingface/optimum.git
+onnx>=1.14.0
 protobuf==3.20.2
 torch -i https://download.pytorch.org/whl/nightly/cu118
+transformers>=4.33.2

--- a/examples/open_llama/user_script.py
+++ b/examples/open_llama/user_script.py
@@ -129,7 +129,7 @@ def calib_dataloader(data_dir, batch_size, *args, **kwargs):
     return PileDataloader(model_path, batch_size=batch_size)
 
 
-def eval_accuracy(model: OliveModel, data_dir, batch_size, device, execution_providers):
+def eval_accuracy(model: OliveModel, data_dir, batch_size, device, device_id, execution_providers):
     from intel_extension_for_transformers.llm.evaluation.lm_eval import evaluate
 
     if model.framework == Framework.PYTORCH:

--- a/examples/resnet/user_script.py
+++ b/examples/resnet/user_script.py
@@ -122,8 +122,10 @@ def resnet_calibration_reader(data_dir, batch_size, *args, **kwargs):
 
 
 # keep this to demo/test custom evaluation function
-def eval_accuracy(model: OliveModel, data_dir, batch_size, device, execution_providers):
-    sess = model.prepare_session(inference_settings=None, device=device, execution_providers=execution_providers)
+def eval_accuracy(model: OliveModel, data_dir, batch_size, device, device_id, execution_providers):
+    sess = model.prepare_session(
+        inference_settings=None, device=device, rank=device_id, execution_providers=execution_providers
+    )
     dataloader = create_dataloader(data_dir, batch_size)
 
     preds = []

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -86,7 +86,7 @@ def set_aml_system(olive_config, is_gpu=False):
         olive_config["systems"]["aml_system"] = {
             "type": "AzureML",
             "config": {
-                "accelerators": ["GPU"],
+                "accelerators": ["gpu"],
                 "aml_compute": "gpu-cluster",
                 "aml_docker_config": {
                     "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04",

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -62,6 +62,7 @@ def main(raw_args=None):
     # get device and ep
     device = config["systems"]["local_system"]["config"]["accelerators"][0]
     ep = config["engine"]["execution_providers"][0]
+    # TODO(trajep): add device_id for whisper
     accelerator_spec = AcceleratorSpec(accelerator_type=device, execution_provider=ep)
 
     # load output model json

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -145,7 +145,9 @@ class Engine:
         self.accelerator_specs: List[AcceleratorSpec] = []
         is_cpu_available = "cpu" in [accelerator.lower() for accelerator in accelerators]
         for accelerator in accelerators:
-            device = Device(accelerator.lower())
+            accelerator_list = accelerator.lower().split(":")
+            device = Device.GPU if accelerator_list[0] == "cuda" else Device(accelerator_list[0])
+            device_id = accelerator_list[1] if len(accelerator_list) > 1 else 0
             if self.target.olive_managed_env:
                 available_eps = AcceleratorLookup.get_managed_supported_execution_providers(device)
             elif self.target.system_type in (SystemType.Local, SystemType.PythonEnvironment):
@@ -166,7 +168,7 @@ class Engine:
                         "Ignore the CPUExecutionProvider for non-cpu device since cpu accelerator is also present."
                     )
                 elif ep in supported_eps:
-                    self.accelerator_specs.append(AcceleratorSpec(device, ep))
+                    self.accelerator_specs.append(AcceleratorSpec(device, ep, device_id=device_id))
                     ep_to_process.remove(ep)
 
         assert self.accelerator_specs, (

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -30,10 +30,11 @@ class AcceleratorSpec:
     version: str = None
     memory: int = None
     num_cores: int = None
+    device_id: int = 0
 
     def __str__(self) -> str:
-        # remove the suffix "ExecutionProvider", len("ExecutionProvider") = 17
-        ep = self.execution_provider[:-17] or self.execution_provider
+        suffix_len = len("ExecutionProvider")
+        ep = self.execution_provider[:-suffix_len] or self.execution_provider
         return f"{str(self.accelerator_type).lower()}-{ep.lower()}"
 
     def to_json(self):

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -254,7 +254,7 @@ def get_benchmark(model, data_root, latency_metric, config, test_params=None):
     evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
     joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
     test_result["latency_ms"] = evaluator.evaluate(
-        model, data_root, [latency_metric], config.device, config.providers_list
+        model, data_root, [latency_metric], config.device, config.device_id, config.providers_list
     )[joint_key].value
     return test_result
 
@@ -281,6 +281,7 @@ class OrtPerfTuning(Pass):
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
         device = accelerator_spec.accelerator_type
+        device_id = accelerator_spec.device_id
         execution_provider = accelerator_spec.execution_provider
 
         return {
@@ -314,6 +315,9 @@ class OrtPerfTuning(Pass):
             ),
             "device": PassConfigParam(
                 type_=str, default_value=device, description="Device selected for tuning process."
+            ),
+            "device_id": PassConfigParam(
+                type_=int, default_value=device_id, description="Device id selected for tuning process."
             ),
             "cpu_cores": PassConfigParam(
                 type_=int, default_value=None, description="CPU cores used for thread tuning."

--- a/olive/passes/pytorch/tensor_parallel.py
+++ b/olive/passes/pytorch/tensor_parallel.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class PyTorchTensorParallel(Pass):
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
-        # Note : The default world_size should be the no of gpus (AceleratorSpec.Device == GPU)
+        # Note : The default world_size should be the no of gpus (AcceleratorSpec.Device == GPU)
         # in the target OliveSystem
         return {
             "world_size": PassConfigParam(

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -44,7 +44,14 @@ class LocalSystem(OliveSystem):
 
         model = model_config.create_model()
         evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-        return evaluator.evaluate(model, data_root, metrics, device=device, execution_providers=execution_providers)
+        return evaluator.evaluate(
+            model,
+            data_root,
+            metrics,
+            device=device,
+            device_id=accelerator.device_id,
+            execution_providers=execution_providers,
+        )
 
     def get_supported_execution_providers(self) -> List[str]:
         """Get the available execution providers."""

--- a/test/unit_test/assets/user_script.py
+++ b/test/unit_test/assets/user_script.py
@@ -5,7 +5,7 @@
 from olive.model import OliveModel
 
 
-def eval_func(model: OliveModel, data_dir, batch_size, device, execution_providers):
+def eval_func(model: OliveModel, data_dir, batch_size, device, device_id, execution_providers):
     return 0.382715310
 
 

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -94,15 +94,15 @@ class TestLocalSystem:
         # assert
         if metric.type == MetricType.ACCURACY:
             mock_evaluate_accuracy.assert_called_once_with(
-                olive_model, None, metric, None, None, "cpu", "CPUExecutionProvider"
+                olive_model, None, metric, None, None, "cpu", 0, "CPUExecutionProvider"
             )
         if metric.type == MetricType.LATENCY:
             mock_evaluate_latency.assert_called_once_with(
-                olive_model, None, metric, None, None, "cpu", "CPUExecutionProvider"
+                olive_model, None, metric, None, None, "cpu", 0, "CPUExecutionProvider"
             )
         if metric.type == MetricType.CUSTOM:
             mock_evaluate_custom.assert_called_once_with(
-                olive_model, None, metric, None, None, None, "cpu", "CPUExecutionProvider"
+                olive_model, None, metric, None, None, None, "cpu", 0, "CPUExecutionProvider"
             )
 
         joint_keys = [joint_metric_key(metric.name, sub_metric.name) for sub_metric in metric.sub_types]


### PR DESCRIPTION
## Describe your changes
This pull request includes a variety of changes to improve flexibility and performance in the codebase, particularly related to specifying the device to use for inference. The most important changes include adding support for device id in the `Device` class and adding methods to handle them, updating the `device` parameter in multiple methods to accept a string or a `Device` enum, and updating the way accelerators are set up and managed in the engine.

Main interface changes:

* <a href="diffhunk://#diff-ab44dbdadfba37e2a86acb6110ea2147c24ae3aa9ac8df7e674143c4cfac4cefR6-R61">`olive/hardware/accelerator.py`</a>: Added support for device id in the `Device` class and added methods to handle them. <a href="diffhunk://#diff-ab44dbdadfba37e2a86acb6110ea2147c24ae3aa9ac8df7e674143c4cfac4cefR6-R61">[1]</a> <a href="diffhunk://#diff-ab44dbdadfba37e2a86acb6110ea2147c24ae3aa9ac8df7e674143c4cfac4cefR75-R82">[2]</a>
* <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L133-R133">`olive/model/__init__.py`</a>: Updated the `device` parameter in several methods to accept a string or a `Device` enum, and converted the parameter to a `Device` object if it is a string. <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L133-R133">[1]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L229-R229">[2]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L325-R329">[3]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L408-R414">[4]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L619-R625">[5]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L834-R841">[6]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L886-R906">[7]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L937-R955">[8]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L957-R965">[9]</a> <a href="diffhunk://#diff-10a7e98b2eb102b4246031efabef4995ea5c165b4b5b5c14639d51a4df349802L1044-R1052">[10]</a>
* <a href="diffhunk://#diff-f1038110c73dab1688ffe460efc340cdf2537ad870d6ef1e767c57836f73dcceL160-R164">`olive/engine/engine.py`</a>: Updated the way accelerators are set up and managed in the engine, including changes to use `device.name` instead of `device` and updating the `get_managed_supported_execution_providers` method to accept a string instead of a `Device` object. <a href="diffhunk://#diff-f1038110c73dab1688ffe460efc340cdf2537ad870d6ef1e767c57836f73dcceL160-R164">[1]</a> <a href="diffhunk://#diff-f1038110c73dab1688ffe460efc340cdf2537ad870d6ef1e767c57836f73dcceL150-R150">[2]</a>

Other important changes:

* `olive/evaluator/olive_evaluator.py`: Updated the `device` parameter in multiple methods to accept a string or a `Device` enum, allowing for more flexibility in specifying the device to use for inference. (F55dafa6)
* <a href="diffhunk://#diff-3c4b1c200e2ac992cd17d17e72a48402d7376e0dcc11d3c4a3728d630ec48097L57-R57">`test/unit_test/passes/onnx/test_perf_tuning.py`</a>: Updated performance tuning in ONNX tests, such as adding a new accelerator and changing the device value from "gpu" to "cuda". <a href="diffhunk://#diff-3c4b1c200e2ac992cd17d17e72a48402d7376e0dcc11d3c4a3728d630ec48097L57-R57">[1]</a> <a href="diffhunk://#diff-3c4b1c200e2ac992cd17d17e72a48402d7376e0dcc11d3c4a3728d630ec48097L39-R39">[2]</a>
* <a href="diffhunk://#diff-13874afac6177702a22337e2731db6da5c680ef7b1326fac40c92b955b66228dL16-R16">`olive/passes/onnx/conversion.py`</a>: Removed the `Device` import and replaced it with the `to_torch_device` method of the `AcceleratorType` class. <a href="diffhunk://#diff-13874afac6177702a22337e2731db6da5c680ef7b1326fac40c92b955b66228dL16-R16">[1]</a> <a href="diffhunk://#diff-13874afac6177702a22337e2731db6da5c680ef7b1326fac40c92b955b66228dL214-R214">[2]</a>
* <a href="diffhunk://#diff-29574b795eaec4f329266c39ced57cfcddde5dcea7e73ff66297fed88b5d0d62L72-R72">`olive/systems/python_environment/inference_runner.py`</a>: Updated the device binding for CUDA to use "cuda" instead of "gpu" if `args.device` is "cuda".
* <a href="diffhunk://#diff-2b394e839ea5381905d411fdd72a337faa167c2bfada8966d206c66e569bfa5fL97-R105">`test/unit_test/systems/test_local.py`</a>: Updated the `device` parameter to accept a string instead of a `Device` enum, allowing for more flexibility in specifying the device to use for inference.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
