### PR TITLE
fix security bug 20033

### DIFF
--- a/olive/extra_dependencies.json
+++ b/olive/extra_dependencies.json
@@ -1,6 +1,6 @@
 {
     "azureml": [
-        "azure-ai-ml>=0.1.0b6",
+        "azure-ai-ml>=1.11.1",
         "azure-identity",
         "azureml-fsspec"
     ],


### PR DESCRIPTION
## Describe your changes
Fix bug https://dev.azure.com/aiinfra/Model%20optimization%20Toolkit/_workitems/edit/20033 

This security bug is about pydash used by azure-ai-ml less than 1.11.1, which use pydash 5.1.2. PR https://github.com/Azure/azure-sdk-for-python/pull/32433 fix the security issue. 

In this PR, we just upgrade azure-ai-ml dependency to use that fix.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link

![image](https://github.com/microsoft/Olive/assets/817030/6ec78527-5c3c-41c8-b40a-1ecd852b938e)
