### PR TITLE
🏑 Tests fix for transformers 4.36.0

### DIFF
--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -10,6 +10,7 @@ from urllib import request
 
 from onnxruntime import __version__ as OrtVersion
 from packaging import version
+from transformers import __version__ as TransformersVersion
 
 SUPPORTED_WORKFLOWS = {
     ("cpu", "fp32"): ["conversion", "transformers_optimization", "insert_beam_search", "prepost"],
@@ -75,6 +76,7 @@ def main(raw_args=None):
 
     # version check
     version_1_16 = version.parse(OrtVersion) >= version.parse("1.16.0")
+    transformers_version_4_36 = version.parse(TransformersVersion) >= version.parse("4.36.0")
 
     # multi-lingual support check
     if args.multilingual and not version_1_16:
@@ -87,6 +89,8 @@ def main(raw_args=None):
 
     # update model name
     template_json["input_model"]["config"]["hf_config"]["model_name"] = model_name
+    if transformers_version_4_36:
+        template_json["input_model"]["config"]["hf_config"]["from_pretrained_args"] = {"attn_implementation": "eager"}
 
     # set dataloader
     template_json["evaluators"]["common_evaluator"]["metrics"][0]["user_config"]["dataloader_func"] = (

--- a/test/unit_test/workflows/test_whisper_workflow.py
+++ b/test/unit_test/workflows/test_whisper_workflow.py
@@ -119,5 +119,10 @@ def check_output(footprints):
 
 
 def test_whisper_run(whisper_config):
+    from packaging import version
+    from transformers import __version__ as transformers_version
+
+    if version.parse(transformers_version) >= version.parse("4.36.0"):
+        whisper_config["input_model"]["config"]["hf_config"]["from_pretrained_args"] = {"attn_implementation": "eager"}
     result = olive_run(whisper_config)
     check_output(result)


### PR DESCRIPTION
## Describe your changes

Fix the whisper failure for new released transformers 4.36.0
error info:
> ValueError: Attention using SDPA can not be traced with torch.jit.trace when no attention_mask is provided. To solve this issue, please either load your model with the argument `attn_implementation="eager"` or pass an attention_mask input when tracing the model.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
