### PR TITLE
Whisper: Support `openai/whisper-large-v3` using dynamic `N_MELS`

### DIFF
--- a/examples/whisper/code/user_script.py
+++ b/examples/whisper/code/user_script.py
@@ -166,9 +166,7 @@ def decoder_dummy_inputs(olive_model: PyTorchModelHandler):
     return tuple(inputs.to_list())
 
 
-def whisper_audio_decoder_dataloader(data_dir, batch_size, *args, **kwargs):
-    return WhisperDataset(data_dir=data_dir, use_audio_decoder=True)
-
-
-def whisper_no_audio_decoder_dataloader(data_dir, batch_size, *args, **kwargs):
-    return WhisperDataset(data_dir=data_dir, use_audio_decoder=False)
+def whisper_dataloader(data_dir, batch_size, *args, **kwargs):
+    model_name = kwargs["model_name"]
+    use_audio_decoder = kwargs["use_audio_decoder"]
+    return WhisperDataset(data_dir=data_dir, model_name=model_name, use_audio_decoder=use_audio_decoder)

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -54,6 +54,7 @@ def main(raw_args=None):
         config = json.load(f)
 
     # get model information
+    model_name = config["input_model"]["config"]["hf_config"]["model_name"]
     use_audio_decoder = config["passes"]["prepost"]["config"]["tool_command_args"]["use_audio_decoder"]
     multilingual = config["passes"]["insert_beam_search"]["config"].get("use_forced_decoder_ids", False)
     if not multilingual and not (args.language == "english" and args.task == "transcribe"):
@@ -89,6 +90,7 @@ def main(raw_args=None):
     # dataset
     dataset = WhisperDataset(
         data_dir=temp_dir_path,
+        model_name=model_name,
         use_audio_decoder=use_audio_decoder,
         file_ext=temp_audio_path.suffix,
         language=args.language,

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -43,7 +43,13 @@
                         "user_script": "code/user_script.py",
                         "script_dir": "code",
                         "data_dir": "data",
-                        "dataloader_func": "<place_holder>"
+                        "dataloader_func": "whisper_dataloader",
+                        "func_kwargs": {
+                            "dataloader_func": {
+                                "model_name" : "<place_holder>",
+                                "use_audio_decoder" : "<place_holder>"
+                            }
+                        }
                     }
                 }
             ]

--- a/olive/passes/utils/whisper_prepost.py
+++ b/olive/passes/utils/whisper_prepost.py
@@ -16,12 +16,26 @@ def add_pre_post_processing_to_model(
     use_onnx_stft: bool = True,
 ) -> onnx.ModelProto:
     processor = WhisperProcessor.from_pretrained(model_name)
-    # get pre and post processing models
-    pre_model, post_model = gen_processing_models(
-        processor,
-        pre_kwargs={"USE_AUDIO_DECODER": use_audio_decoder, "USE_ONNX_STFT": use_onnx_stft},
-        post_kwargs={},
-        opset=opset,
-    )
+
+    # N_MELS is hardcoded to 80 but whisper-large-v3 uses 128
+    # update the constant in ort-extensions
+    # TODO(jambayk): Remove this once ort-extensions is updated to use dynamic N_MELS
+    from onnxruntime_extensions._torch_cvt import _WhisperHParams
+
+    original_n_mels = _WhisperHParams.N_MELS
+    try:
+        # can also get from config.num_mel_bins
+        _WhisperHParams.N_MELS = processor.feature_extractor.feature_size
+
+        # get pre and post processing models
+        pre_model, post_model = gen_processing_models(
+            processor,
+            pre_kwargs={"USE_AUDIO_DECODER": use_audio_decoder, "USE_ONNX_STFT": use_onnx_stft},
+            post_kwargs={},
+            opset=opset,
+        )
+    finally:
+        _WhisperHParams.N_MELS = original_n_mels
+
     # merge pre, model, and post models
     return util.quick_merge(pre_model, model, post_model)


### PR DESCRIPTION
## Describe your changes
Whisper example doesn't work with `openai/whisper-large-v3` since `N_MELS` is hardcoded to `80` in both olive and onnxruntime-extensions but the v3 model uses `128`.
In this PR:
- Use whisper config/processor to get the correct number of mel bins
- for onnxruntime-extensions, we update the constant used by it in the append pre/post processing utils. This is a temporary workaround until ort-extensions also supports dynamic value for `N_MELS`. 
- Dataloader updated to accept `model_name`

Fixes:
https://github.com/microsoft/Olive/issues/823

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
