### PR TITLE
Add Linux GPU unit test to pipelines

### DIFF
--- a/.azure_pipelines/job_templates/olive-build-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-template.yaml
@@ -3,6 +3,7 @@
 parameters:
   name: ''
   pool: ''
+  windows: False
   device: 'cpu'
   onnxruntime: 'onnxruntime'
 

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -2,116 +2,118 @@ parameters:
   name: ''
   pool: ''
   test_type: ''
+  windows: False
   device: 'cpu'
   python_version: '3.8'
   onnxruntime: 'onnxruntime'
+  requirements_file: 'requirements-test.txt'
 
 jobs:
-- ${{ if eq(parameters.device, 'cpu') }}:
-  - job: ${{parameters.name}}
-    timeoutInMinutes: 300
-    pool:
-      name: ${{ parameters.pool}}
-    variables:
-      WINDOWS: ${{ parameters.windows}}
-      runCodesignValidationInjection: false
-      testType: ${{ parameters.test_type }}
-      python_version: ${{ parameters.python_version }}
+- job: ${{parameters.name}}
+  timeoutInMinutes: 300
+  pool:
+    name: ${{ parameters.pool}}
+  variables:
+    WINDOWS: ${{ parameters.windows}}
+    runCodesignValidationInjection: false
+    testType: ${{ parameters.test_type }}
+    python_version: ${{ parameters.python_version }}
+    requirements_file: ${{ parameters.requirements_file }}
 
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: $(python_version)
-      displayName: Use Python $(python_version)
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(python_version)
+    displayName: Use Python $(python_version)
 
-    - script: docker system df && docker system prune -a -f && docker system df
-      displayName: Clean docker images
-      continueOnError: true
+  - script: docker system df && docker system prune -a -f && docker system df
+    displayName: Clean docker images
+    continueOnError: true
 
+  - script: |
+      python -m pip install .
+    displayName: Install Olive
+
+  - ${{ if startsWith(parameters.onnxruntime, 'ort-nightly') }}:
     - script: |
-        python -m pip install .
-      displayName: Install Olive
+        pip install onnxruntime
+        pip uninstall -y onnxruntime
+        pip install ${{ parameters.onnxruntime }} --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
+      displayName: Install ${{ parameters.onnxruntime }}
+  - ${{ else }}:
+    - script: |
+        pip install ${{ parameters.onnxruntime }}
+      displayName: Install ${{ parameters.onnxruntime }}
 
-    - ${{ if startsWith(parameters.onnxruntime, 'ort-nightly') }}:
-      - script: |
-          pip install onnxruntime
-          pip uninstall -y onnxruntime
-          pip install ${{ parameters.onnxruntime }} --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-        displayName: Install ${{ parameters.onnxruntime }}
-    - ${{ else }}:
-      - script: |
-          pip install ${{ parameters.onnxruntime }}
-        displayName: Install ${{ parameters.onnxruntime }}
-
-    - ${{ if and(eq(variables.WINDOWS, 'True'), eq(variables.testType, 'multiple_ep')) }}:
-      - task: AzureCLI@1
-        inputs:
-          azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            call python -m pip install pytest
-            call curl --output openvino_toolkit.zip https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0.1/windows/w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64.zip
-            call 7z x openvino_toolkit.zip
-            call w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64\\setupvars.bat
-            call python -m pip install numpy psutil coverage protobuf==3.20.3
-            call coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml $(Build.SourcesDirectory)/test/$(testType)
-            call coverage xml
-        displayName: Test Olive
-        env:
-          OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)
-          WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
-          WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
-          WORKSPACE_NAME: $(workspace-name)
-          AZURE_TENANT_ID: $(azure-tenant-id)
-          AZURE_CLIENT_ID: $(olive-rg-sp-id)
-          AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
-    - ${{ else }}:
-      - task: AzureCLI@1
-        inputs:
-          azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            python -m pip install pytest
-            python -m pip install -r $(Build.SourcesDirectory)/test/requirements-test.txt
-
-            coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml $(Build.SourcesDirectory)/test/$(testType)
-            coverage xml
-        displayName: Test Olive
-        env:
-          OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)
-          WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
-          WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
-          WORKSPACE_NAME: $(workspace-name)
-          AZURE_TENANT_ID: $(azure-tenant-id)
-          AZURE_CLIENT_ID: $(olive-rg-sp-id)
-          AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
-
-    - task: CredScan@3
-      displayName: 'Run CredScan'
+  - ${{ if and(eq(variables.WINDOWS, 'True'), eq(variables.testType, 'multiple_ep')) }}:
+    - task: AzureCLI@1
       inputs:
-        debugMode: false
-      continueOnError: true
-
-    - task: ComponentGovernanceComponentDetection@0
+        azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          call python -m pip install pytest
+          call curl --output openvino_toolkit.zip https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0.1/windows/w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64.zip
+          call 7z x openvino_toolkit.zip
+          call w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64\\setupvars.bat
+          call python -m pip install numpy psutil coverage protobuf==3.20.3
+          call coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml $(Build.SourcesDirectory)/test/$(testType)
+          call coverage xml
+      displayName: Test Olive
+      env:
+        OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)
+        WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
+        WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
+        WORKSPACE_NAME: $(workspace-name)
+        AZURE_TENANT_ID: $(azure-tenant-id)
+        AZURE_CLIENT_ID: $(olive-rg-sp-id)
+        AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
+  - ${{ else }}:
+    - task: AzureCLI@1
       inputs:
-        scanType: 'Register'
-        verbosity: 'Verbose'
-        alertWarningLevel: 'High'
-      displayName: Component Detection
+        azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          python -m pip install pytest
+          python -m pip install -r $(Build.SourcesDirectory)/test/$(requirements_file)
 
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFiles: '**/*TestOlive*.xml'
-        testRunTitle: '$(Build.BuildNumber)[$(Agent.JobName)]'
-        failTaskOnFailedTests: true
-      displayName: Upload pipeline run test results
+          coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml $(Build.SourcesDirectory)/test/$(testType)
+          coverage xml
+      displayName: Test Olive
+      env:
+        OLIVEWHEELS_STORAGE_CONNECTION_STRING: $(olive-wheels-storage-connection-string)
+        WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
+        WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
+        WORKSPACE_NAME: $(workspace-name)
+        AZURE_TENANT_ID: $(azure-tenant-id)
+        AZURE_CLIENT_ID: $(olive-rg-sp-id)
+        AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
 
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: 'Cobertura'
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+  - task: CredScan@3
+    displayName: 'Run CredScan'
+    inputs:
+      debugMode: false
+    continueOnError: true
 
-    - script: git clean -dfX
-      condition: always()
-      displayName: Clean remaining artifacts
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      scanType: 'Register'
+      verbosity: 'Verbose'
+      alertWarningLevel: 'High'
+    displayName: Component Detection
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/*TestOlive*.xml'
+      testRunTitle: '$(Build.BuildNumber)[$(Agent.JobName)]'
+      failTaskOnFailedTests: true
+    displayName: Upload pipeline run test results
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+
+  - script: git clean -dfX
+    condition: always()
+    displayName: Clean remaining artifacts

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -55,6 +55,17 @@ jobs:
     windows: False
     onnxruntime: onnxruntime
 
+# Linux GPU unit test
+- template: job_templates/olive-test-template.yaml
+  parameters:
+    name: Linux_GPU_CI_Unit_Test_Olive
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
+    test_type: 'unit_test'
+    windows: False
+    device: 'gpu'
+    onnxruntime: onnxruntime-gpu
+    requirements_file: 'requirements-test-gpu.txt'
+
 # Windows unit test and integration test
 - template: job_templates/olive-build-template.yaml
   parameters:

--- a/.azure_pipelines/olive-ort-last.yaml
+++ b/.azure_pipelines/olive-ort-last.yaml
@@ -23,6 +23,17 @@ jobs:
     test_type: 'unit_test'
     onnxruntime: 'onnxruntime==1.15.1'
 
+# Linux GPU unit test
+- template: job_templates/olive-test-template.yaml
+  parameters:
+    name: Linux_GPU_CI_Unit_Test_Olive
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
+    device: 'gpu'
+    windows: False
+    test_type: 'unit_test'
+    onnxruntime: 'onnxruntime-gpu==1.15.1'
+    requirements_file: 'requirements-test-gpu.txt'
+
 # Windows unit test
 - template: job_templates/olive-test-template.yaml
   parameters:

--- a/.azure_pipelines/olive-ort-nightly.yaml
+++ b/.azure_pipelines/olive-ort-nightly.yaml
@@ -23,6 +23,17 @@ jobs:
     test_type: 'unit_test'
     onnxruntime: ort-nightly
 
+# Linux GPU unit test
+- template: job_templates/olive-test-template.yaml
+  parameters:
+    name: Linux_GPU_CI_Unit_Test_Olive
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
+    device: 'gpu'
+    windows: False
+    test_type: 'unit_test'
+    onnxruntime: ort-nightly-gpu
+    requirements_file: 'requirements-test-gpu.txt'
+
 # Windows unit test
 - template: job_templates/olive-test-template.yaml
   parameters:

--- a/.azure_pipelines/performance.yaml
+++ b/.azure_pipelines/performance.yaml
@@ -30,7 +30,7 @@ jobs:
 - template: job_templates/olive-performance-template.yaml
   parameters:
     name: Linux_GPU_CI
-    pool: $(OLIVE_GPU_POOL_UBUNTU2004)
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     windows: False
     device: gpu
     examples:

--- a/test/requirements-test-gpu.txt
+++ b/test/requirements-test-gpu.txt
@@ -1,0 +1,3 @@
+-r requirements-test.txt
+# only available in Linux currently
+bitsandbytes

--- a/test/requirements-test-gpu.txt
+++ b/test/requirements-test-gpu.txt
@@ -1,3 +1,3 @@
 -r requirements-test.txt
-# only available in Linux currently
+# only available on Linux currently
 bitsandbytes

--- a/test/unit_test/passes/onnx/test_bnb_quantization.py
+++ b/test/unit_test/passes/onnx/test_bnb_quantization.py
@@ -2,9 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import sys
 from test.unit_test.utils import get_onnx_model, pytorch_model_loader
-from unittest.mock import MagicMock, patch
 
 import onnx
 import onnxruntime
@@ -17,17 +15,6 @@ from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OnnxBnb4Quantization
 
 # pylint: disable=protected-access
-
-
-# TODO(jambayk): Remove this fixture after ORT 1.16.2 is released
-# replace with skipif
-@pytest.fixture
-def mock_ort_1_16_2():
-    mock_matmul_bnb4_quantizer = MagicMock()
-    sys.modules["onnxruntime.quantization.matmul_bnb4_quantizer"] = mock_matmul_bnb4_quantizer
-    with patch("onnxruntime.__version__", "1.16.2"):
-        yield
-    del sys.modules["onnxruntime.quantization.matmul_bnb4_quantizer"]
 
 
 def get_onnx_matmul_model(model_path, model_attributes=None):
@@ -51,7 +38,10 @@ def get_onnx_gemm_model(model_path=None, model_attributes=None):
     return model
 
 
-@pytest.mark.usefixtures("mock_ort_1_16_2")
+@pytest.mark.skipif(
+    version.parse(onnxruntime.__version__) < version.parse("1.16.2"),
+    reason="OnnxBnb4Quantization requires ORT >= 1.16.2",
+)
 @pytest.mark.parametrize(
     "pass_config,model_attributes,expected_error",
     [


### PR DESCRIPTION
## Describe your changes
- Add a new Linux GPU unit test to the CI, nightly and last stable pipelines
- Tests that mocked bitsandbytes and torch cuda devices are now made gpu only. Some are linux gpu only if they require bitsandbytes. 
- The above also fixes the inconsistent lora and qlora tests. 
- `OLIVE_POOL_UBUNTU2004_GPU_V100` uses a `Standard_NC6s_v3` agent (1 V100 GPU, 16GB vram, 112 ram).

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
