### PR TITLE
Add a --model_dir argument to the DirectML LLaMA 2 example

### DIFF
--- a/examples/directml/llama_v2/run_llama_v2_io_binding.py
+++ b/examples/directml/llama_v2/run_llama_v2_io_binding.py
@@ -1,5 +1,6 @@
 # This program will run the ONNX version of the LlamaV2 model.
 import argparse
+import os
 import time
 from pathlib import Path
 from typing import List
@@ -43,6 +44,7 @@ def run_llama_v2_io_binding(
     device_id: int = 0,
     disable_metacommands: bool = False,
     ignore_eos: bool = False,
+    model_dir: str = "models/optimized/llama_v2",
 ) -> str:
     onnxruntime.set_default_logger_severity(3)
 
@@ -58,7 +60,7 @@ def run_llama_v2_io_binding(
     ]
 
     argmax_sampling_session = onnxruntime.InferenceSession(
-        "models/optimized/llama_v2/argmax_sampling/model.onnx",
+        os.path.join(model_dir, "argmax_sampling/model.onnx"),
         sess_options=onnxruntime.SessionOptions(),
         providers=providers,
     )
@@ -67,7 +69,7 @@ def run_llama_v2_io_binding(
     llm_session_options.add_free_dimension_override_by_name("max_seq_len", max_seq_len)
     llm_session_options.add_free_dimension_override_by_name("seq_len_increment", 1)
     llm_session = onnxruntime.InferenceSession(
-        "models/optimized/llama_v2/llama_v2/decoder_model_merged.onnx",
+        os.path.join(model_dir, "llama_v2/decoder_model_merged.onnx"),
         sess_options=llm_session_options,
         providers=providers,
     )
@@ -85,7 +87,7 @@ def run_llama_v2_io_binding(
     binding_device = "dml"
 
     # Initialize the tokenizer and produce the initial tokens.
-    tokenizer = Tokenizer(model_path="models/optimized/llama_v2/tokenizer.model")
+    tokenizer = Tokenizer(model_path=os.path.join(model_dir, "tokenizer.model"))
     tokens = tokenizer.encode(prompt, bos=True, eos=False)
     tokens = np.expand_dims(np.asarray(tokens, dtype=np.int64), 0)
     tokens = onnxruntime.OrtValue.ortvalue_from_numpy(tokens, binding_device)
@@ -195,6 +197,13 @@ if __name__ == "__main__":
     parser.add_argument("--disable_metacommands", action="store_true")
     parser.add_argument("--ignore_eos", action="store_true")
     parser.add_argument("--device_id", type=int, default=0)
+    parser.add_argument(
+        "--model_dir",
+        type=str,
+        default="models/optimized/llama_v2",
+        help="Path to the folder containing the argmax_sampling folder, llama_v2 folder and the tokenizer.model file",
+    )
+
     args = parser.parse_args()
     run_llama_v2_io_binding(
         args.prompt,
@@ -203,4 +212,5 @@ if __name__ == "__main__":
         args.device_id,
         args.disable_metacommands,
         args.ignore_eos,
+        args.model_dir,
     )


### PR DESCRIPTION
## Describe your changes

Adding a --model_dir argument allows users to easily point the example to their models that have already been pre-optimized.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
