### PR TITLE
Add `pydantic_v1` module to make Olive `pydantic` version agnostic

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 120
-per-file-ignores = __init__.py:F401
+per-file-ignores =
+    __init__.py:F401
+    pydantic_v1.py:F401

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+# we use v1 API so need autodoc_pydantic<2.0.0
+# will also install pydantic<2.0.0
 autodoc_pydantic<2.0.0
 azure-ai-ml>=0.1.0b6
 azure-identity

--- a/olive/azureml/azureml_client.py
+++ b/olive/azureml/azureml_client.py
@@ -7,9 +7,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pydantic import Field, validator
-
 from olive.common.config_utils import ConfigBase
+from olive.common.pydantic_v1 import Field, validator
 
 logger = logging.getLogger(__name__)
 

--- a/olive/common/auto_config.py
+++ b/olive/common/auto_config.py
@@ -33,7 +33,7 @@ class AutoConfigClass(ABC):
     Additional validators
     Sub-class developer can also add additional validators by implementing the static method _validators
     E.g.,
-        from pydantic import validator
+        from olive.common.pydantic_v1 import validator
 
         def validate_func_param(v, values):
             ...

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -11,8 +11,7 @@ from pathlib import Path
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
-from pydantic import BaseModel, Field, create_model, root_validator, validator
-
+from olive.common.pydantic_v1 import BaseModel, Field, create_model, root_validator, validator
 from olive.common.utils import hash_function, hash_object
 
 logger = logging.getLogger(__name__)

--- a/olive/common/pydantic_v1.py
+++ b/olive/common/pydantic_v1.py
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Pydantic v1 compatibility module.
+
+Pydantic v2 has breaking changes that are not compatible with the current version of Olive.
+Migration Guide: https://docs.pydantic.dev/latest/migration/.
+
+In order to support both versions of Pydantic, we use this module to access pydantic's v1 API.
+"""
+
+try:
+    # pydantic v2
+    from pydantic.v1 import *  # noqa: F403
+except ImportError:
+    # pydantic v1
+    from pydantic import *  # noqa: F403

--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -10,9 +10,9 @@ from typing import Callable, Dict, List, Union
 
 import torch
 import transformers
-from pydantic import validator
 
 from olive.common.config_utils import ConfigBase, validate_config, validate_object
+from olive.common.pydantic_v1 import validator
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.component.dataset import BaseDataset
 from olive.data.constants import IGNORE_INDEX

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -8,10 +8,9 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Union
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase
 from olive.common.import_lib import import_user_module
+from olive.common.pydantic_v1 import validator
 from olive.data.constants import DataComponentType, DefaultDataComponent, DefaultDataContainer
 from olive.data.registry import Registry
 

--- a/olive/data/container/data_container.py
+++ b/olive/data/container/data_container.py
@@ -2,11 +2,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import ClassVar, Optional
-
-from pydantic import BaseModel
+from typing import ClassVar, Optional, Tuple
 
 from olive.cache import get_local_path_from_root
+from olive.common.pydantic_v1 import BaseModel
 from olive.data.component.dataloader import default_calibration_dataloader
 from olive.data.config import DataConfig, DefaultDataComponentCombos
 from olive.data.constants import DataContainerType, DefaultDataContainer
@@ -25,11 +24,7 @@ class DataContainer(BaseModel):
 
     # not be used, for read only. when you update the components function,
     # please update the _params_list. It should be key name of params_config
-    _params_list: list = [
-        "data_dir",
-        "label_cols",
-        "batch_size",
-    ]
+    _params_list: Tuple[str, ...] = ("data_dir", "label_cols", "batch_size")
 
     def load_dataset(self, data_root_path: Optional[str] = None):
         """Run load dataset."""

--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -7,9 +7,8 @@ import logging
 from enum import Enum
 from typing import ClassVar, Dict, List, Optional, Union
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase, ConfigDictBase, validate_config
+from olive.common.pydantic_v1 import validator
 from olive.data.config import DataConfig
 from olive.evaluator.accuracy import AccuracyBase
 from olive.evaluator.metric_config import LatencyMetricConfig, MetricGoal, ThroughputMetricConfig, get_user_config_class

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -6,9 +6,8 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, create_config_class
+from olive.common.pydantic_v1 import validator
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 WARMUP_NUM = 10

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -13,12 +13,12 @@ from typing import Any, ClassVar, Dict, List, NamedTuple, Tuple, Type, Union
 
 import numpy as np
 import torch
-from pydantic import validator
 from torch.utils.data import Dataset
 
 import olive.data.template as data_config_template
 from olive.cache import get_local_path_from_root
 from olive.common.config_utils import ConfigBase
+from olive.common.pydantic_v1 import validator
 from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import tensor_data_to_device
 from olive.constants import Framework

--- a/olive/model/__init__.py
+++ b/olive/model/__init__.py
@@ -14,11 +14,11 @@ import onnx
 import torch
 import yaml
 from onnx import AttributeProto, GraphProto
-from pydantic import validator
 
 import olive.data.template as data_config_template
 from olive.common.config_utils import ConfigBase, serialize_to_json, validate_config
 from olive.common.ort_inference import get_ort_inference_session
+from olive.common.pydantic_v1 import validator
 from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import copy_dir
 from olive.constants import Framework, ModelFileFormat

--- a/olive/model/hf_utils.py
+++ b/olive/model/hf_utils.py
@@ -10,10 +10,10 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 import transformers
-from pydantic import Field, validator
 from transformers import AutoConfig, AutoModel, AutoTokenizer
 
 from olive.common.config_utils import ConfigBase, ConfigWithExtraArgs
+from olive.common.pydantic_v1 import Field, validator
 from olive.common.utils import resolve_torch_dtype
 from olive.model.hf_mappings import FEATURE_TO_PEFT_TASK_TYPE, MODELS_TO_MAX_LENGTH_MAPPING, TASK_TO_FEATURE
 from olive.model.model_config import IOConfig

--- a/olive/model/model_config.py
+++ b/olive/model/model_config.py
@@ -4,9 +4,8 @@
 # --------------------------------------------------------------------------
 from typing import Dict, List, Union
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase
+from olive.common.pydantic_v1 import validator
 
 
 class IOConfig(ConfigBase):

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -8,9 +8,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, Optional, Tuple, Type, Union, get_args
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase, ParamCategory, validate_config
+from olive.common.pydantic_v1 import validator
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.config import DataConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec

--- a/olive/passes/onnx/append_pre_post_processing_ops.py
+++ b/olive/passes/onnx/append_pre_post_processing_ops.py
@@ -8,9 +8,9 @@ from typing import Any, Callable, Dict, List, Union
 
 import onnx
 from packaging import version
-from pydantic import Field, validator
 
 from olive.common.config_utils import ConfigBase
+from olive.common.pydantic_v1 import Field, validator
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModel
 from olive.passes import Pass

--- a/olive/passes/onnx/moe_experts_distributor.py
+++ b/olive/passes/onnx/moe_experts_distributor.py
@@ -16,8 +16,8 @@ import numpy as np
 import onnx
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import Message
-from pydantic import validator
 
+from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import DistributedOnnxModel, ONNXModel
 from olive.passes import Pass
@@ -370,7 +370,7 @@ class MoEExpertsDistributor(Pass):
                 type_=int,
                 default=2,
                 required=True,
-                description=("Number of GPU nodes to distribute the model for. Must be greater than 1."),
+                description="Number of GPU nodes to distribute the model for. Must be greater than 1.",
             ),
             "parallel_jobs": PassConfigParam(
                 type_=int,

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -6,9 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Dict, Optional, Type, Union
 
-from pydantic import create_model, validator
-
 from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, validate_object, validate_resource_path
+from olive.common.pydantic_v1 import create_model, validator
 from olive.strategy.search_parameter import SearchParameter, json_to_search_parameter
 
 

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -19,10 +19,10 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 import torch
 import transformers
 from packaging import version
-from pydantic import Field, validator
 from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizer
 
 from olive.common.config_utils import ConfigBase, ConfigWithExtraArgs
+from olive.common.pydantic_v1 import Field, validator
 from olive.common.utils import find_submodules
 from olive.data.config import DataConfig
 from olive.data.constants import IGNORE_INDEX

--- a/olive/passes/pytorch/tensor_parallel.py
+++ b/olive/passes/pytorch/tensor_parallel.py
@@ -13,9 +13,9 @@ from pathlib import Path
 from typing import Any, Callable, Dict
 
 import torch
-from pydantic import validator
 
 from olive.common.config_utils import ParamCategory
+from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import DistributedPyTorchModel, PyTorchModel
 from olive.passes import Pass

--- a/olive/passes/snpe/conversion.py
+++ b/olive/passes/snpe/conversion.py
@@ -5,8 +5,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Union
 
-from pydantic import validator
-
+from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModel, SNPEModel, TensorFlowModel
 from olive.passes.olive_pass import Pass

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -4,8 +4,7 @@
 # --------------------------------------------------------------------------
 from typing import Any, Callable, Dict
 
-from pydantic import validator
-
+from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModel, SNPEModel
 from olive.passes.olive_pass import Pass

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -11,11 +11,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
 
-from pydantic import Field, validator
-
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.common.auto_config import AutoConfigClass
 from olive.common.config_utils import ConfigBase, ConfigParam, serialize_to_json, validate_config
+from olive.common.pydantic_v1 import Field, validator
 from olive.common.utils import copy_dir, retry_func
 
 logger = logging.getLogger(__name__)

--- a/olive/strategy/search_strategy.py
+++ b/olive/strategy/search_strategy.py
@@ -6,9 +6,8 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase, validate_config
+from olive.common.pydantic_v1 import validator
 from olive.strategy.search_algorithm import REGISTRY, SearchAlgorithm
 from olive.strategy.search_results import SearchResults
 

--- a/olive/systems/common.py
+++ b/olive/systems/common.py
@@ -6,9 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, Union
 
-from pydantic import validator
-
 from olive.common.config_utils import ConfigBase
+from olive.common.pydantic_v1 import validator
 
 
 class SystemType(str, Enum):

--- a/olive/systems/python_environment/common_requirements.txt
+++ b/olive/systems/python_environment/common_requirements.txt
@@ -1,4 +1,4 @@
 numpy
 protobuf<4.0.0
 psutil
-pydantic<2.0.0
+pydantic

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -7,11 +7,10 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Union
 
-from pydantic import root_validator, validator
-
 import olive.systems.system_alias as system_alias
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.common.config_utils import ConfigBase, validate_config
+from olive.common.pydantic_v1 import root_validator, validator
 from olive.systems.common import AzureMLDockerConfig, LocalDockerConfig, SystemType
 
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -6,10 +6,9 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Union
 
-from pydantic import validator
-
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.common.config_utils import ConfigBase, validate_config
+from olive.common.pydantic_v1 import validator
 from olive.data.config import DataConfig
 from olive.data.container.huggingface_container import HuggingfaceContainer
 from olive.engine import Engine, EngineConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ ban-relative-imports = "all"
 
 [tool.ruff.pep8-naming]
 # Allow Pydantic's `@validator` decorator to trigger class method treatment.
-classmethod-decorators = ["classmethod", "pydantic.validator", "pydantic.root_validator"]
+classmethod-decorators = ["classmethod", "olive.common.pydantic_v1.validator", "olive.common.pydantic_v1.root_validator"]
 
 [tool.ruff.per-file-ignores]
 ".azure_pipelines/**" = ["INP001"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ onnx
 optuna
 pandas
 protobuf<4.0.0
-pydantic<2.0.0
+pydantic
 pyyaml
 torch
 torchmetrics>=1.0.0

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -18,8 +18,8 @@ from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic.error_wrappers import ValidationError
 
+from olive.common.pydantic_v1 import ValidationError
 from olive.evaluator.metric import AccuracySubType, LatencySubType, ThroughputSubType
 from olive.evaluator.olive_evaluator import (
     OliveEvaluator,

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -6,9 +6,9 @@ import pytest
 import torch
 import transformers
 from packaging import version
-from pydantic import ValidationError
 from transformers.onnx import OnnxConfig
 
+from olive.common.pydantic_v1 import ValidationError
 from olive.model.hf_utils import (
     HFFromPretrainedArgs,
     get_onnx_config,

--- a/test/unit_test/passes/common/test_user_script.py
+++ b/test/unit_test/passes/common/test_user_script.py
@@ -5,8 +5,8 @@
 import tempfile
 
 import pytest
-from pydantic import ValidationError
 
+from olive.common.pydantic_v1 import ValidationError
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.passes.onnx import OrtPerfTuning
 


### PR DESCRIPTION
## Describe your changes
Pydantic v2 had significant breaking changes which blocks migration to it. So, we pinned the version to v1. 

Pydantic v2 has a `v1` namespace inside it. 

This PR introduces `olive.common.pydantic_v1` module that handles the import of `v1` api so that Olive can be version agnostic wrt pydantic. This way, we won't have version conflict with client applications such as that in https://github.com/microsoft/Olive/issues/709. 

Note:
The doc builder still needs pydantic v1 and autodoc_pydantic v1 since we are using the v1 api.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
