### PR TITLE
🔑 Distinct metric priority with joint key

### DIFF
--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1011,9 +1011,10 @@ class OliveEvaluatorConfig(ConfigBase):
         rank_set = set()
         for metric in v:
             for sub_type in metric.sub_types:
-                sub_type_names.add(joint_metric_key(metric.name, sub_type.name))
+                unique_metric_name = joint_metric_key(metric.name, sub_type.name)
+                sub_type_names.add(unique_metric_name)
                 if sub_type.priority != -1:
-                    sub_type_with_rank.add(sub_type.name)
+                    sub_type_with_rank.add(unique_metric_name)
                     rank_set.add(sub_type.priority)
 
         if not rank_set and len(sub_type_names) == 1:


### PR DESCRIPTION
## Describe your changes

Use the joint metric key to ensure the uniqueness of metric set with priorities.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
