### PR TITLE
Fix perftuning to meet DLIS integration requirements

### DIFF
--- a/docs/source/features/passes/onnx.md
+++ b/docs/source/features/passes/onnx.md
@@ -323,7 +323,20 @@ improve performance.
     "config": {
         "user_script": "user_script.py",
         "dataloader_func": "create_dataloader",
-        "batch_size": 1
+        "batch_size": 1,
+        "providers_list" : [
+            [
+                "CUDAExecutionProvider",
+                {
+                    "device_id": 0,
+                    "arena_extend_strategy": "kNextPowerOfTwo",
+                    "gpu_mem_limit": 2147483648, // 2 * 1024 * 1024 * 1024,
+                    "cudnn_conv_algo_search": "EXHAUSTIVE",
+                    "do_copy_in_default_stream": true,
+                },
+            ],
+            "CPUExecutionProvider",
+        ]
     }
 }
 ```

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -47,11 +47,11 @@ def get_ort_inference_session(
         for key, value in extra_session_config.items():
             sess_options.add_session_config_entry(key, value)
 
-    if isinstance(execution_provider, list):
-        # execution_provider may be a list of tuples/lists where the first item in each tuple is the EP name
-        execution_provider = [i[0] if isinstance(i, (tuple, list)) else i for i in execution_provider]
-    elif isinstance(execution_provider, str):
+    if isinstance(execution_provider, str):
         execution_provider = [execution_provider]
+    else:
+        # execution providers should be list[str]
+        assert isinstance(execution_provider, list) and all(isinstance(ep, str) for ep in execution_provider)
 
     for idx, ep in enumerate(execution_provider):
         if ep == "QNNExecutionProvider":

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -27,18 +27,12 @@ _common_user_config = {
     "input_shapes": ConfigParam(type_=List),
     "input_types": ConfigParam(type_=List),
     "shared_kv_buffer": ConfigParam(type_=bool, default_value=False),
+    "io_bind": ConfigParam(type_=bool, default_value=False),
 }
 
 _common_user_config_validators = {}
 
 _type_to_user_config = {
-    "latency": {
-        # TODO(anyone): extract io_bind to a _common_user_config
-        "io_bind": ConfigParam(type_=bool, default_value=False),
-    },
-    "throughput": {
-        "io_bind": ConfigParam(type_=bool, default_value=False),
-    },
     "accuracy": {
         "post_processing_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
     },

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -44,7 +44,6 @@ from olive.model import (
     SNPEModelHandler,
 )
 from olive.model.config.io_config import is_io_config_static
-from olive.model.utils.onnx_utils import check_ort_fallback
 from olive.snpe.data_loader import SNPECommonDataLoader, SNPEDataLoader
 
 logger = logging.getLogger(__name__)
@@ -468,8 +467,6 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             execution_providers=execution_providers,
         )
 
-        check_ort_fallback(session, execution_providers)
-
         io_config = model.get_io_config()
 
         preds = []
@@ -531,8 +528,6 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             device=device,
             execution_providers=execution_providers,
         )
-        check_ort_fallback(session, execution_providers)
-
         io_config = model.get_io_config()
 
         input_data, _ = next(iter(dataloader))

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -82,15 +82,11 @@ class OliveEvaluator(ABC):
         )
 
     @classmethod
-    def io_bind_enabled(cls, metric: Metric, model: ONNXModelHandler) -> bool:
+    def io_bind_enabled(cls, metric: Metric, inference_settings: Dict) -> bool:
         if metric.user_config.io_bind:
             return True
 
-        inference_settings = cls.get_inference_settings(metric)
         if inference_settings and inference_settings.get("io_bind"):
-            return True
-
-        if model.inference_settings and model.inference_settings.get("io_bind"):
             return True
 
         return False
@@ -441,7 +437,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         logits = []
         logits_dict = collections.defaultdict(list)
         output_names = io_config["output_names"]
-        io_bind = self.io_bind_enabled(metric, model)
+        io_bind = self.io_bind_enabled(metric, model.inference_settings)
         if io_bind:
             io_bind_op = session.io_binding()
             kv_cache_ortvalues = {} if metric.user_config.shared_kv_buffer else None
@@ -460,7 +456,12 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
                     kv_cache_ortvalues=kv_cache_ortvalues,
                 )
                 bind_output_data(
-                    io_bind_op, use_fp16, session.get_outputs(), device, kv_cache_ortvalues=kv_cache_ortvalues
+                    io_bind_op,
+                    session.get_outputs(),
+                    use_fp16,
+                    device,
+                    shared_kv_buffer=metric.user_config.shared_kv_buffer,
+                    kv_cache_ortvalues=kv_cache_ortvalues,
                 )
                 io_bind_op.synchronize_inputs()
                 session.run_with_iobinding(io_bind_op)
@@ -504,7 +505,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
 
     def _evaluate_onnx_latency(
         self,
-        model: OliveModelHandler,
+        model: ONNXModelHandler,
         metric: Metric,
         dataloader: Dataset,
         post_func=None,
@@ -525,7 +526,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         # no deepcopy for kv_cache_ortvalues, will update the value inplace and keep it shared across runs
         kv_cache_ortvalues = {} if metric.user_config.shared_kv_buffer else None
 
-        io_bind = self.io_bind_enabled(metric, model)
+        io_bind = self.io_bind_enabled(metric, model.inference_settings)
         if io_bind:
             io_bind_op = prepare_io_bindings(
                 session,
@@ -680,7 +681,7 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         input_feed = OnnxEvaluator.format_input(input_feed, io_config)
         kv_cache_ortvalues = {} if metric.user_config.shared_kv_buffer else None
 
-        io_bind = OnnxEvaluator.io_bind_enabled(metric, model)
+        io_bind = OnnxEvaluator.io_bind_enabled(metric, model.inference_settings)
         if io_bind:
             io_bind_op = prepare_io_bindings(
                 session,

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -59,6 +59,7 @@ class AcceleratorLookup:
             "DmlExecutionProvider",
             "CUDAExecutionProvider",
             "ROCMExecutionProvider",
+            "MIGraphXExecutionProvider",
             "TensorrtExecutionProvider",
             "CPUExecutionProvider",
             "OpenVINOExecutionProvider",

--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -89,7 +89,7 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
         # Originally, the inference_settings priority is higher than the execution_providers specified in arguments.
         # as the result, when calling OnnxEvaluator.evaluate with the provider_list in baseline evaluation,
         # the execution provider will be used as ["MIGraphXExecutionProvider"].
-        # later, the OnnxEvaluator.disable_ort_fallback(session, execution_providers) will check the
+        # later, the check_ort_fallback(session, execution_providers) will check the
         # whether the underlying session's providers(MIGraphXExecutionProvider, CPUExecutionProvider) contains the
         # execution_providers(ROCMExecutionProvider, MIGraphXExecutionProvider). In this case, the
         # ROCMExecutionProvider is excluded when creating inference session. and the OliveEvaluationError exception
@@ -104,7 +104,7 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
         if not execution_providers:
             execution_providers = self.get_default_execution_providers(device)
             provider_options = None
-        elif isinstance(execution_providers, str):
+        elif isinstance(execution_providers, (str, tuple)):
             execution_providers = [execution_providers]
         else:
             # the execution_providers is a list

--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -100,11 +100,11 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
         else:
             execution_providers = inference_settings.get("execution_provider")
             provider_options = inference_settings.get("provider_options")
+            if not execution_providers:
+                execution_providers = self.get_default_execution_providers(device)
+                provider_options = None
 
-        if not execution_providers:
-            execution_providers = self.get_default_execution_providers(device)
-            provider_options = None
-        elif isinstance(execution_providers, (str, tuple)):
+        if isinstance(execution_providers, (str, tuple)):
             execution_providers = [execution_providers]
         else:
             # the execution_providers is a list

--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -16,7 +16,7 @@ from olive.hardware.accelerator import AcceleratorLookup, Device
 from olive.model.config.registry import model_handler_registry
 from olive.model.handler.base import OliveModelHandler
 from olive.model.handler.mixin import OnnxEpValidateMixin, OnnxGraphMixin
-from olive.model.utils.onnx_utils import check_and_normalize_provider_args, get_onnx_file_path
+from olive.model.utils.onnx_utils import check_and_normalize_provider_args, check_ort_fallback, get_onnx_file_path
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 logger = logging.getLogger(__name__)
@@ -123,7 +123,9 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
                     provider_options[i] = {"device_id": str(rank)}
         inference_settings["execution_provider"] = execution_providers
         inference_settings["provider_options"] = provider_options
-        return get_ort_inference_session(self.model_path, inference_settings, self.use_ort_extensions)
+        session = get_ort_inference_session(self.model_path, inference_settings, self.use_ort_extensions)
+        check_ort_fallback(session, execution_providers)
+        return session
 
     def get_default_execution_providers(self, device: Device):
         # return firstly available ep as ort default ep

--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -103,6 +103,7 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
 
         if not execution_providers:
             execution_providers = self.get_default_execution_providers(device)
+            provider_options = None
         elif isinstance(execution_providers, str):
             execution_providers = [execution_providers]
         else:

--- a/olive/model/utils/onnx_utils.py
+++ b/olive/model/utils/onnx_utils.py
@@ -143,7 +143,7 @@ def check_and_normalize_provider_args(
             if isinstance(provider, str):
                 set_provider_options(provider, {})
             elif (
-                isinstance(provider, tuple)
+                isinstance(provider, (tuple, list))
                 and len(provider) == 2
                 and isinstance(provider[0], str)
                 and isinstance(provider[1], dict)

--- a/olive/model/utils/onnx_utils.py
+++ b/olive/model/utils/onnx_utils.py
@@ -6,7 +6,7 @@ import collections
 import collections.abc
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -254,3 +254,56 @@ def prepare_io_bindings(
     bind_input_data(io_bind_op, input_data, use_fp16, device, device_id, shared_kv_buffer, kv_cache_ortvalues)
     bind_output_data(io_bind_op, session.get_outputs(), use_fp16, device, shared_kv_buffer, kv_cache_ortvalues)
     return io_bind_op
+
+
+class CudaGraphHelper:
+    def __init__(
+        self,
+        ort_session,
+        input_and_output_shape: Dict[str, List[int]],
+        device,
+        device_id: int = 0,
+    ):
+        from onnxruntime import OrtValue
+
+        self.input_names = [i.name for i in ort_session.get_inputs()]
+        self.output_names = [o.name for o in ort_session.get_outputs()]
+
+        self.input_and_output_shape = input_and_output_shape
+        self.io_numpy_type = self.get_io_numpy_type_map(ort_session)
+        self.io_binding = ort_session.io_binding()
+        self.io_ort_value = {}
+
+        for name in self.input_names + self.output_names:
+            ort_value = OrtValue.ortvalue_from_shape_and_type(
+                input_and_output_shape[name], self.io_numpy_type[name], device, device_id
+            )
+            self.io_ort_value[name] = ort_value
+            if name in self.input_names:
+                self.io_binding.bind_ortvalue_input(name, ort_value)
+            else:
+                self.io_binding.bind_ortvalue_output(name, ort_value)
+
+    def get_io_numpy_type_map(self, ort_session):
+        ort_type_to_numpy_type = {
+            "tensor(int64)": np.longlong,
+            "tensor(int32)": np.intc,
+            "tensor(float)": np.float32,
+            "tensor(float16)": np.float16,
+        }
+
+        name_to_numpy_type = {}
+        for _input in ort_session.get_inputs():
+            name_to_numpy_type[_input.name] = ort_type_to_numpy_type[_input.type]
+
+        for output in ort_session.get_outputs():
+            name_to_numpy_type[output.name] = ort_type_to_numpy_type[output.type]
+
+        return name_to_numpy_type
+
+    def update_inputs(self, inputs: Dict[str, np.ndarray]):
+        for input_name in self.input_names:
+            self.io_ort_value[input_name].update_inplace(inputs[input_name])
+
+    def get_output(self, output_name: str):
+        return self.io_ort_value[output_name].numpy()

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -107,10 +107,7 @@ def tune_onnx_model(model, data_root, config):
     logger.info("Best result: %s", best_result)
     if best_result.get("test_name") != PERFTUNING_BASELINE:
         optimized_model = copy.copy(model)
-        if optimized_model.inference_settings:
-            optimized_model.inference_settings["execution_provider"] = best_result.get("execution_provider")
-        else:
-            optimized_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
+        optimized_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
         session_options = best_result.get("session_options")
         if session_options is not None:
             optimized_model.inference_settings["session_options"] = session_options
@@ -118,12 +115,8 @@ def tune_onnx_model(model, data_root, config):
         return optimized_model
     else:
         # If the best result is baseline, we need add the execution_provider to the inference_settings of the model
-        result_model = copy.deepcopy(model)
-        if result_model.inference_settings:
-            result_model.inference_settings["execution_provider"] = best_result.get("execution_provider")
-        else:
-            result_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
-
+        result_model = copy.copy(model)
+        result_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
         return result_model
 
 

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -158,7 +158,7 @@ def threads_num_tuning(model, data_root, latency_metric, config, tuning_combo):
     io_bind = tuning_combo[3]
 
     provider, options = populate_provider_options(provider, config)
-    if provider == "CPUExecutionProvider" and config.enable_cuda_graph:
+    if provider == "CUDAExecutionProvider" and config.enable_cuda_graph:
         io_bind = True
 
     test_params = {

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -63,12 +63,12 @@ def valid_config(tuning_combos, config):
     if provider != "TensorrtExecutionProvider" and config.trt_fp16_enable:
         logger.info("[Ignored] Because EP is not TensorrtExecutionProvider, the trt_fp16_enable is ignored")
         return True
-    if provider == "CUDAExecutionProvider" and config.enable_cuda_graph and tuning_combos[1] == 1:
-        logger.warning(
-            "[Ignored] Because EP is CUDAExecutionProvider, the execution_mode should not be 1 "
-            "in case of enable_cuda_graph is True"
-        )
-        return False
+    # if provider == "CUDAExecutionProvider" and config.enable_cuda_graph and tuning_combos[1] == 1:
+    #     logger.warning(
+    #         "[Ignored] Because EP is CUDAExecutionProvider, the execution_mode should not be 1 "
+    #         "in case of enable_cuda_graph is True"
+    #     )
+    #     return False
     return True
 
 
@@ -119,10 +119,10 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
         tuning_results.extend(threads_num_tuning(model, data_root, latency_metric, config, *tuning_combo))
 
     for tuning_result in tuning_results:
-        logger.debug("Tuning result: %s", tuning_result["latency_ms"])
+        logger.debug("Tuning result for %s: %s", tuning_result["test_name"], tuning_result["latency_ms"])
 
     best_result = parse_tuning_result(*tuning_results, pretuning_inference_result)
-    logger.info("Best result(%s): %s", best_result["test_name"], best_result)
+    logger.info("Best result: %s", best_result)
     # Both baseline and pertuning result should have the execution provider in the test_results.
     assert "execution_provider" in best_result, "execution_provider should be in best_result"
     optimized_model = copy.copy(model)

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -101,7 +101,7 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
             assert isinstance(tuning_ep, str)
 
         # TODO(myguo): we need disable the following check when we enable cache in perf tuning.
-        if tuning_ep != perf_tuning_pass_ep:
+        if tuning_ep != perf_tuning_pass_ep and not config.force_evaluate_other_eps:
             logger.warning("Ignore perf tuning for EP %s since current pass EP is %s", tuning_ep, perf_tuning_pass_ep)
             continue
         tuning_item = ["provider", "execution_mode", "ort_opt_level", "io_bind"]
@@ -443,6 +443,14 @@ class OrtPerfTuning(Pass):
                 type_=Dict[str, Any],
                 default_value=None,
                 description="Extra customized session options during tuning process.",
+            ),
+            "force_evaluate_other_eps": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description=(
+                    "Whether force to evaluate all execution providers"
+                    " which are different with the associated execution provider."
+                ),
             ),
         }
 

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -116,7 +116,11 @@ def tune_onnx_model(model, data_root, config):
     else:
         # If the best result is baseline, we need add the execution_provider to the inference_settings of the model
         result_model = copy.deepcopy(model)
-        result_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
+        if result_model.inference_settings:
+            result_model.inference_settings["execution_provider"] = best_result.get("execution_provider")
+        else:
+            result_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
+
         return result_model
 
 

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -121,6 +121,19 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
     for provider, execution_mode, opt_level in generate_tuning_combos(config):
         provider, options = populate_provider_options(provider, config)  # noqa: PLW2901
         if provider == "CUDAExecutionProvider":
+            # if enable_cuda_graph is True but the io_bind is False, the following errors will be raised.
+            # onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : CUDA failure 700:
+            #    an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ;
+            #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_graph.cc ; line=49 ;
+            #    expr=cudaGraphLaunch(graph_exec_, stream_);
+            # [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDA failure 700:
+            #    an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ;
+            #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=286 ;
+            #    expr=cudaStreamDestroy(stream_);
+            # [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDNN failure 4:
+            #    CUDNN_STATUS_INTERNAL_ERROR ; GPU=0 ; hostname=c93f1847c000000 ;
+            #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=181 ;
+            #    expr=cudnnDestroy(cudnn_handle_);
             io_bind = True
         elif provider == "CPUExecutionProvider":
             io_bind = False

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -107,7 +107,10 @@ def tune_onnx_model(model, data_root, config):
     logger.info("Best result: %s", best_result)
     if best_result.get("test_name") != PERFTUNING_BASELINE:
         optimized_model = copy.copy(model)
-        optimized_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
+        if optimized_model.inference_settings:
+            optimized_model.inference_settings["execution_provider"] = best_result.get("execution_provider")
+        else:
+            optimized_model.inference_settings = {"execution_provider": best_result.get("execution_provider")}
         session_options = best_result.get("session_options")
         if session_options is not None:
             optimized_model.inference_settings["session_options"] = session_options

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -102,7 +102,6 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
     pretuning_inference_result = get_benchmark(model, data_root, latency_metric, config)
 
     tuning_results = []
-    #
     for provider, execution_mode, opt_level, io_bind in generate_tuning_combos(config):
         provider, options = populate_provider_options(provider, config)  # noqa: PLW2901
         if provider == "CUDAExecutionProvider" and config.enable_cuda_graph:

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -8,7 +8,12 @@ from olive.hardware.accelerator import Device
 @patch("onnxruntime.InferenceSession")
 def test_model_prepare_session(inference_session_mock):
     mock = MagicMock()
-    mock.get_providers.return_value = ["MIGraphXExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
+    mock.get_providers.return_value = [
+        "MIGraphXExecutionProvider",
+        "ROCMExecutionProvider",
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
     inference_session_mock.return_value = mock
     model = get_onnx_model()
     inference_settings = {
@@ -20,13 +25,13 @@ def test_model_prepare_session(inference_session_mock):
             "inter_op_num_threads": None,
             "intra_op_num_threads": 1,
         },
-        "_io_bind": False,
     }
 
-    execution_providers = ["ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+    execution_providers = ["ROCMExecutionProvider", "MIGraphXExecutionProvider", "CUDAExecutionProvider"]
+    provider_options = [{}, {}, {"device_id": "1"}]
     # The inference session ep priority is lower than specified by argument in DLIS scenarios
-    session = model.prepare_session(inference_settings, Device.GPU, execution_providers)
+    session = model.prepare_session(inference_settings, Device.GPU, execution_providers, rank=1)
     inference_session_mock.assert_called_once_with(
-        model.model_path, sess_options=ANY, providers=execution_providers, provider_options=ANY
+        model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
     )
     OnnxEvaluator.disable_ort_fallback(session, execution_providers)

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -1,8 +1,8 @@
 from test.unit_test.utils import get_onnx_model
 from unittest.mock import ANY, MagicMock, patch
 
-from olive.evaluator.olive_evaluator import OnnxEvaluator
 from olive.hardware.accelerator import Device
+from olive.model.utils.onnx_utils import check_ort_fallback
 
 
 @patch("onnxruntime.InferenceSession")
@@ -34,4 +34,4 @@ def test_model_prepare_session(inference_session_mock):
     inference_session_mock.assert_called_once_with(
         model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
     )
-    OnnxEvaluator.disable_ort_fallback(session, execution_providers)
+    check_ort_fallback(session, execution_providers)

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -13,17 +13,14 @@ def test_model_prepare_session(mock_get_available_providers, inference_session_m
     mock_get_available_providers.return_value = [
         "MIGraphXExecutionProvider",
         "ROCMExecutionProvider",
-        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
     ]
     mock = MagicMock()
-    mock.get_providers.return_value = [
-        "MIGraphXExecutionProvider",
-        "ROCMExecutionProvider",
-        "CUDAExecutionProvider",
-    ]
+    mock.get_providers.return_value = ["MIGraphXExecutionProvider"]
     inference_session_mock.return_value = mock
     model = get_onnx_model()
     inference_settings = {
+        # the EP in inference_settings has higher priority than the EP in arguments
         "execution_provider": [("MIGraphXExecutionProvider", {})],
         "session_options": {
             "execution_mode": 0,
@@ -35,11 +32,10 @@ def test_model_prepare_session(mock_get_available_providers, inference_session_m
     }
 
     execution_providers = ["ROCMExecutionProvider", "MIGraphXExecutionProvider"]
-    provider_options = [{}, {}]
     # The inference session ep priority is lower than specified by argument in DLIS scenarios
     _ = model.prepare_session(inference_settings, Device.GPU, execution_providers, rank=1)
     inference_session_mock.assert_called_once_with(
-        model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
+        model.model_path, sess_options=ANY, providers=["MIGraphXExecutionProvider"], provider_options=[{}]
     )
 
 
@@ -71,16 +67,43 @@ def test_model_prepare_session_with_unsupported_eps(mock_get_available_providers
         },
     }
     execution_providers = ["TensorrtExecutionProvider", "CUDAExecutionProvider"]
-    provider_options = [{}, {"device_id": "1"}]
+    # provider_options = [{}, {"device_id": "1"}]
     with pytest.raises(
         OliveEvaluationError,
         match=(
-            "The onnxruntime fallback happens. TensorrtExecutionProvider is not in the session providers"
+            "The onnxruntime fallback happens. MIGraphXExecutionProvider is not in the session providers"
             r" \['CUDAExecutionProvider', 'CPUExecutionProvider'\]"
         ),
     ):
         # The inference session ep priority is lower than specified by argument in DLIS scenarios
         _ = model.prepare_session(inference_settings, Device.GPU, execution_providers, rank=1)
         inference_session_mock.assert_called_once_with(
-            model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
+            model.model_path, sess_options=ANY, providers=["MIGraphXExecutionProvider"], provider_options=[{}]
         )
+
+
+@patch("onnxruntime.InferenceSession")
+@patch("onnxruntime.get_available_providers")
+def test_distributed_rank_prepare_session(mock_get_available_providers, inference_session_mock):
+    mock_get_available_providers.return_value = [
+        "TensorrtExecutionProvider",
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+    mock = MagicMock()
+    mock.get_providers.return_value = [
+        "TensorrtExecutionProvider",
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    inference_session_mock.return_value = mock
+    model = get_onnx_model()
+
+    execution_providers = ["TensorrtExecutionProvider", "CUDAExecutionProvider"]
+    provider_options = [{}, {"device_id": "1"}]
+    # The inference session ep priority is lower than specified by argument in DLIS scenarios
+    _ = model.prepare_session(None, Device.GPU, execution_providers, rank=1)
+    inference_session_mock.assert_called_once_with(
+        model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
+    )

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -1,0 +1,32 @@
+from test.unit_test.utils import get_onnx_model
+from unittest.mock import ANY, MagicMock, patch
+
+from olive.evaluator.olive_evaluator import OnnxEvaluator
+from olive.hardware.accelerator import Device
+
+
+@patch("onnxruntime.InferenceSession")
+def test_model_prepare_session(inference_session_mock):
+    mock = MagicMock()
+    mock.get_providers.return_value = ["MIGraphXExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
+    inference_session_mock.return_value = mock
+    model = get_onnx_model()
+    inference_settings = {
+        "execution_provider": [("MIGraphXExecutionProvider", {})],
+        "session_options": {
+            "execution_mode": 0,
+            "graph_optimization_level": 99,
+            "extra_session_config": None,
+            "inter_op_num_threads": None,
+            "intra_op_num_threads": 1,
+        },
+        "_io_bind": False,
+    }
+
+    execution_providers = ["ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+    # The inference session ep priority is lower than specified by argument in DLIS scenarios
+    session = model.prepare_session(inference_settings, Device.GPU, execution_providers)
+    inference_session_mock.assert_called_once_with(
+        model.model_path, sess_options=ANY, providers=execution_providers, provider_options=ANY
+    )
+    OnnxEvaluator.disable_ort_fallback(session, execution_providers)

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -1,18 +1,25 @@
 from test.unit_test.utils import get_onnx_model
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
+
+from olive.exception import OliveEvaluationError
 from olive.hardware.accelerator import Device
-from olive.model.utils.onnx_utils import check_ort_fallback
 
 
 @patch("onnxruntime.InferenceSession")
-def test_model_prepare_session(inference_session_mock):
+@patch("onnxruntime.get_available_providers")
+def test_model_prepare_session(mock_get_available_providers, inference_session_mock):
+    mock_get_available_providers.return_value = [
+        "MIGraphXExecutionProvider",
+        "ROCMExecutionProvider",
+        "CUDAExecutionProvider",
+    ]
     mock = MagicMock()
     mock.get_providers.return_value = [
         "MIGraphXExecutionProvider",
         "ROCMExecutionProvider",
         "CUDAExecutionProvider",
-        "CPUExecutionProvider",
     ]
     inference_session_mock.return_value = mock
     model = get_onnx_model()
@@ -27,11 +34,53 @@ def test_model_prepare_session(inference_session_mock):
         },
     }
 
-    execution_providers = ["ROCMExecutionProvider", "MIGraphXExecutionProvider", "CUDAExecutionProvider"]
-    provider_options = [{}, {}, {"device_id": "1"}]
+    execution_providers = ["ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+    provider_options = [{}, {}]
     # The inference session ep priority is lower than specified by argument in DLIS scenarios
-    session = model.prepare_session(inference_settings, Device.GPU, execution_providers, rank=1)
+    _ = model.prepare_session(inference_settings, Device.GPU, execution_providers, rank=1)
     inference_session_mock.assert_called_once_with(
         model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
     )
-    check_ort_fallback(session, execution_providers)
+
+
+@patch("onnxruntime.InferenceSession")
+@patch("onnxruntime.get_available_providers")
+def test_model_prepare_session_with_unsupported_eps(mock_get_available_providers, inference_session_mock):
+    mock_get_available_providers.return_value = [
+        "TensorrtExecutionProvider",
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+    mock = MagicMock()
+    mock.get_providers.return_value = [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    inference_session_mock.return_value = mock
+    inference_session_mock.return_value = mock
+    model = get_onnx_model()
+    inference_settings = {
+        "execution_provider": [("MIGraphXExecutionProvider", {})],
+        "session_options": {
+            "execution_mode": 0,
+            "graph_optimization_level": 99,
+            "extra_session_config": None,
+            "inter_op_num_threads": None,
+            "intra_op_num_threads": 1,
+        },
+    }
+    execution_providers = ["TensorrtExecutionProvider", "CUDAExecutionProvider"]
+    provider_options = [{}, {"device_id": "1"}]
+    with pytest.raises(
+        OliveEvaluationError,
+        match=(
+            "The onnxruntime fallback happens. TensorrtExecutionProvider is not in the session providers"
+            r" \['CUDAExecutionProvider', 'CPUExecutionProvider'\]"
+        ),
+    ):
+        # The inference session ep priority is lower than specified by argument in DLIS scenarios
+        _ = model.prepare_session(inference_settings, Device.GPU, execution_providers, rank=1)
+        inference_session_mock.assert_called_once_with(
+            model.model_path, sess_options=ANY, providers=execution_providers, provider_options=provider_options
+        )

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -116,6 +116,7 @@ def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_ev
                 "gpu_mem_limit": 2 * 1024 * 1024 * 1024,
                 "cudnn_conv_algo_search": "EXHAUSTIVE",
                 "do_copy_in_default_stream": True,
+                "enable_cuda_graph": False,
             },
         ],
         "CPUExecutionProvider",
@@ -138,8 +139,10 @@ def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_ev
     else:
         assert len(acutal_eps) == 1
         assert acutal_eps[0] == "CUDAExecutionProvider"
-        assert "enable_cuda_graph" in result.inference_settings["provider_options"][0]
-        assert "arena_extend_strategy" in result.inference_settings["provider_options"][0]
+        assert result.inference_settings["provider_options"][0][
+            "enable_cuda_graph"
+        ], "enable_cuda_graph is should be overridden to True"
+        assert result.inference_settings["provider_options"][0]["arena_extend_strategy"] == "kNextPowerOfTwo"
 
 
 @pytest.mark.parametrize("force_evaluate", [True, False])

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -122,6 +122,7 @@ def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_ev
     config = {
         "providers_list": execution_providers,
         "device": "gpu",
+        "enable_cuda_graph": True,
     }
     input_model = get_onnx_model()
     p = create_pass_from_dict(OrtPerfTuning, config, disable_search=True, accelerator_spec=DEFAULT_GPU_CUDA_ACCELERATOR)

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -109,6 +109,7 @@ def test_perf_tuning_with_provider_options(mock_evaluate, caplog, return_baselin
     result = p.run(input_model, None, None)
     assert "execution_provider" in result.inference_settings
     acutal_eps = result.inference_settings["execution_provider"]
+    assert "io_bind" in result.inference_settings
     if return_baseline:
         assert len(acutal_eps) == 2
         assert "enable_cuda_graph" not in acutal_eps[0][1]
@@ -156,6 +157,7 @@ def test_perf_tuning_with_force_evaluate(mock_evaluate, caplog, force_evaluate):
     input_model = get_onnx_model()
     p = create_pass_from_dict(OrtPerfTuning, config, disable_search=True, accelerator_spec=DEFAULT_CPU_ACCELERATOR)
     result = p.run(input_model, None, None)
+    assert "io_bind" in result.inference_settings
     if force_evaluate:
         assert "execution_provider" in result.inference_settings
         acutal_eps = result.inference_settings["execution_provider"]

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -118,6 +118,7 @@ def test_perf_tuning_with_provider_options(mock_evaluate, caplog, return_baselin
         assert f"Best result({PERFTUNING_BASELINE}):" in caplog.text
     else:
         assert len(acutal_eps) == 1
+        assert acutal_eps[0][0] in ("CUDAExecutionProvider", "CPUExecutionProvider")
         if acutal_eps[0][0] == "CUDAExecutionProvider":
             assert "enable_cuda_graph" in acutal_eps[0][1]
 

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+import re
 from test.unit_test.utils import create_dataloader, get_onnx_model
 from unittest.mock import patch
 
@@ -133,7 +134,7 @@ def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_ev
     if return_baseline:
         assert acutal_eps == ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
         assert "enable_cuda_graph" not in result.inference_settings["provider_options"][0]
-        assert f"Best result({PERFTUNING_BASELINE}):" in caplog.text
+        assert re.search(f"Best result:.*{PERFTUNING_BASELINE}", caplog.text)
     else:
         assert len(acutal_eps) == 1
         assert acutal_eps[0] == "CUDAExecutionProvider"
@@ -190,12 +191,12 @@ def test_perf_tuning_with_force_evaluate(mock_get_available_providers, mock_eval
         assert "execution_provider" in result.inference_settings
         acutal_eps = result.inference_settings["execution_provider"]
         assert len(acutal_eps) == 1 and acutal_eps[0] == "CUDAExecutionProvider"
-        assert "Best result(('cuda', " in caplog.text
+        assert re.search("Best result:.*cuda", caplog.text)
     else:
         assert "execution_provider" in result.inference_settings
         acutal_eps = result.inference_settings["execution_provider"]
         assert len(acutal_eps) == 1 and acutal_eps[0] == "CPUExecutionProvider"
-        assert "Best result(cpu" in caplog.text
+        assert re.search("Best result: .*cpu", caplog.text)
         assert (
             "Ignore perf tuning for EP CUDAExecutionProvider since current pass EP is CPUExecutionProvider"
             in caplog.text


### PR DESCRIPTION
## Describe your changes

* Change the execution provider priority to use the parameters instead of that one in inference_settings. 
    Bug description: In DLIS scenarios, the inferenece_settings is something like:
{'execution_provider': [('MIGraphXExecutionProvider', {})]} and the provider_lists specified in perf_tuning is: ['ROCMExecutionProvider', 'MIGraphXExecutionProvider'].

    Originally, the inference_settings priority is higher than the execution_providers specified in arguments. As the result, when calling OnnxEvaluator.evaluate with the provider_list in baseline evaluation, the execution provider will be used as ["MIGraphXExecutionProvider"]. Later, the OnnxEvaluator.disable_ort_fallback(session, execution_providers) will check whether the underlying session's providers(MIGraphXExecutionProvider, CPUExecutionProvider) contains the execution_providers(ROCMExecutionProvider, MIGraphXExecutionProvider). In this case, the ROCMExecutionProvider is excluded when creating inference session. and the OliveEvaluationError exception will be raised.

    To fix this issue, we need move the check_ort_fallback into prepare_session in onnx model.
    perf tuning will always pass None as the execution provider to evaluate to make the logic clear

* Change perf tuning to always has execution provider info regardless of whether the best result is baseline or from perf tuning.
* Change perf tuning to accept both provider list and provider list with provider options.
* Add force_evaluate_other_eps to force run all other EPs if the current EP is not same with the additional EPs
* Change OnnxModel.prepare_session to accept both execution provider list and (execution provider, provider options) list
In this way, the EP/provider option handling logic is normalized.
* Add MIGraphXExecutionProvider to the accelerator map
* Fix the critical bug when creating inference session that doesn't respect provider options in ort_inference.py
* Add io_bind inference for accuracy since illegal memory access in cuda will be thrown if enable_cuda_graph. 
  If io_bind is not enabled and enable_cuda_graph is True, the following errors will be raised:

    onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : CUDA failure 700: an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ; file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_graph.cc ; line=49 ; expr=cudaGraphLaunch(graph_exec_, stream_); 
    [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDA failure 700: an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ; file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=286 ; expr=cudaStreamDestroy(stream_); 
    [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDNN failure 4: CUDNN_STATUS_INTERNAL_ERROR ; GPU=0 ; hostname=c93f1847c000000 ; file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=181 ; expr=cudnnDestroy(cudnn_handle_); 


## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
