### PR TITLE
🌵 Complete optimum conversion/merge configs

### DIFF
--- a/olive/passes/onnx/optimum_conversion.py
+++ b/olive/passes/onnx/optimum_conversion.py
@@ -56,8 +56,8 @@ class OptimumConversion(Pass):
         if with_fixed_value:
             search_point = self.config_at_search_point(search_point or {})
 
-        if search_point.get("device") == "cuda" and not search_point.get("fp16"):
-            logger.info("OptimumConversion: fp16 is not set to True, but device is set to cuda.")
+        if search_point.get("fp16") and search_point.get("device") != "cuda":
+            logger.info("OptimumConversion: fp16 is set to True, but device is not set to cuda.")
             return False
 
         return True

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -28,7 +28,21 @@ class OptimumMerging(Pass):
 
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
-        return get_external_data_config()
+        config = {
+            "strict": PassConfigParam(
+                type_=bool,
+                default_value=True,
+                description=(
+                    "When set, the decoder and decoder_with_past are expected to have strictly"
+                    " the same number of outputs. When False, the decoder is allowed to have"
+                    " more outputs that decoder_with_past, in which case constant outputs are"
+                    " added to match the number of outputs."
+                ),
+            ),
+        }
+
+        config.update(get_external_data_config())
+        return config
 
     def _run_for_config(
         self, model: CompositeOnnxModel, data_root: str, config: Dict[str, Any], output_model_path: str
@@ -51,6 +65,7 @@ class OptimumMerging(Pass):
             merged_model = merge_decoders(
                 model.model_components[0].model_path,
                 model.model_components[1].model_path,
+                strict=config["strict"],
             )
         finally:
             ModelProto.ByteSize = prev_byte_size_func

--- a/test/unit_test/passes/onnx/test_optimum_conversion.py
+++ b/test/unit_test/passes/onnx/test_optimum_conversion.py
@@ -33,8 +33,7 @@ def test_optimum_conversion_pass(input_model, extra_args, tmp_path):
     [
         ({"fp16": True}, False),
         ({"fp16": True, "device": "cpu"}, False),
-        ({"fp16": True, "device": "cuda"}, True),
-        ({"fp16": False, "device": "cuda"}, True),
+        ({"fp16": False, "device": "cpu"}, True),
     ],
 )
 def test_optimum_configs(config, is_valid, tmp_path):

--- a/test/unit_test/passes/onnx/test_optimum_conversion.py
+++ b/test/unit_test/passes/onnx/test_optimum_conversion.py
@@ -12,10 +12,13 @@ from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.optimum_conversion import OptimumConversion
 
 
-@pytest.mark.parametrize("input_model", [get_optimum_model_by_hf_config(), get_optimum_model_by_model_path()])
-def test_optimum_conversion_pass(input_model, tmp_path):
+@pytest.mark.parametrize(
+    "input_model,extra_args",
+    [(get_optimum_model_by_hf_config(), {"atol": 0.1}), (get_optimum_model_by_model_path(), {"atol": None})],
+)
+def test_optimum_conversion_pass(input_model, extra_args, tmp_path):
     # setup
-    p = create_pass_from_dict(OptimumConversion, {}, disable_search=True)
+    p = create_pass_from_dict(OptimumConversion, {"extra_args": extra_args}, disable_search=True)
     output_folder = tmp_path
 
     # execute


### PR DESCRIPTION
## Describe your changes

Complete optimum conversion/merge configs.
Take conversion as example, the `fp16=True` means to load the torch model with float16 from huggingface model hub. Then the fp16 torch model is converted to onnx model. 
That is different the fp16 in transformer optimization.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
