### PR TITLE
🧇 Unify the cache model name

### DIFF
--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -308,6 +308,9 @@ class ONNXModel(ONNXModelBase):
 
         resolve_path("c:/foo/bar") -> c:/foo/bar/model.onnx
         """
+        if not model_filename.endswith(".onnx"):
+            raise ValueError(f"ONNXModel's model name must end with '.onnx', got {model_filename}")
+
         path = Path(file_or_dir_path)
         if path.suffix != ".onnx":
             path = path / model_filename

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -359,7 +359,7 @@ class Pass(ABC):
             components = []
             component_names = []
             for cidx, child in enumerate(model.get_model_components()):
-                component_output_path = Path(output_model_path).with_suffix("") / Path(child.model_path).name
+                component_output_path = Path(output_model_path).with_suffix("") / model.get_model_component_name(cidx)
                 output_model_component = self._run_for_config(child, data_root, config, str(component_output_path))
                 output_model_component.model_attributes = (
                     output_model_component.model_attributes or child.model_attributes

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -359,7 +359,7 @@ class Pass(ABC):
             components = []
             component_names = []
             for cidx, child in enumerate(model.get_model_components()):
-                component_output_path = Path(output_model_path).with_suffix("") / str(cidx)
+                component_output_path = Path(output_model_path).with_suffix("") / Path(child.model_path).name
                 output_model_component = self._run_for_config(child, data_root, config, str(component_output_path))
                 output_model_component.model_attributes = (
                     output_model_component.model_attributes or child.model_attributes

--- a/olive/passes/onnx/append_pre_post_processing_ops.py
+++ b/olive/passes/onnx/append_pre_post_processing_ops.py
@@ -84,7 +84,7 @@ class AppendPrePostProcessingOps(Pass):
     ) -> ONNXModel:
         from onnxruntime import __version__ as OrtVersion
 
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         tool_command = config.get("tool_command")
         if tool_command:

--- a/olive/passes/onnx/bnb_quantization.py
+++ b/olive/passes/onnx/bnb_quantization.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 import re
+from pathlib import Path
 from typing import Any, Dict, List
 
 import onnx
@@ -55,7 +56,7 @@ class OnnxBnb4Quantization(Pass):
 
         from onnxruntime.quantization.matmul_bnb4_quantizer import MatMulBnb4Quantizer
 
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         quant_type = config["quant_type"]
         quantized_modules = config["quantized_modules"]

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -106,7 +106,8 @@ class OnnxConversion(Pass):
             for component_name in model.components:
                 # convert each component
                 component_model = model.get_component(component_name)
-                component_output_path = str(Path(output_model_path).with_suffix("") / component_name)
+                # component_name is set with Path(component_model.onnx).stem
+                component_output_path = str(Path(output_model_path).with_suffix("") / f"{component_name}.onnx")
                 output_model_component = self._convert_model_on_device(
                     component_model, data_root, config, component_output_path, device, torch_dtype
                 )
@@ -345,7 +346,7 @@ class OnnxConversion(Pass):
         )
 
         # save the model to the output path and return the model
-        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
+        output_model_path = ONNXModel.resolve_path(output_model_path)
         output_model = model_proto_to_olive_model(converted_onnx_model, output_model_path, config)
         output_model.model_attributes = model_attributes
         return output_model

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -345,7 +345,7 @@ class OnnxConversion(Pass):
         )
 
         # save the model to the output path and return the model
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
         output_model = model_proto_to_olive_model(converted_onnx_model, output_model_path, config)
         output_model.model_attributes = model_attributes
         return output_model

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -106,8 +106,7 @@ class OnnxConversion(Pass):
             for component_name in model.components:
                 # convert each component
                 component_model = model.get_component(component_name)
-                # component_name is set with Path(component_model.onnx).stem
-                component_output_path = str(Path(output_model_path).with_suffix("") / f"{component_name}.onnx")
+                component_output_path = str(Path(output_model_path).with_suffix("") / component_name)
                 output_model_component = self._convert_model_on_device(
                     component_model, data_root, config, component_output_path, device, torch_dtype
                 )

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from pathlib import Path
 from typing import Any, Dict, List
 
 import onnx
@@ -50,7 +51,7 @@ class OnnxFloatToFloat16(Pass):
     ) -> ONNXModel:
         from onnxconverter_common import float16
 
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         config = self._config_class(**config)
 

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-import os
 import tempfile
 from copy import deepcopy
 from pathlib import Path
@@ -495,7 +494,7 @@ class IncQuantization(Pass):
                 config["dataloader_func"] or config["data_config"]
             ), "dataloader_func or data_config is required for {} quantization.".format(run_config["approach"])
 
-        output_model_path = ONNXModel.resolve_path(os.path.join(output_model_path, os.path.basename(model.model_path)))
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         eval_func, accuracy_criterion, tuning_criterion = self._set_tuning_config(run_config, data_root)
         weight_only_config = self._set_woq_config(run_config)

--- a/olive/passes/onnx/insert_beam_search.py
+++ b/olive/passes/onnx/insert_beam_search.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from pathlib import Path
 from typing import Any, Dict
 
 from onnx import ModelProto, TensorProto, helper
@@ -245,5 +246,5 @@ class InsertBeamSearch(Pass):
             model_proto_A, model_A_name, model_proto_B, model_B_name, model.model_attributes, config
         )
         # save the model to the output path and return the model
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
         return model_proto_to_olive_model(combined_model, output_model_path, config, True)

--- a/olive/passes/onnx/insert_beam_search.py
+++ b/olive/passes/onnx/insert_beam_search.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-from pathlib import Path
 from typing import Any, Dict
 
 from onnx import ModelProto, TensorProto, helper
@@ -246,5 +245,5 @@ class InsertBeamSearch(Pass):
             model_proto_A, model_A_name, model_proto_B, model_B_name, model.model_attributes, config
         )
         # save the model to the output path and return the model
-        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
+        output_model_path = ONNXModel.resolve_path(output_model_path, "model_with_beam_search.onnx")
         return model_proto_to_olive_model(combined_model, output_model_path, config, True)

--- a/olive/passes/onnx/mixed_precision.py
+++ b/olive/passes/onnx/mixed_precision.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from pathlib import Path
 from typing import Any, Dict, List
 
 from onnx import ValueInfoProto
@@ -93,7 +94,7 @@ class OrtMixedPrecision(Pass):
         fp16_model = self._convert_float_to_float16(
             model=model.load_model(), use_symbolic_shape_infer=True, **parameters
         )
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
         config = self._config_class(**config)
         return model_proto_to_olive_model(fp16_model, output_model_path, config.dict())
 

--- a/olive/passes/onnx/model_optimizer.py
+++ b/olive/passes/onnx/model_optimizer.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np
@@ -227,7 +228,7 @@ class OnnxModelOptimizer(Pass):
     def _run_for_config(
         self, model: ONNXModel, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModel:
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         # optimize model
         model_optimizer = ModelOptimizer(model.model_path)

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -70,7 +70,7 @@ class OptimumMerging(Pass):
             ModelProto.ByteSize = prev_byte_size_func
 
         # onnx.save will fail if the directory doesn't already exist
-        ONNXModel.resolve_path(output_model_path, "decoder_model_merged.onnx")
+        output_model_path = ONNXModel.resolve_path(output_model_path, "decoder_model_merged.onnx")
 
         olive_model = model_proto_to_olive_model(merged_model, output_model_path, config)
 

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import os
-from pathlib import Path
 from typing import Any, Dict, Union
 
 from onnx import ModelProto
@@ -72,8 +70,7 @@ class OptimumMerging(Pass):
             ModelProto.ByteSize = prev_byte_size_func
 
         # onnx.save will fail if the directory doesn't already exist
-        Path(output_model_path).mkdir(parents=True, exist_ok=True)
-        output_model_path = os.path.join(output_model_path, "decoder_model_merged.onnx")
+        ONNXModel.resolve_path(output_model_path, "decoder_model_merged.onnx")
 
         olive_model = model_proto_to_olive_model(merged_model, output_model_path, config)
 

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -320,7 +320,7 @@ class OnnxQuantization(Pass):
                 config["dataloader_func"] or config["data_config"]
             ), "dataloader_func or data_config is required for static quantization."
 
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         # extra config
         extra_options = deepcopy(config["extra_options"]) if config["extra_options"] else {}
@@ -547,7 +547,7 @@ class OnnxMatMul4Quantizer(Pass):
 
         from onnxruntime.quantization.matmul_4bits_quantizer import MatMul4BitsQuantizer
 
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         quant = MatMul4BitsQuantizer(
             model.load_model(), config["block_size"], config["is_symmetric"], config["nodes_to_exclude"]

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -217,10 +217,7 @@ class OrtTransformersOptimization(Pass):
                 "OrtTransformersOptimization.config"
             )
 
-        output_model_path = Path(output_model_path)
-        if output_model_path.suffix != ".onnx":
-            output_model_path = output_model_path / Path(model.model_path).name
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         optimization_options = config["optimization_options"]
         if optimization_options:

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -267,7 +267,7 @@ class VitisAIQuantization(Pass):
         # start with a copy of the config
         run_config = deepcopy(config)
 
-        output_model_path = ONNXModel.resolve_path(output_model_path)
+        output_model_path = ONNXModel.resolve_path(output_model_path, Path(model.model_path).name)
 
         # extra config
         extra_options = deepcopy(config["extra_options"]) if config["extra_options"] else {}


### PR DESCRIPTION
## Describe your changes

For example in the case of onnx model components optimization workflow: conversion -> optimization -> mixed_precision -> etc.
Some passes like mixed_precision will forget the original model name(decoder.onnx, encoder.onnx etc) and use the default `main.onnx`.

This PR is used to unify the output cache model name.

Previous:
![image](https://github.com/microsoft/Olive/assets/13343117/118d6bed-ad1a-42e7-bcff-c08086a40e3d)

Now:

![image](https://github.com/microsoft/Olive/assets/13343117/789a5b58-5d65-43d3-8a1a-4df924169940)

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
