### PR TITLE
Make VitisAI quantization compatible with latest ORT-nightly

### DIFF
--- a/olive/passes/onnx/vitis_ai/quant_utils.py
+++ b/olive/passes/onnx/vitis_ai/quant_utils.py
@@ -367,3 +367,13 @@ def is_ort_version_below_1_16():
         True if the current ORT version is less than 1.16.0, False otherwise.
     """
     return version.parse(OrtVersion) < version.parse("1.16.0")
+
+
+def is_ort_version_below_1_17():
+    """
+    This function checks whether the current version of ONNX Runtime (ORT) is below 1.17.0.
+
+    Returns:
+        True if the current ORT version is less than 1.17.0, False otherwise.
+    """
+    return version.parse(OrtVersion) < version.parse("1.17.0")

--- a/olive/passes/onnx/vitis_ai/quantizer.py
+++ b/olive/passes/onnx/vitis_ai/quantizer.py
@@ -425,7 +425,7 @@ class VitisQOpQuantizer(ONNXQuantizer):
         return q_weight_name, zp_name, scale_name
 
     def calculate_quantization_params(self):
-        from olive.passes.onnx.vitis_ai.quant_utils import is_ort_version_below_1_16
+        from olive.passes.onnx.vitis_ai.quant_utils import is_ort_version_below_1_16, is_ort_version_below_1_17
 
         if self.tensors_range is None:
             return
@@ -461,7 +461,12 @@ class VitisQOpQuantizer(ONNXQuantizer):
                 qmin, qmax = get_qmin_qmax_for_qType(self.activation_qType, symmetric=self.is_activation_symmetric)
 
                 zero, scale = compute_scale_zp_pof2s(rmin, rmax, qmin, qmax, self.is_activation_symmetric)
-                quantization_params[tensor_name] = QuantizationParams(zero_point=zero, scale=scale)
+                if is_ort_version_below_1_17():
+                    quantization_params[tensor_name] = QuantizationParams(zero_point=zero, scale=scale)
+                else:
+                    quantization_params[tensor_name] = QuantizationParams(
+                        zero_point=zero, scale=scale, quant_type=self.activation_qType
+                    )
 
         return quantization_params
 


### PR DESCRIPTION
## Describe your changes
https://github.com/microsoft/onnxruntime/pull/18465 made some changes that make the vitis ai quantizer incompatible with the latest ort code. 

This PR updates the vitis ai code to add `quant_type` to `QuantizationParams` if the ORT version >= 1.17.0.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
