### PR TITLE
Fix accuracy eval func in bert example

### DIFF
--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -224,7 +224,7 @@ def eval_accuracy(model: OliveModelHandler, data_dir, batch_size, device, execut
 
     preds_tensor = torch.tensor(preds, dtype=torch.int)
     target_tensor = torch.tensor(target, dtype=torch.int)
-    accuracy = torchmetrics.Accuracy()
+    accuracy = torchmetrics.Accuracy(task="binary")
     result = accuracy(preds_tensor, target_tensor)
     return result.item()
 


### PR DESCRIPTION
## Describe your changes

Fix bug of  `TypeError: Accuracy.__new__() missing 1 required positional argument: 'task'` in bert example

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
