### PR TITLE
SDXL: Remove incorrect dynamic axis for text_encoder_2

### DIFF
--- a/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
@@ -46,7 +46,7 @@
                 ],
                 "dynamic_axes": {
                     "input_ids": { "0": "batch_size", "1": "sequence_length" },
-                    "text_embeds": { "0": "batch_size", "1": "sequence_length" },
+                    "text_embeds": { "0": "batch_size"},
                     "last_hidden_state": { "0": "batch_size", "1": "sequence_length" },
                     "hidden_states.0": { "0": "batch_size", "1": "sequence_length" },
                     "hidden_states.1": { "0": "batch_size", "1": "sequence_length" },


### PR DESCRIPTION
## Describe your changes
The second dimension for `text_embeds` output in `text_encoder_2` is `1280` and not dynamic. We can also see it in the same of `text_embeds` passed to the unet https://github.com/microsoft/Olive/blob/1344ff16b7cbf272a2e727ae9ba1ed7a20d51d2e/examples/directml/stable_diffusion_xl/user_script.py#L86

![image](https://github.com/microsoft/Olive/assets/94929125/0c1a22d1-508b-4976-a7c8-6c3edf0d6b9f)

We remove the incorrect dynamic axis for this output. The hufggingface converted onnx text_encoder_2 also has the same incorrect shape. https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/tree/main/text_encoder_2

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
