### PR TITLE
Add `LoftQ` pass

### DIFF
--- a/docs/source/api/passes.rst
+++ b/docs/source/api/passes.rst
@@ -108,10 +108,16 @@ QLoRA
 ------
 .. autoconfigclass:: olive.passes.QLoRA
 
+.. _loftq:
+
+LoftQ
+-----
+.. autoconfigclass:: olive.passes.LoftQ
+
 .. _lora_hf_training_arguments:
 
-LoRA/QLoRA HFTrainingArguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LoRA/QLoRA/LoftQ HFTrainingArguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autopydantic_settings:: olive.passes.pytorch.lora.HFTrainingArguments
 

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -55,7 +55,7 @@ This pass only supports Hugging Face transformers PyTorch models. Please refer t
 Please refer to [QLoRA HFTrainingArguments](lora_hf_training_arguments) for more details on supported the `"training_args"` and their default values.
 
 ## LoftQ
-`LoftQ` is a quantization framework which simultaneously quantizes and finds a proper low-rank initialization for LoRA fine-tuning. It is based on the LoftQ [paper](https://arxiv.org/pdf/2310.08659.pdf)
+`LoftQ` is a quantization framework which simultaneously quantizes and finds a proper low-rank initialization for LoRA fine-tuning. It is based on the LoftQ [paper](https://arxiv.org/abs/2310.08659)
 and [code](https://github.com/yxli2123/LoftQ). More information on LoRA can be found in the [paper](https://arxiv.org/abs/2106.09685).
 
 The `LoftQ` pass initializes the quantized LoRA model using the LoftQ initialization method and then fine-tunes the adapters. The output model has new quantization aware master weights and the fine-tuned LoRA adapters.

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -54,6 +54,30 @@ This pass only supports Hugging Face transformers PyTorch models. Please refer t
 ```
 Please refer to [QLoRA HFTrainingArguments](lora_hf_training_arguments) for more details on supported the `"training_args"` and their default values.
 
+## LoftQ
+`LoftQ` is a quantization framework which simultaneously quantizes and finds a proper low-rank initialization for LoRA fine-tuning. It is based on the LoftQ [paper](https://arxiv.org/pdf/2310.08659.pdf)
+and [code](https://github.com/yxli2123/LoftQ). More information on LoRA can be found in the [paper](https://arxiv.org/abs/2106.09685).
+
+The `LoftQ` pass initializes the quantized LoRA model using the LoftQ initialization method and then fine-tunes the adapters. The output model has new quantization aware master weights and the fine-tuned LoRA adapters.
+
+This pass only supports Hugging Face transformers PyTorch models. Please refer to [LoftQ](loftq) for more details about the pass and its config parameters.
+
+**Note:** LoftQ requires a GPU to run.
+```json
+{
+    "type": "LoftQ",
+    "config": {
+        "compute_dtype": "bfloat16",
+        "train_data_config": // ...,
+        "training_args": {
+            "learning_rate": 0.0002,
+            // ...
+        }
+    }
+}
+```
+Please refer to [LoftQ HFTrainingArguments](lora_hf_training_arguments) for more details on supported the `"training_args"` and their default values.
+
 ## Quantization Aware Training
 The Quantization Aware Training (QAT) technique is used to improve the performance and efficiency of deep learning models by quantizing their
 weights and activations to lower bit-widths. The technique is applied during training, where the weights and activations are fake quantized

--- a/examples/open_llama/README.md
+++ b/examples/open_llama/README.md
@@ -102,6 +102,16 @@ Note: You must be logged in to HuggingFace using `huggingface-cli login` to down
 
 Requirements file: [requirements-lora.txt](requirements-lora.txt)
 
+### Fine-tune Open Llama Model on a code generation dataset using LoftQ
+This workflow fine-tunes Open LLaMA model using [LoftQ](https://arxiv.org/abs/2310.08659) to generate code given a prompt.
+
+The relevant config file is [open_llama_loftq_tinycodes.json](open_llama_loftq_tinycodes.json). The code language is set to `Python` but can be changed to other languages by changing the `language` field in the config file.
+Supported languages are Python, TypeScript, JavaScript, Ruby, Julia, Rust, C++, Bash, Java, C#, and Go. Refer to the [dataset card](https://huggingface.co/datasets/nampdn-ai/tiny-codes) for more details on the dataset.
+
+Note: You must be logged in to HuggingFace using `huggingface-cli login` to download the dataset or update `token` field in the config file with your HuggingFace token.
+
+Requirements file: [requirements-lora.txt](requirements-lora.txt)
+
 **Train using ONNX Runtime Training**
 You can also train the model using [ONNX Runtime Training](https://techcommunity.microsoft.com/t5/ai-machine-learning-blog/onnx-runtime-training-technical-deep-dive/ba-p/1398310).
 

--- a/examples/open_llama/open_llama_loftq_tinycodes.json
+++ b/examples/open_llama/open_llama_loftq_tinycodes.json
@@ -1,0 +1,74 @@
+{
+    "input_model":{
+        "type": "PyTorchModel",
+        "config": {
+            "hf_config": {
+                "model_name": "openlm-research/open_llama_7b_v2",
+                "task": "text-generation"
+            }
+        }
+    },
+    "data_configs": {
+        "tiny_codes_train": {
+            "name": "tiny_codes_train",
+            "type": "HuggingfaceContainer",
+            "user_script": "lora_user_script.py",
+            "components": {
+                "load_dataset": {
+                    "type": "load_tiny_code_dataset"
+                }
+            },
+            "params_config": {
+                "data_name": "nampdn-ai/tiny-codes",
+                "split": "train",
+                "component_kwargs": {
+                    "load_dataset": {
+                        "language": "Python",
+                        "token": true
+                    },
+                    "pre_process_data": {
+                        "corpus_strategy": "join",
+                        "text_template": "### Question: {prompt} \n### Answer: {response}",
+                        "source_max_len": 1024
+                    }
+                }
+            }
+        }
+    },
+    "passes": {
+        "loftq": {
+            "type": "LoftQ",
+            "config": {
+                "lora_dropout": 0.1,
+                "train_data_config": "tiny_codes_train",
+                "eval_dataset_size": 1024,
+                "training_args": {
+                    "per_device_train_batch_size": 16,
+                    "per_device_eval_batch_size": 16,
+                    "gradient_accumulation_steps": 1,
+                    "max_steps": 1500,
+                    "logging_steps": 100,
+                    "save_steps": 100,
+                    "evaluation_strategy": "steps",
+                    "adam_beta2": 0.999,
+                    "max_grad_norm": 0.3,
+                    "load_best_model_at_end": true
+                }
+            }
+        }
+    },
+    "engine": {
+        "log_severity_level": 0,
+        "search_strategy": false,
+        "evaluate_input_model": false,
+        "target": {
+            "type": "LocalSystem",
+            "config": {
+                "accelerators": ["gpu"]
+            }
+        },
+        "execution_providers": ["CPUExecutionProvider"],
+        "cache_dir": "cache",
+        "output_dir" : "models/open_llama_loftq_tinycodes"
+    }
+}

--- a/examples/open_llama/requirements-lora.txt
+++ b/examples/open_llama/requirements-lora.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 accelerate
 bitsandbytes
-peft
+peft>=0.7.0
 scikit-learn

--- a/olive/passes/pytorch/__init__.py
+++ b/olive/passes/pytorch/__init__.py
@@ -2,13 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.passes.pytorch.lora import LoRA, QLoRA
+from olive.passes.pytorch.lora import LoftQ, LoRA, QLoRA
 from olive.passes.pytorch.quantization_aware_training import QuantizationAwareTraining
 from olive.passes.pytorch.sparsegpt import SparseGPT
 from olive.passes.pytorch.tensor_parallel import PyTorchTensorParallel
 from olive.passes.pytorch.torch_trt_conversion import TorchTRTConversion
 
 __all__ = [
+    "LoftQ",
     "LoRA",
     "PyTorchTensorParallel",
     "QLoRA",

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -885,6 +885,7 @@ class QLoRA(QLoRABase):
         # this doesn't pick up the embedding layer and projection layer since those are not quantized
         # this is good since we don't want to touch those, LoRA might not work with input output embedding layers
         quantized_modules = find_submodules(pytorch_model, bnb.nn.Linear4bit)
+        logger.debug(f"Quantized modules: {quantized_modules}")
 
         # tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
@@ -956,6 +957,7 @@ class LoftQ(QLoRA):
 
         # find the quantized modules
         quantized_modules = find_submodules(pytorch_model, bnb.nn.Linear4bit)
+        logger.debug(f"Quantized modules: {quantized_modules}")
 
         # only need the quantized module to find the quantized modules
         # delete quantized model to free memory
@@ -967,7 +969,7 @@ class LoftQ(QLoRA):
             model, config, device_map="auto", quantization_method=None, quantization_config=None
         )
         # get loftq initialized lora model
-        logger.debug("Initialize LoRA with LoftQ")
+        logger.debug("Initializing LoRA with LoftQ")
         pytorch_model = self.init_lora_adapters(
             pytorch_model, new_model_handler.hf_config.task, config, quantized_modules, use_loftq=True
         )

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -15,7 +15,7 @@ import torch
 from olive.data.template import huggingface_data_config_template
 from olive.model import PyTorchModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
-from olive.passes.pytorch import LoRA, QLoRA
+from olive.passes.pytorch import LoftQ, LoRA, QLoRA
 
 # pylint: disable=redefined-outer-name
 
@@ -86,16 +86,27 @@ def test_lora(tmp_path):
     platform.system() == "Windows" or not torch.cuda.is_available(),
     reason="bitsandbytes requires Linux GPU.",
 )
-@pytest.mark.parametrize("use_loftq", [True, False])
-def test_qlora(use_loftq, tmp_path):
+def test_qlora(tmp_path):
     # execute
     # bfloat16 is not supported on all gpu
-    out = run_finetuning(QLoRA, tmp_path, torch_dtype="float32", use_loftq=use_loftq)
+    out = run_finetuning(QLoRA, tmp_path, torch_dtype="float32")
 
     # assert
     assert Path(out.get_resource("adapter_path")).exists()
-    if use_loftq:
-        assert Path(out.get_resource("model_path")).exists()
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows" or not torch.cuda.is_available(),
+    reason="bitsandbytes requires Linux GPU.",
+)
+def test_loftq(tmp_path):
+    # execute
+    # bfloat16 is not supported on all gpu
+    out = run_finetuning(LoftQ, tmp_path, torch_dtype="float32")
+
+    # assert
+    assert Path(out.get_resource("model_path")).exists()
+    assert Path(out.get_resource("adapter_path")).exists()
 
 
 @pytest.fixture(name="mock_torch_ort")


### PR DESCRIPTION
## Describe your changes
This PR adds a new pass `LoftQ` which is based on the paper https://arxiv.org/abs/2310.08659. 
It adds on the qlora fine tuning approach by initializing the quantization and lora adapters together. This "alleviates the discrepancy between the quantized and full-precision model and significantly improves generalization in downstream tasks". 

Since most of the fine-tuning steps are the same as `QLoRA`, the common code has been abstracted into a new base class called `QLoRABase`. `LoftQ` is a separate pass and not an option for `QLoRA` so that we don't conflate it too much and make the configuration confusing for the user. They can just switch the pass type instead.

 
## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

Introduced a new pass `LoftQ` which performs model fine-tuning using the LoftQ initialization proposed in https://arxiv.org/abs/2310.08659.

## (Optional) Issue link
