### PR TITLE
Handle `shutil.Error` from `shutil.copytree`

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import subprocess
 import time
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -255,3 +256,52 @@ def aml_runner_hf_login():
         secret_client = SecretClient(vault_url=f"https://{keyvault_name}.vault.azure.net/", credential=credential)
         token = secret_client.get_secret("hf-token").value
         huggingface_login(token)
+
+
+def all_files(path, ignore=None):
+    """Find all files in a directory recursively, optionally ignoring some paths.
+
+    :param path: The path to the directory to search. Can be a string or a `Path` object.
+    :param ignore: A callable similar to `ignore` parameter of `shutil.copytree`.
+        E.g. `shutil.ignore_patterns('__pycache__')`.
+    :return: A generator of `Path` objects.
+    """
+    for member in Path(path).iterdir():
+        ignored = ignore(path, [member.name]) if ignore else set()
+        if member.name in ignored:
+            continue
+        if member.is_dir():
+            yield from all_files(member, ignore)
+        else:
+            yield member
+
+
+def copy_dir(src_dir, dst_dir, ignore=None, **kwargs):
+    """Copy a directory recursively using `shutil.copytree`.
+
+    Handles shutil.Error exceptions that happen even though all files were copied successfully.
+
+    :param src_dir: The source directory. Can be a string or a `Path` object.
+    :param dst_dir: The destination directory. Can be a string or a `Path` object.
+    :param ignore: A callable that is used as `ignore` parameter to `shutil.copytree`.
+    :param kwargs: Additional kwargs to pass to `shutil.copytree`.
+    """
+    try:
+        shutil.copytree(src_dir, dst_dir, ignore=ignore, **kwargs)
+    except shutil.Error as e:
+        src_dir = Path(src_dir).resolve()
+        dst_dir = Path(dst_dir).resolve()
+        # Check if all files were copied successfully
+        # only check files names so it is not foolproof
+        not_copied = [
+            member.relative_to(src_dir)
+            for member in all_files(src_dir, ignore)
+            if not (dst_dir / member.relative_to(src_dir)).exists()
+        ]
+        if not_copied:
+            raise RuntimeError(f"Failed to copy {not_copied}") from e
+        else:
+            logger.warning(
+                f"Received shutil.Error '{e}' but all required file names exist in destination directory. "
+                "Assuming all files were copied successfully and continuing."
+            )

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Dict, List
 
 import pkg_resources
 
-from olive.common.utils import get_package_name_from_ep, run_subprocess
+from olive.common.utils import copy_dir, get_package_name_from_ep, run_subprocess
 from olive.engine.packaging.packaging_config import PackagingConfig, PackagingType
 from olive.model import ONNXModel
 from olive.resource_path import ResourceType, create_resource_path
@@ -68,7 +68,7 @@ def _generate_zipfile_output(
 
 
 def _package_sample_code(cur_path, tempdir):
-    shutil.copytree(cur_path / "sample_code", tempdir / "SampleCode")
+    copy_dir(cur_path / "sample_code", tempdir / "SampleCode")
 
 
 def _package_candidate_models(

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------
 import logging
 import os
-import shutil
 import tempfile
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -21,6 +20,7 @@ import olive.data.template as data_config_template
 from olive.common.config_utils import ConfigBase, serialize_to_json, validate_config
 from olive.common.ort_inference import get_ort_inference_session
 from olive.common.user_module_loader import UserModuleLoader
+from olive.common.utils import copy_dir
 from olive.constants import Framework, ModelFileFormat
 from olive.hardware import AcceleratorLookup, Device
 from olive.model.hf_utils import HFConfig, huggingface_model_loader
@@ -594,9 +594,9 @@ class PyTorchModel(OliveModel):
     def load_mlflow_model(self):
         logger.info(f"Loading MLFlow model from {self.model_path}")
         with tempfile.TemporaryDirectory(prefix="mlflow_tmp") as tmp_dir:
-            shutil.copytree(os.path.join(self.model_path, "data/model"), tmp_dir, dirs_exist_ok=True)
-            shutil.copytree(os.path.join(self.model_path, "data/config"), tmp_dir, dirs_exist_ok=True)
-            shutil.copytree(os.path.join(self.model_path, "data/tokenizer"), tmp_dir, dirs_exist_ok=True)
+            copy_dir(os.path.join(self.model_path, "data/model"), tmp_dir, dirs_exist_ok=True)
+            copy_dir(os.path.join(self.model_path, "data/config"), tmp_dir, dirs_exist_ok=True)
+            copy_dir(os.path.join(self.model_path, "data/tokenizer"), tmp_dir, dirs_exist_ok=True)
 
             with open(os.path.join(self.model_path, "MLmodel")) as fp:  # noqa: PTH123
                 mlflow_data = yaml.safe_load(fp)

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -16,7 +16,7 @@ from pydantic import Field, validator
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.common.auto_config import AutoConfigClass
 from olive.common.config_utils import ConfigBase, ConfigParam, serialize_to_json, validate_config
-from olive.common.utils import retry_func
+from olive.common.utils import copy_dir, retry_func
 
 logger = logging.getLogger(__name__)
 
@@ -220,7 +220,7 @@ class LocalResourcePath(ResourcePath):
         if is_file:
             shutil.copy(self.config.path, new_path)
         else:
-            shutil.copytree(self.config.path, new_path)
+            copy_dir(self.config.path, new_path)
 
         return str(new_path)
 

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -12,7 +12,7 @@ from onnxruntime import __version__ as ort_version
 from packaging import version
 
 from olive.common.config_utils import ParamCategory, validate_config
-from olive.common.utils import aml_runner_hf_login
+from olive.common.utils import aml_runner_hf_login, copy_dir
 from olive.data.config import DataConfig
 from olive.hardware import AcceleratorSpec
 from olive.model import ModelConfig
@@ -113,7 +113,7 @@ def main(raw_args=None):
                 shutil.copy(old_path, new_path)
             else:
                 new_path.mkdir(parents=True, exist_ok=True)
-                shutil.copytree(old_path, new_path, dirs_exist_ok=True)
+                copy_dir(old_path, new_path, dirs_exist_ok=True)
             input_model_config["config"]["model_path"] = str(new_path)
 
     # pass specific args

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -19,7 +19,7 @@ from azure.core.exceptions import HttpResponseError, ServiceResponseError
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.cache import normalize_data_path
 from olive.common.config_utils import ParamCategory, validate_config
-from olive.common.utils import retry_func
+from olive.common.utils import copy_dir, retry_func
 from olive.data.config import DataConfig
 from olive.evaluator.metric import Metric, MetricResult
 from olive.model import ModelConfig
@@ -345,7 +345,7 @@ class AzureMLSystem(OliveSystem):
                 "It will overwrite the Olive package in AML computer with latest code."
             )
             project_folder = cur_dir.parent.parent
-            shutil.copytree(project_folder, code_root / "olive", ignore=shutil.ignore_patterns("__pycache__"))
+            copy_dir(project_folder, code_root / "olive", ignore=shutil.ignore_patterns("__pycache__"))
 
         accelerator_info = {
             "pass_accelerator_type": pass_config["accelerator"]["accelerator_type"],
@@ -636,7 +636,7 @@ class AzureMLSystem(OliveSystem):
                 "It will overwrite the Olive package in AML computer with latest code."
             )
             project_folder = cur_dir.parent.parent
-            shutil.copytree(project_folder, code_root / "olive", ignore=shutil.ignore_patterns("__pycache__"))
+            copy_dir(project_folder, code_root / "olive", ignore=shutil.ignore_patterns("__pycache__"))
 
         # prepare inputs
         inputs = {

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List
 
 from olive.cache import get_local_path_from_root
+from olive.common.utils import copy_dir
 
 if TYPE_CHECKING:
     from olive.evaluator.metric import Metric
@@ -121,7 +122,7 @@ def create_dev_mount(tempdir: Path, container_root_path: Path):
 
     # copy the whole project folder to tempdir
     project_folder = Path(__file__).resolve().parent.parent.parent
-    shutil.copytree(project_folder, tempdir / "olive", ignore=shutil.ignore_patterns("__pycache__"))
+    copy_dir(project_folder, tempdir / "olive", ignore=shutil.ignore_patterns("__pycache__"))
 
     project_folder_mount_path = str(container_root_path / "olive")
     project_folder_mount_str = f"{tempdir / 'olive'}:{project_folder_mount_path}"

--- a/test/unit_test/common/test_copy_dir.py
+++ b/test/unit_test/common/test_copy_dir.py
@@ -1,0 +1,103 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from olive.common.utils import all_files, copy_dir
+
+
+@pytest.fixture(name="create_dir")
+def create_dir_fixture(tmp_path):
+    src_dir = tmp_path / "src_dir"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    sub_dirs = ["sub_dir1"]
+    files = ["file1.ext1", "file2.ext2", "sub_dir1/file3.ext1", "sub_dir1/file4.ext2"]
+    for sub_dir in sub_dirs:
+        (src_dir / sub_dir).mkdir(parents=True, exist_ok=True)
+    for file in files:
+        (src_dir / file).touch()
+    return src_dir
+
+
+@pytest.mark.parametrize(
+    "ignore,expected_files",
+    [
+        (None, ["file1.ext1", "file2.ext2", "sub_dir1/file3.ext1", "sub_dir1/file4.ext2"]),
+        (shutil.ignore_patterns("*.ext1"), ["file2.ext2", "sub_dir1/file4.ext2"]),
+        (shutil.ignore_patterns("*.ext2"), ["file1.ext1", "sub_dir1/file3.ext1"]),
+        (shutil.ignore_patterns("*.ext*"), []),
+        (shutil.ignore_patterns("*.ext1", "*.ext2"), []),
+        (shutil.ignore_patterns("sub_dir1"), ["file1.ext1", "file2.ext2"]),
+        (shutil.ignore_patterns("sub_dir1", "*.ext1"), ["file2.ext2"]),
+        (shutil.ignore_patterns("sub_dir1", "*.ext2"), ["file1.ext1"]),
+        (shutil.ignore_patterns("sub_dir1", "*.ext*"), []),
+    ],
+)
+def test_all_files(create_dir, ignore, expected_files):
+    actual_files = {file.relative_to(create_dir) for file in all_files(create_dir, ignore=ignore)}
+    expected_files = {Path(file) for file in expected_files}
+    assert actual_files == expected_files
+
+
+def test_copy_dir(create_dir, tmp_path):
+    # setup
+    src_path = create_dir
+    dest_path = tmp_path / "dest_dir"
+
+    # test
+    copy_dir(src_path, dest_path)
+
+    # assert
+    for file in src_path.glob("**/*"):
+        assert (dest_path / file.relative_to(src_path)).exists()
+
+
+def test_copy_dir_raise_file_exists_error(create_dir, tmp_path):
+    # setup
+    src_path = create_dir
+    dest_path = tmp_path / "dest_dir"
+    dest_path.mkdir(parents=True, exist_ok=True)
+    (dest_path / "file1.ext1").touch()
+
+    # test
+    with pytest.raises(FileExistsError):
+        copy_dir(src_path, dest_path)
+
+
+@patch("shutil.copytree", side_effect=shutil.Error("Test Error"))
+def test_copy_dir_raise_from_shutil_error(_, create_dir, tmp_path):
+    # setup
+    src_path = create_dir
+    dest_path = tmp_path / "dest_dir"
+
+    # test
+    with pytest.raises(RuntimeError, match="Failed to copy *"):
+        copy_dir(src_path, dest_path)
+
+
+@patch("shutil.copytree", side_effect=shutil.Error("Test Error"))
+def test_copy_dir_ignore_shutil_error(_, tmp_path, caplog):
+    # setup
+    src_path = tmp_path / "src_dir"
+    src_path.mkdir(parents=True, exist_ok=True)
+    (src_path / "file1.ext1").touch()
+
+    dest_path = tmp_path / "dest_dir"
+    dest_path.mkdir(parents=True, exist_ok=True)
+    shutil.copy(src_path / "file1.ext1", dest_path / "file1.ext1")
+
+    # capture log
+    logger = logging.getLogger("olive")
+    logger.propagate = True
+
+    # test
+    copy_dir(src_path, dest_path, ignore_errors=True)
+
+    # assert
+    assert "Assuming all files were copied successfully and continuing." in caplog.text


### PR DESCRIPTION
## Describe your changes
As described in https://github.com/microsoft/Olive/issues/777, `shutil.copytree` fails with `shutil.Error` even though all files are copied. 
https://bugs.python.org/issue36823

This PR adds a new utils function `copy_dir` that wraps `shutil.copytree` to handle the above case. As a heuristic, we check that all required file names exist in the destination directory in the event of an error. 
 
## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
