### PR TITLE
Make test discovery lazy call functions

### DIFF
--- a/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
+++ b/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
@@ -32,18 +32,20 @@ class TestAMLEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE: ClassVar[List] = [
-        ("PyTorchModel", get_pytorch_model(), get_accuracy_metric(), 0.99),
-        ("PyTorchModel", get_pytorch_model(), get_latency_metric(), 0.001),
-        ("ONNXModel", get_onnx_model(), get_accuracy_metric(), 0.99),
-        ("ONNXModel", get_onnx_model(), get_latency_metric(), 0.001),
+        ("PyTorchModel", get_pytorch_model, get_accuracy_metric, 0.99),
+        ("PyTorchModel", get_pytorch_model, get_latency_metric, 0.001),
+        ("ONNXModel", get_onnx_model, get_accuracy_metric, 0.99),
+        ("ONNXModel", get_onnx_model, get_latency_metric, 0.001),
     ]
 
     @pytest.mark.parametrize(
-        "model_type,model_path,metric,expected_res",
+        "model_type,model_path_func,metric_func,expected_res",
         EVALUATION_TEST_CASE,
     )
-    def test_evaluate_model(self, model_type, model_path, metric, expected_res):
+    def test_evaluate_model(self, model_type, model_path_func, metric_func, expected_res):
         aml_target = get_aml_target()
+        model_path = model_path_func()
+        metric = metric_func()
         config = ModelConfig.parse_obj({"type": model_type, "config": {"model_path": model_path}})
         actual_res = aml_target.evaluate_model(config, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:

--- a/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
+++ b/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import platform
+from functools import partial
 from test.integ_test.evaluator.docker_eval.utils import (
     delete_directories,
     download_data,
@@ -35,23 +36,30 @@ class TestDockerEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE: ClassVar[List] = [
-        ("PyTorchModel", get_pytorch_model(), get_accuracy_metric("post_process"), 0.99),
-        ("PyTorchModel", get_pytorch_model(), get_latency_metric(), 0.001),
-        ("PyTorchModel", get_huggingface_model(), get_accuracy_metric("hf_post_process", "create_hf_dataloader"), 0.1),
-        ("PyTorchModel", get_huggingface_model(), get_latency_metric("create_hf_dataloader"), 0.001),
-        ("ONNXModel", get_onnx_model(), get_accuracy_metric("post_process"), 0.99),
-        ("ONNXModel", get_onnx_model(), get_latency_metric(), 0.001),
-        ("OpenVINOModel", get_openvino_model(), get_accuracy_metric("openvino_post_process"), 0.99),
-        ("OpenVINOModel", get_openvino_model(), get_latency_metric(), 0.001),
+        ("PyTorchModel", get_pytorch_model, partial(get_accuracy_metric, "post_process"), 0.99),
+        ("PyTorchModel", get_pytorch_model, get_latency_metric, 0.001),
+        (
+            "PyTorchModel",
+            get_huggingface_model,
+            partial(get_accuracy_metric, "hf_post_process", "create_hf_dataloader"),
+            0.1,
+        ),
+        ("PyTorchModel", get_huggingface_model, partial(get_latency_metric, "create_hf_dataloader"), 0.001),
+        ("ONNXModel", get_onnx_model, partial(get_accuracy_metric, "post_process"), 0.99),
+        ("ONNXModel", get_onnx_model, get_latency_metric, 0.001),
+        ("OpenVINOModel", get_openvino_model, partial(get_accuracy_metric, "openvino_post_process"), 0.99),
+        ("OpenVINOModel", get_openvino_model, get_latency_metric, 0.001),
     ]
 
     @pytest.mark.parametrize(
-        "model_type,model_config,metric,expected_res",
+        "model_type,model_config_func,metric_func,expected_res",
         EVALUATION_TEST_CASE,
     )
     @pytest.mark.skipif(platform.system() == "Windows", reason="Docker target does not support windows")
-    def test_evaluate_model(self, model_type, model_config, metric, expected_res):
+    def test_evaluate_model(self, model_type, model_config_func, metric_func, expected_res):
         docker_target = get_docker_target()
+        model_config = model_config_func()
+        metric = metric_func()
         model_conf = ModelConfig.parse_obj({"type": model_type, "config": model_config})
         actual_res = docker_target.evaluate_model(model_conf, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:

--- a/test/integ_test/evaluator/local_eval/test_local_evaluation.py
+++ b/test/integ_test/evaluator/local_eval/test_local_evaluation.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from functools import partial
 from test.integ_test.evaluator.local_eval.utils import (
     delete_directories,
     get_accuracy_metric,
@@ -36,21 +37,23 @@ class TestLocalEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE: ClassVar[List] = [
-        ("PyTorchModel", get_pytorch_model(), get_accuracy_metric(post_process), 0.99),
-        ("PyTorchModel", get_pytorch_model(), get_latency_metric(), 0.001),
-        ("PyTorchModel", get_huggingface_model(), get_hf_accuracy_metric(), 0.1),
-        ("PyTorchModel", get_huggingface_model(), get_hf_latency_metric(), 0.001),
-        ("ONNXModel", get_onnx_model(), get_accuracy_metric(post_process), 0.99),
-        ("ONNXModel", get_onnx_model(), get_latency_metric(), 0.001),
-        ("OpenVINOModel", get_openvino_model(), get_accuracy_metric(openvino_post_process), 0.99),
-        ("OpenVINOModel", get_openvino_model(), get_latency_metric(), 0.001),
+        ("PyTorchModel", get_pytorch_model, partial(get_accuracy_metric, post_process), 0.99),
+        ("PyTorchModel", get_pytorch_model, get_latency_metric, 0.001),
+        ("PyTorchModel", get_huggingface_model, get_hf_accuracy_metric, 0.1),
+        ("PyTorchModel", get_huggingface_model, get_hf_latency_metric, 0.001),
+        ("ONNXModel", get_onnx_model, partial(get_accuracy_metric, post_process), 0.99),
+        ("ONNXModel", get_onnx_model, get_latency_metric, 0.001),
+        ("OpenVINOModel", get_openvino_model, partial(get_accuracy_metric, openvino_post_process), 0.99),
+        ("OpenVINOModel", get_openvino_model, get_latency_metric, 0.001),
     ]
 
     @pytest.mark.parametrize(
-        "type,model_config,metric,expected_res",
+        "type,model_config_func,metric_func,expected_res",
         EVALUATION_TEST_CASE,
     )
-    def test_evaluate_model(self, type, model_config, metric, expected_res):  # noqa: A002
+    def test_evaluate_model(self, type, model_config_func, metric_func, expected_res):  # noqa: A002
+        model_config = model_config_func()
+        metric = metric_func()
         model_conf = ModelConfig.parse_obj({"type": type, "config": model_config})
         actual_res = LocalSystem().evaluate_model(model_conf, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:

--- a/test/unit_test/evaluator/test_metric_backend.py
+++ b/test/unit_test/evaluator/test_metric_backend.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from functools import partial
 from test.unit_test.utils import get_accuracy_metric, get_onnx_model_config, get_pytorch_model_config
 from typing import ClassVar, List
 from unittest.mock import patch
@@ -45,27 +46,29 @@ class TestMetricBackend:
 
     HF_ACCURACY_TEST_CASE: ClassVar[List] = [
         (
-            get_pytorch_model_config(),
-            get_accuracy_metric("accuracy", "f1", backend="huggingface_metrics"),
+            get_pytorch_model_config,
+            partial(get_accuracy_metric, "accuracy", "f1", backend="huggingface_metrics"),
             0.99,
         ),
         (
-            get_onnx_model_config(),
-            get_accuracy_metric("accuracy", "f1", backend="huggingface_metrics"),
+            get_onnx_model_config,
+            partial(get_accuracy_metric, "accuracy", "f1", backend="huggingface_metrics"),
             0.99,
         ),
     ]
 
     @pytest.mark.parametrize(
-        "model_config,metric,expected_res",
+        "model_config_func,metric_func,expected_res",
         HF_ACCURACY_TEST_CASE,
     )
-    def test_evaluate_backend(self, model_config, metric, expected_res):
+    def test_evaluate_backend(self, model_config_func, metric_func, expected_res):
         with patch.object(HuggingfaceMetrics, "measure_sub_metric") as mock_measure:
             mock_measure.return_value = SubMetricResult(value=expected_res, higher_is_better=True, priority=-1)
             system = LocalSystem()
 
             # execute
+            model_config = model_config_func()
+            metric = metric_func()
             actual_res = system.evaluate_model(model_config, None, [metric], DEFAULT_CPU_ACCELERATOR)
 
             # assert

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from functools import partial
 from test.unit_test.utils import get_accuracy_metric, get_custom_metric, get_latency_metric
 from typing import ClassVar, List
 from unittest.mock import MagicMock, patch
@@ -36,25 +37,25 @@ class TestLocalSystem:
         p.run.assert_called_once_with(olive_model.create_model(), None, output_model_path, None)
 
     METRIC_TEST_CASE: ClassVar[List[Metric]] = [
-        (get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)),
-        (get_accuracy_metric(AccuracySubType.F1_SCORE)),
-        (get_accuracy_metric(AccuracySubType.PRECISION)),
-        (get_accuracy_metric(AccuracySubType.RECALL)),
-        (get_accuracy_metric(AccuracySubType.AUROC)),
-        (get_latency_metric(LatencySubType.AVG)),
-        (get_latency_metric(LatencySubType.MAX)),
-        (get_latency_metric(LatencySubType.MIN)),
-        (get_latency_metric(LatencySubType.P50)),
-        (get_latency_metric(LatencySubType.P75)),
-        (get_latency_metric(LatencySubType.P90)),
-        (get_latency_metric(LatencySubType.P95)),
-        (get_latency_metric(LatencySubType.P99)),
-        (get_latency_metric(LatencySubType.P999)),
-        (get_custom_metric()),
+        (partial(get_accuracy_metric, AccuracySubType.ACCURACY_SCORE)),
+        (partial(get_accuracy_metric, AccuracySubType.F1_SCORE)),
+        (partial(get_accuracy_metric, AccuracySubType.PRECISION)),
+        (partial(get_accuracy_metric, AccuracySubType.RECALL)),
+        (partial(get_accuracy_metric, AccuracySubType.AUROC)),
+        (partial(get_latency_metric, LatencySubType.AVG)),
+        (partial(get_latency_metric, LatencySubType.MAX)),
+        (partial(get_latency_metric, LatencySubType.MIN)),
+        (partial(get_latency_metric, LatencySubType.P50)),
+        (partial(get_latency_metric, LatencySubType.P75)),
+        (partial(get_latency_metric, LatencySubType.P90)),
+        (partial(get_latency_metric, LatencySubType.P95)),
+        (partial(get_latency_metric, LatencySubType.P99)),
+        (partial(get_latency_metric, LatencySubType.P999)),
+        (get_custom_metric),
     ]
 
     @pytest.mark.parametrize(
-        "metric",
+        "metric_func",
         METRIC_TEST_CASE,
     )
     @patch("olive.evaluator.olive_evaluator.OliveEvaluator.get_user_config")
@@ -66,13 +67,14 @@ class TestLocalSystem:
         side_effect=lambda x, _: x,
     )
     def test_evaluate_model(
-        self, _, mock_evaluate_custom, mock_evaluate_latency, mock_evaluate_accuracy, mock_get_user_config, metric
+        self, _, mock_evaluate_custom, mock_evaluate_latency, mock_evaluate_accuracy, mock_get_user_config, metric_func
     ):
         # setup
         olive_model_config = MagicMock()
         olive_model = olive_model_config.create_model()
         olive_model.framework = Framework.ONNX
 
+        metric = metric_func()
         # olive_model.framework = Framework.ONNX
         expected_res = MetricResult.parse_obj(
             {


### PR DESCRIPTION
## Describe your changes
The purpose of this PR is to make the local UT discovery doesn't depends on the OLIVEWHEELS_STORAGE_CONNECTION_STRING used by integration test download model from azure blob
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
