### PR TITLE
Add hf_token support for olive systems

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -42,6 +42,7 @@ The default value is 3. User can increase if there are network issues and the op
         }
     }
     ```
+- `keyvault_name: [str]` The keyvault name to retrieve secrets.
 
 ### Example
 #### `azureml_client` with `aml_config_path`:
@@ -199,8 +200,11 @@ information of the system contains following items:
   There are some built-in system alias which could also be used as type. For example, `AzureNDV2System`. Please refer to [Olive System Alias](olive_system_alias) for the complete list of system alias.
 
 - `config: [Dict]` The system config dictionary that contains the system specific information.
+ - `accelerators: [List[str]]` The accelerators that will be used for this workflow.
+ - `hf_token: [bool]` Whether to use a Huggingface token to access Huggingface resources. If it is set to `True`, For local system, Docker system, and PythonEnvironment system, Olive will retrieve the token from the `HF_TOKEN` environment variable or from the token file located at `~/.huggingface/token`. For AzureML system, Olive will retrieve the token from user keyvault secret. If set to `False`, no token will be utilized during this workflow run. The default value is `False`.
 
-Please refer to [Configuring OliveSystem](configuring_olivesystem) for the more information of the system config dictionary.
+
+Please refer to [How To Configure System](../tutorials/configure_systems.rst) for the more information of the system config dictionary.
 
 ### Example
 ```json

--- a/olive/azureml/azureml_client.py
+++ b/olive/azureml/azureml_client.py
@@ -49,6 +49,10 @@ class AzureMLClientConfig(ConfigBase):
             " for more details."
         ),
     )
+    keyvault_name: Optional[str] = Field(
+        None,
+        description=("Name of the keyvault to use. If provided, the keyvault will be used to retrieve secrets."),
+    )
 
     @validator("aml_config_path", always=True)
     def validate_aml_config_path(cls, v, values):

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -243,8 +243,8 @@ def huggingface_login(token: str):
 def aml_runner_hf_login():
     import os
 
-    hf_token = os.environ.get("HF_TOKEN")
-    if hf_token:
+    hf_login = os.environ.get("HF_LOGIN")
+    if hf_login:
         from azure.identity import DefaultAzureCredential
         from azure.keyvault.secrets import SecretClient
 

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -243,12 +243,14 @@ def huggingface_login(token: str):
 def aml_runner_hf_login():
     import os
 
-    from azure.identity import DefaultAzureCredential
-    from azure.keyvault.secrets import SecretClient
-
     hf_token = os.environ.get("HF_TOKEN")
     if hf_token:
+        from azure.identity import DefaultAzureCredential
+        from azure.keyvault.secrets import SecretClient
+
         keyvault_name = os.environ.get("KEYVAULT_NAME")
+        logger.debug(f"Getting token from keyvault {keyvault_name}")
+
         credential = DefaultAzureCredential()
         secret_client = SecretClient(vault_url=f"https://{keyvault_name}.vault.azure.net/", credential=credential)
         token = secret_client.get_secret("hf-token").value

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -231,4 +231,25 @@ def find_submodules(module, submodule_types, full_name=False):
                 submodules.add(name)
             else:
                 submodules.add(name.split(".")[-1])
-    return list(submodules)
+    return list(submodules) if submodules else None
+
+
+def huggingface_login(token: str):
+    from huggingface_hub import login
+
+    login(token=token)
+
+
+def aml_runner_hf_login():
+    import os
+
+    from azure.identity import DefaultAzureCredential
+    from azure.keyvault.secrets import SecretClient
+
+    hf_token = os.environ.get("HF_TOKEN")
+    if hf_token:
+        keyvault_name = os.environ.get("KEYVAULT_NAME")
+        credential = DefaultAzureCredential()
+        secret_client = SecretClient(vault_url=f"https://{keyvault_name}.vault.azure.net/", credential=credential)
+        token = secret_client.get_secret("hf-token").value
+        huggingface_login(token)

--- a/olive/extra_dependencies.json
+++ b/olive/extra_dependencies.json
@@ -1,6 +1,7 @@
 {
     "azureml": [
         "azure-ai-ml>=1.11.1",
+        "azure-keyvault-secrets",
         "azure-identity",
         "azureml-fsspec"
     ],

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -48,7 +48,7 @@ def create_metric(metric_config, metric_args):
 
 
 def main(raw_args=None):
-    # login to hf if HF_TOKEN is set to True
+    # login to hf if HF_LOGIN is set to True
     aml_runner_hf_login()
 
     model_config, pipeline_output, extra_args = get_common_args(raw_args)

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from olive.common.utils import aml_runner_hf_login
 from olive.evaluator.metric import Metric
 from olive.hardware import AcceleratorSpec
 from olive.model import ModelConfig
@@ -47,6 +48,9 @@ def create_metric(metric_config, metric_args):
 
 
 def main(raw_args=None):
+    # login to hf if HF_TOKEN is set to True
+    aml_runner_hf_login()
+
     model_config, pipeline_output, extra_args = get_common_args(raw_args)
     metric_args, extra_args = parse_metric_args(extra_args)
     accelerator_args = parse_accelerator_args(extra_args)

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -12,6 +12,7 @@ from onnxruntime import __version__ as ort_version
 from packaging import version
 
 from olive.common.config_utils import ParamCategory, validate_config
+from olive.common.utils import aml_runner_hf_login
 from olive.data.config import DataConfig
 from olive.hardware import AcceleratorSpec
 from olive.model import ModelConfig
@@ -83,6 +84,9 @@ def update_data_config(p, extra_args):
 
 
 def main(raw_args=None):
+    # login to hf if HF_TOKEN is set to True
+    aml_runner_hf_login()
+
     input_model_config, pipeline_output, extra_args = get_common_args(raw_args)
     pass_config_arg, extra_args = parse_pass_config_arg(extra_args)
 

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------
 import argparse
 import json
-import logging
 import shutil
 import tempfile
 from pathlib import Path
@@ -16,16 +15,11 @@ from olive.common.config_utils import ParamCategory, validate_config
 from olive.common.utils import aml_runner_hf_login
 from olive.data.config import DataConfig
 from olive.hardware import AcceleratorSpec
-from olive.logging import set_verbosity_debug
 from olive.model import ModelConfig
 from olive.passes import REGISTRY as PASS_REGISTRY
 from olive.passes import FullPassConfig
 from olive.resource_path import create_resource_path
 from olive.systems.utils import get_common_args
-
-logging.basicConfig(level=logging.DEBUG)
-
-set_verbosity_debug()
 
 
 def parse_pass_config_arg(raw_args):

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import argparse
 import json
+import logging
 import shutil
 import tempfile
 from pathlib import Path
@@ -15,11 +16,16 @@ from olive.common.config_utils import ParamCategory, validate_config
 from olive.common.utils import aml_runner_hf_login
 from olive.data.config import DataConfig
 from olive.hardware import AcceleratorSpec
+from olive.logging import set_verbosity_debug
 from olive.model import ModelConfig
 from olive.passes import REGISTRY as PASS_REGISTRY
 from olive.passes import FullPassConfig
 from olive.resource_path import create_resource_path
 from olive.systems.utils import get_common_args
+
+logging.basicConfig(level=logging.DEBUG)
+
+set_verbosity_debug()
 
 
 def parse_pass_config_arg(raw_args):
@@ -84,7 +90,7 @@ def update_data_config(p, extra_args):
 
 
 def main(raw_args=None):
-    # login to hf if HF_TOKEN is set to True
+    # login to hf if HF_LOGIN is set to True
     aml_runner_hf_login()
 
     input_model_config, pipeline_output, extra_args = get_common_args(raw_args)

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -111,7 +111,7 @@ class AzureMLSystem(OliveSystem):
                 "hf_token is set to True but keyvault name is not provided. "
                 "Please provide a keyvault name to use HF_TOKEN."
             )
-        env_vars = {"HF_TOKEN": True}
+        env_vars = {"HF_LOGIN": True}
         env_vars.update({"KEYVAULT_NAME": keyvault_name})
         return env_vars
 

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, 
 from azure.ai.ml import Input, Output, command
 from azure.ai.ml.constants import AssetTypes
 from azure.ai.ml.dsl import pipeline
-from azure.ai.ml.entities import BuildContext, Environment, Model
+from azure.ai.ml.entities import BuildContext, Environment, Model, UserIdentityConfiguration
 from azure.core.exceptions import HttpResponseError, ServiceResponseError
 
 from olive.azureml.azureml_client import AzureMLClientConfig
@@ -88,8 +88,9 @@ class AzureMLSystem(OliveSystem):
         accelerators: List[str] = None,
         olive_managed_env: bool = False,
         requirements_file: Union[Path, str] = None,
+        hf_token: bool = None,
     ):
-        super().__init__(accelerators, olive_managed_env=olive_managed_env)
+        super().__init__(accelerators, olive_managed_env=olive_managed_env, hf_token=hf_token)
         self.instance_count = instance_count
         self.resources = resources
         self.is_dev = is_dev
@@ -102,6 +103,17 @@ class AzureMLSystem(OliveSystem):
         if aml_docker_config:
             aml_docker_config = validate_config(aml_docker_config, AzureMLDockerConfig)
             self.environment = self._create_environment(aml_docker_config)
+        self.env_vars = self._get_hf_token_env(azureml_client_config.keyvault_name) if self.hf_token else None
+
+    def _get_hf_token_env(self, keyvault_name: str):
+        if keyvault_name is None:
+            raise ValueError(
+                "hf_token is set to True but keyvault name is not provided. "
+                "Please provide a keyvault name to use HF_TOKEN."
+            )
+        env_vars = {"HF_TOKEN": True}
+        env_vars.update({"KEYVAULT_NAME": keyvault_name})
+        return env_vars
 
     def _create_environment(self, docker_config: AzureMLDockerConfig):
         if docker_config.build_context_path:
@@ -300,11 +312,13 @@ class AzureMLSystem(OliveSystem):
             command=cmd_line,
             resources=resources,
             environment=aml_environment,
+            environment_variables=self.env_vars,
             code=str(code),
             inputs=inputs,
             outputs=outputs,
             instance_count=instance_count,
             compute=compute,
+            identity=UserIdentityConfiguration(),
         )
 
     def _create_pipeline_for_pass(

--- a/olive/systems/docker/eval.py
+++ b/olive/systems/docker/eval.py
@@ -8,6 +8,7 @@ import logging
 import os
 import sys
 
+from olive.common.utils import huggingface_login
 from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorConfig, OliveEvaluatorFactory
 from olive.model import ModelConfig
 
@@ -17,6 +18,11 @@ logger = logging.getLogger(__name__)
 def evaluate_entry(config, output_path, output_name, accelerator_type, execution_provider):
     with open(config) as f:  # noqa: PTH123
         config_json = json.load(f)
+
+    hf_token = os.environ.get("HF_TOKEN")
+    if hf_token:
+        huggingface_login(hf_token)
+
     evaluator_config = OliveEvaluatorConfig(metrics=config_json["metrics"])
     model_json = config_json["model"]
 

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class LocalSystem(OliveSystem):
     system_type = SystemType.Local
 
-    def __init__(self, accelerators: List[str] = None):
+    def __init__(self, accelerators: List[str] = None, hf_token: bool = None):
         super().__init__(accelerators=accelerators, olive_managed_env=False)
 
     def run_pass(

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -21,9 +21,15 @@ logger = logging.getLogger(__name__)
 class OliveSystem(ABC):
     system_type: SystemType
 
-    def __init__(self, accelerators: List[str] = None, olive_managed_env: bool = False):
+    def __init__(
+        self,
+        accelerators: List[str] = None,
+        olive_managed_env: bool = False,
+        hf_token: bool = None,
+    ):
         self.accelerators = accelerators
         self.olive_managed_env = olive_managed_env
+        self.hf_token = hf_token
 
     @abstractmethod
     def run_pass(

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -49,6 +49,7 @@ class PythonEnvironmentSystem(OliveSystem):
         accelerators: List[str] = None,
         olive_managed_env: bool = False,
         requirements_file: Union[Path, str] = None,
+        hf_token: bool = None,
     ):
         super().__init__(accelerators=accelerators, olive_managed_env=olive_managed_env)
         self.config = PythonEnvironmentTargetUserConfig(

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -17,6 +17,7 @@ from olive.systems.common import AzureMLDockerConfig, LocalDockerConfig, SystemT
 
 class TargetUserConfig(ConfigBase):
     accelerators: List[str] = None
+    hf_token: bool = None
 
 
 class LocalTargetUserConfig(TargetUserConfig):

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from azure.ai.ml import Input, Output
 from azure.ai.ml.constants import AssetTypes
+from azure.ai.ml.entities import UserIdentityConfiguration
 
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.data.config import DataConfig
@@ -258,11 +259,13 @@ class TestAzureMLSystem:
             command=self.create_command(script_name, inputs, outputs),
             resources=resources,
             environment=aml_environment,
+            environment_variables=None,
             code=code,
             inputs=inputs,
             outputs=outputs,
             instance_count=1,
             compute=compute,
+            identity=UserIdentityConfiguration(),
         )
 
     def test__create_data_script_inputs_and_args(self):
@@ -340,8 +343,8 @@ class TestAzureMLSystem:
     @patch("olive.systems.azureml.aml_system.AzureMLSystem._create_metric_args")
     def test__create_metric_component(self, mock_create_metric_args, mock_command, mock_copy, model_resource_type):
         # setup
-        tem_dir = Path()
-        code_path = tem_dir / "code"
+        tmp_dir = Path()
+        code_path = tmp_dir / "code"
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
         metric.user_config = {}
         model_args = {"input": Input(type=AssetTypes.URI_FILE, path="path")}
@@ -359,7 +362,7 @@ class TestAzureMLSystem:
             "metric_script_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
             "metric_data_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
         }
-        accelerator_config_path = tem_dir / "accelerator_config.json"
+        accelerator_config_path = tmp_dir / "accelerator_config.json"
         inputs = {
             **model_inputs,
             **metric_inputs,
@@ -386,7 +389,12 @@ class TestAzureMLSystem:
         else:
             model_resource_path = create_resource_path(ONNX_MODEL_PATH)
         actual_res = self.system._create_metric_component(
-            None, tem_dir, metric, model_args, {"model_path": model_resource_path}, accelerator_config_path
+            data_root=None,
+            tmp_dir=tmp_dir,
+            metric=metric,
+            model_args=model_args,
+            model_resource_paths={"model_path": model_resource_path},
+            accelerator_config_path=accelerator_config_path,
         )
 
         # assert
@@ -398,11 +406,13 @@ class TestAzureMLSystem:
             command=self.create_command("aml_evaluation_runner.py", inputs, outputs),
             resources=None,
             environment=self.system.environment,
+            environment_variables=self.system.env_vars,
             code=str(code_path),
             inputs=inputs,
             outputs={"pipeline_output": Output(type=AssetTypes.URI_FOLDER)},
             instance_count=1,
             compute=self.system.compute,
+            identity=UserIdentityConfiguration(),
         )
 
         # cleanup
@@ -662,3 +672,34 @@ class TestAzureMLSystem:
 
         aml_pass_runner_main(args)
         mock_conversion_run.assert_called_once()
+
+
+@patch("olive.systems.azureml.aml_system.Environment")
+def test_aml_system_with_hf_token(mock_env):
+    # setup
+    mock_azureml_client_config = Mock(spec=AzureMLClientConfig)
+    mock_azureml_client_config.keyvault_name = "keyvault_name"
+    docker_config = AzureMLDockerConfig(
+        base_image="base_image",
+        conda_file_path="conda_file_path",
+    )
+    system = AzureMLSystem(mock_azureml_client_config, "dummy", docker_config, hf_token=True)
+    expected_env_vars = {"HF_TOKEN": True, "KEYVAULT_NAME": "keyvault_name"}
+
+    # assert
+    assert system.env_vars == expected_env_vars
+
+
+@patch("olive.systems.azureml.aml_system.Environment")
+def test_aml_system_no_keyvault_name_raise_valueerror(mock_env):
+    # setup
+    mock_azureml_client_config = Mock(spec=AzureMLClientConfig)
+    mock_azureml_client_config.keyvault_name = None
+    docker_config = AzureMLDockerConfig(
+        base_image="base_image",
+        conda_file_path="conda_file_path",
+    )
+
+    # assert
+    with pytest.raises(ValueError):
+        AzureMLSystem(mock_azureml_client_config, "dummy", docker_config, hf_token=True)

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -683,8 +683,10 @@ def test_aml_system_with_hf_token(mock_env):
         base_image="base_image",
         conda_file_path="conda_file_path",
     )
+    expected_env_vars = {"HF_LOGIN": True, "KEYVAULT_NAME": "keyvault_name"}
+
+    # execute
     system = AzureMLSystem(mock_azureml_client_config, "dummy", docker_config, hf_token=True)
-    expected_env_vars = {"HF_TOKEN": True, "KEYVAULT_NAME": "keyvault_name"}
 
     # assert
     assert system.env_vars == expected_env_vars


### PR DESCRIPTION
## Describe your changes

Add hf_token support for olive systems.
- For local system, Docker system, and PythonEnvironment system, Olive will get the token from local.
- For AzureML system, Olive will retrieve the token from user keyvault secret. Olive will reserve `HF_TOKEN` secret name specifically for hf token fetch.

I'll send another PR to update [huggingface doc](https://microsoft.github.io/Olive/features/huggingface_model_optimization.html) for the keyvault detailed use case. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
