### PR TITLE
add enable_profiling options to collect ORT perf data in Olive

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -347,7 +347,14 @@ information of the evaluator contains following items:
                 "user_config":{
                     "user_script": "user_script.py",
                     "dataloader_func": "create_dataloader",
-                    "batch_size": 1
+                    "batch_size": 1,
+                    "inference_settings" : {
+                        "onnx": {
+                            "session_options": {
+                                "enable_profiling": true
+                            }
+                        }
+                    }
                 }
             }
         ]

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -26,9 +26,12 @@ def get_ort_inference_session(
     session_options = inference_settings.get("session_options", {})
     inter_op_num_threads = session_options.get("inter_op_num_threads")
     intra_op_num_threads = session_options.get("intra_op_num_threads")
+    enable_profiling = session_options.get("enable_profiling", False)
     execution_mode = session_options.get("execution_mode")
     graph_optimization_level = session_options.get("graph_optimization_level")
     extra_session_config = session_options.get("extra_session_config")
+    if enable_profiling:
+        sess_options.enable_profiling = True
     if inter_op_num_threads:
         sess_options.inter_op_num_threads = inter_op_num_threads
     if intra_op_num_threads:


### PR DESCRIPTION
## Describe your changes
Add the inference_settings options to turn on the ORT profiling when there are perf issues.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
