### PR TITLE
⏰ Allow pareto_frontier footprint be empty

### DIFF
--- a/examples/bert/bert_ptq_cpu.json
+++ b/examples/bert/bert_ptq_cpu.json
@@ -32,7 +32,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [
-                        {"name": "avg", "priority": 2, "goal": {"type": "percent-min-improvement", "value": 5}},
+                        {"name": "avg", "priority": 2, "goal": {"type": "percent-min-improvement", "value": 0.1}},
                         {"name": "max"},
                         {"name": "min"}
                     ]

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -534,6 +534,8 @@ class Engine:
 
     def create_pareto_frontier_footprints(self, accelerator_spec, output_model_num, output_dir, prefix_output_name):
         pf_footprints = self.footprints[accelerator_spec].create_pareto_frontier(output_model_num)
+        if not pf_footprints:
+            return None
         pf_footprints.to_file(output_dir / f"{prefix_output_name}pareto_frontier_footprints.json")
 
         if self._config.plot_pareto_frontier:

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -581,8 +581,7 @@ class TestEngine:
                 actual_res = engine.run(
                     onnx_model_config, [DEFAULT_CPU_ACCELERATOR], data_root=None, output_dir=output_dir
                 )
-                pf = actual_res[DEFAULT_CPU_ACCELERATOR]
-                assert not pf.nodes, "Expect empty dict when quantization fails"
+                assert not actual_res, "Expect empty dict when quantization fails"
         else:
             options = {
                 "cache_dir": tmpdir,

--- a/test/unit_test/engine/test_footprint.py
+++ b/test/unit_test/engine/test_footprint.py
@@ -52,7 +52,7 @@ class TestFootprint:
         for v in unmet_goals_nodes.values():
             v.metrics.if_goals_met = False
         new_fp = Footprint(nodes=unmet_goals_nodes)
-        assert not new_fp.create_pareto_frontier()
+        assert new_fp.create_pareto_frontier() is None
 
     def test_trace_back_run_history(self):
         for model_id in self.fp.nodes:

--- a/test/unit_test/engine/test_footprint.py
+++ b/test/unit_test/engine/test_footprint.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -44,6 +45,14 @@ class TestFootprint:
         assert isinstance(pareto_frontier_fp, Footprint)
         assert len(pareto_frontier_fp.nodes) == 2
         assert all(v.is_pareto_frontier for v in pareto_frontier_fp.nodes.values())
+
+    def test_empty_pareto_frontier(self):
+        # set all `is_goals_met` as false
+        unmet_goals_nodes = deepcopy(self.fp.nodes)
+        for v in unmet_goals_nodes.values():
+            v.metrics.if_goals_met = False
+        new_fp = Footprint(nodes=unmet_goals_nodes)
+        assert not new_fp.create_pareto_frontier()
 
     def test_trace_back_run_history(self):
         for model_id in self.fp.nodes:


### PR DESCRIPTION
## Describe your changes
1. Allow pareto_frontier footprint be empty.
2. Adjust the metric goal for bert cpu to mitigate this kind of issue: https://dev.azure.com/aiinfra/PublicPackages/_build/results?buildId=402365&view=logs&j=dbbdd4d8-ffd3-515a-31fd-659375dbdff8&t=13dad60e-7187-5e88-dbc0-776ed0850a3f


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
