### PR TITLE
use pipeline variable for last ort version

### DIFF
--- a/.azure_pipelines/olive-ort-last.yaml
+++ b/.azure_pipelines/olive-ort-last.yaml
@@ -21,7 +21,7 @@ jobs:
     device: 'cpu'
     windows: False
     test_type: 'unit_test'
-    onnxruntime: 'onnxruntime==1.15.1'
+    onnxruntime: 'onnxruntime==$(OrtVersion)'
 
 # Linux GPU unit test
 - template: job_templates/olive-test-template.yaml
@@ -31,7 +31,7 @@ jobs:
     device: 'gpu'
     windows: False
     test_type: 'unit_test'
-    onnxruntime: 'onnxruntime-gpu==1.15.1'
+    onnxruntime: 'onnxruntime-gpu==$(OrtVersion)'
     requirements_file: 'requirements-test-gpu.txt'
 
 # Windows unit test
@@ -42,14 +42,14 @@ jobs:
     device: 'cpu'
     windows: True
     test_type: 'unit_test'
-    onnxruntime: 'onnxruntime==1.15.1'
+    onnxruntime: 'onnxruntime==$(OrtVersion)'
 
 # Linux examples test
 - template: job_templates/olive-example-template.yaml
   parameters:
     name: Linux_CI
     pool: $(OLIVE_POOL_UBUNTU2004)
-    onnxruntime: onnxruntime==1.15.1
+    onnxruntime: onnxruntime==$(OrtVersion)
     examples:
       bert_ptq_cpu:
         exampleFolder: bert
@@ -72,7 +72,7 @@ jobs:
   parameters:
     name: Windows_CI
     pool: $(OLIVE_POOL_WIN2019)
-    onnxruntime: onnxruntime==1.15.1
+    onnxruntime: onnxruntime==$(OrtVersion)
     examples:
       bert_ptq_cpu:
         exampleFolder: bert
@@ -92,7 +92,7 @@ jobs:
   parameters:
     name: Linux_GPU_CI
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
-    onnxruntime: onnxruntime-gpu==1.15.1
+    onnxruntime: onnxruntime-gpu==$(OrtVersion)
     examples:
       bert_cuda_gpu:
         exampleFolder: bert


### PR DESCRIPTION
## Describe your changes
Use variable to specify last ort version to avoid changing the yaml whenever new ort is released.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
