### PR TITLE
Add CUDA EP optimization option to Stable Diffusion examples

### DIFF
--- a/examples/directml/stable_diffusion/README.md
+++ b/examples/directml/stable_diffusion/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to optimize [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4), [Stable Diffusion v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5) or [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2) to run with ONNX Runtime and DirectML.
 
-Stable Diffusion comprises multiple PyTorch models tied together into a *pipeline*. This Olive sample will convert each PyTorch model to ONNX, and then run the converted ONNX models through the `OrtTransformersOptimization` pass. The transformer optimization pass performs several time-consuming graph transformations that make the models more efficient for inference at runtime. Output models are only guaranteed to be compatible with onnxruntime-directml 1.15.0 or newer.
+Stable Diffusion comprises multiple PyTorch models tied together into a *pipeline*. This Olive sample will convert each PyTorch model to ONNX, and then run the converted ONNX models through the `OrtTransformersOptimization` pass. The transformer optimization pass performs several time-consuming graph transformations that make the models more efficient for inference at runtime. Output models are only guaranteed to be compatible with onnxruntime-directml 1.16.2 or newer.
 
 **Contents**:
 - [Setup](#setup)
@@ -20,10 +20,10 @@ Olive is currently under pre-release, with constant updates and improvements to 
 
 ```
 # Install stable release of the Olive tool
-pip install olive-ai[directml]==0.2.1
+pip install olive-ai[directml]==0.4.0
 
 # Clone Olive repo to access sample code
-git clone https://github.com/microsoft/olive --branch v0.2.1
+git clone https://github.com/microsoft/olive --branch v0.4.0
 ```
 
 Once you've installed Olive, install the requirements for this sample matching the version of the library you are using:

--- a/examples/directml/stable_diffusion/config_safety_checker.json
+++ b/examples/directml/stable_diffusion/config_safety_checker.json
@@ -82,8 +82,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "unet",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": false
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion/config_text_encoder.json
+++ b/examples/directml/stable_diffusion/config_text_encoder.json
@@ -79,8 +79,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "clip",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": false
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion/config_text_encoder_2.json
@@ -79,8 +79,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "clip",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": false
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion/config_unet.json
+++ b/examples/directml/stable_diffusion/config_unet.json
@@ -86,8 +86,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "unet",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": false
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion/config_vae_decoder.json
@@ -79,8 +79,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "vae",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": false
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion/config_vae_encoder.json
@@ -79,8 +79,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "vae",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": false
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion/requirements-common.txt
+++ b/examples/directml/stable_diffusion/requirements-common.txt
@@ -1,0 +1,8 @@
+accelerate
+diffusers
+onnx
+pillow
+protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
+torch
+torchvision==0.14.1
+transformers

--- a/examples/directml/stable_diffusion/requirements.txt
+++ b/examples/directml/stable_diffusion/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 diffusers
 onnx
-onnxruntime-directml>=1.16.0
+onnxruntime-directml>=1.16.2
 pillow
 protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 torch

--- a/examples/directml/stable_diffusion/requirements.txt
+++ b/examples/directml/stable_diffusion/requirements.txt
@@ -1,2 +1,2 @@
 -r requirements-common.txt
-onnxruntime-directml>=1.16.2
+onnxruntime-directml>=1.16.0

--- a/examples/directml/stable_diffusion/requirements.txt
+++ b/examples/directml/stable_diffusion/requirements.txt
@@ -1,9 +1,2 @@
-accelerate
-diffusers
-onnx
+-r requirements-common.txt
 onnxruntime-directml>=1.16.2
-pillow
-protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
-torch
-torchvision==0.14.1
-transformers

--- a/examples/directml/stable_diffusion/stable_diffusion.py
+++ b/examples/directml/stable_diffusion/stable_diffusion.py
@@ -368,7 +368,7 @@ if __name__ == "__main__":
         )
 
     if args.provider == "dml" and version.parse(ort.__version__) < version.parse("1.16.0"):
-        print("This script requires onnxruntime-directml 1.16.2 or newer")
+        print("This script requires onnxruntime-directml 1.16.0 or newer")
         sys.exit(1)
     elif args.provider == "cuda" and version.parse(ort.__version__) < version.parse("1.17.0"):
         print("This script requires onnxruntime-gpu 1.17.0 or newer")

--- a/examples/directml/stable_diffusion/stable_diffusion.py
+++ b/examples/directml/stable_diffusion/stable_diffusion.py
@@ -367,8 +367,11 @@ if __name__ == "__main__":
             "as expected."
         )
 
-    if version.parse(ort.__version__) < version.parse("1.16.2"):
+    if args.provider == "dml" and version.parse(ort.__version__) < version.parse("1.16.2"):
         print("This script requires onnxruntime-directml 1.16.2 or newer")
+        sys.exit(1)
+    elif args.provider == "cuda" and version.parse(ort.__version__) < version.parse("1.17.0"):
+        print("This script requires onnxruntime-gpu 1.17.0 or newer")
         sys.exit(1)
 
     script_dir = Path(__file__).resolve().parent

--- a/examples/directml/stable_diffusion/stable_diffusion.py
+++ b/examples/directml/stable_diffusion/stable_diffusion.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_id", default="runwayml/stable-diffusion-v1-5", type=str)
     parser.add_argument(
-        "--provider", default="directml", type=str, choices=["dml", "cuda"], help="Execution provider to use"
+        "--provider", default="dml", type=str, choices=["dml", "cuda"], help="Execution provider to use"
     )
     parser.add_argument("--interactive", action="store_true", help="Run with a GUI")
     parser.add_argument("--optimize", action="store_true", help="Runs the optimization step")
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         help="DEPRECATED (now enabled by default). Use --dynamic_dims to disable static_dims.",
     )
     parser.add_argument("--dynamic_dims", action="store_true", help="Disable static shape optimization")
-    parser.add_argument("--tempdir", type=str, help="Root directory for tempfile directories and files", required=False)
+    parser.add_argument("--tempdir", default=None, type=str, help="Root directory for tempfile directories and files")
     args = parser.parse_args()
 
     if args.static_dims:
@@ -367,7 +367,7 @@ if __name__ == "__main__":
             "as expected."
         )
 
-    if args.provider == "dml" and version.parse(ort.__version__) < version.parse("1.16.2"):
+    if args.provider == "dml" and version.parse(ort.__version__) < version.parse("1.16.0"):
         print("This script requires onnxruntime-directml 1.16.2 or newer")
         sys.exit(1)
     elif args.provider == "cuda" and version.parse(ort.__version__) < version.parse("1.17.0"):

--- a/examples/directml/stable_diffusion/stable_diffusion.py
+++ b/examples/directml/stable_diffusion/stable_diffusion.py
@@ -6,11 +6,13 @@ import argparse
 import json
 import shutil
 import sys
+import tempfile
 import threading
 import tkinter as tk
 import tkinter.ttk as ttk
 import warnings
 from pathlib import Path
+from typing import Dict
 
 import config
 import onnxruntime as ort
@@ -134,7 +136,15 @@ def run_inference_gui(pipeline, prompt, num_images, batch_size, image_size, num_
 
 
 def run_inference(
-    optimized_model_dir, prompt, num_images, batch_size, image_size, num_inference_steps, static_dims, interactive
+    optimized_model_dir,
+    provider,
+    prompt,
+    num_images,
+    batch_size,
+    image_size,
+    num_inference_steps,
+    static_dims,
+    interactive,
 ):
     ort.set_default_logger_severity(3)
 
@@ -154,8 +164,13 @@ def run_inference(
         sess_options.add_free_dimension_override_by_name("unet_hidden_batch", batch_size * 2)
         sess_options.add_free_dimension_override_by_name("unet_hidden_sequence", 77)
 
+    provider_map = {
+        "dml": "DmlExecutionProvider",
+        "cuda": "CUDAExecutionProvider",
+    }
+    assert provider in provider_map, f"Unsupported provider: {provider}"
     pipeline = OnnxStableDiffusionPipeline.from_pretrained(
-        optimized_model_dir, provider="DmlExecutionProvider", sess_options=sess_options
+        optimized_model_dir, provider=provider_map[provider], sess_options=sess_options
     )
 
     if interactive:
@@ -164,8 +179,21 @@ def run_inference(
         run_inference_loop(pipeline, prompt, num_images, batch_size, image_size, num_inference_steps)
 
 
+def update_config_with_provider(config: Dict, provider: str):
+    if provider == "dml":
+        # DirectML EP is the default, so no need to update config.
+        return config
+    elif provider == "cuda":
+        config["pass_flows"] = [["convert", "optimize_cuda"]]
+        config["engine"]["execution_providers"] = ["CUDAExecutionProvider"]
+        return config
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
+
+
 def optimize(
     model_id: str,
+    provider: str,
     unoptimized_model_dir: Path,
     optimized_model_dir: Path,
 ):
@@ -209,6 +237,7 @@ def optimize(
         olive_config = None
         with (script_dir / f"config_{submodel_name}.json").open() as fin:
             olive_config = json.load(fin)
+        olive_config = update_config_with_provider(olive_config, provider)
 
         if submodel_name in ("unet", "text_encoder"):
             olive_config["input_model"]["config"]["model_path"] = model_id
@@ -221,7 +250,7 @@ def optimize(
         olive_run(olive_config)
 
         footprints_file_path = (
-            Path(__file__).resolve().parent / "footprints" / f"{submodel_name}_gpu-dml_footprints.json"
+            Path(__file__).resolve().parent / "footprints" / f"{submodel_name}_gpu-{provider}_footprints.json"
         )
         with footprints_file_path.open("r") as footprint_file:
             footprints = json.load(footprint_file)
@@ -289,6 +318,9 @@ def optimize(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_id", default="runwayml/stable-diffusion-v1-5", type=str)
+    parser.add_argument(
+        "--provider", default="directml", type=str, choices=["dml", "cuda"], help="Execution provider to use"
+    )
     parser.add_argument("--interactive", action="store_true", help="Run with a GUI")
     parser.add_argument("--optimize", action="store_true", help="Runs the optimization step")
     parser.add_argument("--clean_cache", action="store_true", help="Deletes the Olive cache")
@@ -310,6 +342,7 @@ if __name__ == "__main__":
         help="DEPRECATED (now enabled by default). Use --dynamic_dims to disable static_dims.",
     )
     parser.add_argument("--dynamic_dims", action="store_true", help="Disable static shape optimization")
+    parser.add_argument("--tempdir", type=str, help="Root directory for tempfile directories and files", required=False)
     args = parser.parse_args()
 
     if args.static_dims:
@@ -334,13 +367,14 @@ if __name__ == "__main__":
             "as expected."
         )
 
-    if version.parse(ort.__version__) < version.parse("1.15.0"):
-        print("This script requires onnxruntime-directml 1.15.0 or newer")
+    if version.parse(ort.__version__) < version.parse("1.16.2"):
+        print("This script requires onnxruntime-directml 1.16.2 or newer")
         sys.exit(1)
 
     script_dir = Path(__file__).resolve().parent
     unoptimized_model_dir = script_dir / "models" / "unoptimized" / args.model_id
-    optimized_model_dir = script_dir / "models" / "optimized" / args.model_id
+    optimized_dir_name = "optimized" if args.provider == "directml" else "optimized-cuda"
+    optimized_model_dir = script_dir / "models" / optimized_dir_name / args.model_id
 
     if args.clean_cache:
         shutil.rmtree(script_dir / "cache", ignore_errors=True)
@@ -348,10 +382,16 @@ if __name__ == "__main__":
     config.image_size = model_to_image_size.get(args.model_id, 512)
 
     if args.optimize or not optimized_model_dir.exists():
+        if args.tempdir is not None:
+            # set tempdir if specified
+            tempdir = Path(args.tempdir).resolve()
+            tempdir.mkdir(parents=True, exist_ok=True)
+            tempfile.tempdir = str(tempdir)
+
         # TODO(jstoecker): clean up warning filter (mostly during conversion from torch to ONNX)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            optimize(args.model_id, unoptimized_model_dir, optimized_model_dir)
+            optimize(args.model_id, args.provider, unoptimized_model_dir, optimized_model_dir)
 
     if not args.optimize:
         model_dir = unoptimized_model_dir if args.test_unoptimized else optimized_model_dir
@@ -361,6 +401,7 @@ if __name__ == "__main__":
             warnings.simplefilter("ignore")
             run_inference(
                 model_dir,
+                args.provider,
                 args.prompt,
                 args.num_images,
                 args.batch_size,

--- a/examples/directml/stable_diffusion_xl/README.md
+++ b/examples/directml/stable_diffusion_xl/README.md
@@ -76,7 +76,7 @@ If you omit `--interactive`, the script will generate the requested number of im
 The minimum number of inferences will be `ceil(num_images / batch_size)`; additional inferences may be required of some outputs are flagged by the safety checker to ensure the desired number of outputs are produced.
 
 ## Stable Diffusion Optimization with CUDA
-This example can also be used to optimize Stable Diffusion models for CUDA. You can use the same `stable_diffusion.py` script with `--provider cuda` option to optimize the models for CUDA and test inference. The optimized models will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/runwayml/stable-diffusion-v1-5`).
+This example can also be used to optimize Stable Diffusion models for CUDA. You can use the same `stable_diffusion.py` script with `--provider cuda` option to optimize the models for CUDA and test inference. The optimized models will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/stabilityai/stable-diffusion-xl-base-1.0`).
 
 Install the common requirements:
 ```

--- a/examples/directml/stable_diffusion_xl/README.md
+++ b/examples/directml/stable_diffusion_xl/README.md
@@ -8,14 +8,15 @@ Stable Diffusion XL comprises multiple PyTorch models tied together into a *pipe
 - [Setup](#setup)
 - [Conversion to ONNX and Latency Optimization](#conversion-to-onnx-and-latency-optimization)
 - [Test Inference](#test-inference)
+- [Optimization for CUDA EP](#stable-diffusion-optimization-with-cuda)
 - [Issues](#issues)
 - [Stable Diffusion Pipeline](#stable-diffusion-pipeline)
 
-# Setup
+## Setup
 
 Olive is currently under pre-release, with constant updates and improvements to the functions and usage. This sample code will be frequently updated as Olive evolves, so it is important to install Olive from source when checking out this code from the main branch. See the [README for examples](https://github.com/microsoft/Olive/blob/main/examples/README.md#important) for detailed instructions on how to do this.
 
-# Conversion to ONNX and Latency Optimization
+## Conversion to ONNX and Latency Optimization
 
 The easiest way to optimize the pipeline is with the `stable_diffusion_xl.py` helper script. For SDXL Base, run the following:
 
@@ -39,7 +40,7 @@ Once the script successfully completes:
 
 Re-running the script with `--optimize` will delete the output models, but it will *not* delete the Olive cache. Subsequent runs will complete much faster since it will simply be copying previously optimized models; you may use the `--clean_cache` option to start from scratch (not typically used unless you are modifying the scripts, for example).
 
-# Test Inference
+## Test Inference
 
 This sample code is primarily intended to illustrate model optimization with Olive, but it also provides a simple interface for testing inference with the ONNX models. Inference is done by creating an `OnnxStableDiffusionPipeline` from the saved models, which leans on ONNX runtime for inference of the core models (text encoder, u-net and decoder).
 
@@ -74,7 +75,24 @@ If you omit `--interactive`, the script will generate the requested number of im
 
 The minimum number of inferences will be `ceil(num_images / batch_size)`; additional inferences may be required of some outputs are flagged by the safety checker to ensure the desired number of outputs are produced.
 
-# Issues
+## Stable Diffusion Optimization with CUDA
+This example can also be used to optimize Stable Diffusion models for CUDA. You can use the same `stable_diffusion.py` script with `--provider cuda` option to optimize the models for CUDA and test inference. The optimized models will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/runwayml/stable-diffusion-v1-5`).
+
+Install the common requirements:
+```
+pip install -r requirements-common.txt
+```
+
+The CUDA example requires the latest onnxruntime-gpu code which can either be built from source or installed from the nightly builds. The following command can be used to install the latest nightly build of onnxruntime-gpu:
+```
+# uninstall any pre-existing onnxruntime packages
+pip uninstall -y onnxruntime onnxruntime-gpu onnxruntime-directml ort-nightly ort-nightly-gpu ort-nightly-directml
+
+# install onnxruntime-gpu nightly build
+pip install ort-nightly-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
+```
+
+## Issues
 
 If you run into the following error while optimizing models, it is likely that your local HuggingFace cache has an incomplete copy of the stable diffusion model pipeline. Deleting `C:\users\<username>\.cache\huggingface` should resolve the issue by ensuring a fresh copy is downloaded.
 
@@ -82,7 +100,9 @@ If you run into the following error while optimizing models, it is likely that y
 OSError: Can't load tokenizer for 'C:\Users\<username>\.cache\huggingface\hub\models--stabilityai--stable-diffusion-xl-base-1.0\snapshots\<sha>'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'C:\Users\<username>\.cache\huggingface\hub\models--stabilityai--stable-diffusion-xl-base-1.0\snapshots\<sha>' is the correct path to a directory containing all relevant files for a CLIPTokenizer tokenizer.
 ```
 
-# Stable Diffusion Pipeline
+If you want to use `stabilityai/stable-diffusion-xl-base-1.0` for image-to-image pipeline, set `"float16": false` in `config_vae_encoder.json`. Otherwise, the output image will be black.
+
+## Stable Diffusion Pipeline
 
 The figure below is a high-level overview of the Stable Diffusion pipeline, and is based on a figure from [Hugging Face Blog](https://huggingface.co/blog/stable_diffusion) that covers Stable Diffusion with Diffusers library. The blue boxes are the converted & optimized ONNX models. The gray boxes remain implemented by diffusers library when using this example for inference; a custom pipeline may implement the full pipeline without leveraging Python or the diffusers library.
 

--- a/examples/directml/stable_diffusion_xl/config_text_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder.json
@@ -112,8 +112,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "clip",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": true
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
@@ -152,8 +152,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "clip",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": true
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion_xl/config_unet.json
+++ b/examples/directml/stable_diffusion_xl/config_unet.json
@@ -88,8 +88,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "unet",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": true
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion_xl/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_decoder.json
@@ -104,8 +104,21 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "vae",
+                "opt_level": 0,
+                "float16": false,
+                "use_gpu": true
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion_xl/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_encoder.json
@@ -82,8 +82,22 @@
                     "GroupNorm": [0, 1, 2]
                 }
             }
+        },
+        "optimize_cuda": {
+            "type": "OrtTransformersOptimization",
+            "disable_search": true,
+            "config": {
+                "model_type": "vae",
+                "opt_level": 0,
+                "float16": true,
+                "use_gpu": true,
+                "keep_io_types": true
+            }
         }
     },
+    "pass_flows": [
+        ["convert", "optimize"]
+    ],
     "engine": {
         "search_strategy": {
             "execution_order": "joint",

--- a/examples/directml/stable_diffusion_xl/requirements-common.txt
+++ b/examples/directml/stable_diffusion_xl/requirements-common.txt
@@ -1,0 +1,10 @@
+accelerate
+diffusers
+invisible-watermark
+onnx
+optimum
+pillow
+protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
+torch
+torchvision==0.14.1
+transformers

--- a/examples/directml/stable_diffusion_xl/requirements.txt
+++ b/examples/directml/stable_diffusion_xl/requirements.txt
@@ -1,11 +1,2 @@
-accelerate
-diffusers
-invisible-watermark
-onnx
+-r requirements-common.txt
 onnxruntime-directml>=1.16.2
-optimum
-pillow
-protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
-torch
-torchvision==0.14.1
-transformers

--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -6,11 +6,13 @@ import argparse
 import json
 import shutil
 import sys
+import tempfile
 import threading
 import tkinter as tk
 import tkinter.ttk as ttk
 import warnings
 from pathlib import Path
+from typing import Dict
 
 import config
 import onnxruntime as ort
@@ -183,6 +185,7 @@ def run_inference_gui(pipeline, prompt, num_images, batch_size, image_size, num_
 
 def run_inference(
     model_dir,
+    provider,
     prompt,
     num_images,
     batch_size,
@@ -215,17 +218,23 @@ def run_inference(
         sess_options.add_free_dimension_override_by_name("unet_time_ids_batch", batch_size * 2)
         sess_options.add_free_dimension_override_by_name("unet_time_ids_size", 6)
 
+    provider_map = {
+        "dml": "DmlExecutionProvider",
+        "cuda": "CUDAExecutionProvider",
+    }
+    assert provider in provider_map, f"Unsupported provider: {provider}"
+
     provider_options = {
         "device_id": device_id,
     }
 
     if base_images is None:
         pipeline = ORTStableDiffusionXLPipeline.from_pretrained(
-            model_dir, provider="DmlExecutionProvider", provider_options=provider_options, session_options=sess_options
+            model_dir, provider=provider_map[provider], provider_options=provider_options, session_options=sess_options
         )
     else:
         pipeline = ORTStableDiffusionXLImg2ImgPipeline.from_pretrained(
-            model_dir, provider="DmlExecutionProvider", provider_options=provider_options, session_options=sess_options
+            model_dir, provider=provider_map[provider], provider_options=provider_options, session_options=sess_options
         )
 
     if interactive:
@@ -234,9 +243,22 @@ def run_inference(
         run_inference_loop(pipeline, prompt, num_images, batch_size, image_size, num_inference_steps, base_images)
 
 
+def update_config_with_provider(config: Dict, provider: str):
+    if provider == "dml":
+        # DirectML EP is the default, so no need to update config.
+        return config
+    elif provider == "cuda":
+        config["pass_flows"] = [["convert", "optimize_cuda"]]
+        config["engine"]["execution_providers"] = ["CUDAExecutionProvider"]
+        return config
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
+
+
 def optimize(
     model_id: str,
     is_refiner_model: bool,
+    provider: str,
     unoptimized_model_dir: Path,
     optimized_model_dir: Path,
 ):
@@ -274,6 +296,7 @@ def optimize(
         olive_config = None
         with (script_dir / f"config_{submodel_name}.json").open() as fin:
             olive_config = json.load(fin)
+        olive_config = update_config_with_provider(olive_config, provider)
 
         # TODO(PatriceVignola): Remove this once we figure out which nodes are causing the black screen
         if is_refiner_model and submodel_name == "vae_encoder":
@@ -283,7 +306,7 @@ def optimize(
         olive_run(olive_config)
 
         footprints_file_path = (
-            Path(__file__).resolve().parent / "footprints" / f"{submodel_name}_gpu-dml_footprints.json"
+            Path(__file__).resolve().parent / "footprints" / f"{submodel_name}_gpu-{provider}_footprints.json"
         )
         with footprints_file_path.open("r") as footprint_file:
             footprints = json.load(footprint_file)
@@ -390,6 +413,9 @@ def optimize(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_id", default="stabilityai/stable-diffusion-xl-base-1.0", type=str)
+    parser.add_argument(
+        "--provider", default="dml", type=str, choices=["dml", "cuda"], help="Execution provider to use"
+    )
     parser.add_argument("--base_images", default=None, nargs="+")
     parser.add_argument("--interactive", action="store_true", help="Run with a GUI")
     parser.add_argument("--optimize", action="store_true", help="Runs the optimization step")
@@ -414,6 +440,7 @@ if __name__ == "__main__":
         help="DEPRECATED (now enabled by default). Use --dynamic_dims to disable static_dims.",
     )
     parser.add_argument("--dynamic_dims", action="store_true", help="Disable static shape optimization")
+    parser.add_argument("--tempdir", default=None, type=str, help="Root directory for tempfile directories and files")
     args = parser.parse_args()
 
     if args.static_dims:
@@ -443,8 +470,11 @@ if __name__ == "__main__":
             "expected."
         )
 
-    if version.parse(ort.__version__) < version.parse("1.15.0"):
-        print("This script requires onnxruntime-directml 1.15.0 or newer")
+    if args.provider == "dml" and version.parse(ort.__version__) < version.parse("1.16.2"):
+        print("This script requires onnxruntime-directml 1.16.2 or newer")
+        sys.exit(1)
+    elif args.provider == "cuda" and version.parse(ort.__version__) < version.parse("1.17.0"):
+        print("This script requires onnxruntime-gpu 1.17.0 or newer")
         sys.exit(1)
 
     script_dir = Path(__file__).resolve().parent
@@ -454,7 +484,8 @@ if __name__ == "__main__":
 
     # Optimize the models
     unoptimized_model_dir = script_dir / "models" / "unoptimized" / args.model_id
-    optimized_model_dir = script_dir / "models" / "optimized" / args.model_id
+    optimized_dir_name = "optimized" if args.provider == "directml" else "optimized-cuda"
+    optimized_model_dir = script_dir / "models" / optimized_dir_name / args.model_id
 
     model_config = model_to_config.get(args.model_id, {})
     config.image_size = model_config.get("image_size", 1024)
@@ -471,16 +502,19 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if args.optimize or not optimized_model_dir.exists():
+        if args.tempdir is not None:
+            # set tempdir if specified
+            tempdir = Path(args.tempdir).resolve()
+            tempdir.mkdir(parents=True, exist_ok=True)
+            tempfile.tempdir = str(tempdir)
+
         # TODO(PatriceVignola): clean up warning filter (mostly during conversion from torch to ONNX)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            optimize(args.model_id, is_refiner_model, unoptimized_model_dir, optimized_model_dir)
+            optimize(args.model_id, is_refiner_model, args.provider, unoptimized_model_dir, optimized_model_dir)
 
     # Run inference on the models
     if not args.optimize:
-        unoptimized_model_dir = script_dir / "models" / "unoptimized" / args.model_id
-        optimized_model_dir = script_dir / "models" / "optimized" / args.model_id
-
         model_dir = unoptimized_model_dir if args.test_unoptimized else optimized_model_dir
         use_static_dims = not args.dynamic_dims
 
@@ -488,6 +522,7 @@ if __name__ == "__main__":
             warnings.simplefilter("ignore")
             run_inference(
                 model_dir,
+                args.provider,
                 args.prompt,
                 args.num_images,
                 args.batch_size,


### PR DESCRIPTION
## Describe your changes
This PR adds `--provider` option to the stable diffusion example so that the user can optimize the model for cuda ep instead if desired. 
The directml ep and settings are still the default so the interface and outputs does not change at all for it. 

In a follow-up PR, I will add an example test for the cuda ep if the memory and time requirements for the stable diffusion (not xl) example fits on our gpu pool. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
Stable Diffusion and Stable Diffusion XL models can now be optimized for CUDA EP using `--provider cuda` option.
## (Optional) Issue link
