### PR TITLE
`trust_remote_code` for hf data components, Default text-gen corpus dataset_type

### DIFF
--- a/examples/falcon/config.json
+++ b/examples/falcon/config.json
@@ -6,19 +6,17 @@
                 "model_name": "tiiuae/falcon-7b",
                 "task": "text-generation",
                 "dataset": {
-                    "data_name":"tiiuae/falcon-refinedweb",
+                    "data_name":"timdettmers/openassistant-guanaco",
                     "split": "train",
-                    "input_cols": ["content"],
-                    "batch_size": 1
+                    "component_kwargs": {
+                        "pre_process_data": {
+                            "text_cols": ["text"],
+                            "corpus_strategy": "join",
+                            "source_max_len": 512,
+                            "max_samples": 1
+                        }
+                    }
                 }
-            }
-        }
-    },
-    "systems": {
-        "local_system": {
-            "type": "LocalSystem",
-            "config": {
-                "accelerators": ["GPU"]
             }
         }
     },
@@ -55,8 +53,6 @@
     "engine": {
         "search_strategy": false,
         "evaluator": "common_evaluator",
-        "host": "local_system",
-        "target": "local_system",
         "execution_providers": ["CUDAExecutionProvider"],
         "cache_dir": "cache",
         "output_dir" : "models/falcon"

--- a/examples/llama2/llama2_qlora.json
+++ b/examples/llama2/llama2_qlora.json
@@ -30,7 +30,6 @@
                         "token": true
                     },
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
                         "source_max_len": 1024

--- a/examples/open_llama/llama_qlora.json
+++ b/examples/open_llama/llama_qlora.json
@@ -17,7 +17,6 @@
                 "split": "train",
                 "component_kwargs": {
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "text_cols": ["text"],
                         "corpus_strategy": "line-by-line",
                         "source_max_len": 512,

--- a/examples/open_llama/open_llama_lora_tinycodes.json
+++ b/examples/open_llama/open_llama_lora_tinycodes.json
@@ -27,7 +27,6 @@
                         "token": true
                     },
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
                         "source_max_len": 1024

--- a/examples/open_llama/open_llama_qlora_ort_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_ort_tinycodes.json
@@ -27,7 +27,6 @@
                         "token": true
                     },
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
                         "source_max_len": 1024

--- a/examples/open_llama/open_llama_qlora_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_tinycodes.json
@@ -27,7 +27,6 @@
                         "token": true
                     },
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
                         "source_max_len": 1024

--- a/examples/open_llama/open_llama_sparsegpt_gpu.json
+++ b/examples/open_llama/open_llama_sparsegpt_gpu.json
@@ -19,7 +19,6 @@
                 "data_files": {"train": "en/c4-train.00000-of-01024.json.gz"},
                 "component_kwargs": {
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "text_cols": ["text"],
                         "corpus_strategy": "join-random",
                         "add_special_tokens": false,
@@ -39,7 +38,6 @@
                 "split": "test",
                 "component_kwargs": {
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "text_cols": ["text"],
                         "corpus_strategy": "join",
                         "add_special_tokens": false,

--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -30,7 +30,6 @@
                         "token": true
                     },
                     "pre_process_data": {
-                        "dataset_type": "corpus",
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
                         "source_max_len": 1024,

--- a/olive/data/component/load_dataset.py
+++ b/olive/data/component/load_dataset.py
@@ -23,9 +23,7 @@ def simple_dataset(data_dir, input_data, label_cols=None, **kwargs):
 
 
 @Registry.register_dataset()
-def huggingface_dataset(
-    data_dir, data_name=None, subset=None, split="validation", data_files=None, token=False, **kwargs
-):
+def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation", data_files=None, **kwargs):
     """Create a dataset from huggingface datasets."""
     from datasets.utils.logging import disable_progress_bar, set_verbosity_error
 
@@ -34,7 +32,7 @@ def huggingface_dataset(
     from datasets import load_dataset
 
     assert data_name is not None, "Please specify the data name"
-    return load_dataset(path=data_name, name=subset, split=split, data_files=data_files, token=token, **kwargs)
+    return load_dataset(path=data_name, name=subset, split=split, data_files=data_files, **kwargs)
 
 
 @Registry.register_dataset()

--- a/olive/data/component/load_dataset.py
+++ b/olive/data/component/load_dataset.py
@@ -23,7 +23,9 @@ def simple_dataset(data_dir, input_data, label_cols=None, **kwargs):
 
 
 @Registry.register_dataset()
-def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation", data_files=None, **kwargs):
+def huggingface_dataset(
+    data_dir, data_name=None, subset=None, split="validation", data_files=None, token=False, **kwargs
+):
     """Create a dataset from huggingface datasets."""
     from datasets.utils.logging import disable_progress_bar, set_verbosity_error
 
@@ -32,7 +34,7 @@ def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation
     from datasets import load_dataset
 
     assert data_name is not None, "Please specify the data name"
-    return load_dataset(path=data_name, name=subset, split=split, data_files=data_files, **kwargs)
+    return load_dataset(path=data_name, name=subset, split=split, data_files=data_files, token=token, **kwargs)
 
 
 @Registry.register_dataset()

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -56,7 +56,7 @@ def _huggingface_pre_process_helper(dataset, model_name, input_cols, label_cols,
 
 @Registry.register_pre_process()
 def huggingface_pre_process(
-    dataset, model_name, input_cols, label_cols, max_samples=None, token=None, trust_remote_code=None, **kwargs
+    dataset, model_name, input_cols, label_cols, max_samples=None, trust_remote_code=None, **kwargs
 ):
     """Pre-process data.
 
@@ -66,8 +66,6 @@ def huggingface_pre_process(
         input_cols (list): List of input columns.
         label_cols (list): List of label columns.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
-        token (bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
-            use the token generated  when running `huggingface-cli login`. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.
         **kwargs: Additional arguments.
@@ -78,7 +76,7 @@ def huggingface_pre_process(
     from transformers import AutoConfig, AutoTokenizer
 
     def _tokenizer_and_align_labels(examples):
-        tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=trust_remote_code)
         tokenized_inputs = tokenizer(
             *[examples[input_col] for input_col in input_cols],
             padding=kwargs.get("padding", True),
@@ -97,7 +95,7 @@ def huggingface_pre_process(
     # Also to support customized operation arguments from users
     if kwargs.pop("align_labels", False):
         model_hf_config = AutoConfig.from_pretrained(
-            model_config_path or model_name, token=token, trust_remote_code=trust_remote_code
+            model_config_path or model_name, trust_remote_code=trust_remote_code
         )
         if model_hf_config and model_hf_config.label2id:
             dataset = dataset.align_labels_with_mapping(model_hf_config.label2id, label_cols[0])
@@ -111,7 +109,7 @@ def huggingface_pre_process(
 
 @Registry.register_pre_process()
 def ner_huggingface_preprocess(
-    dataset, model_name, input_cols, label_cols, max_samples=None, token=None, trust_remote_code=None, **kwargs
+    dataset, model_name, input_cols, label_cols, max_samples=None, trust_remote_code=None, **kwargs
 ):
     """Pre-process data for ner task."""
     from transformers import AutoTokenizer
@@ -138,7 +136,7 @@ def ner_huggingface_preprocess(
         return new_labels
 
     def _tokenizer_and_align_labels(examples):
-        tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=trust_remote_code)
         tokenized_inputs = tokenizer(
             *[examples[input_col] for input_col in input_cols],
             padding=kwargs.get("padding", True),
@@ -168,7 +166,6 @@ def text_generation_huggingface_pre_process(
     source_max_len: int,
     dataset_type: TextGenDatasetType = TextGenDatasetType.CORPUS,
     max_samples: Optional[int] = None,
-    token: Optional[bool] = None,
     trust_remote_code: Optional[bool] = None,
     **kwargs
 ):
@@ -181,8 +178,6 @@ def text_generation_huggingface_pre_process(
             For pair, this is the max length of the input sequence.
         dataset_type (TextGenDatasetType): Type of the dataset - 'corpus' or 'pair'. Defaults to 'corpus'.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
-        token (bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
-            use the token generated  when running `huggingface-cli login`. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.
         **kwargs: Additional arguments.
@@ -196,7 +191,7 @@ def text_generation_huggingface_pre_process(
     all_kwargs = deepcopy(kwargs)
     all_kwargs.update({"max_samples": max_samples, "source_max_len": source_max_len})
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=trust_remote_code)
 
     if dataset_type == TextGenDatasetType.CORPUS:
         return text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs)

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -66,7 +66,7 @@ def huggingface_pre_process(
         input_cols (list): List of input columns.
         label_cols (list): List of label columns.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
-        token (str, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
+        token (bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
             use the token generated  when running `huggingface-cli login`. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.
@@ -181,7 +181,7 @@ def text_generation_huggingface_pre_process(
             For pair, this is the max length of the input sequence.
         dataset_type (TextGenDatasetType): Type of the dataset - 'corpus' or 'pair'. Defaults to 'corpus'.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
-        token (str, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
+        token (bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
             use the token generated  when running `huggingface-cli login`. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -54,7 +54,9 @@ def _huggingface_pre_process_helper(dataset, model_name, input_cols, label_cols,
 
 
 @Registry.register_pre_process()
-def huggingface_pre_process(dataset, model_name, input_cols, label_cols, max_samples=None, **kwargs):
+def huggingface_pre_process(
+    dataset, model_name, input_cols, label_cols, max_samples=None, token=None, trust_remote_code=None, **kwargs
+):
     """Pre-process data.
 
     Args:
@@ -63,6 +65,10 @@ def huggingface_pre_process(dataset, model_name, input_cols, label_cols, max_sam
         input_cols (list): List of input columns.
         label_cols (list): List of label columns.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
+        token (str | bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
+            use the token generated  when running `huggingface-cli login`. Defaults to None.
+        trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
+            modeling files. Defaults to None.
         **kwargs: Additional arguments.
 
     Returns:
@@ -71,7 +77,7 @@ def huggingface_pre_process(dataset, model_name, input_cols, label_cols, max_sam
     from transformers import AutoConfig, AutoTokenizer
 
     def _tokenizer_and_align_labels(examples):
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
         tokenized_inputs = tokenizer(
             *[examples[input_col] for input_col in input_cols],
             padding=kwargs.get("padding", True),
@@ -89,7 +95,9 @@ def huggingface_pre_process(dataset, model_name, input_cols, label_cols, max_sam
     # align_labels -> align_labels_with_mapping
     # Also to support customized operation arguments from users
     if kwargs.pop("align_labels", False):
-        model_hf_config = AutoConfig.from_pretrained(model_config_path or model_name)
+        model_hf_config = AutoConfig.from_pretrained(
+            model_config_path or model_name, token=token, trust_remote_code=trust_remote_code
+        )
         if model_hf_config and model_hf_config.label2id:
             dataset = dataset.align_labels_with_mapping(model_hf_config.label2id, label_cols[0])
 
@@ -101,7 +109,9 @@ def huggingface_pre_process(dataset, model_name, input_cols, label_cols, max_sam
 
 
 @Registry.register_pre_process()
-def ner_huggingface_preprocess(dataset, model_name, input_cols, label_cols, max_samples=None, **kwargs):
+def ner_huggingface_preprocess(
+    dataset, model_name, input_cols, label_cols, max_samples=None, token=None, trust_remote_code=None, **kwargs
+):
     """Pre-process data for ner task."""
     from transformers import AutoTokenizer
 
@@ -127,7 +137,7 @@ def ner_huggingface_preprocess(dataset, model_name, input_cols, label_cols, max_
         return new_labels
 
     def _tokenizer_and_align_labels(examples):
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
         tokenized_inputs = tokenizer(
             *[examples[input_col] for input_col in input_cols],
             padding=kwargs.get("padding", True),
@@ -152,17 +162,28 @@ def ner_huggingface_preprocess(dataset, model_name, input_cols, label_cols, max_
 
 @Registry.register_pre_process()
 def text_generation_huggingface_pre_process(
-    dataset, model_name: str, dataset_type: TextGenDatasetType, source_max_len: int, max_samples=None, **kwargs
+    dataset,
+    model_name: str,
+    source_max_len: int,
+    dataset_type: TextGenDatasetType = TextGenDatasetType.CORPUS,
+    max_samples=None,
+    token=None,
+    trust_remote_code=None,
+    **kwargs
 ):
     """Pre-process data for text generation task.
 
     Args:
         dataset (object): Data to be pre-processed, reserved for internal dataset assignment.
         model_name (str): Name of the huggingface model.
-        dataset_type (TextGenDatasetType): Type of the dataset - 'corpus' or 'pair'.
         source_max_len (int): Max length of source sequence. For corpus, this is the max length of each sequence.
             For pair, this is the max length of the input sequence.
+        dataset_type (TextGenDatasetType): Type of the dataset - 'corpus' or 'pair'. Defaults to 'corpus'.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
+        token (str | bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
+            use the token generated  when running `huggingface-cli login`. Defaults to None.
+        trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
+            modeling files. Defaults to None.
         **kwargs: Additional arguments.
             The common arguments are the fields in olive.data.component.text_generation.TextGenParams.
             'corpus' arguments are the fields in olive.data.component.text_generation.TextGenCorpusParams.
@@ -174,7 +195,7 @@ def text_generation_huggingface_pre_process(
     all_kwargs = deepcopy(kwargs)
     all_kwargs.update({"max_samples": max_samples, "source_max_len": source_max_len})
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
 
     if dataset_type == TextGenDatasetType.CORPUS:
         return text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs)

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -5,6 +5,7 @@
 
 
 from copy import deepcopy
+from typing import Optional
 
 from olive.data.component.dataset import BaseDataset
 from olive.data.component.text_generation import (
@@ -65,7 +66,7 @@ def huggingface_pre_process(
         input_cols (list): List of input columns.
         label_cols (list): List of label columns.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
-        token (str | bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
+        token (str, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
             use the token generated  when running `huggingface-cli login`. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.
@@ -166,9 +167,9 @@ def text_generation_huggingface_pre_process(
     model_name: str,
     source_max_len: int,
     dataset_type: TextGenDatasetType = TextGenDatasetType.CORPUS,
-    max_samples=None,
-    token=None,
-    trust_remote_code=None,
+    max_samples: Optional[int] = None,
+    token: Optional[bool] = None,
+    trust_remote_code: Optional[bool] = None,
     **kwargs
 ):
     """Pre-process data for text generation task.
@@ -180,7 +181,7 @@ def text_generation_huggingface_pre_process(
             For pair, this is the max length of the input sequence.
         dataset_type (TextGenDatasetType): Type of the dataset - 'corpus' or 'pair'. Defaults to 'corpus'.
         max_samples (int, optional): Max number of samples to use. Defaults to None.
-        token (str | bool, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
+        token (str, optional): The token to use as HTTP bearer authorization for remote files. If `True`, will
             use the token generated  when running `huggingface-cli login`. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.

--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -542,7 +542,9 @@ def append_text_gen_input_ids(
     # create attention_mask
     if use_attention_mask:
         attention_mask = (
-            torch.ones_like(input_ids) if tokenizer.pad_token_id is None else input_ids.ne(tokenizer.pad_token_id)
+            torch.ones_like(input_ids)
+            if tokenizer.pad_token_id is None
+            else input_ids.ne(tokenizer.pad_token_id).to(input_ids.dtype)  # is boolean otherwise
         )
         inputs["attention_mask"] = attention_mask
 

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -151,7 +151,7 @@ class DataConfig(ConfigBase):
                     if info.kind in (info.VAR_POSITIONAL, info.VAR_KEYWORD):
                         continue
                     elif info.default is info.empty:
-                        logger.debug(f"Missing parameter {param} for component {k}")
+                        logger.debug(f"Missing parameter {param} for component {k} with type {v.type}. Set to None.")
                         v.params[param] = None
                     else:
                         v.params[param] = params[param].default

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -672,7 +672,6 @@ class PyTorchModel(OliveModel):
                 logger.debug("Using hf onnx_config to get dummy inputs")
                 kwargs = {}
                 if self.hf_config.model_loading_args:
-                    kwargs["token"] = self.hf_config.model_loading_args.token
                     kwargs["trust_remote_code"] = self.hf_config.model_loading_args.trust_remote_code
                 dummy_inputs = get_hf_model_dummy_input(
                     self.hf_config.model_name, self.hf_config.task, self.hf_config.feature, **kwargs

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -670,8 +670,12 @@ class PyTorchModel(OliveModel):
                 )
             elif not self.hf_config.components:
                 logger.debug("Using hf onnx_config to get dummy inputs")
+                kwargs = {}
+                if self.hf_config.model_loading_args:
+                    kwargs["token"] = self.hf_config.model_loading_args.token
+                    kwargs["trust_remote_code"] = self.hf_config.model_loading_args.trust_remote_code
                 dummy_inputs = get_hf_model_dummy_input(
-                    self.hf_config.model_name, self.hf_config.task, self.hf_config.feature
+                    self.hf_config.model_name, self.hf_config.task, self.hf_config.feature, **kwargs
                 )
 
         if dummy_inputs is None:

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -75,7 +75,14 @@ class HFModelLoadingArgs(ConfigWithExtraArgs):
             " details for the supported parameters."
         ),
     )
-    # TODO(xiaoyuzhang): seems not working. need to check.
+    # for remote files that require authentication
+    token: Union[bool, str] = Field(
+        None,
+        description=(
+            "The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated "
+            " when running `huggingface-cli login`."
+        ),
+    )
     # whether to trust remote code
     trust_remote_code: bool = Field(
         None,
@@ -132,7 +139,7 @@ class HFModelLoadingArgs(ConfigWithExtraArgs):
     def get_loading_args(self):
         loading_args = {}
         # copy args that can be directly copied
-        direct_copy_args = ["device_map", "max_memory"]
+        direct_copy_args = ["device_map", "max_memory", "token", "trust_remote_code"]
         for arg in direct_copy_args:
             if getattr(self, arg):
                 loading_args[arg] = deepcopy(getattr(self, arg))
@@ -143,8 +150,6 @@ class HFModelLoadingArgs(ConfigWithExtraArgs):
         quantization_config = self.get_quantization_config()
         if quantization_config:
             loading_args["quantization_config"] = quantization_config
-        if self.trust_remote_code:
-            loading_args["trust_remote_code"] = self.trust_remote_code
         # add extra args
         if self.extra_args:
             loading_args.update(deepcopy(self.extra_args))

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -76,12 +76,12 @@ class HFModelLoadingArgs(ConfigWithExtraArgs):
         ),
     )
     # for remote files that require authentication
-    token: Union[bool, str] = Field(
+    # expose `str` type if needed in the future
+    token: bool = Field(
         None,
         description=(
             "The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated "
-            " when running `huggingface-cli login`. `True` is recommended over a string token since the token will be "
-            " stored in the config file in plain text if a string token is provided."
+            " when running `huggingface-cli login`."
         ),
     )
     # whether to trust remote code
@@ -378,7 +378,11 @@ def get_hf_model_io_config(model_name: str, task: str, feature: Optional[str] = 
 
 
 def get_hf_model_dummy_input(
-    model_name: str, task: str, feature: Optional[str] = None, token=None, trust_remote_code=None
+    model_name: str,
+    task: str,
+    feature: Optional[str] = None,
+    token: Optional[bool] = None,
+    trust_remote_code: Optional[bool] = None,
 ):
     model_config = get_onnx_config(model_name, task, feature)
     tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -80,7 +80,8 @@ class HFModelLoadingArgs(ConfigWithExtraArgs):
         None,
         description=(
             "The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated "
-            " when running `huggingface-cli login`."
+            " when running `huggingface-cli login`. `True` is recommended over a string token since the token will be "
+            " stored in the config file in plain text if a string token is provided."
         ),
     )
     # whether to trust remote code
@@ -376,9 +377,11 @@ def get_hf_model_io_config(model_name: str, task: str, feature: Optional[str] = 
     return io_config
 
 
-def get_hf_model_dummy_input(model_name: str, task: str, feature: Optional[str] = None):
+def get_hf_model_dummy_input(
+    model_name: str, task: str, feature: Optional[str] = None, token=None, trust_remote_code=None
+):
     model_config = get_onnx_config(model_name, task, feature)
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=trust_remote_code)
     return model_config.generate_dummy_inputs(tokenizer, framework="pt")
 
 

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -595,7 +595,11 @@ class LoRA(LoRABase):
         pytorch_model.config.torch_dtype = model_dtype
 
         # tokenizer
-        tokenizer = AutoTokenizer.from_pretrained(new_model.hf_config.model_name)
+        tokenizer = AutoTokenizer.from_pretrained(
+            new_model.hf_config.model_name,
+            token=new_model.hf_config.model_loading_args.token,
+            trust_remote_code=new_model.hf_config.model_loading_args.trust_remote_code,
+        )
 
         # add lora modules
         pytorch_model = self.enable_lora(
@@ -719,7 +723,11 @@ class QLoRA(LoRABase):
         pytorch_model.config.torch_dtype = model_dtype
 
         # tokenizer
-        tokenizer = AutoTokenizer.from_pretrained(new_model.hf_config.model_name)
+        tokenizer = AutoTokenizer.from_pretrained(
+            new_model.hf_config.model_name,
+            token=new_model.hf_config.model_loading_args.token,
+            trust_remote_code=new_model.hf_config.model_loading_args.trust_remote_code,
+        )
 
         # TODO(jambayk): need to see if we still need this line
         # https://github.com/artidoro/qlora/blob/main/qlora.py#L362

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -597,7 +597,6 @@ class LoRA(LoRABase):
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             new_model.hf_config.model_name,
-            token=new_model.hf_config.model_loading_args.token,
             trust_remote_code=new_model.hf_config.model_loading_args.trust_remote_code,
         )
 
@@ -725,7 +724,6 @@ class QLoRA(LoRABase):
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             new_model.hf_config.model_name,
-            token=new_model.hf_config.model_loading_args.token,
             trust_remote_code=new_model.hf_config.model_loading_args.trust_remote_code,
         )
 

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -215,11 +215,11 @@ class LoRABase(Pass):
         if with_fixed_value:
             search_point = self.config_at_search_point(search_point or {})
         if search_point.get("use_ort_trainer"):
-            # if search_point.get("torch_dtype") == "bfloat16":
-            #     logger.info(
-            #         "bfloat16 is not supported by onnxruntime-training yet. Please use a different torch_dtype."
-            #     )
-            #     return False
+            if search_point.get("torch_dtype") == "bfloat16":
+                logger.info(
+                    "bfloat16 is not supported by onnxruntime-training yet. Please use a different torch_dtype."
+                )
+                return False
             if search_point.get("training_args", {}).get("gradient_checkpointing"):
                 logger.info(
                     "gradient_checkpointing is not supported by onnxruntime-training. Please set gradient_checkpointing"

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -215,11 +215,11 @@ class LoRABase(Pass):
         if with_fixed_value:
             search_point = self.config_at_search_point(search_point or {})
         if search_point.get("use_ort_trainer"):
-            if search_point.get("torch_dtype") == "bfloat16":
-                logger.info(
-                    "bfloat16 is not supported by onnxruntime-training yet. Please use a different torch_dtype."
-                )
-                return False
+            # if search_point.get("torch_dtype") == "bfloat16":
+            #     logger.info(
+            #         "bfloat16 is not supported by onnxruntime-training yet. Please use a different torch_dtype."
+            #     )
+            #     return False
             if search_point.get("training_args", {}).get("gradient_checkpointing"):
                 logger.info(
                     "gradient_checkpointing is not supported by onnxruntime-training. Please set gradient_checkpointing"

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -110,9 +110,10 @@ class RunConfig(ConfigBase):
                 "task": hf_config.get("task", None),
                 **hf_config_dataset,
             }
-            # insert token and trust_remote_code from model_loading_args if present
+            # insert trust_remote_code from model_loading_args if present
             # won't override if value was set to False explicitly
-            for key in ["token", "trust_remote_code"]:
+            # will keep as list of keys for future extension
+            for key in ["trust_remote_code"]:
                 if hf_config.get("model_loading_args", {}).get(key, None) and params_config.get(key, None) is None:
                     params_config[key] = hf_config["model_loading_args"][key]
             v[INPUT_MODEL_DATA_CONFIG] = {
@@ -144,7 +145,7 @@ class RunConfig(ConfigBase):
                     v["params_config"][key] = hf_config.get(key, None)
             # auto insert token and trust_remote_code from input model hf config
             # won't override if value was set to False explicitly
-            for key in ["token", "trust_remote_code"]:
+            for key in ["trust_remote_code"]:
                 if hf_config.get("model_loading_args", {}).get(key, None) and v["params_config"].get(key, None) is None:
                     v["params_config"][key] = hf_config["model_loading_args"][key]
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -143,7 +143,7 @@ class RunConfig(ConfigBase):
             for key in ["model_name", "task"]:
                 if not v["params_config"].get(key, None):
                     v["params_config"][key] = hf_config.get(key, None)
-            # auto insert token and trust_remote_code from input model hf config
+            # auto insert trust_remote_code from input model hf config
             # won't override if value was set to False explicitly
             for key in ["trust_remote_code"]:
                 if hf_config.get("model_loading_args", {}).get(key, None) and v["params_config"].get(key, None) is None:

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -27,7 +27,6 @@ def get_dataset():
         "split": "train",
         "component_kwargs": {
             "pre_process_data": {
-                "dataset_type": "corpus",
                 "text_cols": ["sentence"],
                 "corpus_strategy": "line-by-line",
                 "source_max_len": 512,

--- a/test/unit_test/passes/pytorch/test_sparsegpt.py
+++ b/test/unit_test/passes/pytorch/test_sparsegpt.py
@@ -19,7 +19,6 @@ def test_sparsegpt(tmp_path):
         "split": "train",
         "component_kwargs": {
             "pre_process_data": {
-                "dataset_type": "corpus",
                 "text_cols": ["sentence"],
                 "corpus_strategy": "join-random",
                 "source_max_len": 1024,

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -65,7 +65,6 @@ def test_torch_trt_conversion_success(
         "split": "train",
         "component_kwargs": {
             "pre_process_data": {
-                "dataset_type": "corpus",
                 "text_cols": ["sentence"],
                 "corpus_strategy": "join-random",
                 "source_max_len": 100,

--- a/test/unit_test/workflows/mock_data/text_generation_dataset.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset.json
@@ -11,7 +11,6 @@
                     "split": "train",
                     "component_kwargs": {
                         "pre_process_data": {
-                            "dataset_type": "corpus",
                             "text_cols": ["sentence"],
                             "corpus_strategy": "join-sliding-window",
                             "source_max_len": 1024,

--- a/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
@@ -11,7 +11,6 @@
                     "split": "train",
                     "component_kwargs": {
                         "pre_process_data": {
-                            "dataset_type": "corpus",
                             "text_cols": ["sentence"],
                             "corpus_strategy": "join-random",
                             "source_max_len": 1024,

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -198,10 +198,9 @@ class TestDataConfigValidation:
             (True, True, None, True),
             (True, None, None, None),
             (True, None, True, True),
-            (True, "dummy_token", None, "dummy_token"),
-            (True, "dummy_token", True, True),
-            (True, "dummy_token", False, False),
-            (True, "dummy_token", "dummy_token2", "dummy_token2"),
+            (True, None, False, False),
+            (True, True, False, False),
+            (True, False, True, True),
         ],
     )
     def test_auto_insert_token(self, has_loading_args, token, data_config_token, expected_token):

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -191,7 +191,7 @@ class TestDataConfigValidation:
 
     # works similarly for trust_remote_args
     @pytest.mark.parametrize(
-        "has_loading_args,token,data_config_token,expected_token",
+        "has_loading_args,trust_remote_code,data_config_trust_remote_code,expected_trust_remote_code",
         [
             (False, None, None, None),
             (False, None, True, True),
@@ -203,18 +203,27 @@ class TestDataConfigValidation:
             (True, False, True, True),
         ],
     )
-    def test_auto_insert_token(self, has_loading_args, token, data_config_token, expected_token):
+    def test_auto_insert_trust_remote_code(
+        self, has_loading_args, trust_remote_code, data_config_trust_remote_code, expected_trust_remote_code
+    ):
         config_dict = self.template.copy()
         if has_loading_args:
-            config_dict["input_model"]["config"]["hf_config"]["model_loading_args"] = {"token": token}
-        if data_config_token is not None:
-            config_dict["data_configs"]["dummy_data_config2"]["params_config"]["token"] = data_config_token
+            config_dict["input_model"]["config"]["hf_config"]["model_loading_args"] = {
+                "trust_remote_code": trust_remote_code
+            }
+        if data_config_trust_remote_code is not None:
+            config_dict["data_configs"]["dummy_data_config2"]["params_config"][
+                "trust_remote_code"
+            ] = data_config_trust_remote_code
 
         run_config = RunConfig.parse_obj(config_dict)
-        if expected_token is None:
-            assert "token" not in run_config.data_configs["dummy_data_config2"].params_config
+        if expected_trust_remote_code is None:
+            assert "trust_remote_code" not in run_config.data_configs["dummy_data_config2"].params_config
         else:
-            assert run_config.data_configs["dummy_data_config2"].params_config["token"] == expected_token
+            assert (
+                run_config.data_configs["dummy_data_config2"].params_config["trust_remote_code"]
+                == expected_trust_remote_code
+            )
 
     @pytest.mark.parametrize(
         "data_config_str",

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -189,6 +189,34 @@ class TestDataConfigValidation:
         assert run_config.data_configs["dummy_data_config2"].params_config["model_name"] == expected_model_name
         assert run_config.data_configs["dummy_data_config2"].params_config["task"] == expected_task
 
+    # works similarly for trust_remote_args
+    @pytest.mark.parametrize(
+        "has_loading_args,token,data_config_token,expected_token",
+        [
+            (False, None, None, None),
+            (False, None, True, True),
+            (True, True, None, True),
+            (True, None, None, None),
+            (True, None, True, True),
+            (True, "dummy_token", None, "dummy_token"),
+            (True, "dummy_token", True, True),
+            (True, "dummy_token", False, False),
+            (True, "dummy_token", "dummy_token2", "dummy_token2"),
+        ],
+    )
+    def test_auto_insert_token(self, has_loading_args, token, data_config_token, expected_token):
+        config_dict = self.template.copy()
+        if has_loading_args:
+            config_dict["input_model"]["config"]["hf_config"]["model_loading_args"] = {"token": token}
+        if data_config_token is not None:
+            config_dict["data_configs"]["dummy_data_config2"]["params_config"]["token"] = data_config_token
+
+        run_config = RunConfig.parse_obj(config_dict)
+        if expected_token is None:
+            assert "token" not in run_config.data_configs["dummy_data_config2"].params_config
+        else:
+            assert run_config.data_configs["dummy_data_config2"].params_config["token"] == expected_token
+
     @pytest.mark.parametrize(
         "data_config_str",
         [None, INPUT_MODEL_DATA_CONFIG, "dummy_data_config2"],


### PR DESCRIPTION
## Describe your changes
This PR 
- exposes `trust_remote_code` arguments to huggingface data components that require user permission to run remote code. For input models with hf config model_loading_args, the value for `trust_remote_code` is auto inserted into the data configs without these specified. 
- makes the default value for `dataset_type` in `test_generation_pre_process` component to `corpus`. Previously, the data config set it to `None` if not given and this results in using `pair` strategy. 
- Casts attention mask to input_id's data type to ensure it has the expected data type. 
- Removes `"dataset_type":"corpus"` from the examples since it is the default and the most common type.
- Corrects the dataset config in falcon example. Dataset is also changed to `timdettmers/openassistant-guanaco` since the previous dataset is massive (>1TB) and we only need it for latency measurement. 
 
## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
