### PR TITLE
Fix output path for ranked models generated by transformer optimization pass

### DIFF
--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-import os
 from copy import deepcopy
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import onnx
@@ -217,10 +217,12 @@ class OrtTransformersOptimization(Pass):
                 "OrtTransformersOptimization.config"
             )
 
-        output_model_path = ONNXModel.resolve_path(os.path.join(output_model_path, os.path.basename(model.model_path)))
+        output_model_path = Path(output_model_path)
+        if output_model_path.suffix != ".onnx":
+            output_model_path = output_model_path / Path(model.model_path).name
+        output_model_path = ONNXModel.resolve_path(output_model_path)
 
         optimization_options = config["optimization_options"]
-
         if optimization_options:
             self._set_fusion_options(run_config)
 


### PR DESCRIPTION
## Describe your changes

Fix output path for ranked models generated by transformer optimization pass

Ranked model includes the model suffix name i.e. model_XX.onnx and the pass should avoid appending it again.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
