### PR TITLE
add quantization UT for calibration bug in ort-nightly build

### DIFF
--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -7,7 +7,7 @@ from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OnnxQuantization
 
 
-class ResnetCalibrationDataReader(CalibrationDataReader):
+class DummyCalibrationDataReader(CalibrationDataReader):
     def __init__(self, data_dir: str, batch_size: int = 16):
         super().__init__()
         self.sample_counter = 500
@@ -25,8 +25,8 @@ class ResnetCalibrationDataReader(CalibrationDataReader):
             return None
 
 
-def resnet_calibration_reader(data_dir, batch_size, *args, **kwargs):
-    return ResnetCalibrationDataReader(data_dir, batch_size=batch_size)
+def dummpy_dataloader_func(data_dir, batch_size, *args, **kwargs):
+    return DummyCalibrationDataReader(data_dir, batch_size=batch_size)
 
 
 @pytest.mark.parametrize("calibrate_method", ["MinMax", "Entropy", "Percentile"])
@@ -39,7 +39,7 @@ def test_quantization(calibrate_method, tmp_path):
         "MatMulConstBOnly": False,
         "per_channel": True,
         "reduce_range": True,
-        "dataloader_func": resnet_calibration_reader,
+        "dataloader_func": dummpy_dataloader_func,
         "weight_type": "QUInt8",
         "activation_type": "QUInt8",
         "quant_preprocess": True,

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -1,0 +1,44 @@
+from test.unit_test.utils import get_onnx_model, get_pytorch_model_dummy_input
+
+from onnxruntime.quantization.calibrate import CalibrationDataReader
+
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx import OnnxQuantization
+
+
+class ResnetCalibrationDataReader(CalibrationDataReader):
+    def __init__(self, data_dir: str, batch_size: int = 16):
+        super().__init__()
+        self.sample_counter = 500
+
+    def get_next(self) -> dict:
+        if self.sample_counter <= 0:
+            return None
+
+        data = get_pytorch_model_dummy_input()
+        try:
+            item = {"input": data.numpy()}
+            self.sample_counter -= 1
+            return item
+        except Exception:
+            return None
+
+
+def resnet_calibration_reader(data_dir, batch_size, *args, **kwargs):
+    return ResnetCalibrationDataReader(data_dir, batch_size=batch_size)
+
+
+def test_quantization(tmp_path):
+    input_model = get_onnx_model()
+    config = {
+        "quant_mode": "static",
+        "calibrate_method": "Entropy",
+        "quant_format": "QOperator",
+        "MatMulConstBOnly": False,
+        "per_channel": True,
+        "reduce_range": True,
+        "dataloader_func": resnet_calibration_reader,
+    }
+    p = create_pass_from_dict(OnnxQuantization, config, disable_search=True)
+    out = p.run(input_model, None, tmp_path)
+    assert out is not None


### PR DESCRIPTION
## Describe your changes
The UT is used to cover the calibration signature changes in ORT. After the PR is merged, the CI pipelines with ort-nightly would fail with the following error message.
```txt
C:\Users\myguo\.conda\envs\ortnightly\lib\site-packages\onnxruntime\quantization\quantize.py:497: in quantize_static
    tensors_range = calibrator.compute_data()
C:\Users\myguo\.conda\envs\ortnightly\lib\site-packages\onnxruntime\quantization\calibrate.py:523: in compute_data
    return TensorsData(cal, self.collector.compute_collection_result())
C:\Users\myguo\.conda\envs\ortnightly\lib\site-packages\onnxruntime\quantization\calibrate.py:64: in __init__
    self.data[k] = TensorData(lowest=v[0], highest=v[1], hist=v[2], bins=v[3])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
self = <onnxruntime.quantization.calibrate.TensorData object at 0x0000013B4FC94EB0>
kwargs = {'bins': array([-3.3985636 , -3.3454611 , -3.2923584 , -3.239256  , -3.1861534 ,
       -3.133051  , -3.0799482 , -3.0...  1,    1,    1,    0,    1,    0,    2,
          0,    0,    0,    0,    0,    0,    1], dtype=int64), 'lowest': 0.0}
k = 'highest', v = 3.3985636234283447
 
    def __init__(self, **kwargs):
        for k, v in kwargs.items():
            if k not in TensorData._allowed:
                raise ValueError(f"Unexpected value {k!r} not in {TensorData._allowed}.")
            if k in TensorData._floats:
                if not hasattr(v, "dtype"):
>                   raise ValueError(f"Unexpected type {type(v)} for k={k!r}")
E                   ValueError: Unexpected type <class 'float'> for k='highest'
 
C:\Users\myguo\.conda\envs\ortnightly\lib\site-packages\onnxruntime\quantization\calibrate.py:34: ValueError
```

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
