### PR TITLE
🧇 Warn the S8S8 QOperator quantization but not pruning

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -304,7 +304,6 @@ class OnnxQuantization(Pass):
                 logger.warning(
                     "S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general, try QDQ instead."
                 )
-                return True
             if config["EnableSubgraph"] is True:
                 logger.info("EnableSubgraph is not supported for static quantization.")
                 return False

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -298,8 +298,13 @@ class OnnxQuantization(Pass):
                 and config["activation_type"] == "QInt8"
                 and config["quant_format"] == "QOperator"
             ):
-                logger.info("S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general")
-                return False
+                # S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general.
+                # https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
+                # But we still allow it for users to try at their own risk. Olive just warns this to users.
+                logger.warning(
+                    "S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general, try QDQ instead."
+                )
+                return True
             if config["EnableSubgraph"] is True:
                 logger.info("EnableSubgraph is not supported for static quantization.")
                 return False


### PR DESCRIPTION
## Describe your changes
For some uses, they still want to try S8S8 with QOperator quantization config. But Olive directly prune it.
This PR is used to warn the S8S8 QOperator quantization but not pruning.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
