### PR TITLE
Set an opt_level of 0 for the DML examples

### DIFF
--- a/examples/directml/dolly_v2/config_dolly_v2.json
+++ b/examples/directml/dolly_v2/config_dolly_v2.json
@@ -44,6 +44,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "gpt2",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": false,
                 "keep_io_types": true,

--- a/examples/directml/llama_v2/config_llama_v2.json
+++ b/examples/directml/llama_v2/config_llama_v2.json
@@ -477,6 +477,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "gpt2",
+                "opt_level": 0,
                 "num_heads": 32,
                 "hidden_size": 4096,
                 "float16": true,

--- a/examples/directml/stable_diffusion/config_safety_checker.json
+++ b/examples/directml/stable_diffusion/config_safety_checker.json
@@ -52,6 +52,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "unet",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": false,

--- a/examples/directml/stable_diffusion/config_text_encoder.json
+++ b/examples/directml/stable_diffusion/config_text_encoder.json
@@ -49,6 +49,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "clip",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": false,

--- a/examples/directml/stable_diffusion/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion/config_text_encoder_2.json
@@ -49,6 +49,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "clip",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": false,

--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -56,6 +56,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "unet",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": false,

--- a/examples/directml/stable_diffusion/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion/config_vae_decoder.json
@@ -49,6 +49,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "vae",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": false,

--- a/examples/directml/stable_diffusion/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion/config_vae_encoder.json
@@ -49,6 +49,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "vae",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": false,

--- a/examples/directml/stable_diffusion_xl/config_text_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder.json
@@ -82,6 +82,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "clip",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": true,

--- a/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
@@ -122,6 +122,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "clip",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": true,

--- a/examples/directml/stable_diffusion_xl/config_unet.json
+++ b/examples/directml/stable_diffusion_xl/config_unet.json
@@ -58,6 +58,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "unet",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": true,

--- a/examples/directml/stable_diffusion_xl/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_decoder.json
@@ -52,6 +52,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "vae",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": true,

--- a/examples/directml/stable_diffusion_xl/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_encoder.json
@@ -52,6 +52,7 @@
             "disable_search": true,
             "config": {
                 "model_type": "vae",
+                "opt_level": 0,
                 "float16": true,
                 "use_gpu": true,
                 "keep_io_types": true,


### PR DESCRIPTION
## Describe your changes

`opt_level` isn't used for DML since we don't use the `optimize_by_onnxruntime` pass and instead specify each fusion manually. But if we set an opt_level higher than 0, we get some non-fatal error that confuses users and makes them think that the models didn't get optimized.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
