### PR TITLE
`task` instead of `task_type` in HF container config

### DIFF
--- a/docs/source/tutorials/configure_data.rst
+++ b/docs/source/tutorials/configure_data.rst
@@ -92,7 +92,7 @@ Convert the huggingface data config to the data container.
                 "type": "HuggingfaceContainer",
                 "params_config": {
                     "model_name": "Intel/bert-base-uncased-mrpc",
-                    "task_type": "text-classification",
+                    "task": "text-classification",
                     "batch_size": 1,
                     "data_name": "glue",
                     "input_cols": ["sentence1", "sentence2"],
@@ -112,7 +112,7 @@ Convert the huggingface data config to the data container.
                 type="HuggingfaceContainer",
                 params_config={
                     "model_name": "Intel/bert-base-uncased-mrpc",
-                    "task_type": "text-classification",
+                    "task": "text-classification",
                     "batch_size": 1,
                     "data_name": "glue",
                     "input_cols": ["sentence1", "sentence2"],

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -33,6 +33,8 @@ class TestPyTorchMLflowModel(unittest.TestCase):
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(self.architecture)
         self.input_text = "Today was an amazing day."
         self.hf_conf = {
+            # this is `task_type` and not `task` since it's an input to aml_mlflow.hftransformers.save_model
+            # which expects `task_type` as the key
             "task_type": self.task,
         }
 

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -557,7 +557,7 @@ class TestAzureMLSystem:
                     "model_name": "Intel/bert-base-uncased-mrpc",
                     "split": "validation",
                     "subset": "mrpc",
-                    "task_type": "text-classification",
+                    "task": "text-classification",
                 },
                 "type": "HuggingfaceContainer",
             },


### PR DESCRIPTION
## Describe your changes
The correct parameter name is `task` and not `task_type`. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
