### PR TITLE
SD/SDXL: Remove torchvision from requirements, CUDA instructions under main README

### DIFF
--- a/examples/directml/stable_diffusion/README.md
+++ b/examples/directml/stable_diffusion/README.md
@@ -9,7 +9,6 @@ Stable Diffusion comprises multiple PyTorch models tied together into a *pipelin
 - [Conversion to ONNX and Latency Optimization](#conversion-to-onnx-and-latency-optimization)
 - [Test Inference](#test-inference)
 - [LoRA Models (Experimental)](#lora-models-experimental)
-- [Optimization for CUDA EP](#stable-diffusion-optimization-with-cuda)
 - [Issues](#issues)
 - [Stable Diffusion Pipeline](#stable-diffusion-pipeline)
 
@@ -110,23 +109,6 @@ This script does not yet support loading [LoRA weights from a .safetensors file]
 LoRA adds additional linear layers (attention processors) to the base PyTorch model. The added layers have their own small set of weights ("LoRA weights"), which allows users to replace only a portion of the the full model weights when switching between LoRA variants. Without preprocessing, the additional LoRA layers reduce inference speed since there are more layers in the network architecture. In practice, the added LoRA layers can be folded into existing layers of the base model to completely remove the inference overhead; however, once the LoRA weights are merged with the base weights it is no longer possible to swap out new LoRA weights (the model is "baked").
 
 Olive merges the LoRA weights into the base model before conversion to ONNX (see `user_script.py:merge_lora_weights`), which means the output models are fully baked. This approach simplifies downstream ONNX-based graph optimizations and enables performance-critical fusions (e.g. multi-head attention) that will not occur if the injected LoRA layers remain in the graph. As a consequence, if you want to switch LoRA weights you must reoptimize the affected models (generally U-Net). Retaining the flexibility of pluggable LoRA weights in the output ONNX models would require the LoRA weights be saved as external data along with fusion of the attention processors at runtime.
-
-## Stable Diffusion Optimization with CUDA
-This example can also be used to optimize Stable Diffusion models for CUDA. You can use the same `stable_diffusion.py` script with `--provider cuda` option to optimize the models for CUDA and test inference. The optimized models will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/runwayml/stable-diffusion-v1-5`).
-
-Install the common requirements:
-```
-pip install -r requirements-common.txt
-```
-
-The CUDA example requires the latest onnxruntime-gpu code which can either be built from source or installed from the nightly builds. The following command can be used to install the latest nightly build of onnxruntime-gpu:
-```
-# uninstall any pre-existing onnxruntime packages
-pip uninstall -y onnxruntime onnxruntime-gpu onnxruntime-directml ort-nightly ort-nightly-gpu ort-nightly-directml
-
-# install onnxruntime-gpu nightly build
-pip install ort-nightly-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-```
 
 ## Issues
 

--- a/examples/directml/stable_diffusion/requirements-common.txt
+++ b/examples/directml/stable_diffusion/requirements-common.txt
@@ -4,5 +4,4 @@ onnx
 pillow
 protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 torch
-torchvision==0.14.1
 transformers

--- a/examples/directml/stable_diffusion_xl/README.md
+++ b/examples/directml/stable_diffusion_xl/README.md
@@ -8,7 +8,6 @@ Stable Diffusion XL comprises multiple PyTorch models tied together into a *pipe
 - [Setup](#setup)
 - [Conversion to ONNX and Latency Optimization](#conversion-to-onnx-and-latency-optimization)
 - [Test Inference](#test-inference)
-- [Optimization for CUDA EP](#stable-diffusion-optimization-with-cuda)
 - [Issues](#issues)
 - [Stable Diffusion Pipeline](#stable-diffusion-pipeline)
 
@@ -61,7 +60,7 @@ Generated result_1.png
 Inference Batch End.
 ```
 
-Inference will loop until the generated image passes the safety checker (otherwise you would see black images). The result will be saved as `result_<i>.png` on disk, which is then loaded and displayed in the UI.
+The result will be saved as `result_<i>.png` on disk, which is then loaded and displayed in the UI.
 
 Run `python stable_diffusion_xl.py --help` for additional options. A few particularly relevant ones:
 - `--model_id <string>` : name of a stable diffusion model ID hosted by huggingface.co. This script has been tested with the following:
@@ -74,23 +73,6 @@ Run `python stable_diffusion_xl.py --help` for additional options. A few particu
 If you omit `--interactive`, the script will generate the requested number of images without displaying a UI and then terminate. Use the `--prompt` option to specify the prompt when using non-interactive mode.
 
 The minimum number of inferences will be `ceil(num_images / batch_size)`; additional inferences may be required of some outputs are flagged by the safety checker to ensure the desired number of outputs are produced.
-
-## Stable Diffusion XL Optimization with CUDA
-This example can also be used to optimize Stable Diffusion models for CUDA. You can use the same `stable_diffusion.py` script with `--provider cuda` option to optimize the models for CUDA and test inference. The optimized models will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/stabilityai/stable-diffusion-xl-base-1.0`).
-
-Install the common requirements:
-```
-pip install -r requirements-common.txt
-```
-
-The CUDA example requires the latest onnxruntime-gpu code which can either be built from source or installed from the nightly builds. The following command can be used to install the latest nightly build of onnxruntime-gpu:
-```
-# uninstall any pre-existing onnxruntime packages
-pip uninstall -y onnxruntime onnxruntime-gpu onnxruntime-directml ort-nightly ort-nightly-gpu ort-nightly-directml
-
-# install onnxruntime-gpu nightly build
-pip install ort-nightly-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-```
 
 ## Issues
 

--- a/examples/directml/stable_diffusion_xl/requirements-common.txt
+++ b/examples/directml/stable_diffusion_xl/requirements-common.txt
@@ -6,5 +6,4 @@ optimum
 pillow
 protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 torch
-torchvision==0.14.1
 transformers

--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -1,11 +1,113 @@
-# Stable Diffusion Optimization
+# Stable Diffusion and Stable Diffusion XL Optimization
 
-Please see the following to optimize stable diffusion models with Olive for different ONNX Runtime execution providers:
-- [DirectML](../directml/stable_diffusion/README.md)
-- [CUDA](../directml/stable_diffusion/README.md#stable-diffusion-optimization-with-cuda)
+This folder contains sample use cases of Olive to optimize:
+- Stable Diffusion: [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4), [Stable Diffusion v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5), [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2)
+- Stable Diffusion XL: [Stable Diffusion XL Base](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0), [Stable Diffusion XL Refiner](https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0)
 
-# Stable Diffusion XL Optimization
+Stable Diffusion comprises multiple PyTorch models tied together into a *pipeline*. This Olive sample will convert each PyTorch model to ONNX, and then run the converted ONNX models through the `OrtTransformersOptimization` pass. The transformer optimization pass performs several time-consuming graph transformations that make the models more efficient for inference at runtime.
 
-Please see the following to optimize stable diffusion XL models with Olive for different ONNX Runtime execution providers:
-- [DirectML](../directml/stable_diffusion_xl/README.md)
-- [CUDA](../directml/stable_diffusion_xl/README.md#stable-diffusion-optimization-with-cuda)
+See the following for instructions on how to optimize Stable Diffusion models with Olive for different ONNX Runtime execution providers:
+- DirectML:
+    - [Stable Diffusion](../directml/stable_diffusion/README.md)
+    - [Stable Diffusion XL](../directml/stable_diffusion_xl/README.md)
+- [CUDA](#optimization-with-cuda)
+
+## Optimization with CUDA
+This sample performs the following optimization workflow for each model in the Stable Diffusion pipeline:
+- *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model fp16*
+<br/><br/>
+
+Transformers optimization uses the following optimizations to speed up Stable Diffusion in CUDA:
+* [Flash Attention](https://arxiv.org/abs/2205.14135) for float16 precision. Flash Attention uses tiling to reduce number of GPU memory reads/writes, and improves performance with less memory for long sequence length. The kernel requires GPUs of Compute Capability >= 7.5 (like T4, A100, and RTX 2060~4090). Only availanle in Linux.
+* [Memory Efficient Attention](https://arxiv.org/abs/2112.05682v2) for float32 precision or older GPUs (like V100). We used the fused multi-head attention kernel in CUTLASS, and the kernel was contributed by xFormers.
+* Channel-last (NHWC) convolution. For NVidia GPU with Tensor Cores support, NHWC tensor layout is recommended for convolution. See [Tensor Layouts In Memory: NCHW vs NHWC](https://docs.nvidia.com/deeplearning/performance/dl-performance-convolutional/index.html#tensor-layout).
+* GroupNorm for NHWC tensor layout, and SkipGroupNorm fusion which fuses GroupNorm with Add bias and residual inputs
+* SkipLayerNormalization which fuses LayerNormalization with Add bias and residual inputs.
+* BiasSplitGelu is a fusion of Add bias with SplitGelu activation.
+* BiasAdd fuses Add bias and residual.
+* Reduce Transpose nodes by graph transformation.
+
+### Prerequisites
+#### Clone the repository and install Olive
+
+Refer to the instructions in the [examples README](../README.md) to clone the repository and install Olive.
+
+
+We use the same olive workflow config files and scripts as the DirectML examples. The only difference is the `--provider cuda` option provided to the `stable_diffusion.py`  and `stable_diffusion_xl.py` scripts.
+
+So, cd into the corresponding DirectML example folder from the root of the cloned repository:
+
+**_Stable Diffusion_**
+```bash
+cd examples/directml/stable_diffusion
+```
+
+**_Stable Diffusion XL_**
+```bash
+cd examples/directml/stable_diffusion_xl
+```
+
+#### Install onnxruntime
+This example requires the latest onnxruntime-gpu code which can either be built from source or installed from the nightly builds. The following command can be used to install the latest nightly build of onnxruntime-gpu:
+
+```bash
+# uninstall any pre-existing onnxruntime packages
+pip uninstall -y onnxruntime onnxruntime-gpu onnxruntime-directml ort-nightly ort-nightly-gpu ort-nightly-directml
+
+# install onnxruntime-gpu nightly build
+pip install ort-nightly-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
+```
+
+#### Install other dependencies
+Install the necessary python packages:
+
+```bash
+python -m pip install -r requirements-common.txt
+```
+
+### Conversion to ONNX and Latency Optimization
+
+The easiest way to optimize the pipeline is with the `stable_diffusion.py` and `stable_diffusion_xl.py` scripts. These scripts will enumerate the `config_<model_name>.json` files and optimize each with Olive, then gather the optimized models into a directory structure suitable for testing inference.
+
+**_Stable Diffusion_**
+```bash
+# default model_id is "runwayml/stable-diffusion-v1-5"
+python stable_diffusion.py --provider cuda --optimize
+```
+
+**_Stable Diffusion XL_**
+```bash
+# default model_id is "stabilityai/stable-diffusion-xl-base-1.0"
+python stable_diffusion_xl.py --provider cuda --optimize
+
+# or specify a different model_id
+python stable_diffusion_xl.py --provider cuda --model_id stabilityai/stable-diffusion-xl-refiner-1.0 --optimize
+```
+
+Once the script successfully completes:
+- The optimized ONNX pipeline will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/runwayml/stable-diffusion-v1-5` or `models/optimized-cuda/stabilityai/stable-diffusion-xl-base-1.0`).
+- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/[model_id]` (for example `models/unoptimized/runwayml/stable-diffusion-v1-5` or `models/unoptimized/stabilityai/stable-diffusion-xl-base-1.0`).
+
+Re-running the script with `--optimize` will delete the output models, but it will *not* delete the Olive cache. Subsequent runs will complete much faster since it will simply be copying previously optimized models; you may use the `--clean_cache` option to start from scratch (not typically used unless you are modifying the scripts, for example).
+
+## Test Inference
+
+Test ONNX runtime inference with the optimized models using `OnnxStableDiffusionPipeline`:
+
+**_Stable Diffusion_**
+```bash
+python stable_diffusion.py --provider cuda --num_images 2
+```
+Inference will loop until the generated image passes the safety checker (otherwise you would see black images). The result will be saved as `result_<i>.png` on disk.
+
+
+**_Stable Diffusion XL_**
+```bash
+python stable_diffusion_xl.py --provider cuda --num_images 2
+```
+The result will be saved as `result_<i>.png` on disk.
+
+
+Refer to the corresponding section in the DirectML READMEs for more details on the test inference options:
+- [Stable Diffusion](../directml/stable_diffusion/README.md#test-inference)
+- [Stable Diffusion XL](../directml/stable_diffusion_xl/README.md#test-inference)

--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -13,6 +13,7 @@ See the following for instructions on how to optimize Stable Diffusion models wi
 - [CUDA](#optimization-with-cuda)
 
 ## Optimization with CUDA
+
 This sample performs the following optimization workflow for each model in the Stable Diffusion pipeline:
 - *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model fp16*
 <br/><br/>
@@ -48,6 +49,7 @@ cd examples/directml/stable_diffusion_xl
 ```
 
 #### Install onnxruntime
+
 This example requires the latest onnxruntime-gpu code which can either be built from source or installed from the nightly builds. The following command can be used to install the latest nightly build of onnxruntime-gpu:
 
 ```bash
@@ -59,6 +61,7 @@ pip install ort-nightly-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.
 ```
 
 #### Install other dependencies
+
 Install the necessary python packages:
 
 ```bash
@@ -100,13 +103,11 @@ python stable_diffusion.py --provider cuda --num_images 2
 ```
 Inference will loop until the generated image passes the safety checker (otherwise you would see black images). The result will be saved as `result_<i>.png` on disk.
 
-
 **_Stable Diffusion XL_**
 ```bash
 python stable_diffusion_xl.py --provider cuda --num_images 2
 ```
 The result will be saved as `result_<i>.png` on disk.
-
 
 Refer to the corresponding section in the DirectML READMEs for more details on the test inference options:
 - [Stable Diffusion](../directml/stable_diffusion/README.md#test-inference)


### PR DESCRIPTION
## Describe your changes
- Remove torchvision from the requirements since it is not used at all. It also caused torch to be pinned to 1.13.1 unnecessarily.
- Move CUDA EP instructions to the readme under `examples/stable_diffusion`.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
