### PR TITLE
Fix quantization dtypes after ORT PR #18043

### DIFF
--- a/olive/passes/onnx/vitis_ai/quantizer.py
+++ b/olive/passes/onnx/vitis_ai/quantizer.py
@@ -310,18 +310,21 @@ class VitisQOpQuantizer(ONNXQuantizer):
         # Update packed weight, zero point, and scale initializers
         weight_data = tensor_proto_to_array(weight)
         _, _, zero_point, scale, q_weight_data = quantize_data_pof2s(
-            weight_data.flatten().tolist(),
+            weight_data.flatten(),
             qType,
             self.is_weight_symmetric,
             self.reduce_range and reduce_range,
             method=PowerOfTwoMethod.NonOverflow,
         )
-        scale_initializer = onnx.helper.make_tensor(scale_name, onnx_proto.TensorProto.FLOAT, [], [scale])
-        zero_initializer = onnx.helper.make_tensor(zp_name, qType, [], [zero_point])
+
+        scale_initializer = onnx.helper.make_tensor(
+            scale_name, onnx.helper.np_dtype_to_tensor_dtype(scale.dtype), [], [float(scale)]
+        )
+        zero_initializer = onnx.helper.make_tensor(zp_name, qType, [], [int(zero_point)])
         self.model.initializer().extend([scale_initializer, zero_initializer])
 
         if not keep_float_weight:
-            q_weight_data = np.asarray(q_weight_data, dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[qType]).reshape(
+            q_weight_data = np.asarray(q_weight_data, dtype=onnx.helper.tensor_dtype_to_np_dtype(qType)).reshape(
                 weight.dims
             )
             q_weight_initializer = onnx.numpy_helper.from_array(q_weight_data, q_weight_name)
@@ -545,14 +548,23 @@ class VitisQDQQuantizer(VitisQOpQuantizer):
         """
         Check if tensor can be quantized
         """
+        return self._tensor_quantizable_data_type(tensor_name) is not None
+
+    def _tensor_quantizable_data_type(self, tensor_name):
+        """
+        Return the tensor type if it is quantizable.
+        """
         weight = find_by_name(tensor_name, self.model.initializer())
         if weight is not None:
-            if weight.data_type == onnx_proto.TensorProto.FLOAT:
-                return True
+            if weight.data_type in {onnx_proto.TensorProto.FLOAT, onnx_proto.TensorProto.FLOAT16}:
+                return weight.data_type
         elif tensor_name in self.value_infos.keys():
             vi = self.value_infos[tensor_name]
-            if vi.type.HasField("tensor_type") and vi.type.tensor_type.elem_type == TensorProto.FLOAT:
-                return True
+            if vi.type.HasField("tensor_type") and vi.type.tensor_type.elem_type in {
+                TensorProto.FLOAT,
+                TensorProto.FLOAT16,
+            }:
+                return vi.type.tensor_type.elem_type
         else:
             logger.warning(
                 "failed to infer the type of tensor: {}. Skip to quantize it. Please check if it is expected.".format(
@@ -560,7 +572,7 @@ class VitisQDQQuantizer(VitisQOpQuantizer):
                 )
             )
 
-        return False
+        return None
 
     def __quantize_tensor(self, tensor_name, quant_sharing_param=None, tensor_type=QDQQuantTensorType.ACTIVATION):
         """
@@ -571,13 +583,14 @@ class VitisQDQQuantizer(VitisQOpQuantizer):
             quant_sharing_param: name of the tensor that provides quantization parameter
             tensor_type: QDQQuantTensorType default ACTIVATION
         """
-        if self._is_tensor_quantizable(tensor_name):
+        data_type = self._tensor_quantizable_data_type(tensor_name)
+        if data_type is not None:
             if quant_sharing_param:
                 self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo(
-                    tensor_type=tensor_type, quant_para_provider=quant_sharing_param
+                    tensor_type=tensor_type, quant_para_provider=quant_sharing_param, data_type=data_type
                 )
             elif tensor_name not in self.tensors_to_quantize:
-                self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo(tensor_type=tensor_type)
+                self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo(tensor_type=tensor_type, data_type=data_type)
 
     def quantize_activation_tensor(self, tensor_name, quant_sharing_param=None):
         """

--- a/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
+++ b/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
@@ -58,3 +58,31 @@ def test_vitis_ai_quantization_pass(tmp_path):
     assert quantized_model.model_path.endswith(".onnx")
     assert Path(quantized_model.model_path).exists()
     assert Path(quantized_model.model_path).is_file()
+
+
+def test_vitis_ai_quantization_pass_oveflow(tmp_path):
+    # setup
+    input_model = get_onnx_model()
+    dummy_user_script = tmp_path / "dummy_user_script.py"
+    dummy_data: Path = tmp_path / "dummy_data"
+    with dummy_user_script.open("w") as f:
+        f.write(" ")
+    if not dummy_data.exists():
+        dummy_data.mkdir()
+
+    config = {
+        "user_script": str(dummy_user_script),
+        "data_dir": str(dummy_data),
+        "dataloader_func": dummy_calibration_reader,
+        "calibrate_method": "NonOverflow",
+    }
+    output_folder = str(tmp_path / "vitis_ai_quantized")
+
+    # create VitisAIQuantization pass
+    p = create_pass_from_dict(VitisAIQuantization, config, disable_search=True)
+    # execute
+    quantized_model = p.run(input_model, None, output_folder)
+    # assert
+    assert quantized_model.model_path.endswith(".onnx")
+    assert Path(quantized_model.model_path).exists()
+    assert Path(quantized_model.model_path).is_file()


### PR DESCRIPTION
## Describe your changes
PR https://github.com/microsoft/onnxruntime/pull/18043 (onnxruntime) extends onnxruntime quantization tools to support float16 weights. To do so, it enforces scale and zerop_point to be strongly typed (as `numpy.array(single_value, dtype=dtype)`). scale type should always be the weight type, and zero_point type the quantized weight type. That convention is checked all along the quantization tools to make sure there is loss of information. This change was made to avoid adding new arguments in many functions to carry this information.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
