### PR TITLE
Fix pytorch tensor parallel implementation

### DIFF
--- a/examples/llama2/llama2_tensor_parallel.json
+++ b/examples/llama2/llama2_tensor_parallel.json
@@ -22,9 +22,11 @@
     },
     "passes": {
         "tensor_parallel": {
-            "type": "LlamaPyTorchTensorParallel",
+            "type": "PyTorchTensorParallel",
             "config": {
-                "world_size": 2
+                "user_script": "llama2_tensor_parallel.py",
+                "class_name": "LlamaPyTorchTensorParallel",
+                "world_size": 4
             }
         },
         "conversion": {
@@ -33,6 +35,19 @@
                 "target_opset": 17,
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
+            }
+        },
+        "transformers_optimization_fp16": {
+            "type": "OrtTransformersOptimization",
+            "config": {
+                "save_as_external_data": true,
+                "all_tensors_to_one_file": true,
+                "model_type": "gpt2",
+                "opt_level": 0,
+                "only_onnxruntime": false,
+                "keep_io_types": false,
+                "float16": true,
+                "use_gqa": true
             }
         }
     },

--- a/olive/passes/pytorch/__init__.py
+++ b/olive/passes/pytorch/__init__.py
@@ -5,12 +5,12 @@
 from olive.passes.pytorch.lora import LoRA, QLoRA
 from olive.passes.pytorch.quantization_aware_training import QuantizationAwareTraining
 from olive.passes.pytorch.sparsegpt import SparseGPT
-from olive.passes.pytorch.tensor_parallel_llama2 import LlamaPyTorchTensorParallel
+from olive.passes.pytorch.tensor_parallel import PyTorchTensorParallel
 from olive.passes.pytorch.torch_trt_conversion import TorchTRTConversion
 
 __all__ = [
-    "LlamaPyTorchTensorParallel",
     "LoRA",
+    "PyTorchTensorParallel",
     "QLoRA",
     "QuantizationAwareTraining",
     "SparseGPT",

--- a/olive/passes/pytorch/tensor_parallel.py
+++ b/olive/passes/pytorch/tensor_parallel.py
@@ -6,14 +6,17 @@
 # --------------------------------------------------------------------------
 
 import logging
+import multiprocessing
 from abc import abstractmethod
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict
 
 import torch
 from pydantic import validator
 
-from olive.hardware.accelerator import AcceleratorSpec
+from olive.common.config_utils import ParamCategory
+from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import DistributedPyTorchModel, PyTorchModel
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
@@ -21,17 +24,66 @@ from olive.passes.olive_pass import PassConfigParam
 logger = logging.getLogger(__name__)
 
 
+class TensorParallel:
+    def __init__(self, rank: int, world_size: int):
+        self.rank = rank
+        self.world_size = world_size
+
+    @abstractmethod
+    def replace_layers(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def restore_layers(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def split_weights(self, model: torch.nn.Module):
+        raise NotImplementedError
+
+    @abstractmethod
+    def load_rank_weights(self, model: torch.nn.Module):
+        raise NotImplementedError
+
+
 class PyTorchTensorParallel(Pass):
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
-        # Note : The default world_size should be the no of gpus (AceleratorSpec.Device == GPU)
+        # Note : The default world_size should be the no of gpus (AcceleratorSpec.Device == GPU)
         # in the target OliveSystem
         return {
+            "script_dir": PassConfigParam(
+                type_=str,
+                required=False,
+                category=ParamCategory.PATH,
+                description="Directory containing user script dependencies.",
+            ),
+            "user_script": PassConfigParam(
+                type_=str,
+                required=False,
+                category=ParamCategory.PATH,
+                description=(
+                    "Path to user script. The values for other parameters which were assigned"
+                    " function or object names will be imported from this script."
+                ),
+            ),
+            "class_name": PassConfigParam(
+                type_=str,
+                required=True,
+                category=ParamCategory.OBJECT,
+                description="Class implementing model specific logic",
+            ),
             "world_size": PassConfigParam(
                 type_=int,
                 default=2,
                 required=True,
-                description=("Number of GPU nodes to distribute the model for. Must be greater than 1."),
+                description="Number of GPU nodes to distribute the model for. Must be greater than 1.",
+            ),
+            "parallel_jobs": PassConfigParam(
+                type_=int,
+                default=multiprocessing.cpu_count(),
+                required=False,
+                description="Number of parallel jobs. Defaulted to number of CPUs. Set it to 0 to disable.",
             ),
         }
 
@@ -50,51 +102,91 @@ class PyTorchTensorParallel(Pass):
             )
         }
 
+    @staticmethod
+    def _generate_one(params):
+        script_dir, user_script, class_name, model_config, rank, world_size, output_filepath = params
+
+        from olive.passes.pytorch.tensor_parallel_llama2 import LlamaPyTorchTensorParallel
+
+        logger.debug(f"Exporting tensor parallel model for rank: {rank}, {output_filepath}")
+
+        # TODO(shaahji): Parameterize the specific class implementation to use
+        # cls = UserModuleLoader.load_global(class_name)
+        # impl = cls(rank, world_size)
+
+        impl = LlamaPyTorchTensorParallel(rank, world_size)
+
+        # 1. Replace the layers
+        impl.replace_layers()
+
+        try:
+            # 2. Load the model
+            olive_model = PyTorchModel(**model_config)
+            pytorch_model = olive_model.load_model()
+            pytorch_model.eval()
+            pytorch_model.requires_grad_(False)
+            pytorch_model.config.world_size = 1
+
+            # 3. Split the weights
+            impl.split_weights(pytorch_model)
+
+            # 4. Load rank specific weights
+            impl.load_rank_weights(pytorch_model)
+
+            # 5. Save it out for each rank
+            pytorch_model.config.world_size = world_size
+            pytorch_model.save_pretrained(output_filepath)
+        finally:
+            # 6. Restore layers that were replaced
+            impl.restore_layers()
+
+        logger.debug(f"Successfully exported tensor parallel model for rank: {rank}, {output_filepath}")
+
+        return 1  # Return 1 for success.
+
     def _run_for_config(
         self, model: PyTorchModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> DistributedPyTorchModel:
+        script_dir = config["script_dir"]
+        user_script = config["user_script"]
+        class_name = config["class_name"]
         world_size = int(config["world_size"])
         output_model_path = Path(output_model_path)
+        output_model_path.mkdir(parents=True, exist_ok=True)
 
-        # 1. Load the model
-        pytorch_model = model.load_model()
-
-        # 2. Replace the layers
-        self.replace_layers()
-
-        # 3. Split the weights
-        self.split_weights(pytorch_model, world_size)
-
-        try:
-            # 4. Save the weights for each rank
-            for rank in range(world_size):
-                self.load_rank_weights(pytorch_model, rank, world_size)
-                output_model_name = DistributedPyTorchModel.DEFAULT_RANKED_MODEL_NAME_FORMAT.format(rank)
-                output_filepath = str(output_model_path / output_model_name)
-                pytorch_model.save_pretrained(output_filepath)
-        finally:
-            # 5. Restore layers that were replaced
-            self.restore_layers()
-
-        # 6. Construct DistributedPyTorchModel from saved wegihts for each rank
         model_config = model.to_json()["config"]
+        params = [
+            (
+                script_dir,
+                user_script,
+                class_name,
+                model_config,
+                rank,
+                world_size,
+                output_model_path / DistributedPyTorchModel.DEFAULT_RANKED_MODEL_NAME_FORMAT.format(rank),
+            )
+            for rank in range(world_size)
+        ]
+
+        max_parallel_jobs = min(world_size, config["parallel_jobs"] or multiprocessing.cpu_count())
+        if max_parallel_jobs <= 1:
+            results = [PyTorchTensorParallel._generate_one(_) for _ in params]
+        else:
+            with multiprocessing.Pool(processes=max_parallel_jobs) as pool:
+                results = pool.map(PyTorchTensorParallel._generate_one, params)
+
+        if self.accelerator_spec.accelerator_type == Device.GPU and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        if world_size != sum(results):
+            raise RuntimeError("Failed to create ranked tensor parallel models")
+
+        # Finally, create DistributedPyTorchModel from ranked models for each rank
+        model_config = model.to_json()["config"]
+        del model_config["model_loader"]
         model_config["model_path"] = output_model_path
         model_config["model_name_pattern"] = DistributedPyTorchModel.DEFAULT_RANKED_MODEL_NAME_FORMAT
         model_config["num_ranks"] = world_size
+        model_config["model_attributes"] = deepcopy(model.model_attributes)
+        model_config["model_attributes"]["world_size"] = world_size
         return DistributedPyTorchModel(**model_config)
-
-    @abstractmethod
-    def replace_layers(self):
-        raise NotImplementedError
-
-    @abstractmethod
-    def restore_layers(self):
-        raise NotImplementedError
-
-    @abstractmethod
-    def split_weights(self, model: torch.nn.Module, world_size: int):
-        raise NotImplementedError
-
-    @abstractmethod
-    def load_rank_weights(self, model: torch.nn.Module, rank: int, world_size: int):
-        raise NotImplementedError


### PR DESCRIPTION
## Describe your changes

Fix pytorch tensor parallel implementation

* Previous verification was a false positive. The process was loading the entire model during the OnnxConversion pass resulting in exporting the same model i.e. the entire model for reach rank. The issue was found when attempting to export the Llama 70b model which kept running out of memory and the number of parameters reflected the error.

* Swap out of use of MPI in favor of multiprocessing since the latter is much easier to work with and debug. Important finding is that TensorParallel & OnnxConversion pass doesn't require MPI to succeed.

* Refactored the TensorParallel pass to work with multiprocessing jobs to speed up the process.

* Added OrtTransformersOptimization to Llama2 tensor parallel config
* Fixed Llama2 user script to account for world size to work with tensor parallel pass

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
