### PR TITLE
enable file logging

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -545,6 +545,9 @@ This is a dictionary that contains the information of the engine. The informatio
 - `ort_py_log_severity_level: [int]`, `3` by default. The log severity level of ONNX Runtime Python logs. The options are `0` for `VERBOSE`, `1` for
     `INFO`, `2` for `WARNING`, `3` for `ERROR`, `4` for `FATAL`.
 
+- `log_to_file: [Boolean]`, `false` by default. This decides whether to log to file. If `true`, the log will be stored in a olive-<timestamp>.log file
+    under the current working directory.
+
 Please find the detailed config options from following table for each search algorithm:
 
 | Algorithm  | Description |

--- a/olive/logging.py
+++ b/olive/logging.py
@@ -4,10 +4,15 @@
 # --------------------------------------------------------------------------
 import logging
 import sys
+from datetime import datetime
+
+
+def get_olive_logger():
+    return logging.getLogger(__name__.split(".", maxsplit=1)[0])
 
 
 def set_verbosity(verbose):
-    logging.getLogger(__name__.split(".", maxsplit=1)[0]).setLevel(verbose)
+    get_olive_logger().setLevel(verbose)
 
 
 def set_verbosity_info():
@@ -30,20 +35,26 @@ def set_verbosity_critical():
     set_verbosity(logging.CRITICAL)
 
 
+def get_logger_level(level):
+    """Get Python logging level for the integer level.
+
+    :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
+    """
+    level_map = {0: logging.DEBUG, 1: logging.INFO, 2: logging.WARNING, 3: logging.ERROR, 4: logging.CRITICAL}
+    # check if level is valid
+    if level not in level_map:
+        raise ValueError(f"Invalid level {level}, should be one of {list(level_map.keys())}")
+
+    return level_map[level]
+
+
 def set_default_logger_severity(level):
     """Set log level for olive package.
 
     :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
     """
-    # mapping from level to logging level
-    level_map = {0: logging.DEBUG, 1: logging.INFO, 2: logging.WARNING, 3: logging.ERROR, 4: logging.CRITICAL}
-
-    # check if level is valid
-    if level not in level_map:
-        raise ValueError(f"Invalid level {level}, should be one of {list(level_map.keys())}")
-
     # set logger level
-    set_verbosity(level_map[level])
+    set_verbosity(get_logger_level(level))
 
 
 def set_ort_logger_severity(level):
@@ -51,19 +62,24 @@ def set_ort_logger_severity(level):
 
     :param level: 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL
     """
-    # mapping from level to logging level
-    level_map = {0: logging.DEBUG, 1: logging.INFO, 2: logging.WARNING, 3: logging.ERROR, 4: logging.CRITICAL}
-
-    # check if level is valid
-    if level not in level_map:
-        raise ValueError(f"Invalid level {level}, should be one of {list(level_map.keys())}")
+    logger_level = get_logger_level(level)
 
     # set logger level
     ort_logger = logging.getLogger("onnxruntime")
-    ort_logger.setLevel(level_map[level])
+    ort_logger.setLevel(logger_level)
     formatter = logging.Formatter(
         "[%(asctime)s] [%(levelname)s] [onnxruntime]-[%(filename)s:%(lineno)d:%(funcName)s] %(message)s"
     )
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setFormatter(formatter)
     ort_logger.addHandler(stream_handler)
+
+
+def enable_filelog(level):
+    olive_logger = get_olive_logger()
+
+    file_handler = logging.FileHandler("olive-{:%Y-%m-%d-%H-%M}.log".format(datetime.now()))
+    file_handler.setLevel(get_logger_level(level))
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
+    file_handler.setFormatter(formatter)
+    olive_logger.addHandler(file_handler)

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -38,6 +38,7 @@ class RunEngineConfig(EngineConfig):
     log_severity_level: int = 1
     ort_log_severity_level: int = 3
     ort_py_log_severity_level: int = 3
+    log_to_file: bool = False
 
     def create_engine(self):
         config = self.dict()

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -13,7 +13,7 @@ from typing import List, Union
 import onnxruntime as ort
 
 from olive.hardware import Device
-from olive.logging import set_default_logger_severity, set_ort_logger_severity, set_verbosity_info
+from olive.logging import enable_filelog, set_default_logger_severity, set_ort_logger_severity, set_verbosity_info
 from olive.passes import Pass
 from olive.systems.common import SystemType
 from olive.workflows.run.config import RunConfig
@@ -149,6 +149,8 @@ def run(config: Union[str, Path, dict], setup: bool = False, data_root: str = No
     # ort_log_severity_level: C++ logging levels
     set_ort_logger_severity(config.engine.ort_py_log_severity_level)
     ort.set_default_logger_severity(config.engine.ort_log_severity_level)
+    if config.engine.log_to_file:
+        enable_filelog(config.engine.log_severity_level)
 
     # input model
     input_model = config.input_model


### PR DESCRIPTION
## Describe your changes

This pull request to the `olive` package introduces changes related to logging. It enable logging to file.

Summary of changes:
* <a href="diffhunk://#diff-a827196271eab94264068963f45451a73f0c526598f07be943152a189fee81b1R41">`olive/workflows/run/config.py`</a>: Added a new `log_to_file` attribute to the `RunEngineConfig` class to control logging to a file in the `run` function.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
