### PR TITLE
OptimumConversion: `components` option, version check

### DIFF
--- a/examples/directml/dolly_v2/config_dolly_v2.json
+++ b/examples/directml/dolly_v2/config_dolly_v2.json
@@ -41,9 +41,7 @@
                 "extra_args": {
                     "legacy": true,
                     "no_post_process": true
-                },
-                "save_as_external_data": true,
-                "all_tensors_to_one_file": true
+                }
             }
         },
         "optimize": {

--- a/examples/directml/dolly_v2/config_dolly_v2.json
+++ b/examples/directml/dolly_v2/config_dolly_v2.json
@@ -37,8 +37,11 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
-                "legacy": true,
                 "components": ["decoder_model", "decoder_with_past_model"],
+                "extra_args": {
+                    "legacy": true,
+                    "no_post_process": true
+                },
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/directml/dolly_v2/config_dolly_v2.json
+++ b/examples/directml/dolly_v2/config_dolly_v2.json
@@ -3,8 +3,7 @@
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
-                "model_name": "databricks/dolly-v2-7b",
-                "components": [{ "name": "decoder_model" }, { "name": "decoder_with_past_model" }]
+                "model_name": "databricks/dolly-v2-7b"
             }
         }
     },
@@ -37,6 +36,8 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
+                "legacy": true,
+                "components": ["decoder_model", "decoder_with_past_model"],
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/directml/dolly_v2/config_dolly_v2.json
+++ b/examples/directml/dolly_v2/config_dolly_v2.json
@@ -3,7 +3,8 @@
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
-                "model_name": "databricks/dolly-v2-7b"
+                "model_name": "databricks/dolly-v2-7b",
+                "task": "text-generation"
             }
         }
     },

--- a/examples/open_llama/open_llama_arc.json
+++ b/examples/open_llama/open_llama_arc.json
@@ -62,9 +62,7 @@
                 "extra_args": {
                     "legacy": true,
                     "no_post_process": true
-                },
-                "save_as_external_data": true,
-                "all_tensors_to_one_file": true
+                }
             }
         },
         "optimize": {

--- a/examples/open_llama/open_llama_arc.json
+++ b/examples/open_llama/open_llama_arc.json
@@ -58,8 +58,11 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
-                "legacy": true,
                 "components": ["decoder_model", "decoder_with_past_model"],
+                "extra_args": {
+                    "legacy": true,
+                    "no_post_process": true
+                },
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/open_llama/open_llama_arc.json
+++ b/examples/open_llama/open_llama_arc.json
@@ -9,8 +9,7 @@
         "config": {
             "hf_config": {
                 "model_name": "openlm-research/open_llama_3b",
-                "model_class": "LlamaForCausalLM",
-                "components": [{ "name": "decoder_model" }, { "name": "decoder_with_past_model" }]
+                "model_class": "LlamaForCausalLM"
             }
         }
     },
@@ -59,6 +58,8 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
+                "legacy": true,
+                "components": ["decoder_model", "decoder_with_past_model"],
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/open_llama/open_llama_arc.json
+++ b/examples/open_llama/open_llama_arc.json
@@ -9,7 +9,7 @@
         "config": {
             "hf_config": {
                 "model_name": "openlm-research/open_llama_3b",
-                "model_class": "LlamaForCausalLM"
+                "task": "text-generation"
             }
         }
     },

--- a/examples/open_llama/open_llama_config.json
+++ b/examples/open_llama/open_llama_config.json
@@ -33,9 +33,7 @@
                 "extra_args": {
                     "legacy": true,
                     "no_post_process": true
-                },
-                "save_as_external_data": true,
-                "all_tensors_to_one_file": true
+                }
             }
         },
         "optimize": {

--- a/examples/open_llama/open_llama_config.json
+++ b/examples/open_llama/open_llama_config.json
@@ -29,8 +29,11 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
-                "legacy": true,
                 "components": ["decoder_model", "decoder_with_past_model"],
+                "extra_args": {
+                    "legacy": true,
+                    "no_post_process": true
+                },
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/open_llama/open_llama_config.json
+++ b/examples/open_llama/open_llama_config.json
@@ -4,7 +4,7 @@
         "config": {
             "hf_config": {
                 "model_name": "openlm-research/open_llama_3b",
-                "model_class": "LlamaForCausalLM"
+                "task": "text-generation"
             }
         }
     },

--- a/examples/open_llama/open_llama_config.json
+++ b/examples/open_llama/open_llama_config.json
@@ -4,16 +4,7 @@
         "config": {
             "hf_config": {
                 "model_name": "openlm-research/open_llama_3b",
-                "model_class": "LlamaForCausalLM",
-                "components": [{ "name": "decoder_model" }, { "name": "decoder_with_past_model" }]
-            }
-        }
-    },
-    "systems": {
-        "local_system": {
-            "type": "LocalSystem",
-            "config": {
-                "accelerators": ["gpu"]
+                "model_class": "LlamaForCausalLM"
             }
         }
     },
@@ -38,6 +29,8 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
+                "legacy": true,
+                "components": ["decoder_model", "decoder_with_past_model"],
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }
@@ -64,8 +57,7 @@
         "evaluator": "common_evaluator",
         "cache_dir": "cache",
         "output_name": "ollama",
-        "target": "local_system",
-        "host": "local_system",
+        "execution_providers": ["CUDAExecutionProvider"],
         "output_dir": "models/open_llama"
     }
 }

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -4,8 +4,7 @@
         "config": {
             "hf_config": {
                 "model_name": "openlm-research/open_llama_3b",
-                "model_class": "LlamaForCausalLM",
-                "components": [{ "name": "decoder_model" }, { "name": "decoder_with_past_model" }]
+                "model_class": "LlamaForCausalLM"
             }
         }
     },
@@ -32,6 +31,8 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
+                "legacy": true,
+                "components": ["decoder_model", "decoder_with_past_model"],
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -31,8 +31,11 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 14,
-                "legacy": true,
                 "components": ["decoder_model", "decoder_with_past_model"],
+                "extra_args": {
+                    "legacy": true,
+                    "no_post_process": true
+                },
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -4,7 +4,7 @@
         "config": {
             "hf_config": {
                 "model_name": "openlm-research/open_llama_3b",
-                "model_class": "LlamaForCausalLM"
+                "task": "text-generation"
             }
         }
     },

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -35,9 +35,7 @@
                 "extra_args": {
                     "legacy": true,
                     "no_post_process": true
-                },
-                "save_as_external_data": true,
-                "all_tensors_to_one_file": true
+                }
             }
         },
         "optimize": {

--- a/examples/open_llama/requirements-woq.txt
+++ b/examples/open_llama/requirements-woq.txt
@@ -1,7 +1,7 @@
 datasets
 # TODO: remove commit hash once update
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
-git+https://github.com/intel/intel-extension-for-transformers.git@abce937aa70ed2e30fbdf0aefd38cc3dd9d1d32a
+intel-extension-for-transformers>=1.2.2
 neural-compressor>=2.3
 onnxruntime
 sentencepiece

--- a/examples/red_pajama/config.json
+++ b/examples/red_pajama/config.json
@@ -35,8 +35,11 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 16,
-                "legacy": true,
                 "components": ["decoder_model", "decoder_with_past_model"],
+                "extra_args": {
+                    "legacy": true,
+                    "no_post_process": true
+                },
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/examples/red_pajama/config.json
+++ b/examples/red_pajama/config.json
@@ -39,9 +39,7 @@
                 "extra_args": {
                     "legacy": true,
                     "no_post_process": true
-                },
-                "save_as_external_data": true,
-                "all_tensors_to_one_file": true
+                }
             }
         },
         "optimize": {

--- a/examples/red_pajama/config.json
+++ b/examples/red_pajama/config.json
@@ -4,8 +4,7 @@
         "config": {
             "hf_config": {
                 "model_name": "togethercomputer/RedPajama-INCITE-Base-3B-v1",
-                "model_class": "GPTNeoXForCausalLM",
-                "components": [{ "name": "decoder_model" }, { "name": "decoder_with_past_model" }]
+                "model_class": "GPTNeoXForCausalLM"
             }
         }
     },
@@ -36,6 +35,8 @@
             "type": "OptimumConversion",
             "config": {
                 "target_opset": 16,
+                "legacy": true,
+                "components": ["decoder_model", "decoder_with_past_model"],
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true
             }

--- a/olive/passes/onnx/optimum_conversion.py
+++ b/olive/passes/onnx/optimum_conversion.py
@@ -98,17 +98,14 @@ class OptimumConversion(Pass):
         # TODO(anyone): consider using a temporary directory to export the model and then save the relevant components
         export_optimum_model(model.model_path or hf_config.model_name, output_model_path, **extra_args)
 
-        output_model_path = Path(output_model_path)
-
         # check the exported components
-        exported_models = [name.stem for name in output_model_path.iterdir() if name.suffix == ".onnx"]
-        logger.debug(f"Exported models: {exported_models}")
+        exported_models = [name.stem for name in Path(output_model_path).iterdir() if name.suffix == ".onnx"]
         if config["components"]:
             assert all(
                 component in exported_models for component in config["components"]
             ), f"Components {config['components']} are not exported. Only {exported_models} are exported."
         components = config["components"] or exported_models
-        logger.debug(f"Components to export: {components}")
+        logger.debug(f"Exported models are: {exported_models}. Returning components: {components}.")
 
         # if there is only one component, return it directly
         if len(components) == 1:

--- a/test/unit_test/passes/onnx/test_optimum_conversion.py
+++ b/test/unit_test/passes/onnx/test_optimum_conversion.py
@@ -65,12 +65,11 @@ def test_optimum_conversion_pass_with_components(components, extra_args, expecte
         assert Path(output_model.model_path).exists()
     else:
         assert isinstance(output_model, CompositeModelHandler)
-        component_models = list(output_model.get_model_components())
-        assert len(component_models) == len(expected_components)
-        for i, (component_name, component_model) in enumerate(component_models):
-            assert component_name == expected_components[i]
-            assert isinstance(component_model, ONNXModelHandler)
+        component_names = []
+        for component_name, component_model in output_model.get_model_components():
+            component_names.append(component_name)
             assert Path(component_model.model_path).exists()
+        assert set(component_names) == set(expected_components)
 
 
 @pytest.mark.parametrize(

--- a/test/unit_test/passes/onnx/test_optimum_conversion.py
+++ b/test/unit_test/passes/onnx/test_optimum_conversion.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 
 from pathlib import Path
-from test.unit_test.utils import get_optimum_model_by_hf_config, get_optimum_model_by_model_path
+from test.unit_test.utils import get_hf_model
 
 import pytest
 
@@ -12,11 +12,9 @@ from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.optimum_conversion import OptimumConversion
 
 
-@pytest.mark.parametrize(
-    "input_model,extra_args",
-    [(get_optimum_model_by_hf_config(), {"atol": 0.1}), (get_optimum_model_by_model_path(), {"atol": None})],
-)
-def test_optimum_conversion_pass(input_model, extra_args, tmp_path):
+@pytest.mark.parametrize("extra_args", [{"atol": 0.1}, {"atol": None}])
+def test_optimum_conversion_pass(extra_args, tmp_path):
+    input_model = get_hf_model()
     # setup
     p = create_pass_from_dict(OptimumConversion, {"extra_args": extra_args}, disable_search=True)
     output_folder = tmp_path
@@ -37,7 +35,7 @@ def test_optimum_conversion_pass(input_model, extra_args, tmp_path):
     ],
 )
 def test_optimum_configs(config, is_valid, tmp_path):
-    input_model = get_optimum_model_by_hf_config()
+    input_model = get_hf_model()
     # setup
     p = create_pass_from_dict(OptimumConversion, config, disable_search=True)
     output_folder = tmp_path

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -80,21 +80,12 @@ def get_pytorch_model():
     )
 
 
-def get_optimum_model_by_model_path():
+def get_hf_model():
     return PyTorchModelHandler(
         hf_config={
             "model_name": "hf-internal-testing/tiny-random-gptj",
             "task": "text-generation",
         }
-    )
-
-
-def get_optimum_model_by_hf_config():
-    return PyTorchModelHandler(
-        hf_config={
-            "model_name": "hf-internal-testing/tiny-random-gptj",
-            "task": "text-generation",
-        },
     )
 
 


### PR DESCRIPTION
## Describe your changes
The `OptimumConversion` pass adds the following config parameters:
- `components`: #833 deprecated the `OptimumModelHandler` but uses a pytorch model with components. However, the components in the pytorch model handler doesn't make sense since conceptually, the pytorch model has no components and also causes #847. They are only used by the optimum conversion pass. So, making this a config parameter of the pass makes more sense.

Some other changes:
- Check the version of optimum and log a warning message about the different behavior of optimum for <1.14.0. 
- `legacy` and `no_post_process` must be passed as part of `extra_args`. The examples are still on legacy model but could be updated in the future to the latest single model.
- all external data config parameters are removed since they are ignored anyways. We save directly using the exporter.

Fixes:
#847 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
OptimumConversion pass:
- Provide parameter `components` if the user wants to export only some models such as `decoder_model` and `decoder_with_past_model`.
- Uses the default exporter args and behavior of the underlying optimum version. For versions 1.14.0+, this means `legacy=False` and `no_post_process=False`. User must provide them using `extra_args` if legacy behavior is desired.

## (Optional) Issue link
