### PR TITLE
move metric get_inference_settings method to metric class

### DIFF
--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -101,6 +101,14 @@ class Metric(ConfigBase):
     user_config: ConfigBase = None
     data_config: Optional[DataConfig] = None
 
+    def get_inference_settings(self, framework):
+        if self.user_config is None:
+            return None
+        if self.user_config.inference_settings:
+            return self.user_config.inference_settings.get(framework)
+        else:
+            return None
+
     def get_sub_type_info(self, info_name, no_priority_filter=True, callback=lambda x: x):
         sub_type_info = {}
         for sub_type in self.sub_types:

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -854,6 +854,7 @@ class PyTorchEvaluator(OliveEvaluator, framework=Framework.PYTORCH):
     ):
         # pylint: disable=expression-not-assigned
         warmup_num, repeat_test_num, _ = get_latency_config_from_metric(metric)
+        # pytorch model doesn't use inference_settings, so we can pass None
         session = model.prepare_session(inference_settings=None, device=device)
 
         input_data, _ = next(iter(dataloader))

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -272,10 +272,7 @@ class PythonEnvironmentSystem(OliveSystem):
         self, model: ONNXModelHandler, metric: Metric, accelerator: AcceleratorSpec
     ) -> Dict[str, Any]:
         """Get the model inference settings."""
-        metric_inference_settings = metric.user_config.inference_settings
-        inference_settings = (
-            metric_inference_settings.get(model.framework.lower()) if metric_inference_settings else None
-        )
+        inference_settings = metric.get_inference_settings(model.framework.lower())
         inference_settings = inference_settings or model.inference_settings or {}
         inference_settings = deepcopy(inference_settings)
 


### PR DESCRIPTION
## Describe your changes
refactor get_inference_settings to make it could contains the settings used by next perf tuning feature
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
