### PR TITLE
Remove `log_to_file` from RunEngineConfig.create_engine

### DIFF
--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -50,6 +50,7 @@ class RunEngineConfig(EngineConfig):
             "log_severity_level",
             "ort_log_severity_level",
             "ort_py_log_severity_level",
+            "log_to_file",
         ]
         for key in to_del:
             del config[key]


### PR DESCRIPTION
## Describe your changes
`log_to_file` is a field of `RunEngineConfig` but it is not used to instantiate the engine. Remove it from the config dict before creating the engine. 

Otherwise it triggers the following warning:
```
[WARNING] [config_utils.py:308:validate_config] Keys {'log_to_file'} are not part of EngineConfig. Ignoring them.
```

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
