### PR TITLE
Add option to generate fewer layers in DML llama 2 example

### DIFF
--- a/examples/directml/llama_v2/config.py
+++ b/examples/directml/llama_v2/config.py
@@ -6,3 +6,4 @@
 decoder_model = None
 normalization_type = None
 model_type = None
+num_layers = 32

--- a/examples/directml/llama_v2/run_llama_v2_dynamic_io_binding.py
+++ b/examples/directml/llama_v2/run_llama_v2_dynamic_io_binding.py
@@ -74,7 +74,11 @@ def run_llama_v2_io_binding(
 
     hidden_size = 4096
     n_heads = 32
-    n_layers = 32
+    n_layers = 0
+
+    for inputs_meta in llm_session._inputs_meta:
+        if inputs_meta.name.startswith("cache.") and inputs_meta.name.endswith(".key"):
+            n_layers += 1
 
     binding_device = "dml"
 

--- a/examples/directml/llama_v2/run_llama_v2_io_binding.py
+++ b/examples/directml/llama_v2/run_llama_v2_io_binding.py
@@ -74,7 +74,11 @@ def run_llama_v2_io_binding(
 
     hidden_size = 4096
     n_heads = 32
-    n_layers = 32
+    n_layers = 0
+
+    for inputs_meta in llm_session._inputs_meta:
+        if inputs_meta.name.startswith("cache.") and inputs_meta.name.endswith(".key"):
+            n_layers += 1
 
     binding_device = "dml"
 


### PR DESCRIPTION
Being able to generate the model with few layers makes the ONNX conversion and optimization steps so much faster, which makes it easier to debug it.