### PR TITLE
LoRA/QLoRA: Add `bfloat16` support for ort-training

### DIFF
--- a/examples/open_llama/README.md
+++ b/examples/open_llama/README.md
@@ -115,6 +115,11 @@ python -m pip uninstall -y onnxruntime onnxruntime-gpu ort-nightly ort-nightly-g
 python -m pip install onnxruntime-training --pre --upgrade --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 ```
 
+Configure `torch-ort`:
+```bash
+python -m torch_ort.configure
+```
+
 ### Optimizing Open Llama Model with Azure Arc
 This workflow optimizes Open Llama model on Azure ML compute, and evaluate output models on your device. Please connect your device to Azure Arc by following instruction: [Self-hosted Kubernetes cluster](https://microsoft.github.io/Olive/tutorials/azure_arc.html)
 

--- a/examples/open_llama/open_llama_qlora_ort_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_ort_tinycodes.json
@@ -40,7 +40,6 @@
             "type": "QLoRA",
             "config": {
                 "use_ort_trainer": true,
-                "torch_dtype": "float32",
                 "lora_dropout": 0.1,
                 "train_data_config": "tiny_codes_train",
                 "eval_dataset_size": 1024,

--- a/examples/open_llama/requirements-qlora-ort.txt
+++ b/examples/open_llama/requirements-qlora-ort.txt
@@ -6,3 +6,4 @@ bitsandbytes==0.41.1
 optimum
 peft
 scikit-learn
+torch-ort

--- a/olive/extra_dependencies.json
+++ b/olive/extra_dependencies.json
@@ -34,19 +34,14 @@
     ],
     "lora": [
         "accelerate",
-        "peft"
-    ],
-    "qlora": [
-        "accelerate",
-        "bitsandbytes",
-        "peft"
-    ],
-    "qlora-ort": [
-        "accelerate",
-        "bitsandbytes",
-        "onnxruntime-training",
-        "optimum",
         "peft",
+        "scipy"
+    ],
+    "bnb": [
+        "bitsandbytes"
+    ],
+    "ort-training": [
+        "onnxruntime-training",
         "torch-ort"
     ]
 }

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -163,7 +163,7 @@ class OnnxConversion(Pass):
             # available since torch==2.1.0
             torch_version = torch.__version__
             if version.parse(torch_version) < version.parse("2.1.0"):
-                raise RuntimeError(
+                raise ImportError(
                     f"torch.onnx.dynamo_export is not available for torch version {torch_version}. "
                     "Please upgrade your torch version to 2.1.0 or above."
                 )

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -235,7 +235,7 @@ class LoRABase(Pass):
 
                 assert is_onnxruntime_training_available(), "onnxruntime-training is not available."
             except (ImportError, AssertionError):
-                raise RuntimeError(
+                raise ImportError(
                     "Please install `olive-ai[optimum,ort-training]` or `onnxruntime-training optimum torch-ort` to use"
                     f" {cls.__name__} pass with use_ort_trainer=True."
                 ) from None
@@ -250,7 +250,7 @@ class LoRABase(Pass):
 
             # onnxruntime-training doesn't support bfloat16 fully until 1.17.0
             if uses_bf16 and version.parse(OrtVersion) < version.parse("1.17.0"):
-                raise RuntimeError(
+                raise ImportError(
                     f"Please install onnxruntime >= 1.17.0 to use {cls.__name__} with bfloat16 and"
                     " use_ort_trainer=True."
                 )
@@ -262,6 +262,8 @@ class LoRABase(Pass):
                 try:
                     original_opset_version = int(original_opset_version)
                 except (ValueError, TypeError):
+                    # ValueError: original_opset_version is not a string representation of an integer. E.g. "dummy"
+                    # TypeError: original_opset_version is None
                     original_opset_version = -1
                 if original_opset_version < 16:
                     logger.debug("Setting ORTMODULE_ONNX_OPSET_VERSION to 16")
@@ -269,7 +271,7 @@ class LoRABase(Pass):
 
         # bitsandbytes quantization only supported after transformers 4.30.0
         if is_qlora and version.parse(transformers.__version__) < version.parse("4.30.0"):
-            raise RuntimeError(f"Please install transformers >= 4.30.0 to use {cls.__name__} pass.")
+            raise ImportError(f"Please install transformers >= 4.30.0 to use {cls.__name__} pass.")
 
     @staticmethod
     def collate_batch(batch: List[Dict], tokenizer: transformers.PreTrainedTokenizer) -> Dict[str, torch.Tensor]:

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -81,23 +81,22 @@ def dependency_setup(config):
             "QuantizationAwareTraining": ["pytorch-lightning"],
         }
 
-        pass_to_extra_name = {
-            "OpenVINOConversion": "openvino",
-            "OpenVINOQuantization": "openvino",
-            "IncQuantization": "inc",
-            "IncDynamicQuantization": "inc",
-            "IncStaticQuantization": "inc",
-            "OptimumConversion": "optimum",
-            "OptimumMerging": "optimum",
-            "TorchTRTConversion": "torch-tensorrt",
-            "LoRA": "lora",
-            "QLoRA": "qlora",
+        pass_to_extra_names = {
+            "OpenVINOConversion": ["openvino"],
+            "OpenVINOQuantization": ["openvino"],
+            "IncQuantization": ["inc"],
+            "IncDynamicQuantization": ["inc"],
+            "IncStaticQuantization": ["inc"],
+            "OptimumConversion": ["optimum"],
+            "OptimumMerging": ["optimum"],
+            "TorchTRTConversion": ["torch-tensorrt"],
+            "LoRA": ["lora"],
+            "QLoRA": ["bnb", "lora"],
         }
 
         extra_results = []
         extra_results.extend(pass_to_extra.get(pass_type, []))
-        extra_name = pass_to_extra_name.get(pass_type, None)
-        if extra_name:
+        for extra_name in pass_to_extra_names.get(pass_type, []):
             extra_results.extend(extras.get(extra_name))
         return extra_results
 


### PR DESCRIPTION
## Describe your changes
ONNX Runtime training now supports `bfloat16` for lora and qlora.

This PR
- Enables ort-training + bfloat16 by setting `ORTMODULE_ONNX_OPSET_VERSION` environment variable. Default value is 16 which is required for models with operators such as Where.
- Adds unit test for the environment variable.
- Improves dependency checks in the lora passes.
- Better organizes the extras for lora/qlora. Workflow setup allows assigning multiple extras to a single pass.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
LoRA/QLoRA support `bfloat16` with ort-training.
## (Optional) Issue link
