### PR TITLE
add tuning op support for ROCM ep

### DIFF
--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -416,16 +416,16 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
         # user.config.inference_settings > model.inference_settings > default inference_settings
         # when user.config.inference_settings is None, the model.inference_settings
         # will be used in model.prepare_session(..)
-        metric_inference_settings = metric.get_inference_settings(cls.framework.lower())
+        inference_settings = {}
         model_infrerence_settings = model.inference_settings
         if model_infrerence_settings:
-            if metric_inference_settings:
-                model_infrerence_settings.update(metric_inference_settings)
-            return model_infrerence_settings
-        elif metric_inference_settings:
-            return metric_inference_settings
-        else:
-            return {}
+            inference_settings.update(model_infrerence_settings)
+
+        metric_inference_settings = metric.get_inference_settings(cls.framework.lower())
+        if metric_inference_settings:
+            inference_settings.update(metric_inference_settings)
+
+        return inference_settings
 
     def _inference(
         self,

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -45,13 +45,7 @@ from olive.model import (
     SNPEModelHandler,
 )
 from olive.model.config.io_config import is_io_config_static
-from olive.model.utils.onnx_utils import (
-    bind_input_data,
-    bind_output_data,
-    dump_tuning_result,
-    prepare_io_bindings,
-    set_tuning_result,
-)
+from olive.model.utils.onnx_utils import bind_input_data, bind_output_data, dump_tuning_result, prepare_io_bindings
 from olive.platform_sdk.qualcomm.utils.data_loader import FileListCommonDataLoader, FileListDataLoader
 
 logger = logging.getLogger(__name__)
@@ -444,10 +438,6 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             execution_providers=execution_providers,
         )
 
-        tuning_op_result = inference_settings.get("tuning_op_result")
-        if tuning_op_result:
-            set_tuning_result(session, tuning_op_result)
-
         io_config = model.get_io_config()
 
         preds = []
@@ -551,10 +541,6 @@ class OnnxEvaluator(OliveEvaluator, framework=Framework.ONNX):
             device=device,
             execution_providers=execution_providers,
         )
-
-        tuning_op_result = inference_settings.get("tuning_op_result")
-        if tuning_op_result:
-            set_tuning_result(session, tuning_op_result)
 
         io_config = model.get_io_config()
 

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -101,7 +101,7 @@ class AcceleratorLookup:
         assert isinstance(execution_providers, list)
         assert isinstance(available_providers, list)
 
-        return [ep for ep in execution_providers if ep in available_providers]
+        return [ep for ep in available_providers if ep in execution_providers]
 
     @staticmethod
     def infer_accelerators_from_execution_provider(execution_provider: List[str]):

--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -83,8 +83,7 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin):
             inference_settings_merged.update(inference_settings)
         inference_settings = inference_settings_merged
 
-        # if user doesn't not provide ep list, use default value([ep]). Otherwise, use the user's ep list
-        # user provided ep list > eps given by arguments > default eps
+        # user provided eps in inference_settings > eps given by arguments > default eps
         if inference_settings.get("execution_provider") is not None:
             execution_providers = inference_settings.get("execution_provider")
             provider_options = inference_settings.get("provider_options")

--- a/olive/model/utils/onnx_utils.py
+++ b/olive/model/utils/onnx_utils.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import collections
 import collections.abc
+import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
@@ -254,3 +255,15 @@ def prepare_io_bindings(
     bind_input_data(io_bind_op, input_data, use_fp16, device, device_id, shared_kv_buffer, kv_cache_ortvalues)
     bind_output_data(io_bind_op, session.get_outputs(), use_fp16, device, shared_kv_buffer, kv_cache_ortvalues)
     return io_bind_op
+
+
+def set_tuning_result(session, tuning_op_result):
+    assert isinstance(tuning_op_result, list)
+    session.set_tuning_results(tuning_op_result)
+
+
+def dump_tuning_result(session, tuning_result_path):
+    assert tuning_result_path.endswith(".json")
+    tuning_result = session.get_tuning_results()
+    with Path(tuning_result_path).open("w") as f:
+        json.dump(tuning_result, f, indent=2)

--- a/olive/model/utils/onnx_utils.py
+++ b/olive/model/utils/onnx_utils.py
@@ -257,11 +257,6 @@ def prepare_io_bindings(
     return io_bind_op
 
 
-def set_tuning_result(session, tuning_op_result):
-    assert isinstance(tuning_op_result, list)
-    session.set_tuning_results(tuning_op_result)
-
-
 def dump_tuning_result(session, tuning_result_path):
     assert tuning_result_path.endswith(".json")
     tuning_result = session.get_tuning_results()

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -5,8 +5,11 @@
 
 import copy
 import itertools
+import json
 import logging
+import tempfile
 import time
+from pathlib import Path
 from typing import Any, Callable, Dict, Union
 
 from olive.data.config import DataConfig
@@ -116,8 +119,11 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
     # TODO(myguo): from the time being, the baseline evaluation doesn't enable enable_cuda_graph.
     # do we need enable it?
     io_bind = config.io_bind
-    pretuning_inference_result = get_benchmark(model, data_root, latency_metric, config, io_bind=io_bind)
+    pretuning_inference_result = get_benchmark(
+        model, data_root, latency_metric, config, io_bind=io_bind, tuning_result=None
+    )
 
+    tuning_op_result = pretuning_inference_result.get("tuning_result")
     tuning_results = []
     for provider, execution_mode, opt_level in generate_tuning_combos(config):
         provider, options = populate_provider_options(provider, config)  # noqa: PLW2901
@@ -149,7 +155,9 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
         if not valid_config(tuning_combo, config):
             continue
         logger.info("Run tuning for: %s", list(zip(tuning_item, tuning_combo)))
-        tuning_results.extend(threads_num_tuning(model, data_root, latency_metric, config, *tuning_combo))
+        tuning_results.extend(
+            threads_num_tuning(model, data_root, latency_metric, config, *tuning_combo, tuning_op_result)
+        )
 
     for tuning_result in tuning_results:
         logger.debug("Tuning result for %s: %s", tuning_result["test_name"], tuning_result["latency_ms"])
@@ -163,12 +171,25 @@ def tune_onnx_model(perf_tuning_pass_ep, model, data_root, config):
         "execution_provider": best_result["execution_provider"],
         "provider_options": best_result["provider_options"],
         "io_bind": best_result["io_bind"],
+        "tuning_result": best_result.get("tuning_result"),
     }
     session_options = best_result.get("session_options")
     if session_options is not None:
         optimized_model.inference_settings["session_options"] = session_options
 
     return optimized_model
+
+
+def rocm_tuning_enable(provider, provider_options):
+    assert provider == "ROCMExecutionProvider", "provider should be ROCMExecutionProvider"
+    # Please refer to the following links for the config or ROCMExecutionProvider
+    # https://github.com/microsoft/onnxruntime/blob/71657d1eb8b0a24a4b6584d9e904506a0b4e1521/onnxruntime/core/providers/rocm/rocm_execution_provider_info.cc#L24C1-L25
+    provider_options["tunable_op_enable"] = True
+    provider_options["tunable_op_tuning_enable"] = True
+    if "device_id" not in provider_options:
+        provider_options["device_id"] = 0
+
+    return provider_options
 
 
 def populate_provider_options(execution_provider, config):
@@ -186,11 +207,15 @@ def populate_provider_options(execution_provider, config):
         provider_options["trt_fp16_enable"] = config.trt_fp16_enable
     elif provider == "CUDAExecutionProvider":
         provider_options["enable_cuda_graph"] = config.enable_cuda_graph
+    elif provider == "ROCMExecutionProvider":
+        provider_options = rocm_tuning_enable(provider, provider_options)
 
     return provider, provider_options
 
 
-def threads_num_tuning(model, data_root, latency_metric, config, providers, execution_mode, ort_opt_level, io_bind):
+def threads_num_tuning(
+    model, data_root, latency_metric, config, providers, execution_mode, ort_opt_level, io_bind, tuning_op_result
+):
     tuning_results = []
     provider, options = providers
 
@@ -214,7 +239,7 @@ def threads_num_tuning(model, data_root, latency_metric, config, providers, exec
                 if intra is not None:
                     test_params["session_options"]["intra_op_num_threads"] = intra
                 tuning_result = threads_num_binary_search(
-                    model, data_root, latency_metric, config, test_params, io_bind
+                    model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result
                 )
                 tuning_results.extend(tuning_result)
     except EXCEPTIONS_TO_RAISE:
@@ -229,7 +254,7 @@ def threads_num_tuning(model, data_root, latency_metric, config, providers, exec
     return tuning_results
 
 
-def threads_num_binary_search(model, data_root, latency_metric, config, test_params, io_bind):
+def threads_num_binary_search(model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result):
     """Binary search based benchmark for inter_op_num_threads and intra_op_num_threads."""
     import onnxruntime as ort
     import psutil
@@ -251,14 +276,14 @@ def threads_num_binary_search(model, data_root, latency_metric, config, test_par
         and test_params["session_options"].get("intra_op_num_threads") is not None
     ):
         # If user specify both inter_op_num_threads and intra_op_num_threads, we will not do tuning
-        test_result = get_benchmark(model, data_root, latency_metric, config, test_params, io_bind)
+        test_result = get_benchmark(model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result)
         return [test_result]
 
     tuning_results = []
 
     def benchmark_with_threads_num(threads_name, threads_num):
         test_params["session_options"][threads_name] = threads_num
-        test_result = get_benchmark(model, data_root, latency_metric, config, test_params, io_bind)
+        test_result = get_benchmark(model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result)
         tuning_results.append(test_result)
         return test_result["latency_ms"]
 
@@ -350,21 +375,41 @@ def generate_test_name(test_params, io_bind):
     return "-".join(f"{str(i)}" for i in name_list)
 
 
-def get_benchmark(model, data_root, latency_metric, config, test_params=None, io_bind=False):
+def get_benchmark(model, data_root, latency_metric, config, test_params=None, io_bind=False, tuning_result=None):
     import onnxruntime as ort
 
     from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
 
     # prepare the inference_settings for metrics.
+    tuning_result_file = None
     if test_params:
         assert "provider_options" in test_params, "provider_options should be in test_params"
         inference_settings = test_params
+        execution_providers = inference_settings["execution_provider"]
+        if execution_providers[0] == "ROCMExecutionProvider":
+            tuning_result_file = "tuning_result.json"
+        if tuning_result:
+            assert isinstance(tuning_result, list), "tuning_result should be a list"
+            tuning_op_result = None
+            for ep_result in tuning_result:
+                # find the tuning result for the associated execution provider
+                if ep_result["ep"] == execution_providers[0]:
+                    tuning_op_result = [ep_result]
+                    break
+            tuning_result = tuning_op_result
     else:
         inference_settings = copy.deepcopy(model.inference_settings) if model.inference_settings else {}
         # put the execution_provider and provider_options in inference_settings for baseline evaluation
         execution_providers, provider_options = check_and_normalize_provider_args(
             config.providers_list, None, ort.get_available_providers()
         )
+        for i, ep in enumerate(execution_providers):
+            if ep == "ROCMExecutionProvider":
+                rocm_options = rocm_tuning_enable(ep, provider_options[i])
+                provider_options[i] = rocm_options
+                tuning_result_file = "tuning_result_baseline.json"
+                break
+
         inference_settings["execution_provider"] = execution_providers
         inference_settings["provider_options"] = provider_options
 
@@ -377,25 +422,40 @@ def get_benchmark(model, data_root, latency_metric, config, test_params=None, io
     latency_metric.user_config.io_bind = io_bind
     latency_metric.user_config.inference_settings = {"onnx": inference_settings}
 
-    session_name = generate_test_name(test_params, io_bind)
-    logger.debug(f"Run benchmark for: {session_name}")
-    evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-    joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
-    start_time = time.perf_counter()
-    # We deliberately set the execution_providers to None so that the evaluator will use the one in inference_settings
-    latency_ms = evaluator.evaluate(model, data_root, [latency_metric], config.device, None)[joint_key].value
-    end_time = time.perf_counter()
-    logger.debug(f"It takes {(end_time - start_time):.5f} seconds to benchmark for: {session_name}")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        if tuning_result_file:
+            tuning_result_file = Path(temp_dir) / tuning_result_file
+            if tuning_result:
+                with tuning_result_file.open("w") as f:
+                    json.dump(tuning_result, f)
+            inference_settings["tuning_result_file"] = str(Path(temp_dir) / tuning_result_file)
+        session_name = generate_test_name(test_params, io_bind)
+        logger.debug(f"Run benchmark for: {session_name}")
+        evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
+        joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
+        start_time = time.perf_counter()
+        # We deliberately set the execution_providers to None so that the evaluator will
+        # use the one in inference_settings
+        latency_ms = evaluator.evaluate(model, data_root, [latency_metric], config.device, None)[joint_key].value
+        end_time = time.perf_counter()
+        logger.debug(f"It takes {(end_time - start_time):.5f} seconds to benchmark for: {session_name}")
 
-    session_options = inference_settings.get("session_options")
-    return {
-        "test_name": session_name,
-        "io_bind": io_bind,
-        "latency_ms": latency_ms,
-        "execution_provider": inference_settings["execution_provider"],
-        "provider_options": inference_settings["provider_options"],
-        "session_options": session_options if session_options else {},
-    }
+        session_options = inference_settings.get("session_options")
+
+        tuning_result_ret = None
+        if tuning_result_file:
+            with tuning_result_file.open() as f:
+                tuning_result_ret = json.load(f)
+
+        return {
+            "test_name": session_name,
+            "io_bind": io_bind,
+            "latency_ms": latency_ms,
+            "execution_provider": inference_settings["execution_provider"],
+            "provider_options": inference_settings["provider_options"],
+            "session_options": session_options if session_options else {},
+            "tuning_result": tuning_result_ret,
+        }
 
 
 def parse_tuning_result(*tuning_results):

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -420,10 +420,11 @@ def get_benchmark(model, data_root, latency_metric, config, test_params=None, io
 
     with tempfile.TemporaryDirectory() as temp_dir:
         if tuning_result_file:
-            tuning_result_file = Path(temp_dir) / tuning_result_file
+            # Only set the tuning_op_result for ROCM. In this case, the tuning_result_file is not None.
             if tuning_result:
                 inference_settings["tuning_op_result"] = tuning_result
-            inference_settings["tuning_result_file"] = str(Path(temp_dir) / tuning_result_file)
+            tuning_result_file = Path(temp_dir) / tuning_result_file
+            inference_settings["tuning_result_file"] = str(tuning_result_file)
 
         # set the session_options for metrics so that the evalute will use them by default
         latency_metric.user_config.io_bind = io_bind

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -418,17 +418,17 @@ def get_benchmark(model, data_root, latency_metric, config, test_params=None, io
             inference_settings["session_options"] = {}
         inference_settings["session_options"]["enable_profiling"] = True
 
-    # set the session_options for metrics so that the evalute will use them by default
-    latency_metric.user_config.io_bind = io_bind
-    latency_metric.user_config.inference_settings = {"onnx": inference_settings}
-
     with tempfile.TemporaryDirectory() as temp_dir:
         if tuning_result_file:
             tuning_result_file = Path(temp_dir) / tuning_result_file
             if tuning_result:
-                with tuning_result_file.open("w") as f:
-                    json.dump(tuning_result, f)
+                inference_settings["tuning_op_result"] = tuning_result
             inference_settings["tuning_result_file"] = str(Path(temp_dir) / tuning_result_file)
+
+        # set the session_options for metrics so that the evalute will use them by default
+        latency_metric.user_config.io_bind = io_bind
+        latency_metric.user_config.inference_settings = {"onnx": inference_settings}
+
         session_name = generate_test_name(test_params, io_bind)
         logger.debug(f"Run benchmark for: {session_name}")
         evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -204,8 +204,8 @@ class TestOliveEvaluator:
         ],
     )
     @patch("onnxruntime.get_available_providers")
-    def test_evaluate_latency_with_unsupported_ep(self, mock_get_available_providers, execution_providers):
-        mock_get_available_providers.return_value = ["CPUExecutionProvider"]
+    def test_evaluate_latency_with_unsupported_ep(self, get_available_providers_mock, execution_providers):
+        get_available_providers_mock.return_value = ["CPUExecutionProvider"]
         model = get_onnx_model()
         evaluator = OnnxEvaluator()
         latency_metric = get_latency_metric(LatencySubType.AVG)
@@ -329,8 +329,7 @@ class TestOliveEvaluator:
         )
 
     @patch("onnxruntime.InferenceSession")
-    @patch("onnxruntime.get_available_providers")
-    def test_evaluate_latency_with_tunable_op(self, mock_get_available_providers, inference_session_mock):
+    def test_evaluate_latency_with_tunable_op(self, inference_session_mock):
         tuning_result = [
             {
                 "ep": "ROCMExecutionProvider",

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -405,7 +405,7 @@ class TestOliveEvaluator:
     def test_evaluator_get_inference_session(self, metric_inference_settings, model_inference_settings, result_keys):
         """Test get_inference_session method in evaluator when both metric and model have inference settings.
 
-        The model.inference_settings will be overriden by the metric.inference_settings.
+        The model.inference_settings will be overridden by the metric.inference_settings.
         """
         metric = get_latency_metric(LatencySubType.AVG)
         if metric_inference_settings:

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -9,8 +9,8 @@ from olive.hardware.accelerator import Device
 
 @patch("onnxruntime.InferenceSession")
 @patch("onnxruntime.get_available_providers")
-def test_model_prepare_session(mock_get_available_providers, inference_session_mock):
-    mock_get_available_providers.return_value = [
+def test_model_prepare_session(get_available_providers_mock, inference_session_mock):
+    get_available_providers_mock.return_value = [
         "MIGraphXExecutionProvider",
         "ROCMExecutionProvider",
         "CPUExecutionProvider",
@@ -162,14 +162,14 @@ def test_model_prepare_session(mock_get_available_providers, inference_session_m
 @patch("onnxruntime.InferenceSession")
 @patch("onnxruntime.get_available_providers")
 def test_model_prepare_session_multiple_inference_settings(
-    mock_get_available_providers,
+    get_available_providers_mock,
     inference_session_mock,
     inference_setting,
     model_inference_settings,
     execution_providers,
     merged_inference_settings,
 ):
-    mock_get_available_providers.return_value = [
+    get_available_providers_mock.return_value = [
         "MIGraphXExecutionProvider",
         "ROCMExecutionProvider",
         "CPUExecutionProvider",
@@ -196,8 +196,8 @@ def test_model_prepare_session_multiple_inference_settings(
 
 @patch("onnxruntime.InferenceSession")
 @patch("onnxruntime.get_available_providers")
-def test_model_prepare_session_with_unsupported_eps(mock_get_available_providers, inference_session_mock):
-    mock_get_available_providers.return_value = [
+def test_model_prepare_session_with_unsupported_eps(get_available_providers_mock, inference_session_mock):
+    get_available_providers_mock.return_value = [
         "TensorrtExecutionProvider",
         "CUDAExecutionProvider",
         "CPUExecutionProvider",
@@ -238,8 +238,8 @@ def test_model_prepare_session_with_unsupported_eps(mock_get_available_providers
 
 @patch("onnxruntime.InferenceSession")
 @patch("onnxruntime.get_available_providers")
-def test_distributed_rank_prepare_session(mock_get_available_providers, inference_session_mock):
-    mock_get_available_providers.return_value = [
+def test_distributed_rank_prepare_session(get_available_providers_mock, inference_session_mock):
+    get_available_providers_mock.return_value = [
         "TensorrtExecutionProvider",
         "CUDAExecutionProvider",
         "CPUExecutionProvider",

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -39,6 +39,161 @@ def test_model_prepare_session(mock_get_available_providers, inference_session_m
     )
 
 
+@pytest.mark.parametrize(
+    "inference_setting, model_inference_settings, execution_providers, merged_inference_settings",
+    [
+        # Non inference_settings cases
+        (
+            None,
+            None,
+            None,
+            {
+                "execution_provider": ["MIGraphXExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"],
+                "provider_options": [{}, {}, {}],
+            },
+        ),
+        (
+            None,
+            None,
+            "ROCMExecutionProvider",
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{}],
+            },
+        ),
+        (
+            None,
+            None,
+            ["ROCMExecutionProvider", "CPUExecutionProvider"],
+            {
+                "execution_provider": ["ROCMExecutionProvider", "CPUExecutionProvider"],
+                "provider_options": [{}, {}],
+            },
+        ),
+        (
+            None,
+            None,
+            ("ROCMExecutionProvider", {"device_id": 0, "tunable_op_enable": True, "tunable_op_tuning_enable": True}),
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [
+                    {"device_id": "0", "tunable_op_enable": "True", "tunable_op_tuning_enable": "True"}
+                ],
+            },
+        ),
+        # parameter inference_settings cases
+        (
+            {
+                "execution_provider": [("ROCMExecutionProvider", {"device_id": 0})],
+            },
+            None,
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": "0"}],
+            },
+        ),
+        (
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": 1}],
+            },
+            None,
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": "1"}],
+            },
+        ),
+        # model inference_settings cases
+        (
+            None,
+            {
+                "execution_provider": [("ROCMExecutionProvider", {"device_id": 2})],
+            },
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": "2"}],
+            },
+        ),
+        (
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": 3}],
+            },
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": "3"}],
+            },
+        ),
+        # parameter inference_settings and model inference_settings cases
+        (
+            {
+                "execution_provider": [("ROCMExecutionProvider", {"device_id": 4})],
+            },
+            {
+                "execution_provider": ["MIGraphXExecutionProvider"],
+            },
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": "4"}],
+            },
+        ),
+        (
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": 5}],
+            },
+            {
+                "execution_provider": [("MIGraphXExecutionProvider", {})],
+            },
+            None,
+            {
+                "execution_provider": ["ROCMExecutionProvider"],
+                "provider_options": [{"device_id": "5"}],
+            },
+        ),
+    ],
+)
+@patch("onnxruntime.InferenceSession")
+@patch("onnxruntime.get_available_providers")
+def test_model_prepare_session_multiple_inference_settings(
+    mock_get_available_providers,
+    inference_session_mock,
+    inference_setting,
+    model_inference_settings,
+    execution_providers,
+    merged_inference_settings,
+):
+    mock_get_available_providers.return_value = [
+        "MIGraphXExecutionProvider",
+        "ROCMExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    mock = MagicMock()
+    mock.get_providers.return_value = ["MIGraphXExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
+    inference_session_mock.return_value = mock
+
+    model_inference_settings_copy = model_inference_settings.copy() if model_inference_settings else None
+    inference_settings_copy = inference_setting.copy() if inference_setting else None
+    model = get_onnx_model()
+    model.inference_settings = model_inference_settings
+    model.prepare_session(inference_setting, Device.GPU, execution_providers, rank=1)
+    inference_session_mock.assert_called_with(
+        model.model_path,
+        sess_options=ANY,
+        providers=merged_inference_settings["execution_provider"],
+        provider_options=merged_inference_settings["provider_options"],
+    )
+    # assert the inference_settings and model.inference_settings are not changed when calling prepare_session
+    assert model.inference_settings == model_inference_settings_copy
+    assert inference_setting == inference_settings_copy
+
+
 @patch("onnxruntime.InferenceSession")
 @patch("onnxruntime.get_available_providers")
 def test_model_prepare_session_with_unsupported_eps(mock_get_available_providers, inference_session_mock):

--- a/test/unit_test/model/test_onnx_model.py
+++ b/test/unit_test/model/test_onnx_model.py
@@ -54,7 +54,6 @@ def test_model_prepare_session_with_unsupported_eps(mock_get_available_providers
         "CPUExecutionProvider",
     ]
     inference_session_mock.return_value = mock
-    inference_session_mock.return_value = mock
     model = get_onnx_model()
     inference_settings = {
         "execution_provider": [("MIGraphXExecutionProvider", {})],

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -344,7 +344,7 @@ def test_rocm_tuning_enable(mock_get_available_providers, inference_session_mock
     result = p.run(input_model, None, output_folder)
     tuning_result_ret = result.inference_settings["tuning_op_result"]
     assert tuning_result_ret == tuning_result
-    set_tuning_result_binary_search_count_per_iteration = int(math.log2(psutil.cpu_count())) + 1
-    set_tuning_result_count = 2 * set_tuning_result_binary_search_count_per_iteration + 1
-    assert mock.set_tuning_results.call_count == set_tuning_result_count
-    assert mock.get_tuning_results.call_count == set_tuning_result_count + 1
+    set_tuning_result_binary_search_count_per_iteration = int(math.log2(psutil.cpu_count(logical=False))) + 1
+    set_tuning_result_count = 3 * set_tuning_result_binary_search_count_per_iteration
+    assert mock.set_tuning_results.call_count >= set_tuning_result_count
+    assert mock.get_tuning_results.call_count == mock.set_tuning_results.call_count + 1

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -71,10 +71,10 @@ def test_ort_perf_tuning_with_customized_configs(mock_run, config):
 @pytest.mark.parametrize("return_baseline", [True, False])
 @patch.object(OnnxEvaluator, "evaluate")
 @patch("onnxruntime.get_available_providers")
-def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_evaluate, caplog, return_baseline):
+def test_perf_tuning_with_provider_options(get_available_providers_mock, evaluate_mock, caplog, return_baseline):
     logger = logging.getLogger("olive")
     logger.propagate = True
-    mock_get_available_providers.return_value = [
+    get_available_providers_mock.return_value = [
         "TensorrtExecutionProvider",
         "CUDAExecutionProvider",
         "CPUExecutionProvider",
@@ -102,7 +102,7 @@ def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_ev
         metrics_res[metrics[0].name] = latency_metric
         return flatten_metric_result(metrics_res)
 
-    mock_evaluate.side_effect = mock_evaluate_method
+    evaluate_mock.side_effect = mock_evaluate_method
     execution_providers = [
         (
             "TensorrtExecutionProvider",
@@ -150,11 +150,11 @@ def test_perf_tuning_with_provider_options(mock_get_available_providers, mock_ev
 @pytest.mark.parametrize("force_evaluate", [True, False])
 @patch.object(OnnxEvaluator, "evaluate")
 @patch("onnxruntime.get_available_providers")
-def test_perf_tuning_with_force_evaluate(mock_get_available_providers, mock_evaluate, caplog, force_evaluate):
+def test_perf_tuning_with_force_evaluate(get_available_providers_mock, evaluate_mock, caplog, force_evaluate):
     logger = logging.getLogger("olive")
     logger.propagate = True
 
-    mock_get_available_providers.return_value = [
+    get_available_providers_mock.return_value = [
         "TensorrtExecutionProvider",
         "CUDAExecutionProvider",
         "CPUExecutionProvider",
@@ -178,7 +178,7 @@ def test_perf_tuning_with_force_evaluate(mock_get_available_providers, mock_eval
         metrics_res[metrics[0].name] = latency_metric
         return flatten_metric_result(metrics_res)
 
-    mock_evaluate.side_effect = mock_evaluate_method
+    evaluate_mock.side_effect = mock_evaluate_method
     execution_providers = [
         "CUDAExecutionProvider",
         "CPUExecutionProvider",
@@ -230,8 +230,8 @@ def test_ort_perf_tuning_pass_with_dynamic_shapes(mock_get_io_config, tmp_path):
 
 
 @patch("olive.passes.onnx.perf_tuning.threads_num_binary_search")
-def test_ort_perf_tuning_pass_with_import_error(mock_threads_num_binary_search, tmp_path):
-    mock_threads_num_binary_search.side_effect = ModuleNotFoundError("test")
+def test_ort_perf_tuning_pass_with_import_error(threads_num_binary_search_mock, tmp_path):
+    threads_num_binary_search_mock.side_effect = ModuleNotFoundError("test")
 
     input_model = get_onnx_model()
     p = create_pass_from_dict(OrtPerfTuning, {}, disable_search=True)
@@ -287,7 +287,7 @@ def test_generate_test_name():
 
 @patch("onnxruntime.InferenceSession")
 @patch("onnxruntime.get_available_providers")
-def test_rocm_tuning_enable(mock_get_available_providers, inference_session_mock, tmp_path):
+def test_rocm_tuning_enable(get_available_providers_mock, inference_session_mock, tmp_path):
     tuning_result = [
         {
             "ep": "ROCMExecutionProvider",
@@ -319,7 +319,7 @@ def test_rocm_tuning_enable(mock_get_available_providers, inference_session_mock
     mock.get_tuning_results.return_value = tuning_result
     inference_session_mock.return_value = mock
 
-    mock_get_available_providers.return_value = [
+    get_available_providers_mock.return_value = [
         "MIGraphXExecutionProvider",
         "ROCMExecutionProvider",
         "CPUExecutionProvider",

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -339,5 +339,5 @@ def test_rocm_tuning_enable(mock_get_available_providers, inference_session_mock
 
     # execute
     result = p.run(input_model, None, output_folder)
-    tuning_result_ret = result.inference_settings["tuning_result"]
+    tuning_result_ret = result.inference_settings["tuning_op_result"]
     assert tuning_result_ret == tuning_result


### PR DESCRIPTION
## Describe your changes
allow `tunable_op_enable` and `tunable_op_tuning_enable` for ROCM ep to speed up the performance.

The two flags need to be set to True for ROCMExecutionProvider to speed up the performance when running in AMD hardware.
This PR enable the support of ROCM ep speed up in perf tuning.
This PR also fix a bug when both metrics and model has inference settings by merging them. The metric.inference_settings has higher priority.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
