### PR TITLE
SDXL: Allow using fp16 fixed vae for CUDA provider

### DIFF
--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -260,7 +260,7 @@ def run_inference(
             model_dir, provider=provider_map[provider], provider_options=provider_options, session_options=sess_options
         )
     if is_fp16:
-        # the pipeline watermarker doesn't work with fp16 images
+        # the pipeline default watermarker doesn't work with fp16 images
         pipeline.watermark = None
 
     if interactive:
@@ -297,7 +297,7 @@ def update_config_with_provider(config: Dict, provider: str, is_fp16: bool) -> D
             config["passes"]["optimize_cuda"]["config"]["optimization_options"] = {"enable_skip_group_norm": False}
         # keep model fully in fp16 if use_fp16_fixed_vae is set
         if is_fp16:
-            config["passes"]["optimze_cuda"]["config"].update({"float16": True, "keep_io_types": False})
+            config["passes"]["optimize_cuda"]["config"].update({"float16": True, "keep_io_types": False})
         config["pass_flows"] = [["convert", "optimize_cuda"]]
         config["engine"]["execution_providers"] = ["CUDAExecutionProvider"]
         return config

--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -215,6 +215,7 @@ def run_inference(
     static_dims,
     device_id,
     interactive,
+    is_fp16,
     base_images=None,
 ):
     ort.set_default_logger_severity(3)
@@ -258,6 +259,9 @@ def run_inference(
         pipeline = ORTStableDiffusionXLImg2ImgPipeline.from_pretrained(
             model_dir, provider=provider_map[provider], provider_options=provider_options, session_options=sess_options
         )
+    if is_fp16:
+        # the pipeline watermarker doesn't work with fp16 images
+        pipeline.watermark = None
 
     if interactive:
         run_inference_gui(
@@ -283,7 +287,7 @@ def run_inference(
         )
 
 
-def update_config_with_provider(config: Dict, provider: str):
+def update_config_with_provider(config: Dict, provider: str, is_fp16: bool) -> Dict:
     if provider == "dml":
         # DirectML EP is the default, so no need to update config.
         return config
@@ -291,6 +295,9 @@ def update_config_with_provider(config: Dict, provider: str):
         if version.parse(OrtVersion) < version.parse("1.17.0"):
             # disable skip_group_norm fusion since there is a shape inference bug which leads to invalid models
             config["passes"]["optimize_cuda"]["config"]["optimization_options"] = {"enable_skip_group_norm": False}
+        # keep model fully in fp16 if use_fp16_fixed_vae is set
+        if is_fp16:
+            config["passes"]["optimze_cuda"]["config"].update({"float16": True, "keep_io_types": False})
         config["pass_flows"] = [["convert", "optimize_cuda"]]
         config["engine"]["execution_providers"] = ["CUDAExecutionProvider"]
         return config
@@ -302,6 +309,7 @@ def optimize(
     model_id: str,
     is_refiner_model: bool,
     provider: str,
+    use_fp16_fixed_vae: bool,
     unoptimized_model_dir: Path,
     optimized_model_dir: Path,
 ):
@@ -342,13 +350,19 @@ def optimize(
         olive_config = None
         with (script_dir / f"config_{submodel_name}.json").open() as fin:
             olive_config = json.load(fin)
-        olive_config = update_config_with_provider(olive_config, provider)
+        olive_config = update_config_with_provider(olive_config, provider, use_fp16_fixed_vae)
 
-        # TODO(PatriceVignola): Remove this once we figure out which nodes are causing the black screen
-        if is_refiner_model and submodel_name == "vae_encoder":
+        if is_refiner_model and submodel_name == "vae_encoder" and not use_fp16_fixed_vae:
+            # TODO(PatriceVignola): Remove this once we figure out which nodes are causing the black screen
             olive_config["passes"]["optimize"]["config"]["float16"] = False
+            olive_config["passes"]["optimize_cuda"]["config"]["float16"] = False
 
-        olive_config["input_model"]["config"]["model_path"] = model_id
+        # Use fp16 fixed vae if use_fp16_fixed_vae is set
+        if use_fp16_fixed_vae and "vae" in submodel_name:
+            olive_config["input_model"]["config"]["model_path"] = "madebyollin/sdxl-vae-fp16-fix"
+        else:
+            olive_config["input_model"]["config"]["model_path"] = model_id
+
         olive_run(olive_config)
 
         footprints_file_path = (
@@ -462,6 +476,15 @@ def main(raw_args=None):
     parser.add_argument(
         "--provider", default="dml", type=str, choices=["dml", "cuda"], help="Execution provider to use"
     )
+    parser.add_argument(
+        "--use_fp16_fixed_vae",
+        action="store_true",
+        help=(
+            "Use madebyollin/sdxl-vae-fp16-fix as VAE. All models will be in fp16 if this flag is set. Otherwise, vae"
+            " will be in fp32 while other sub models will be fp16 with fp32 input/outputs. Only supported for cuda"
+            " provider."
+        ),
+    )
     parser.add_argument("--base_images", default=None, nargs="+")
     parser.add_argument("--interactive", action="store_true", help="Run with a GUI")
     parser.add_argument("--optimize", action="store_true", help="Runs the optimization step")
@@ -519,6 +542,10 @@ def main(raw_args=None):
             "expected."
         )
 
+    if args.use_fp16_fixed_vae and args.provider != "cuda":
+        print("WARNING: --use_fp16_fixed_vae is only supported for cuda provider currently.")
+        sys.exit(1)
+
     if args.provider == "dml" and version.parse(OrtVersion) < version.parse("1.16.2"):
         print("This script requires onnxruntime-directml 1.16.2 or newer")
         sys.exit(1)
@@ -571,7 +598,14 @@ def main(raw_args=None):
         # TODO(PatriceVignola): clean up warning filter (mostly during conversion from torch to ONNX)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            optimize(args.model_id, is_refiner_model, args.provider, unoptimized_model_dir, optimized_model_dir)
+            optimize(
+                args.model_id,
+                is_refiner_model,
+                args.provider,
+                args.use_fp16_fixed_vae,
+                unoptimized_model_dir,
+                optimized_model_dir,
+            )
 
     # Run inference on the models
     if not args.optimize:
@@ -592,6 +626,7 @@ def main(raw_args=None):
                 use_static_dims,
                 args.device_id,
                 args.interactive,
+                args.use_fp16_fixed_vae,
                 args.base_images,
             )
 

--- a/examples/directml/stable_diffusion_xl/user_script.py
+++ b/examples/directml/stable_diffusion_xl/user_script.py
@@ -119,7 +119,8 @@ def vae_encoder_inputs(batchsize, torch_dtype):
 
 
 def vae_encoder_load(model_name):
-    model = AutoencoderKL.from_pretrained(model_name, subfolder="vae")
+    subfolder = None if model_name == "madebyollin/sdxl-vae-fp16-fix" else "vae"
+    model = AutoencoderKL.from_pretrained(model_name, subfolder=subfolder)
     model.forward = lambda sample, return_dict: model.encode(sample, return_dict)[0].sample()
     return model
 
@@ -147,7 +148,8 @@ def vae_decoder_inputs(batchsize, torch_dtype):
 
 
 def vae_decoder_load(model_name):
-    model = AutoencoderKL.from_pretrained(model_name, subfolder="vae")
+    subfolder = None if model_name == "madebyollin/sdxl-vae-fp16-fix" else "vae"
+    model = AutoencoderKL.from_pretrained(model_name, subfolder=subfolder)
     model.forward = model.decode
     return model
 

--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -81,11 +81,14 @@ python stable_diffusion.py --provider cuda --optimize
 **_Stable Diffusion XL_**
 ```bash
 # default model_id is "stabilityai/stable-diffusion-xl-base-1.0"
-python stable_diffusion_xl.py --provider cuda --optimize
+python stable_diffusion_xl.py --provider cuda --optimize [--use_fp16_fixed_vae]
 
 # or specify a different model_id
-python stable_diffusion_xl.py --provider cuda --model_id stabilityai/stable-diffusion-xl-refiner-1.0 --optimize
+python stable_diffusion_xl.py --provider cuda --model_id stabilityai/stable-diffusion-xl-refiner-1.0 --optimize [--use_fp16_fixed_vae]
 ```
+
+`--use_fp16_fixed_vae` is optional. If provided, will use [madebyollin/sdxl-vae-fp16-fix](https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) for the vae models and all sub-models will be entirely in fp16.
+Otherwise, the vae models (vae-decoder for base and both vae-decoder and vae-encoder for refiner) will be in fp32 and all other sub-models will be in fp16 with fp32 input/output.
 
 Once the script successfully completes:
 - The optimized ONNX pipeline will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/runwayml/stable-diffusion-v1-5` or `models/optimized-cuda/stabilityai/stable-diffusion-xl-base-1.0`).


### PR DESCRIPTION
## Describe your changes
[madebyollin/sdxl-vae-fp16-fix](https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) is a modified SDXL vae that can run in fp16 without generating NaNs. 
This PR:
- Adds `--use_fp16_fixed_vae` option to use this vae instead. With this, the whole model can be in fp16 without need for fp32 io. 
- Only enabled for cuda currently. Will be enabled for dml in a separate PR after validating the model. 

The default stable diffusion watermarker doesn't support fp16 models and there is no option in the `from_pretrained` method to disbable it. I already have PR with a potential fix on the optimum repo https://github.com/huggingface/optimum/pull/1603. For now, we can manually set the watermarker to `None`. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
