### PR TITLE
Use keyword argument for `return_dict` in unet dummy input

### DIFF
--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -165,7 +165,7 @@ def unet_inputs(batchsize, torch_dtype, is_conversion_inputs=False):
         "encoder_hidden_states": torch.rand((batchsize, 77, config.image_size + 256), dtype=torch_dtype),
     }
 
-    # use as kwargs since they wont be in the correct position if passed along with the tuple of inputs
+    # use as kwargs since they won't be in the correct position if passed along with the tuple of inputs
     kwargs = {
         "return_dict": False,
     }

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -167,7 +167,6 @@ def unet_inputs(batchsize, torch_dtype, is_conversion_inputs=False):
 
     # use as kwargs since they wont be in the correct position if passed along with the tuple of inputs
     kwargs = {
-        "timestep_cond": torch.rand((batchsize, 256), dtype=torch_dtype),
         "return_dict": False,
     }
     if is_conversion_inputs:

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -163,17 +163,23 @@ def unet_inputs(batchsize, torch_dtype, is_conversion_inputs=False):
         "sample": torch.rand((batchsize, 4, 64, 64), dtype=torch_dtype),
         "timestep": torch.rand((batchsize,), dtype=torch_dtype),
         "encoder_hidden_states": torch.rand((batchsize, 77, config.image_size + 256), dtype=torch_dtype),
-        "return_dict": False,
     }
 
+    # use as kwargs since they wont be in the correct position if passed along with the tuple of inputs
+    kwargs = {
+        "timestep_cond": torch.rand((batchsize, 256), dtype=torch_dtype),
+        "return_dict": False,
+    }
     if is_conversion_inputs:
         inputs["additional_inputs"] = {
+            **kwargs,
             "added_cond_kwargs": {
                 "text_embeds": torch.rand((1, 1280), dtype=torch_dtype),
                 "time_ids": torch.rand((1, 5), dtype=torch_dtype),
-            }
+            },
         }
     else:
+        inputs.update(kwargs)
         inputs["onnx::Concat_4"] = torch.rand((1, 1280), dtype=torch_dtype)
         inputs["onnx::Shape_5"] = torch.rand((1, 5), dtype=torch_dtype)
 


### PR DESCRIPTION
## Describe your changes
The `unet_inputs` function has `return_dict` as a direct member of `inputs`. 

When `unet_conversion_inputs` changes `inputs` into tuples, `return_dict` is set as the fourth positional argument. But, it is not the fourth positional argument for the `forward` function of the model https://github.com/huggingface/diffusers/blob/4e54dfe985293df9e6e86828d7a2763d076879f5/src/diffusers/models/unet_2d_condition.py#L797. 
Torch exporter incorrectly assumes it is the value for the actual fourth argument `class_labels` and `return_dict` just uses it's default value `True`.

It appears the value of `return_dict` doesn't affect the exported model since the xl example doesn't set it. 
`class_labels` is unused so it didn't catch it too.
But this issue becomes more relevant when we want to add other optional inputs during export like in #730 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
