### PR TITLE
Phi: Unpin transformers version

### DIFF
--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -12,8 +12,8 @@
         }
     },
     "data_configs": {
-        "tiny-codes-train": {
-            "name": "tiny-codes-train",
+        "tiny_codes_train": {
+            "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "components": {
@@ -32,8 +32,7 @@
                     "pre_process_data": {
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
-                        "source_max_len": 1024,
-                        "use_attention_mask": false
+                        "source_max_len": 1024
                     }
                 }
             }
@@ -44,12 +43,12 @@
             "type": "QLoRA",
             "config": {
                 "lora_dropout": 0.1,
-                "train_data_config": "tiny-codes-train",
+                "train_data_config": "tiny_codes_train",
                 "eval_dataset_size": 1024,
                 "training_args": {
-                    "per_device_train_batch_size": 4,
-                    "per_device_eval_batch_size": 4,
-                    "gradient_accumulation_steps": 4,
+                    "per_device_train_batch_size": 2,
+                    "per_device_eval_batch_size": 2,
+                    "gradient_accumulation_steps": 8,
                     "gradient_checkpointing": false,
                     "max_steps": 1500,
                     "logging_steps": 100,
@@ -63,7 +62,6 @@
         }
     },
     "engine": {
-        "log_severity_level": 0,
         "search_strategy": false,
         "evaluate_input_model": false,
         "target": {

--- a/examples/phi/requirements.txt
+++ b/examples/phi/requirements.txt
@@ -1,5 +1,3 @@
 datasets
 einops
 sentencepiece
-# transformers >= 4.35.0 has breaking change for gradient checkpointing
-transformers==4.34.1


### PR DESCRIPTION
## Describe your changes
The transformers version in the phi example is unpinned since the gradient checkpointing issue has already been addressed in Olive. This also resolves the security issue from transformers < 4.36.0. 
Plus some config fixes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
