### PR TITLE
🧮 Update mobilenet_archive_url

### DIFF
--- a/examples/mobilenet_qnn_qualcomm_npu/download_files.py
+++ b/examples/mobilenet_qnn_qualcomm_npu/download_files.py
@@ -43,7 +43,8 @@ def download_model():
     mobilenet_name = "mobilenetv2-12"
     mobilenet_archive_file = "mobilenetv2-12.tar.gz"
     mobilenet_archive_url = (
-        "https://github.com/onnx/models/raw/main/vision/classification/mobilenet/model/" + mobilenet_archive_file
+        "https://github.com/onnx/models/raw/main/validated/vision/classification/mobilenet/model/"
+        f"{mobilenet_archive_file}"
     )
     mobilenet_archive_path = stage_dir / mobilenet_archive_file
     request.urlretrieve(mobilenet_archive_url, mobilenet_archive_path)

--- a/olive/platform_sdk/qualcomm/runner.py
+++ b/olive/platform_sdk/qualcomm/runner.py
@@ -43,10 +43,10 @@ class SDKRunner:
 
 
 class SNPESDKRunner(SDKRunner):
-    def __init__(self, dev: bool = False, runs: int = 1, sleep: int = 0, log_error: bool = True):
-        super().__init__("SNPE", dev, runs, sleep, log_error)
+    def __init__(self, dev: bool = False, runs: int = 1, sleep: int = 0):
+        super().__init__("SNPE", dev, runs, sleep)
 
 
 class QNNSDKRunner(SDKRunner):
-    def __init__(self, dev: bool = False, runs: int = 1, sleep: int = 0, log_error: bool = True):
-        super().__init__("QNN", dev, runs, sleep, log_error)
+    def __init__(self, dev: bool = False, runs: int = 1, sleep: int = 0):
+        super().__init__("QNN", dev, runs, sleep)


### PR DESCRIPTION
## Describe your changes
1. Update mobilenet_archive_url: onnx/model updated model structure recently. The original link to mobilenet is invalid. 
2. remove useless arguments from runner.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
