### PR TITLE
CI: Local CUDA test for Stable Diffusion and Bert

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -37,13 +37,19 @@ jobs:
           pip install ${{ parameters.onnxruntime }}
         displayName: Install ${{ parameters.onnxruntime }}
 
+    # set exampleRequirements to requirements.txt if user does not specify
+    - script:
+        echo "##vso[task.setvariable variable=exampleRequirements]requirements.txt"
+      displayName: Set exampleRequirements
+      condition: eq(variables['exampleRequirements'], '')
+
     - task: AzureCLI@1
       inputs:
         azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
         scriptLocation: 'inlineScript'
         inlineScript: |
           python -m pip install pytest
-          python -m pip install -r $(Build.SourcesDirectory)/examples/$(exampleFolder)/requirements.txt
+          python -m pip install -r $(Build.SourcesDirectory)/examples/$(exampleFolder)/$(exampleRequirements)
           python -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test_examples-TestOlive.xml $(Build.SourcesDirectory)/examples/test/test_$(exampleName).py
       displayName: Test Examples
       env:

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -16,7 +16,8 @@ trigger:
     - .azure_pipelines/performance.yaml
     - .azure_pipelines/job_templates/olive-performance-template.yaml
     # commonly updated examples with no test
-    - examples/directml/*
+    - examples/directml/llama_v2/*
+    - examples/directml/stable_diffusion_xl/*
     - examples/llama2/*
     - examples/open_llama/*
     - examples/stable_diffusion/*
@@ -38,7 +39,8 @@ pr:
     - .azure_pipelines/performance.yaml
     - .azure_pipelines/job_templates/olive-performance-template.yaml
     # commonly updated examples with no test
-    - examples/directml/*
+    - examples/directml/llama_v2/*
+    - examples/directml/stable_diffusion_xl/*
     - examples/llama2/*
     - examples/open_llama/*
     - examples/stable_diffusion/*
@@ -136,12 +138,16 @@ jobs:
 - template: job_templates/olive-example-template.yaml
   parameters:
     name: Linux_GPU_CI
-    pool: $(OLIVE_POOL_UBUNTU2004)
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: onnxruntime-gpu
     examples:
       bert_cuda_gpu:
         exampleFolder: bert
         exampleName: bert_cuda_gpu
+      stable_diffusion_cuda_gpu:
+        exampleFolder: directml/stable_diffusion
+        exampleName: stable_diffusion_cuda_gpu
+        exampleRequirements: requirements-common.txt
 
 # Multiple EP Linux testing
 - template: job_templates/olive-test-template.yaml

--- a/.azure_pipelines/olive-ort-last.yaml
+++ b/.azure_pipelines/olive-ort-last.yaml
@@ -91,7 +91,7 @@ jobs:
 - template: job_templates/olive-example-template.yaml
   parameters:
     name: Linux_GPU_CI
-    pool: $(OLIVE_POOL_UBUNTU2004)
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: onnxruntime-gpu==1.15.1
     examples:
       bert_cuda_gpu:

--- a/.azure_pipelines/olive-ort-nightly.yaml
+++ b/.azure_pipelines/olive-ort-nightly.yaml
@@ -91,9 +91,13 @@ jobs:
 - template: job_templates/olive-example-template.yaml
   parameters:
     name: Linux_GPU_CI
-    pool: $(OLIVE_POOL_UBUNTU2004)
+    pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: ort-nightly-gpu
     examples:
       bert_cuda_gpu:
         exampleFolder: bert
         exampleName: bert_cuda_gpu
+      stable_diffusion_cuda_gpu:
+        exampleFolder: directml/stable_diffusion
+        exampleName: stable_diffusion_cuda_gpu
+        exampleRequirements: requirements-common.txt

--- a/examples/directml/stable_diffusion/stable_diffusion.py
+++ b/examples/directml/stable_diffusion/stable_diffusion.py
@@ -7,9 +7,6 @@ import json
 import shutil
 import sys
 import tempfile
-import threading
-import tkinter as tk
-import tkinter.ttk as ttk
 import warnings
 from pathlib import Path
 from typing import Dict
@@ -20,7 +17,6 @@ import torch
 from diffusers import DiffusionPipeline, OnnxRuntimeModel, OnnxStableDiffusionPipeline
 from onnxruntime import __version__ as OrtVersion
 from packaging import version
-from PIL import Image, ImageTk
 from user_script import get_base_model_name
 
 from olive.model import ONNXModelHandler
@@ -80,6 +76,12 @@ def run_inference_loop(
 def run_inference_gui(
     pipeline, prompt, num_images, batch_size, image_size, num_inference_steps, disable_classifier_free_guidance
 ):
+    import threading
+    import tkinter as tk
+    import tkinter.ttk as ttk
+
+    from PIL import Image, ImageTk
+
     def update_progress_bar(total_steps_completed):
         progress_bar["value"] = total_steps_completed
 

--- a/examples/directml/stable_diffusion/user_script.py
+++ b/examples/directml/stable_diffusion/user_script.py
@@ -36,7 +36,11 @@ def merge_lora_weights(base_model, lora_model_id, submodel_name="unet", scale=1.
     from collections import defaultdict
     from functools import reduce
 
-    from diffusers.loaders import LORA_WEIGHT_NAME
+    try:
+        from diffusers.loaders import LORA_WEIGHT_NAME
+    except ImportError:
+        # moved in version 0.24.0
+        from diffusers.loaders.lora import LORA_WEIGHT_NAME
     from diffusers.models.attention_processor import LoRAAttnProcessor
     from diffusers.utils import DIFFUSERS_CACHE
     from diffusers.utils.hub_utils import _get_model_file

--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -7,9 +7,6 @@ import json
 import shutil
 import sys
 import tempfile
-import threading
-import tkinter as tk
-import tkinter.ttk as ttk
 import warnings
 from pathlib import Path
 from typing import Dict
@@ -22,7 +19,6 @@ from diffusers.utils import load_image
 from onnxruntime import __version__ as OrtVersion
 from optimum.onnxruntime import ORTStableDiffusionXLImg2ImgPipeline, ORTStableDiffusionXLPipeline
 from packaging import version
-from PIL import Image, ImageTk
 
 from olive.model import ONNXModelHandler
 from olive.workflows import run as olive_run
@@ -127,6 +123,12 @@ def run_inference_gui(
     disable_classifier_free_guidance,
     base_images=None,
 ):
+    import threading
+    import tkinter as tk
+    import tkinter.ttk as ttk
+
+    from PIL import Image, ImageTk
+
     def update_progress_bar(total_steps_completed):
         progress_bar["value"] = total_steps_completed
 

--- a/examples/test/test_bert_cuda_gpu.py
+++ b/examples/test/test_bert_cuda_gpu.py
@@ -21,7 +21,7 @@ def setup():
 
 @pytest.mark.parametrize("search_algorithm", ["tpe"])
 @pytest.mark.parametrize("execution_order", ["joint", "pass-by-pass"])
-@pytest.mark.parametrize("system", ["aml_system"])
+@pytest.mark.parametrize("system", ["local_system"])
 @pytest.mark.parametrize("olive_json", ["bert_cuda_gpu.json"])
 @pytest.mark.parametrize("enable_cuda_graph", [True, False])
 def test_bert(search_algorithm, execution_order, system, olive_json, enable_cuda_graph):

--- a/examples/test/test_bert_cuda_gpu.py
+++ b/examples/test/test_bert_cuda_gpu.py
@@ -21,7 +21,7 @@ def setup():
 
 @pytest.mark.parametrize("search_algorithm", ["tpe"])
 @pytest.mark.parametrize("execution_order", ["joint", "pass-by-pass"])
-@pytest.mark.parametrize("system", ["local_system"])
+@pytest.mark.parametrize("system", ["local_system", "aml_system"])
 @pytest.mark.parametrize("olive_json", ["bert_cuda_gpu.json"])
 @pytest.mark.parametrize("enable_cuda_graph", [True, False])
 def test_bert(search_algorithm, execution_order, system, olive_json, enable_cuda_graph):

--- a/examples/test/test_stable_diffusion_cuda_gpu.py
+++ b/examples/test/test_stable_diffusion_cuda_gpu.py
@@ -22,19 +22,25 @@ def setup():
     sys.path.remove(example_dir)
 
 
-def test_stable_diffusion():
+@pytest.mark.parametrize("model_id", [None, "stabilityai/sd-turbo", "sayakpaul/sd-model-finetuned-lora-t4"])
+def test_stable_diffusion(model_id):
     # clean previous artifacts
     for image_file in Path().glob("result_*.png"):
         image_file.unlink()
 
     from stable_diffusion import main as stable_diffusion_main
 
+    # common arguments
+    cmd_args = ["--provider", "cuda"]
+    if model_id is not None:
+        cmd_args.extend(["--model_id", model_id])
+
     # run the optimization
-    stable_diffusion_main(["--provider", "cuda", "--optimize"])
+    stable_diffusion_main([*cmd_args, "--optimize"])
 
     # test inference
     num_images = 2
-    stable_diffusion_main(["--provider", "cuda", "--num_images", str(num_images)])
+    stable_diffusion_main([*cmd_args, "--num_images", str(num_images)])
 
     # check the results
     for i in range(num_images):

--- a/examples/test/test_stable_diffusion_cuda_gpu.py
+++ b/examples/test/test_stable_diffusion_cuda_gpu.py
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    """Setups any state specific to the execution of the given module."""
+    cur_dir = Path(__file__).resolve().parent.parent
+    example_dir = str(cur_dir / "directml" / "stable_diffusion")
+    os.chdir(example_dir)
+    sys.path.append(example_dir)
+
+    yield
+    os.chdir(cur_dir)
+    sys.path.remove(example_dir)
+
+
+def test_stable_diffusion():
+    # clean previous artifacts
+    for image_file in Path().glob("result_*.png"):
+        image_file.unlink()
+
+    from stable_diffusion import main as stable_diffusion_main
+
+    # run the optimization
+    stable_diffusion_main(["--provider", "cuda", "--optimize"])
+
+    # test inference
+    num_images = 2
+    stable_diffusion_main(["--provider", "cuda", "--num_images", str(num_images)])
+
+    # check the results
+    for i in range(num_images):
+        assert Path(f"result_{i}.png").exists()


### PR DESCRIPTION
## Describe your changes
**Stable Diffusion**
- Add test script that parameterizes over three models: base, turbo and lora finetuned.
- Make GUI related imports lazy since the pipeline agents are not configured for tkinter
- Allow onnxruntime 1.16.2/1.16.3 with warning. Disable skip_group_norm fusion which causes the invalid model issue. This lets us test the example with onnxruntime-gpu and ort-nightly-gpu

**Bert**
- Add local_system test case for bert cuda

Will add a similar stable_diffusion_xl example test later if the pipeline resources are enough. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
