### PR TITLE
🌗 Enable windows QNN e2e test

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH
-      condition: eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu')
+      condition: and(eq(parameters.name, 'Windows_CI'), eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu'))
 
     - task: AzureCLI@1
       inputs:

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH
-      condition: and(eq(parameters.name, 'Windows_CI'), eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu'))
+      condition: and(ep('${{ parameters.windows }}', true), eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu'))
 
     - task: AzureCLI@1
       inputs:

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH
-      condition: and(ep('${{ parameters.windows }}', true), eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu'))
+      condition: and(eq('${{ parameters.windows }}', true), eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu'))
 
     - task: AzureCLI@1
       inputs:

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -43,6 +43,10 @@ jobs:
       displayName: Set exampleRequirements
       condition: eq(variables['exampleRequirements'], '')
 
+    - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+      displayName: Add conda to PATH
+      condition: eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu')
+
     - task: AzureCLI@1
       inputs:
         azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -43,10 +43,6 @@ jobs:
       displayName: Set exampleRequirements
       condition: eq(variables['exampleRequirements'], '')
 
-    - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-      displayName: Add conda to PATH
-      condition: and(eq('${{ parameters.windows }}', true), eq(variables['exampleFolder'], 'mobilenet_qnn_qualcomm_npu'))
-
     - task: AzureCLI@1
       inputs:
         azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -130,6 +130,9 @@ jobs:
       whisper:
         exampleFolder: whisper
         exampleName: whisper
+      mobilenet_qnn_toolkit:
+        exampleFolder: mobilenet_qnn_qualcomm_npu
+        exampleName: qnn_tooklit
 
 # Linux GPU examples testing.
 - template: job_templates/olive-example-template.yaml

--- a/examples/test/test_qnn_tooklit.py
+++ b/examples/test/test_qnn_tooklit.py
@@ -35,7 +35,7 @@ def download_qnn_sdk(target_path=None):
     return target_path
 
 
-def setup():
+def setup_resource():
     """Setups any state specific to the execution of the given module."""
     cur_dir = Path(__file__).resolve().parent.parent
     example_dir = cur_dir / "mobilenet_qnn_qualcomm_npu"
@@ -63,7 +63,7 @@ def test_mobilenet_qnn(tmp_path):
     from olive.workflows import run as olive_run
 
     os.environ["QNN_SDK_ROOT"] = str(download_qnn_sdk(tmp_path) / "opt" / "qcom" / "aistack")
-    setup()
+    setup_resource()
 
     footprint = olive_run("raw_qnn_sdk_config.json")
     check_output(footprint)

--- a/examples/test/test_qnn_tooklit.py
+++ b/examples/test/test_qnn_tooklit.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import os
+import platform
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -11,35 +13,56 @@ from utils import check_output, download_azure_blob
 from olive.common.utils import retry_func, run_subprocess
 
 
-def download_qnn_sdk():
+def download_qnn_sdk(target_path=None):
     """Download the qnn sdk."""
+    blob, download_path = "", ""
+    if platform.system() == "Windows":
+        blob, download_path = "qnn_sdk_windows.zip", "qnn_sdk_windows.zip"
+    elif platform.system() == "Linux":
+        blob, download_path = "qnn_sdk_linux.zip", "qnn_sdk_linux.zip"
+
     download_azure_blob(
         container="olivetest",
-        blob="qnn_sdk_linux.zip",
-        download_path="qnn_sdk_linux.zip",
+        blob=blob,
+        download_path=download_path,
     )
-    target_path = Path().resolve()
-    run_subprocess(cmd=f"unzip qnn_sdk_linux.zip -d {str(target_path)}", check=True)
+    if not target_path:
+        target_path = Path().resolve() / "qnn_sdk"
+    target_path.mkdir(parents=True, exist_ok=True)
+    if platform.system() == "Windows":
+        import zipfile
+
+        with zipfile.ZipFile(download_path, "r") as zip_ref:
+            zip_ref.extractall(target_path)
+    elif platform.system() == "Linux":
+        run_subprocess(cmd=f"unzip {download_path} -d {str(target_path)}", check=True)
     return target_path
 
 
 @pytest.fixture(scope="module", autouse=True)
 def setup():
     """Setups any state specific to the execution of the given module."""
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_path = Path(tmp_dir.name)
     cur_dir = Path(__file__).resolve().parent.parent
     example_dir = cur_dir / "mobilenet_qnn_qualcomm_npu"
     os.chdir(example_dir)
 
     # prepare model and data
     # retry since it fails randomly
-    os.environ["QNN_SDK_ROOT"] = str(download_qnn_sdk() / "opt" / "qcom" / "aistack")
+    os.environ["QNN_SDK_ROOT"] = str(download_qnn_sdk(tmp_path) / "opt" / "qcom" / "aistack")
     run_subprocess(cmd="python -m olive.platform_sdk.qualcomm.configure --py_version 3.8 --sdk qnn", check=True)
     # install dependencies
+    python_cmd = ""
+    if platform.system() == "Windows":
+        python_cmd = str(Path(os.environ["QNN_SDK_ROOT"]) / "olive-pyenv" / "python.exe")
+    elif platform.system() == "Linux":
+        python_cmd = str(Path(os.environ["QNN_SDK_ROOT"]) / "olive-pyenv" / "bin" / "python")
     install_cmd = [
-        str(Path(os.environ["QNN_SDK_ROOT"]) / "olive-pyenv" / "bin" / "python"),
+        python_cmd,
         str(Path(os.environ["QNN_SDK_ROOT"]) / "bin" / "check-python-dependency"),
     ]
-    run_subprocess(cmd="\n".join(install_cmd), check=True)
+    run_subprocess(cmd=" ".join(install_cmd), check=True)
     retry_func(run_subprocess, kwargs={"cmd": "python download_files.py", "check": True})
     retry_func(run_subprocess, kwargs={"cmd": "python prepare_config.py --use_raw_qnn_sdk", "check": True})
     yield

--- a/examples/test/test_qnn_tooklit.py
+++ b/examples/test/test_qnn_tooklit.py
@@ -30,10 +30,8 @@ def download_qnn_sdk(target_path=None):
         target_path = Path().resolve() / "qnn_sdk"
     target_path.mkdir(parents=True, exist_ok=True)
     if platform.system() == "Windows":
-        import zipfile
-
-        with zipfile.ZipFile(download_path, "r") as zip_ref:
-            zip_ref.extractall(target_path)
+        cmd = f"powershell Expand-Archive -Path {download_path} -DestinationPath {str(target_path)}"
+        run_subprocess(cmd=cmd, check=True)
     elif platform.system() == "Linux":
         run_subprocess(cmd=f"unzip {download_path} -d {str(target_path)}", check=True)
     return target_path

--- a/olive/platform_sdk/qualcomm/configure.py
+++ b/olive/platform_sdk/qualcomm/configure.py
@@ -28,12 +28,15 @@ def dev(args):
     else:
         sdk_env = QNNSDKEnv()
     sdk_arch = sdk_env.target_arch
-    if sdk_arch != SDKTargetDevice.x86_64_linux:
+    if sdk_arch not in (SDKTargetDevice.x86_64_linux, SDKTargetDevice.x86_64_windows):
         return
 
     logger.info(f"Configuring {args.sdk} for {sdk_arch} with python{args.py_version}...")
     with resources.path(resource_path, script_name) as create_python_env_path:
-        cmd = f"bash {create_python_env_path} -v {args.py_version} --sdk {args.sdk}"
+        if platform.system() == "Linux":
+            cmd = f"bash {create_python_env_path} -v {args.py_version} --sdk {args.sdk}"
+        elif platform.system() == "Windows":
+            cmd = f"powershell {create_python_env_path} {args.py_version} {args.sdk}"
         run_subprocess(cmd, check=True)
     logger.info("Done")
 

--- a/olive/platform_sdk/qualcomm/create_python_env.ps1
+++ b/olive/platform_sdk/qualcomm/create_python_env.ps1
@@ -42,12 +42,15 @@ else {
 # Install snpe requirements
 # if PIP_EXTRA_ARGS is set, then use it else use ""
 $PIP_EXTRA_ARGS = $env:PIP_EXTRA_ARGS
-& (Join-Path $FILES_DIR $PY_ENV_NAME "python.exe") -m pip install --upgrade pip $PIP_EXTRA_ARGS
+# to back-compat with older versions of the powershell
+$PYTHON_PATH = Join-Path (Join-Path $FILES_DIR $PY_ENV_NAME) "python.exe"
+& $PYTHON_PATH -m pip install --upgrade pip $PIP_EXTRA_ARGS
+& $PYTHON_PATH -m pip install --upgrade pip $PIP_EXTRA_ARGS
 if ($PY_VERSION -eq "3.6") {
-    & (Join-Path $FILES_DIR $PY_ENV_NAME "python.exe") -m pip install onnx==1.11.0 onnx-simplifier packaging tensorflow==1.15.0 pyyaml pandas==1.1.5 numpy==1.18.5 $PIP_EXTRA_ARGS
+    & $PYTHON_PATH -m pip install onnx==1.11.0 onnx-simplifier packaging tensorflow==1.15.0 pyyaml pandas==1.1.5 numpy==1.18.5 $PIP_EXTRA_ARGS
 }
 elseif ($PY_VERSION -eq "3.8") {
-    & (Join-Path $FILES_DIR $PY_ENV_NAME "python.exe") -m pip install onnx onnx-simplifier packaging tensorflow==2.10.1 pyyaml pandas==1.1.5 numpy==1.23.5 $PIP_EXTRA_ARGS
+    & $PYTHON_PATH -m pip install onnx onnx-simplifier packaging tensorflow==2.10.1 pyyaml pandas==1.1.5 numpy==1.23.5 $PIP_EXTRA_ARGS
 }
 else {
     Write-Host "Unsupported python version: $PY_VERSION, only 3.6 and 3.8 are supported"

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "olive": ["extra_dependencies.json"],
         "olive.auto_optimizer": ["config_template/*.yaml"],
         "olive.engine.packaging": ["sample_code/*/*/*"],
-        "olive.platform_sdk.qualcomm": ["create_python_env.sh", "copy_libcdsprpc.ps1"],
+        "olive.platform_sdk.qualcomm": ["create_python_env.sh", "create_python_env.ps1", "copy_libcdsprpc.ps1"],
         "olive.systems.docker": ["Dockerfile*"],
     },
     data_files=[],


### PR DESCRIPTION
## Describe your changes
1. Enable windows QNN e2e test
2. Added use conda path into windows ci test if it is for qnn. This is a workaround for this kind of issue only ci pipeline: https://community.anaconda.cloud/t/cant-install-failed-to-extract-packages-error/62687
3. Update pwsh Join-path to back-compat the version of pwsh <= 5.x, 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
