### PR TITLE
🦺 Simplify perf tuning logging output

### DIFF
--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -309,7 +309,7 @@ def get_benchmark(model, data_root, latency_metric, config, test_params=None, io
         test_result["session_options"] = test_params.get("session_options").copy()
         test_result["io_bind"] = io_bind
 
-    logger.info(f"Run benchmark for: {session_name}")
+    logger.debug(f"Run benchmark for: {session_name}")
     evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
     joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
     start_time = time.perf_counter()
@@ -317,7 +317,7 @@ def get_benchmark(model, data_root, latency_metric, config, test_params=None, io
         model, data_root, [latency_metric], config.device, config.providers_list
     )[joint_key].value
     end_time = time.perf_counter()
-    logger.info(f"It takes {end_time - start_time} seconds to benchmark for: {session_name}")
+    logger.debug(f"It takes {(end_time - start_time):.5f} seconds to benchmark for: {session_name}")
 
     return test_result
 


### PR DESCRIPTION
## Describe your changes
 Simplify perf tuning logging output

Before:
![image](https://github.com/microsoft/Olive/assets/13343117/287dd346-2c42-4dd2-ae99-11c1278e3cd9)

After:
![image](https://github.com/microsoft/Olive/assets/13343117/2a44d3ad-3648-4632-aaf5-0cd4e4d9828c)


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
