### PR TITLE
Whisper: Expose missing options, Enable timestamps, Transformers opt in `gpu_int8`

### DIFF
--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -7,7 +7,7 @@ Performs optimization pipeline:
 - CPU, INT8: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Intel® Neural Compressor Dynamic Quantized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 - GPU, FP32: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 - GPU, FP16: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Mixed Precision Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
-- GPU, INT8: *PyTorch Model -> Onnx Model -> Dynamic Quantized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
+- GPU, INT8: *PyTorch Model -> Onnx Model -> Transformers Optimized Onnx Model -> Dynamic Quantized Onnx Model -> Insert Beam Search Op -> Insert Pre/Post Processing Ops*
 
 Outputs the final model and latency results.
 
@@ -30,48 +30,64 @@ Note: Multilingual support requires onnxruntime>=1.16.0
 
 ### Prepare workflow config json
 ```
-python prepare_whisper_configs.py [--model_name MODEL_NAME] [--no_audio_decoder] [--multilingual] [--package_model]
+python prepare_whisper_configs.py [--model_name MODEL_NAME] [--package_model] [--no_audio_decoder] [--multilingual] [--enable_timestamps]
 
 # For example, using whisper tiny model
 python prepare_whisper_configs.py --model_name openai/whisper-tiny.en
 ```
 
-`--model_name MODEL_NAME` is the name or path of the whisper model. The default value is `openai/whisper-tiny.en`.
-`--no_audio_decoder` is optional. If not provided, will use audio decoder in the preprocessing ops.
-`--package_model` is optional. If provided, will package the optimized model along with the required onnxruntime packages and sample code to run inference into a zip file.
+The additional options are:
+- `--model_name MODEL_NAME` is the name or path of the whisper model. The default value is `openai/whisper-tiny.en`.
+- `--package_model` is optional. If provided, will package the optimized model along with the required onnxruntime packages and sample code to run inference into a zip file.
+- `--no_audio_decoder` is optional. If not provided, will use audio decoder in the preprocessing ops. If provided, you need to install `librosa` package before running the optimization steps below.
 
-**Note:** If `--no_audio_decoder` is provided, you need to install `librosa` package before running the optimization steps below.
+    ```bash
+    python -m pip install librosa
+    ```
 
-```bash
-python -m pip install librosa
-```
+- `--multiligual` is optional. If provided, the model produced will support multiple languages that are controlled using `decoder_input_ids` input.
 
-`--multiligual` is optional. If provided, the model produced will support multiple languages that are controlled using `decoder_input_ids` input.
-
-**Example of decoder_input_ids:**
-```python
-import numpy as np
-from transformers import AutoConfig, AutoProcessor
+    **Example of decoder_input_ids:**
+    ```python
+    import numpy as np
+    from transformers import AutoConfig, AutoProcessor
 
 
-model = "openai/whisper-tiny"
-config = AutoConfig.from_pretrained(model)
-processor = AutoProcessor.from_pretrained(model)
+    model = "openai/whisper-tiny"
+    config = AutoConfig.from_pretrained(model)
+    processor = AutoProcessor.from_pretrained(model)
 
-# English transcription
-forced_decoder_ids = processor.get_decoder_prompt_ids(language="english", task="transcribe")
-# forced_decoder_ids is of the format [(1, 50259), (2, 50359), (3, 50363)] and needs to be
-# of the format [50258, 50259, 50359, 50363] where 50258 is the start token id
-forced_decoder_ids = [config.decoder_start_token_id] + list(map(lambda token: token[1], forced_decoder_ids))
+    # English transcription
+    # set no_timestamps=False to get the timestamps in the output
+    forced_decoder_ids = processor.get_decoder_prompt_ids(language="english", task="transcribe", no_timestamps=True)
+    # forced_decoder_ids is of the format [(1, 50259), (2, 50359), (3, 50363)] and needs to be
+    # of the format [50258, 50259, 50359, 50363] where 50258 is the start token id
+    # 50363 is not present if no_timestamps=False
+    forced_decoder_ids = [config.decoder_start_token_id] + list(map(lambda token: token[1], forced_decoder_ids))
 
-# If you don't want to provide specific decoder input ids or you want
-# Whisper to predict the output language and task, you can set
-# forced_decoder_ids = [config.decoder_start_token_id]
-# [50258]
+    # If you don't want to provide specific decoder input ids or you want
+    # Whisper to predict the output language and task, you can set
+    # forced_decoder_ids = [config.decoder_start_token_id]
+    # [50258]
 
-# decoder input ids
-decoder_input_ids = np.array([forced_decoder_ids], dtype=np.int32)
-```
+    # decoder input ids
+    decoder_input_ids = np.array([forced_decoder_ids], dtype=np.int32)
+    ```
+
+- `--enable_timestamps` is optional. If provided, the model produced will support predicting timestamps with the text. Does not work for `openai/whisper-large-v3`!
+    The model input must include `logits_processor`:
+
+    ```python
+    import numpy as np
+
+    # replace 1 with 0 if you don't want to use timestamps
+    logits_processor = np.array([1], dtype=np.int32)
+    ```
+
+    If using with `--multilingual`, be sure to use `no_timestamps=False` when getting `forced_decoder_ids`.
+
+- `--skip_evaluation` is optional. If provided, will skip the latency evaluation for the final model. This is useful if you want to avoid the time consuming latency evaluation for large models.
+
 
 
 ## Run the config to optimize the model
@@ -111,18 +127,20 @@ python -m olive.workflows.run --config whisper_cpu_int8.json 2> $null
 
 ## Test the transcription of the optimized model
 ```bash
-python test_transcription.py --config whisper_{device}_{precision}.json [--auto_path AUDIO_PATH] [--language LANGUAGE] [--task {transcribe,translate}]
+python test_transcription.py --config whisper_{device}_{precision}.json [--auto_path AUDIO_PATH] [--language LANGUAGE] [--task {transcribe,translate}] [--predict_timestamps]
 
 # For example, to test CPU, INT8 with default audio path
 python test_transcription.py --config whisper_cpu_int8.json
 ```
 
-`--audio_path` Optional. Path to audio file. If not provided, will use a default audio file.
+- `--audio_path` Optional. Path to audio file. If not provided, will use a default audio file.
 
-`--language` Optional. Language spoken in audio. Default is `english`. Only used when `--multilingual` is provided to `prepare_whisper_configs.py`
+- `--language` Optional. Language spoken in audio. Default is `english`. Only used when `--multilingual` is provided to `prepare_whisper_configs.py`
 
-`--task` Optional. Whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate'). Default is `transcribe`. Only used
+- `--task` Optional. Whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate'). Default is `transcribe`. Only used
 when `--multilingual` is provided to `prepare_whisper_configs.py`
+
+- `--predict_timestamps` Optional. Whether to predict timestamps with the text. Default is `False`. Only used when `--enable_timestamps` is provided to `prepare_whisper_configs.py`
 
 ## FAQ
 The following are some common issues that may be encountered when running this example.
@@ -148,3 +166,5 @@ version of onnxruntime.
         }
     }
     ```
+
+4. If you run out of space in your temp directory, you can add `--tempdir .` to the workflow command to use the current directory as the temp directory root. `.` can be replaced with any other directory with sufficient disk space and write permission.

--- a/examples/whisper/code/user_script.py
+++ b/examples/whisper/code/user_script.py
@@ -169,4 +169,10 @@ def decoder_dummy_inputs(olive_model: PyTorchModelHandler):
 def whisper_dataloader(data_dir, batch_size, *args, **kwargs):
     model_name = kwargs["model_name"]
     use_audio_decoder = kwargs["use_audio_decoder"]
-    return WhisperDataset(data_dir=data_dir, model_name=model_name, use_audio_decoder=use_audio_decoder)
+    predict_timestamps = kwargs.get("predict_timestamps", False)
+    return WhisperDataset(
+        data_dir=data_dir,
+        model_name=model_name,
+        use_audio_decoder=use_audio_decoder,
+        predict_timestamps=predict_timestamps,
+    )

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -99,7 +99,7 @@ def main(raw_args=None):
 
     # multi-lingual support check
     if not version_1_16:
-        if args.multilingual and not version_1_16:
+        if args.multilingual:
             raise ValueError("Multi-lingual support is only supported in ORT >= 1.16.0")
         if args.enable_timestamps:
             raise ValueError("Enabling timestamps is only supported in ORT >= 1.16.0")

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -30,7 +30,13 @@ SUPPORTED_WORKFLOWS = {
     ],
     ("gpu", "fp32"): ["conversion", "transformers_optimization", "insert_beam_search", "prepost"],
     ("gpu", "fp16"): ["conversion", "transformers_optimization", "mixed_precision", "insert_beam_search", "prepost"],
-    ("gpu", "int8"): ["conversion", "onnx_dynamic_quantization", "insert_beam_search", "prepost"],
+    ("gpu", "int8"): [
+        "conversion",
+        "transformers_optimization",
+        "onnx_dynamic_quantization",
+        "insert_beam_search",
+        "prepost",
+    ],
 }
 DEVICE_TO_EP = {
     "cpu": "CPUExecutionProvider",
@@ -50,6 +56,19 @@ def get_args(raw_args):
         "--multilingual",
         action="store_true",
         help="Support using model for multiple languages. Only supported in ORT >= 1.16.0. Default: False",
+    )
+    parser.add_argument(
+        "--enable_timestamps",
+        action="store_true",
+        help=(
+            "Enable model to output timestamps along with text. Only supported in ORT >= 1.16.0 and doesn't work with"
+            " whisper-large-v3. Default: False"
+        ),
+    )
+    parser.add_argument(
+        "--skip_evaluation",
+        action="store_true",
+        help="Skip evaluation. Default: False",
     )
     parser.add_argument(
         "--package_model",
@@ -79,8 +98,16 @@ def main(raw_args=None):
     transformers_version_4_36 = version.parse(TransformersVersion) >= version.parse("4.36.0")
 
     # multi-lingual support check
-    if args.multilingual and not version_1_16:
-        raise ValueError("Multi-lingual support is only supported in ORT >= 1.16.0")
+    if not version_1_16:
+        if args.multilingual and not version_1_16:
+            raise ValueError("Multi-lingual support is only supported in ORT >= 1.16.0")
+        if args.enable_timestamps:
+            raise ValueError("Enabling timestamps is only supported in ORT >= 1.16.0")
+    if "large-v3" in args.model_name and args.enable_timestamps:
+        print(
+            "WARNING: Model has large-v3 in the name. openai/whisper-large-v3 doesn't support enabling timestamps so"
+            " this might not work as expected."
+        )
 
     # load template
     with open("whisper_template.json") as f:  # noqa: PTH123
@@ -93,14 +120,24 @@ def main(raw_args=None):
         template_json["input_model"]["config"]["hf_config"]["from_pretrained_args"] = {"attn_implementation": "eager"}
 
     # set dataloader
-    metric_dataloader_kwargs = template_json["evaluators"]["common_evaluator"]["metrics"][0]["user_config"][
-        "func_kwargs"
-    ]["dataloader_func"]
-    metric_dataloader_kwargs["model_name"] = model_name
-    metric_dataloader_kwargs["use_audio_decoder"] = not args.no_audio_decoder
+    if not args.skip_evaluation:
+        metric_dataloader_kwargs = template_json["evaluators"]["common_evaluator"]["metrics"][0]["user_config"][
+            "func_kwargs"
+        ]["dataloader_func"]
+        metric_dataloader_kwargs["model_name"] = model_name
+        metric_dataloader_kwargs["use_audio_decoder"] = not args.no_audio_decoder
+    else:
+        del template_json["evaluators"]
+        template_json["engine"]["evaluator"] = None
 
     # update multi-lingual support
     template_json["passes"]["insert_beam_search"]["config"]["use_forced_decoder_ids"] = args.multilingual
+    # update predict timestep
+    template_json["passes"]["insert_beam_search"]["config"]["use_logits_processor"] = args.enable_timestamps
+    # update no audio decoder
+    template_json["passes"]["prepost"]["config"]["tool_command_args"]["use_audio_decoder"] = not args.no_audio_decoder
+    # update atol
+    template_json["passes"]["mixed_precision"]["config"]["atol"] = args.atol
 
     # set model name in prepost
     template_json["passes"]["prepost"]["config"]["tool_command_args"]["model_name"] = model_name
@@ -127,12 +164,8 @@ def main(raw_args=None):
             pass_config = deepcopy(template_json["passes"][pass_name])
             if pass_name == "insert_beam_search":
                 pass_config["config"]["fp16"] = precision == "fp16"
-            if pass_name == "mixed_precision":
-                pass_config["config"]["atol"] = args.atol
             if pass_name == "transformers_optimization":
                 pass_config["config"]["use_gpu"] = device == "gpu"
-            if pass_name == "prepost":
-                pass_config["config"]["tool_command_args"]["use_audio_decoder"] = not args.no_audio_decoder
             config["passes"][pass_name] = pass_config
 
         # dump config

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -93,7 +93,8 @@
         "insert_beam_search" : {
             "type" : "InsertBeamSearch",
             "config": {
-                "use_forced_decoder_ids": "<place_holder>"
+                "use_forced_decoder_ids": "<place_holder>",
+                "use_logits_processor": "<place_holder>"
             }
         },
         "prepost": {

--- a/olive/passes/utils/whisper_prepost.py
+++ b/olive/passes/utils/whisper_prepost.py
@@ -14,6 +14,7 @@ def add_pre_post_processing_to_model(
     model_name: str,
     use_audio_decoder: bool = True,
     use_onnx_stft: bool = True,
+    skip_special_tokens: bool = True,
 ) -> onnx.ModelProto:
     processor = WhisperProcessor.from_pretrained(model_name)
 
@@ -31,7 +32,7 @@ def add_pre_post_processing_to_model(
         pre_model, post_model = gen_processing_models(
             processor,
             pre_kwargs={"USE_AUDIO_DECODER": use_audio_decoder, "USE_ONNX_STFT": use_onnx_stft},
-            post_kwargs={},
+            post_kwargs={"skip_special_tokens": skip_special_tokens},
             opset=opset,
         )
     finally:


### PR DESCRIPTION
## Describe your changes
- Expose missing beam search options `use_vocab_mask`, `use_prefix_vocab_mask` and `use_logits_processor` that were added in ORT 1.16 along with `use_forced_decoder_ids`.
- Expose `skip_special_tokens` option in whisper pre-post-processing
- `use_logits_processor` enables timestamps in the whisper output. The output text looks something like 
   ```
   "...<|3.00|> The ache of his overstrained eyes,<|6.00|><|6.00|> even the soaring arena around him with thousands of spectators,<|10.00|><|10.00|> which revealed he's not worth thinking about.<|13.00|>"
   ```
- Add transformers optimization pass to `gpu,int8` workflow. It was originally omitted due to some bug in ort but was corrected a while ago. I had forgotten to add it back since we never used the gpu workflow until the fp16 workflow was recent updated.

**Note:** The time stamp prediction does not work for the new `whisper-large-v3` model since the ort logitsprocessor hardcoded some token ids which are not the same in the v3 model.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
The whisper example now supports generating timestamps along with the text.

## (Optional) Issue link
