### PR TITLE
Add `jsonify_config_keys` to `JsonMixin` to abstract model handler json serialization

### DIFF
--- a/olive/model/handler/mixin/json.py
+++ b/olive/model/handler/mixin/json.py
@@ -17,8 +17,8 @@ class JsonMixin:
     """
 
     # keys for config parameters that are not part of resource_keys or model_attributes
-    # self.{key} must be defined for each key in jsonify_config_keys and should be serializable
-    jsonify_config_keys: Tuple[str, ...] = ()
+    # self.{key} must be defined for each key in json_config_keys and should be serializable
+    json_config_keys: Tuple[str, ...] = ()
 
     def to_json(self, check_object: bool = False):
         config = {
@@ -30,7 +30,7 @@ class JsonMixin:
                     for resource_name, resource_path in self.resource_paths.items()
                 },
                 # serialize other config attributes
-                **{key: getattr(self, key) for key in self.jsonify_config_keys},
+                **{key: getattr(self, key) for key in self.json_config_keys},
                 # serialize model attributes
                 "model_attributes": self.model_attributes,
             },

--- a/olive/model/handler/mixin/json.py
+++ b/olive/model/handler/mixin/json.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from typing import Tuple
 
 from olive.common.config_utils import serialize_to_json
 
@@ -15,14 +16,23 @@ class JsonMixin:
     Different model handler need to override the behavior to add its own attributes.
     """
 
+    # keys for config parameters that are not part of resource_keys or model_attributes
+    # self.{key} must be defined for each key in jsonify_config_keys and should be serializable
+    jsonify_config_keys: Tuple[str, ...] = ()
+
     def to_json(self, check_object: bool = False):
         config = {
             "type": self.model_type,
             "config": {
                 # serialize resource paths
-                resource_name: resource_path if resource_path else None
-                for resource_name, resource_path in self.resource_paths.items()
+                **{
+                    resource_name: resource_path if resource_path else None
+                    for resource_name, resource_path in self.resource_paths.items()
+                },
+                # serialize other config attributes
+                **{key: getattr(self, key) for key in self.jsonify_config_keys},
+                # serialize model attributes
+                "model_attributes": self.model_attributes,
             },
         }
-        config["config"].update({"model_attributes": self.model_attributes})
         return serialize_to_json(config, check_object)

--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -32,7 +32,7 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
     the mixin class OnnxGraphMixin is used to support onnx graph operations.
     """
 
-    jsonify_config_keys: Tuple[str, ...] = ("onnx_file_name", "inference_settings", "use_ort_extensions")
+    json_config_keys: Tuple[str, ...] = ("onnx_file_name", "inference_settings", "use_ort_extensions")
 
     def __init__(
         self,
@@ -121,7 +121,7 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
 
 @model_handler_registry("DistributedOnnxModel")
 class DistributedOnnxModelHandler(OliveModelHandler, OnnxEpValidateMixin):
-    jsonify_config_keys: Tuple[str, ...] = (
+    json_config_keys: Tuple[str, ...] = (
         "model_name_pattern",
         "num_ranks",
         "inference_settings",

--- a/olive/model/handler/optimum.py
+++ b/olive/model/handler/optimum.py
@@ -2,9 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import List
+from typing import List, Tuple
 
-from olive.common.config_utils import serialize_to_json
 from olive.constants import ModelFileFormat
 from olive.model.config.registry import model_handler_registry
 from olive.model.handler.pytorch import PyTorchModelHandler
@@ -14,13 +13,10 @@ from olive.model.handler.pytorch import PyTorchModelHandler
 class OptimumModelHandler(PyTorchModelHandler):
     """TODO(myguo): need refactor this class to support Optimum model."""
 
+    jsonify_config_keys: Tuple[str, ...] = ("model_components",)
+
     def __init__(self, model_components: List[str], **kwargs):
         kwargs = kwargs or {}
         kwargs["model_file_format"] = ModelFileFormat.COMPOSITE_MODEL
         super().__init__(**kwargs)
         self.model_components = model_components
-
-    def to_json(self, check_object: bool = False):
-        config = super().to_json(check_object)
-        config["config"].update({"model_components": self.model_components})
-        return serialize_to_json(config, check_object)

--- a/olive/model/handler/optimum.py
+++ b/olive/model/handler/optimum.py
@@ -13,7 +13,7 @@ from olive.model.handler.pytorch import PyTorchModelHandler
 class OptimumModelHandler(PyTorchModelHandler):
     """TODO(myguo): need refactor this class to support Optimum model."""
 
-    jsonify_config_keys: Tuple[str, ...] = ("model_components",)
+    json_config_keys: Tuple[str, ...] = ("model_components",)
 
     def __init__(self, model_components: List[str], **kwargs):
         kwargs = kwargs or {}

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -200,12 +200,13 @@ class PyTorchModelHandler(OliveModelHandler, HfConfigMixin, DummyInputsMixin):
     def to_json(self, check_object: bool = False):
         config = super().to_json(check_object)
         # only keep model_attributes that are not in hf_config
-        model_attributes = {}
-        hf_config_dict = self.get_hf_model_config().to_dict()
-        for key, value in self.model_attributes.items():
-            if key not in hf_config_dict or hf_config_dict[key] != value:
-                model_attributes[key] = value
-        config["config"]["model_attributes"] = model_attributes
+        if self.model_attributes and self.hf_config:
+            model_attributes = {}
+            hf_config_dict = self.get_hf_model_config().to_dict()
+            for key, value in self.model_attributes.items():
+                if key not in hf_config_dict or hf_config_dict[key] != value:
+                    model_attributes[key] = value
+            config["config"]["model_attributes"] = model_attributes or None
         return serialize_to_json(config, check_object)
 
     def get_user_io_config(self, io_config: Union[Dict[str, Any], IoConfig, str, Callable]) -> Dict[str, Any]:

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -38,7 +38,7 @@ class PyTorchModelHandler(OliveModelHandler, HfConfigMixin, DummyInputsMixin):
     """
 
     resource_keys: Tuple[str, ...] = ("model_path", "script_dir", "model_script", "adapter_path")
-    jsonify_config_keys: Tuple[str, ...] = (
+    json_config_keys: Tuple[str, ...] = (
         "model_file_format",
         "model_loader",
         "io_config",
@@ -252,7 +252,7 @@ class PyTorchModelHandler(OliveModelHandler, HfConfigMixin, DummyInputsMixin):
 @model_handler_registry("DistributedPyTorchModel")
 class DistributedPyTorchModelHandler(OliveModelHandler):
     resource_keys: Tuple[str, ...] = ("model_path", "script_dir", "model_script", "adapter_path")
-    jsonify_config_keys: Tuple[str, ...] = (
+    json_config_keys: Tuple[str, ...] = (
         "model_name_pattern",
         "num_ranks",
         "model_loader",


### PR DESCRIPTION
## Describe your changes
Most model handler classes update the `to_json` method in the same way. This PR makes it unnecessary by allowing a handler class to specify what attributes should be added during json serialization through `jsonify_config_keys` attribute.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
