### PR TITLE
Rename HFModelLoadingArgs to HFFromPretrainedArgs

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -144,6 +144,8 @@ find more details in [Olive Models](https://microsoft.github.io/Olive/api/models
             ```
             For cases where you do not want to use the huggingface model but want to use the huggingface dataset, you can provide `dataset` config only like above.
 
+        - `hf_from_pretrained_args: [dict]`: Arguments to pass to the `from_pretrained` method of the model class. Refer to [this documentation](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained).
+
 Please find the detailed config options from following table for each model type:
 
 | Model Type | Description |

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -144,7 +144,7 @@ find more details in [Olive Models](https://microsoft.github.io/Olive/api/models
             ```
             For cases where you do not want to use the huggingface model but want to use the huggingface dataset, you can provide `dataset` config only like above.
 
-        - `hf_from_pretrained_args: [dict]`: Arguments to pass to the `from_pretrained` method of the model class. Refer to [this documentation](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained).
+        - `from_pretrained_args: [dict]`: Arguments to pass to the `from_pretrained` method of the model class. Refer to [this documentation](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained).
 
 Please find the detailed config options from following table for each model type:
 

--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -5,7 +5,7 @@
             "hf_config": {
                 "model_name": "microsoft/phi-1_5",
                 "task": "text-generation",
-                "model_loading_args": {
+                "hf_from_pretrained_args": {
                     "trust_remote_code": true
                 }
             }

--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -5,7 +5,7 @@
             "hf_config": {
                 "model_name": "microsoft/phi-1_5",
                 "task": "text-generation",
-                "hf_from_pretrained_args": {
+                "from_pretrained_args": {
                     "trust_remote_code": true
                 }
             }

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -209,7 +209,7 @@ class HFConfig(ConfigBase):
     model_class: str = None
     components: List[HFComponent] = None
     dataset: Dict[str, Any] = None
-    hf_from_pretrained_args: HFFromPretrainedArgs = None
+    from_pretrained_args: HFFromPretrainedArgs = None
 
     @validator("model_class", always=True)
     def task_or_model_class_required(cls, v, values):
@@ -219,7 +219,7 @@ class HFConfig(ConfigBase):
         return v
 
     def _get_loading_args(self):
-        return self.hf_from_pretrained_args.get_loading_args() if self.hf_from_pretrained_args else {}
+        return self.from_pretrained_args.get_loading_args() if self.from_pretrained_args else {}
 
     def load_model(self, model_path: str = None):
         """Load model from model_path or model_name."""

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -28,10 +28,10 @@ class HFComponent(ConfigBase):
     dummy_inputs_func: Union[str, Callable]
 
 
-class HFModelLoadingArgs(ConfigWithExtraArgs):
+class HFFromPretrainedArgs(ConfigWithExtraArgs):
     """Arguments to pass to the `from_pretrained` method of the model class.
 
-    Refer to https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L2074
+    Refer to https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained
     """
 
     torch_dtype: str = Field(
@@ -209,7 +209,7 @@ class HFConfig(ConfigBase):
     model_class: str = None
     components: List[HFComponent] = None
     dataset: Dict[str, Any] = None
-    model_loading_args: HFModelLoadingArgs = None
+    hf_from_pretrained_args: HFFromPretrainedArgs = None
 
     @validator("model_class", always=True)
     def task_or_model_class_required(cls, v, values):
@@ -219,7 +219,7 @@ class HFConfig(ConfigBase):
         return v
 
     def _get_loading_args(self):
-        return self.model_loading_args.get_loading_args() if self.model_loading_args else {}
+        return self.hf_from_pretrained_args.get_loading_args() if self.hf_from_pretrained_args else {}
 
     def load_model(self, model_path: str = None):
         """Load model from model_path or model_name."""

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -262,7 +262,7 @@ class OnnxConversion(Pass):
         1. model is not loaded from hf config, or the model loading args is not specified
             - load the model directly
         2. model is loaded from hf config, and the model loading args is specified
-            - update hf_from_pretrained_args.torch_dtype if torch_dtype is specified
+            - update from_pretrained_args.torch_dtype if torch_dtype is specified
             - if torch_dtype not specified, make sure the model loading args specify a dtype that is supported for
                 conversion on the specified device
             - if quantization_method == "bitsandbytes" and load_in_4bit is True
@@ -271,22 +271,22 @@ class OnnxConversion(Pass):
                 - the onnx model must be quantized using OnnxBnb4Quantization pass after conversion
         Model attributes is None if the output model should inherit the model attributes from the input model.
         """
-        if not model.is_model_loaded_from_hf_config() or not model.hf_config.hf_from_pretrained_args:
+        if not model.is_model_loaded_from_hf_config() or not model.hf_config.from_pretrained_args:
             # if the model is not loaded from hf config, or the model loading args is not specified,
             # we can load the model directly
             return model.load_model(), None
 
-        hf_from_pretrained_args = model.hf_config.hf_from_pretrained_args
-        model_dtype = hf_from_pretrained_args.get_torch_dtype()
-        new_hf_from_pretrained_args = deepcopy(hf_from_pretrained_args.dict())
+        from_pretrained_args = model.hf_config.from_pretrained_args
+        model_dtype = from_pretrained_args.get_torch_dtype()
+        new_from_pretrained_args = deepcopy(from_pretrained_args.dict())
         new_model_attributes = model.model_attributes or {}
         if torch_dtype and torch_dtype != model_dtype:
             # if the model loading args specify a different dtype, update the model loading args
             logger.debug(
-                f"Changing torch_dtype in model loading args from {hf_from_pretrained_args.get_torch_dtype()} to"
+                f"Changing torch_dtype in model loading args from {from_pretrained_args.get_torch_dtype()} to"
                 f" {torch_dtype}."
             )
-            new_hf_from_pretrained_args["torch_dtype"] = torch_dtype
+            new_from_pretrained_args["torch_dtype"] = torch_dtype
             new_model_attributes["torch_dtype"] = str(torch_dtype).replace("torch.", "")
         elif model_dtype == torch.float16 and device == "cpu":
             logger.warning(
@@ -295,20 +295,20 @@ class OnnxConversion(Pass):
                 " use_device as 'cuda' or use OrtTransformerOptimization/OnnxFloatToFloat16 pass after conversion to"
                 " convert the model to float16."
             )
-            new_hf_from_pretrained_args["torch_dtype"] = torch.float32
+            new_from_pretrained_args["torch_dtype"] = torch.float32
             new_model_attributes["torch_dtype"] = "float32"
 
         if (
-            hf_from_pretrained_args.quantization_method == "bitsandbytes"
-            and hf_from_pretrained_args.quantization_config["load_in_4bit"]
+            from_pretrained_args.quantization_method == "bitsandbytes"
+            and from_pretrained_args.quantization_config["load_in_4bit"]
         ):
             logger.warning(
                 "Bitsandbytes 4bit quantization is not supported for conversion. The quantization config is removed"
                 " from the model loading args. Use OnnxBnb4Quantization pass after conversion to quantize the model."
             )
-            new_hf_from_pretrained_args["quantization_method"] = None
-            new_hf_from_pretrained_args["quantization_config"] = None
-            new_model_attributes["quantization_config"] = hf_from_pretrained_args.quantization_config
+            new_from_pretrained_args["quantization_method"] = None
+            new_from_pretrained_args["quantization_config"] = None
+            new_model_attributes["quantization_config"] = from_pretrained_args.quantization_config
             if "quantized_modules" not in new_model_attributes:
                 # find and add quantized modules to the model attributes
                 # the QLoRA pass already adds quantized_modules to the model attributes, so this will not be executed
@@ -324,7 +324,7 @@ class OnnxConversion(Pass):
 
         # load the model with the updated model loading args
         new_hf_config = deepcopy(model.hf_config)
-        new_hf_config.hf_from_pretrained_args = HFFromPretrainedArgs(**new_hf_from_pretrained_args)
+        new_hf_config.from_pretrained_args = HFFromPretrainedArgs(**new_from_pretrained_args)
         return new_hf_config.load_model(model.model_path), new_model_attributes
 
     def _convert_model_on_device(

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -28,7 +28,7 @@ from olive.data.config import DataConfig
 from olive.data.constants import IGNORE_INDEX
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import PyTorchModel
-from olive.model.hf_utils import HFModelLoadingArgs, get_peft_task_type_from_task
+from olive.model.hf_utils import HFFromPretrainedArgs, get_peft_task_type_from_task
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
 
@@ -513,7 +513,7 @@ class LoRABase(Pass):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
         # remove the device map since we don't want "auto" device map
-        output_model.hf_config.model_loading_args.device_map = None
+        output_model.hf_config.hf_from_pretrained_args.device_map = None
         # remove model_overwrites from model_attributes
         if output_model.model_attributes:
             for k in self.model_overwrites:
@@ -559,19 +559,19 @@ class LoRABase(Pass):
 
     @classmethod
     def input_model_check(cls, model):
-        """Validate the input model and reset model_loading_args and adapter_path."""
+        """Validate the input model and reset hf_from_pretrained_args and adapter_path."""
         if not model.hf_config:
             raise ValueError(f"{cls.__name__} pass only supports PyTorchModel with hf_config.")
 
-        # load model, reset model_loading_args and adapter_path
-        model_loading_args = {}
-        if model.hf_config.model_loading_args:
-            model_loading_args = model.hf_config.model_loading_args.dict()
+        # load model, reset hf_from_pretrained_args and adapter_path
+        hf_from_pretrained_args = {}
+        if model.hf_config.hf_from_pretrained_args:
+            hf_from_pretrained_args = model.hf_config.hf_from_pretrained_args.dict()
             for k in cls.model_overwrites:
-                if model_loading_args.get(k) is not None:
+                if hf_from_pretrained_args.get(k) is not None:
                     logger.warning(
-                        f"Input model has model_loading_args.{k}. Ignoring. {cls.__name__} will overwrite it based on"
-                        " the pass config."
+                        f"Input model has hf_from_pretrained_args.{k}. Ignoring. "
+                        f"{cls.__name__} will overwrite it based on the pass config."
                     )
 
         if model.get_resource("adapter_path"):
@@ -631,14 +631,14 @@ class LoRA(LoRABase):
         # will use mixed precision since full fp16 is unstable
         model_dtype = torch_dtype if torch_dtype != torch.float16 else torch.float32
 
-        # load model, reset model_loading_args and adapter_path
-        model_loading_args = (
-            new_model.hf_config.model_loading_args.dict() if new_model.hf_config.model_loading_args else {}
+        # load model, reset hf_from_pretrained_args and adapter_path
+        hf_from_pretrained_args = (
+            new_model.hf_config.hf_from_pretrained_args.dict() if new_model.hf_config.hf_from_pretrained_args else {}
         )
-        model_loading_args.update(
+        hf_from_pretrained_args.update(
             {"torch_dtype": model_dtype, "device_map": "auto" if not config.use_ort_trainer else None}
         )
-        new_model.hf_config.model_loading_args = HFModelLoadingArgs(**model_loading_args)
+        new_model.hf_config.hf_from_pretrained_args = HFFromPretrainedArgs(**hf_from_pretrained_args)
         pytorch_model = new_model.load_model()
         if torch.cuda.is_available() and config.use_ort_trainer:
             # put the model on GPU since device_map is None and the model will be on CPU
@@ -648,7 +648,7 @@ class LoRA(LoRABase):
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             new_model.hf_config.model_name,
-            trust_remote_code=new_model.hf_config.model_loading_args.trust_remote_code,
+            trust_remote_code=new_model.hf_config.hf_from_pretrained_args.trust_remote_code,
         )
 
         # add lora modules
@@ -746,11 +746,11 @@ class QLoRA(LoRABase):
         # will use mixed precision since full fp16 is unstable
         model_dtype = torch_dtype if torch_dtype != torch.float16 else torch.float32
 
-        # load model, reset model_loading_args and adapter_path
-        model_loading_args = (
-            new_model.hf_config.model_loading_args.dict() if new_model.hf_config.model_loading_args else {}
+        # load model, reset hf_from_pretrained_args and adapter_path
+        hf_from_pretrained_args = (
+            new_model.hf_config.hf_from_pretrained_args.dict() if new_model.hf_config.hf_from_pretrained_args else {}
         )
-        model_loading_args.update(
+        hf_from_pretrained_args.update(
             {
                 "torch_dtype": model_dtype,
                 # TODO(jambayk): Worry about `use_multi_gpu` and distributed training later
@@ -767,14 +767,14 @@ class QLoRA(LoRABase):
                 },
             }
         )
-        new_model.hf_config.model_loading_args = HFModelLoadingArgs(**model_loading_args)
+        new_model.hf_config.hf_from_pretrained_args = HFFromPretrainedArgs(**hf_from_pretrained_args)
         pytorch_model = new_model.load_model()
         pytorch_model.config.torch_dtype = model_dtype
 
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             new_model.hf_config.model_name,
-            trust_remote_code=new_model.hf_config.model_loading_args.trust_remote_code,
+            trust_remote_code=new_model.hf_config.hf_from_pretrained_args.trust_remote_code,
         )
 
         # TODO(jambayk): need to see if we still need this line

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -513,7 +513,7 @@ class LoRABase(Pass):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
         # remove the device map since we don't want "auto" device map
-        output_model.hf_config.hf_from_pretrained_args.device_map = None
+        output_model.hf_config.from_pretrained_args.device_map = None
         # remove model_overwrites from model_attributes
         if output_model.model_attributes:
             for k in self.model_overwrites:
@@ -559,19 +559,19 @@ class LoRABase(Pass):
 
     @classmethod
     def input_model_check(cls, model):
-        """Validate the input model and reset hf_from_pretrained_args and adapter_path."""
+        """Validate the input model and reset from_pretrained_args and adapter_path."""
         if not model.hf_config:
             raise ValueError(f"{cls.__name__} pass only supports PyTorchModel with hf_config.")
 
-        # load model, reset hf_from_pretrained_args and adapter_path
-        hf_from_pretrained_args = {}
-        if model.hf_config.hf_from_pretrained_args:
-            hf_from_pretrained_args = model.hf_config.hf_from_pretrained_args.dict()
+        # load model, reset from_pretrained_args and adapter_path
+        from_pretrained_args = {}
+        if model.hf_config.from_pretrained_args:
+            from_pretrained_args = model.hf_config.from_pretrained_args.dict()
             for k in cls.model_overwrites:
-                if hf_from_pretrained_args.get(k) is not None:
+                if from_pretrained_args.get(k) is not None:
                     logger.warning(
-                        f"Input model has hf_from_pretrained_args.{k}. Ignoring. "
-                        f"{cls.__name__} will overwrite it based on the pass config."
+                        f"Input model has from_pretrained_args.{k}. Ignoring. "
+                        f"{cls.__name__} will overwrite it based onthe pass config."
                     )
 
         if model.get_resource("adapter_path"):
@@ -631,14 +631,14 @@ class LoRA(LoRABase):
         # will use mixed precision since full fp16 is unstable
         model_dtype = torch_dtype if torch_dtype != torch.float16 else torch.float32
 
-        # load model, reset hf_from_pretrained_args and adapter_path
-        hf_from_pretrained_args = (
-            new_model.hf_config.hf_from_pretrained_args.dict() if new_model.hf_config.hf_from_pretrained_args else {}
+        # load model, reset from_pretrained_args and adapter_path
+        from_pretrained_args = (
+            new_model.hf_config.from_pretrained_args.dict() if new_model.hf_config.from_pretrained_args else {}
         )
-        hf_from_pretrained_args.update(
+        from_pretrained_args.update(
             {"torch_dtype": model_dtype, "device_map": "auto" if not config.use_ort_trainer else None}
         )
-        new_model.hf_config.hf_from_pretrained_args = HFFromPretrainedArgs(**hf_from_pretrained_args)
+        new_model.hf_config.from_pretrained_args = HFFromPretrainedArgs(**from_pretrained_args)
         pytorch_model = new_model.load_model()
         if torch.cuda.is_available() and config.use_ort_trainer:
             # put the model on GPU since device_map is None and the model will be on CPU
@@ -648,7 +648,7 @@ class LoRA(LoRABase):
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             new_model.hf_config.model_name,
-            trust_remote_code=new_model.hf_config.hf_from_pretrained_args.trust_remote_code,
+            trust_remote_code=new_model.hf_config.from_pretrained_args.trust_remote_code,
         )
 
         # add lora modules
@@ -746,11 +746,11 @@ class QLoRA(LoRABase):
         # will use mixed precision since full fp16 is unstable
         model_dtype = torch_dtype if torch_dtype != torch.float16 else torch.float32
 
-        # load model, reset hf_from_pretrained_args and adapter_path
-        hf_from_pretrained_args = (
-            new_model.hf_config.hf_from_pretrained_args.dict() if new_model.hf_config.hf_from_pretrained_args else {}
+        # load model, reset from_pretrained_args and adapter_path
+        from_pretrained_args = (
+            new_model.hf_config.from_pretrained_args.dict() if new_model.hf_config.from_pretrained_args else {}
         )
-        hf_from_pretrained_args.update(
+        from_pretrained_args.update(
             {
                 "torch_dtype": model_dtype,
                 # TODO(jambayk): Worry about `use_multi_gpu` and distributed training later
@@ -767,14 +767,14 @@ class QLoRA(LoRABase):
                 },
             }
         )
-        new_model.hf_config.hf_from_pretrained_args = HFFromPretrainedArgs(**hf_from_pretrained_args)
+        new_model.hf_config.from_pretrained_args = HFFromPretrainedArgs(**from_pretrained_args)
         pytorch_model = new_model.load_model()
         pytorch_model.config.torch_dtype = model_dtype
 
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
             new_model.hf_config.model_name,
-            trust_remote_code=new_model.hf_config.hf_from_pretrained_args.trust_remote_code,
+            trust_remote_code=new_model.hf_config.from_pretrained_args.trust_remote_code,
         )
 
         # TODO(jambayk): need to see if we still need this line

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -571,7 +571,7 @@ class LoRABase(Pass):
                 if from_pretrained_args.get(k) is not None:
                     logger.warning(
                         f"Input model has from_pretrained_args.{k}. Ignoring. "
-                        f"{cls.__name__} will overwrite it based onthe pass config."
+                        f"{cls.__name__} will overwrite it based on the pass config."
                     )
 
         if model.get_resource("adapter_path"):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -112,12 +112,12 @@ class RunConfig(ConfigBase):
                 "task": hf_config.get("task", None),
                 **hf_config_dataset,
             }
-            # insert trust_remote_code from hf_from_pretrained_args if present
+            # insert trust_remote_code from from_pretrained_args if present
             # won't override if value was set to False explicitly
             # will keep as list of keys for future extension
             for key in ["trust_remote_code"]:
-                if hf_config.get("hf_from_pretrained_args", {}).get(key, None) and params_config.get(key, None) is None:
-                    params_config[key] = hf_config["hf_from_pretrained_args"][key]
+                if hf_config.get("from_pretrained_args", {}).get(key, None) and params_config.get(key, None) is None:
+                    params_config[key] = hf_config["from_pretrained_args"][key]
             v[INPUT_MODEL_DATA_CONFIG] = {
                 "name": INPUT_MODEL_DATA_CONFIG,
                 "type": HuggingfaceContainer.__name__,
@@ -163,10 +163,10 @@ class RunConfig(ConfigBase):
             # won't override if value was set to False explicitly
             for key in ["trust_remote_code"]:
                 if (
-                    hf_config.get("hf_from_pretrained_args", {}).get(key, None)
+                    hf_config.get("from_pretrained_args", {}).get(key, None)
                     and v["params_config"].get(key, None) is None
                 ):
-                    v["params_config"][key] = hf_config["hf_from_pretrained_args"][key]
+                    v["params_config"][key] = hf_config["from_pretrained_args"][key]
 
         return validate_config(v, DataConfig)
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -112,12 +112,12 @@ class RunConfig(ConfigBase):
                 "task": hf_config.get("task", None),
                 **hf_config_dataset,
             }
-            # insert trust_remote_code from model_loading_args if present
+            # insert trust_remote_code from hf_from_pretrained_args if present
             # won't override if value was set to False explicitly
             # will keep as list of keys for future extension
             for key in ["trust_remote_code"]:
-                if hf_config.get("model_loading_args", {}).get(key, None) and params_config.get(key, None) is None:
-                    params_config[key] = hf_config["model_loading_args"][key]
+                if hf_config.get("hf_from_pretrained_args", {}).get(key, None) and params_config.get(key, None) is None:
+                    params_config[key] = hf_config["hf_from_pretrained_args"][key]
             v[INPUT_MODEL_DATA_CONFIG] = {
                 "name": INPUT_MODEL_DATA_CONFIG,
                 "type": HuggingfaceContainer.__name__,
@@ -162,8 +162,11 @@ class RunConfig(ConfigBase):
             # auto insert trust_remote_code from input model hf config
             # won't override if value was set to False explicitly
             for key in ["trust_remote_code"]:
-                if hf_config.get("model_loading_args", {}).get(key, None) and v["params_config"].get(key, None) is None:
-                    v["params_config"][key] = hf_config["model_loading_args"][key]
+                if (
+                    hf_config.get("hf_from_pretrained_args", {}).get(key, None)
+                    and v["params_config"].get(key, None) is None
+                ):
+                    v["params_config"][key] = hf_config["hf_from_pretrained_args"][key]
 
         return validate_config(v, DataConfig)
 

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 from transformers.onnx import OnnxConfig
 
 from olive.model.hf_utils import (
-    HFModelLoadingArgs,
+    HFFromPretrainedArgs,
     get_onnx_config,
     load_huggingface_model_from_model_class,
     load_huggingface_model_from_task,
@@ -46,7 +46,7 @@ def test_get_onnx_config(model_name, task, feature):
     assert isinstance(onnx_config, OnnxConfig)
 
 
-class TestHFModelLoadingArgs:
+class TestHFFromPretrainedArgs:
     @pytest.mark.parametrize(
         "inputs,inner,output",
         [
@@ -57,7 +57,7 @@ class TestHFModelLoadingArgs:
         ],
     )
     def test_torch_dtype(self, inputs, inner, output):
-        args = HFModelLoadingArgs(torch_dtype=inputs)
+        args = HFFromPretrainedArgs(torch_dtype=inputs)
         assert args.torch_dtype == inner
         assert args.get_torch_dtype() == output
 
@@ -72,10 +72,10 @@ class TestHFModelLoadingArgs:
         ],
     )
     def test_device_map(self, inputs, inner):
-        args = HFModelLoadingArgs(device_map=inputs)
+        args = HFFromPretrainedArgs(device_map=inputs)
         assert args.device_map == inner
 
-        args = HFModelLoadingArgs(device_map={"": inputs})
+        args = HFFromPretrainedArgs(device_map={"": inputs})
         assert args.device_map == {"": inner}
 
     @pytest.mark.parametrize(
@@ -91,12 +91,14 @@ class TestHFModelLoadingArgs:
     def test_quant(self, quantization_method, quantization_config, valid):
         if not valid:
             with pytest.raises(ValidationError):
-                args = HFModelLoadingArgs(
+                args = HFFromPretrainedArgs(
                     quantization_method=quantization_method, quantization_config=quantization_config
                 )
 
         else:
-            args = HFModelLoadingArgs(quantization_method=quantization_method, quantization_config=quantization_config)
+            args = HFFromPretrainedArgs(
+                quantization_method=quantization_method, quantization_config=quantization_config
+            )
             if quantization_method is None:
                 return
 
@@ -117,7 +119,7 @@ class TestHFModelLoadingArgs:
 
         quanntization_method = "bitsandbytes"
         quantization_config = {"load_in_8bit": True}
-        args = HFModelLoadingArgs(quantization_method=quanntization_method, quantization_config=quantization_config)
+        args = HFFromPretrainedArgs(quantization_method=quanntization_method, quantization_config=quantization_config)
         config = args.get_quantization_config()
 
         assert isinstance(config, BitsAndBytesConfig)

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -98,14 +98,14 @@ class TestPyTorchHFModel(unittest.TestCase):
         pytorch_model = olive_model.load_model()
         assert isinstance(pytorch_model, transformers.BertForSequenceClassification)
 
-    def test_hf_model_loading_args(self):
+    def test_hf_from_pretrained_args(self):
         self.setup()
 
         olive_model = PyTorchModel(
             hf_config={
                 "task": self.task,
                 "model_name": self.model_name,
-                "model_loading_args": {"torch_dtype": self.torch_dtype},
+                "hf_from_pretrained_args": {"torch_dtype": self.torch_dtype},
             }
         )
         pytorch_model = olive_model.load_model()

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -105,7 +105,7 @@ class TestPyTorchHFModel(unittest.TestCase):
             hf_config={
                 "task": self.task,
                 "model_name": self.model_name,
-                "hf_from_pretrained_args": {"torch_dtype": self.torch_dtype},
+                "from_pretrained_args": {"torch_dtype": self.torch_dtype},
             }
         )
         pytorch_model = olive_model.load_model()

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -88,7 +88,7 @@ def mock_bitsandbytes_fixture():
 # quantization requires gpu so we will patch the model loading args with no quantization
 @patch("olive.passes.pytorch.lora.HFFromPretrainedArgs")
 @patch("olive.passes.pytorch.lora.find_submodules", side_effect=patched_find_submodules)
-def test_qlora(patched_hf_from_pretrained_args, patched_find_submodules, tmp_path, mock_bitsandbytes):
+def test_qlora(patched_from_pretrained_args, patched_find_submodules, tmp_path, mock_bitsandbytes):
     # execute
     out = run_finetuning(QLoRA, tmp_path)
 

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -86,9 +86,9 @@ def mock_bitsandbytes_fixture():
 
 
 # quantization requires gpu so we will patch the model loading args with no quantization
-@patch("olive.passes.pytorch.lora.HFModelLoadingArgs")
+@patch("olive.passes.pytorch.lora.HFFromPretrainedArgs")
 @patch("olive.passes.pytorch.lora.find_submodules", side_effect=patched_find_submodules)
-def test_qlora(patched_model_loading_args, patched_find_submodules, tmp_path, mock_bitsandbytes):
+def test_qlora(patched_hf_from_pretrained_args, patched_find_submodules, tmp_path, mock_bitsandbytes):
     # execute
     out = run_finetuning(QLoRA, tmp_path)
 

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -208,7 +208,7 @@ class TestDataConfigValidation:
     ):
         config_dict = self.template.copy()
         if has_loading_args:
-            config_dict["input_model"]["config"]["hf_config"]["model_loading_args"] = {
+            config_dict["input_model"]["config"]["hf_config"]["hf_from_pretrained_args"] = {
                 "trust_remote_code": trust_remote_code
             }
         if data_config_trust_remote_code is not None:

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -208,7 +208,7 @@ class TestDataConfigValidation:
     ):
         config_dict = self.template.copy()
         if has_loading_args:
-            config_dict["input_model"]["config"]["hf_config"]["hf_from_pretrained_args"] = {
+            config_dict["input_model"]["config"]["hf_config"]["from_pretrained_args"] = {
                 "trust_remote_code": trust_remote_code
             }
         if data_config_trust_remote_code is not None:


### PR DESCRIPTION
## Describe your changes

Rename `HFModelLoadingArgs` to `HFFromPretrainedArgs`.

###
User interface change:
In model config, the `model_loading_args` should be `from_pretrained_args` instead:
```
"input_model":{
    "type": "PyTorchModel",
    "config": {
        "hf_config": {
            "model_name": "microsoft/phi-1_5",
            "task": "text-generation",
            "model_loading_args" -> "from_pretrained_args": {
                "trust_remote_code": true
            }
        }
    }
}
```


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
