### PR TITLE
work around TRT register_tensorrt_plugins_as_custom_ops AttributeError

### DIFF
--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -239,12 +239,15 @@ class OrtTransformersOptimization(Pass):
                 version.parse(ort.__version__) >= version.parse("1.17.0")
                 and self.accelerator_spec.execution_provider in ort.get_available_providers()
             ):
+                # TODO(myguo): please consider move EP check with available providers to transformer.optimize_model
                 # from the time being, if ORT doesn't have TensorRT EP, the create inference session would fail
                 # with AttributeError, which complains:
                 # module 'onnxruntime.capi._pybind_state' has no attribute 'register_tensorrt_plugins_as_custom_ops'
                 # Therefore, when user_gpu is True and op_level > 0, we need ensure the EP is available in ORT
                 # by checking the accleerator_spec.execution_provider is in ort.get_available_providers()
                 # if we want to apply transformers graph optimization.
+                # In theory, the EP check against available providers should be done in transformer.optimize_model
+                # Please consider move the check to transformer.optimize_model in the future.
                 run_config["provider"] = self.accelerator_spec.execution_provider.replace(
                     "ExecutionProvider", ""
                 ).lower()

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -175,6 +175,10 @@ class OrtTransformersOptimization(Pass):
             # TODO(myguo): remove the following hacking code after ORT fix the AttributeError when creating session
             # with TensorrtExecutionProvider if ORT doesn't support TensorRT.
             if self.accelerator_spec.execution_provider not in ort.get_available_providers():
+                logger.warning(
+                    f"Transformers optimization is skipped since {self.accelerator_spec.execution_provider} is not "
+                    f"in available execution providers: {ort.get_available_providers()}"
+                )
                 return False
         return True
 


### PR DESCRIPTION
## Describe your changes
If we create InferenceSession by using TRT and TRT not in the available EP, the following error will be raised.

![image](https://github.com/microsoft/Olive/assets/817030/defe82d3-9858-487e-a5a0-c0d859d4492d)

This PR just add working around code. we can consider remove the code later.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
