### PR TITLE
[LlaMA2] Sync with onnxruntime 1.16.2

### DIFF
--- a/examples/llama2/README.md
+++ b/examples/llama2/README.md
@@ -33,37 +33,19 @@ Requirements file: [requirements-qlora.txt](requirements-qlora.txt)
 Refer to the instructions in the [examples README](../README.md) to clone the repository and install Olive.
 
 ### Install onnxruntime
-<!-- TODO(anyone): remove this section after onnxruntime 1.16.2 is released -->
-Also we need latest version of onnxruntime which provides the support of int4 quantization/grouped query attention. Please install the latest version of onnxruntime:
+This example requires onnxruntime>=1.16.2. Please install the latest version of onnxruntime:
 
-1. From source:
-    ```bash
-    git clone https://github.com/microsoft/onnxruntime
-    # compile ort with cuda support, which requires the image with cuda and cudnn installed
-    bash ./build.sh \
-        --config=Release \
-        --build_dir="./test_build" \
-        --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ \
-        --cuda_version=11.7 \
-        --use_cuda --update --build \
-        --build_wheel \
-        --parallel \
-        --skip_tests --cmake_extra_defines ONNXRUNTIME_VERSION=(cat ./VERSION_NUMBER) \CMAKE_CUDA_ARCHITECTURES="70;75;80" \
-        --use_mpi=false
-    ```
-    Then you can find the wheel file under folder of `build_dir`(`test_build/Release/dist/` in this case).
-
-2. From nightly-build:
-    ```bash
-    python -m pip uninstall -y onnxruntime onnxruntime-gpu ort-nightly ort-nightly-gpu
-    python -m pip install ort-nightly-gpu --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-    ```
-
-After installation, you can run the following command to check if the onnxruntime is installed successfully:
-```python
-import onnxruntime as ort
-ort.get_available_providers()  # should contain 'CUDAExecutionProvider'
+For CPU:
+```bash
+python -m pip install onnxruntime>=1.16.2
 ```
+
+For GPU:
+```bash
+python -m pip install onnxruntime-gpu>=1.16.2
+```
+
+**Note:** The GPU package also works for CPU.
 
 ### Install extra dependencies
 Install the necessary python packages:

--- a/examples/llama2/llama2_template.json
+++ b/examples/llama2/llama2_template.json
@@ -57,7 +57,8 @@
                             }
                         },
                         "batch_size": 2,
-                        "io_bind": true
+                        "io_bind": true,
+                        "shared_kv_buffer": true
                     }
                 }
             ]

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -245,7 +245,7 @@ class OrtTransformersOptimization(Pass):
                     )
                 # TODO(anyone): Access `world_size` from the pass config or the model attributes
                 # this is needed for tensor parallel models
-                optimizer = self._replace_mha_with_gqa(optimizer, "attention_mask", kv_num_heads=num_kv_heads)
+                optimizer = self._replace_mha_with_gqa(optimizer, kv_num_heads=num_kv_heads)
                 optimizer.prune_graph()
                 # add allow_remove_graph_inputs to pass config
                 optimizer.update_graph(allow_remove_graph_inputs=True)
@@ -260,7 +260,9 @@ class OrtTransformersOptimization(Pass):
         return model_proto_to_olive_model(optimizer.model, output_model_path, config)
 
     @staticmethod
-    def _replace_mha_with_gqa(model: "OnnxModel", attn_mask: str, kv_num_heads: int = 0, world_size: int = 1):
+    def _replace_mha_with_gqa(
+        model: "OnnxModel", attn_mask: str = "attention_mask", kv_num_heads: int = 0, world_size: int = 1
+    ):
         # Insert attention_mask subgraph to calculate shared inputs for all GroupQueryAttention nodes
         #
         #                attention_mask

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -232,14 +232,18 @@ class OrtTransformersOptimization(Pass):
                 force_fp16_inputs=config["force_fp16_inputs"],
             )
             if config["use_gqa"]:
-                # Replace MultiHeadAttention with GroupQueryAttention and remove attention mask nodes
+                # Replace MultiHeadAttention with GroupQueryAttention
+                # TODO(anyone): treat `num_key_value_heads` like `num_heads` and `hidden_size`.
+                # Should be provided either in the model attributes or in the config.
                 num_kv_heads = model.model_attributes.get("num_key_value_heads", None)
                 if num_kv_heads is None:
                     raise ValueError(
                         "num_key_value_heads is not specified in the model attributes. "
                         "Please specify it in the model attributes."
                     )
-                optimizer = self._replace_mha_with_gqa(optimizer, kv_num_heads=num_kv_heads)
+                # TODO(anyone): Access `world_size` from the pass config or the model attributes
+                # this is needed for tensor parallel models
+                optimizer = self._replace_mha_with_gqa(optimizer, "attention_mask", kv_num_heads=num_kv_heads)
                 optimizer.prune_graph()
                 # add allow_remove_graph_inputs to pass config
                 optimizer.update_graph(allow_remove_graph_inputs=True)
@@ -254,34 +258,96 @@ class OrtTransformersOptimization(Pass):
         return model_proto_to_olive_model(optimizer.model, output_model_path, config)
 
     @staticmethod
-    def _replace_mha_with_gqa(model: "OnnxModel", past_seq_len: str = "past_sequence_length", kv_num_heads: int = 0):
+    def _replace_mha_with_gqa(model: "OnnxModel", attn_mask: str, kv_num_heads: int = 0, world_size: int = 1):
+        # Insert attention_mask subgraph to calculate shared inputs for all GroupQueryAttention nodes
+        #
+        #                attention_mask
+        #               /              \
+        #          ReduceSum          Shape
+        #              |                |
+        #             Sub             Gather
+        #              |                |
+        #          seqlens_k   total_sequence_length
+        #              |                |
+        #        Cast to int32    Cast to int32
         import onnx
+        from onnx import TensorProto
 
-        if past_seq_len not in model.get_graphs_input_names():
-            # Replace model input for past sequence length
-            new_input = onnx.helper.make_tensor_value_info(past_seq_len, onnx.TensorProto.INT64, shape=[1])
-            model.model.graph.input.append(new_input)
+        model.add_initializer(
+            onnx.helper.make_tensor(
+                name="one",
+                data_type=TensorProto.INT64,
+                dims=[1],
+                vals=[1],
+            )
+        )
+        reduce_sum_node = onnx.helper.make_node(
+            "ReduceSum",
+            inputs=[attn_mask, "one"],
+            outputs=[attn_mask + "_row_sums"],
+            name=model.create_node_name("ReduceSum"),
+        )
+        sub_node = onnx.helper.make_node(
+            "Sub",
+            inputs=[attn_mask + "_row_sums", "one"],
+            outputs=["seqlens_k_int64"],
+            name=model.create_node_name("Sub"),
+        )
+        seqlen_k_cast_node = onnx.helper.make_node(
+            "Cast",
+            inputs=["seqlens_k_int64"],
+            outputs=["seqlens_k"],
+            name=model.create_node_name("Cast"),
+            to=TensorProto.INT32,
+        )
+        shape_node = onnx.helper.make_node(
+            "Shape",
+            inputs=[attn_mask],
+            outputs=[attn_mask + "_shape"],
+            name=model.create_node_name("Shape"),
+        )
+        gather_node = onnx.helper.make_node(
+            "Gather",
+            inputs=[attn_mask + "_shape", "one"],
+            outputs=["total_seq_len_int64"],
+            name=model.create_node_name("Gather"),
+            axis=0,
+        )
+        total_seqlen_cast_node = onnx.helper.make_node(
+            "Cast",
+            inputs=["total_seq_len_int64"],
+            outputs=["total_seq_len"],
+            name=model.create_node_name("Cast"),
+            to=TensorProto.INT32,
+        )
+        model.model.graph.node.extend(
+            [reduce_sum_node, sub_node, seqlen_k_cast_node, shape_node, gather_node, total_seqlen_cast_node]
+        )
 
         # Replace MultiHeadAttention with GroupQueryAttention
-        for node in model.model.graph.node:
-            if node.op_type == "MultiHeadAttention":
-                gqa_node = onnx.helper.make_node(
-                    "GroupQueryAttention",
-                    inputs=[
-                        node.input[0],  # query
-                        node.input[1],  # key
-                        node.input[2],  # value
-                        node.input[6],  # past_key
-                        node.input[7],  # past_value
-                        past_seq_len,  # past_sequence_length
-                    ],
-                    outputs=node.output,
-                    name=node.name.replace("MultiHeadAttention", "GroupQueryAttention"),
-                    domain="com.microsoft",
-                    num_heads=node.attribute[0].i,
-                    kv_num_heads=node.attribute[0].i if kv_num_heads == 0 else kv_num_heads,
-                    is_past_bsnh=0,
-                )
-                model.model.graph.node.remove(node)
-                model.model.graph.node.extend([gqa_node])
+        mha_nodes = list(filter(lambda node: node.op_type == "MultiHeadAttention", model.model.graph.node))
+        for node in mha_nodes:
+            num_heads_mha = 0
+            for att in node.attribute:
+                if att.name == "num_heads":
+                    num_heads_mha = att.i
+            gqa_node = onnx.helper.make_node(
+                "GroupQueryAttention",
+                inputs=[
+                    node.input[0],  # query
+                    node.input[1],  # key
+                    node.input[2],  # value
+                    node.input[6],  # past_key
+                    node.input[7],  # past_value
+                    "seqlens_k",  # seqlens_k (for attention_mask)
+                    "total_seq_len",  # total_seq_len (for attention_mask)
+                ],
+                outputs=node.output,
+                name=node.name.replace("MultiHeadAttention", "GroupQueryAttention"),
+                domain="com.microsoft",
+                num_heads=num_heads_mha // world_size,
+                kv_num_heads=num_heads_mha // world_size if kv_num_heads == 0 else kv_num_heads // world_size,
+            )
+            model.model.graph.node.remove(node)
+            model.model.graph.node.extend([gqa_node])
         return model


### PR DESCRIPTION
## Describe your changes
onnxruntime 1.16.2 just got released. The llama example and `OrtTransformersOptimization._replace_mha_with_gqa` are updated to sync with it. 
The calibration dataloaders for Inc smooth quant are removed since we don't have use for them currently and they are out of date. 

**Note:** onnxruntime cpu package is only available for x64 python 3.10 right now. https://github.com/microsoft/onnxruntime/issues/18378

### Results On A100:
**gpu_mha**
![gpu_mha](https://github.com/microsoft/Olive/assets/94929125/00ea1adf-2848-48a6-aa69-63d718027cdf)

**gpu_gqa (no shared kv buffer)**
![gpu_gqa](https://github.com/microsoft/Olive/assets/94929125/37280d0e-b4cb-403c-a91c-dd23599b14cf)

**gpu_gqa (shared kv buffer)**
![gpu_gqa_shared_buffer](https://github.com/microsoft/Olive/assets/94929125/2b1042f8-3df6-404e-9e07-0a356c31c3ef)

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
