### PR TITLE
🪟 snpe windows case

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -147,10 +147,9 @@ jobs:
       mobilenet_qnn_toolkit:
         exampleFolder: mobilenet
         exampleName: qnn_tooklit
-      # ignore the inception_snpe_toolkit example on Windows for time being
-      # inception_snpe_toolkit:
-      #   exampleFolder: inception
-      #   exampleName: snpe_toolkit
+      inception_snpe_toolkit:
+        exampleFolder: inception
+        exampleName: snpe_toolkit
 
 # Linux GPU examples testing.
 - template: job_templates/olive-example-template.yaml

--- a/examples/inception/README.md
+++ b/examples/inception/README.md
@@ -34,6 +34,15 @@ To download the necessary data and model files:
 python download_files.py
 ```
 
+## Prepare the configuration file
+The configuration file `inception_config.json` contains the parameters for the conversion and quantization.
+But the quantization is only supported for `x64-Linux` platform. To run the optimization on Windows, please remove the `quantization` section from the configuration file.
+
+Or you can just run following command to generate the configuration file:
+```sh
+python prepare_config.py
+```
+
 ## Run sample
 Run the conversion and quantization locally. Only supports `x64-Linux`.
 ```

--- a/examples/inception/prepare_config.py
+++ b/examples/inception/prepare_config.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import json
+import platform
+from pathlib import Path
+
+
+def resolve_windows_config():
+    # pylint: disable=redefined-outer-name
+
+    with Path("inception_config.json").open("r") as f:
+        snpe_windows_config = json.load(f)
+
+    del snpe_windows_config["passes"]["snpe_quantization"]
+    with Path("inception_config.json").open("w") as f:
+        json.dump(snpe_windows_config, f, indent=4)
+
+
+if __name__ == "__main__":
+    if platform.system() == "Windows":
+        resolve_windows_config()

--- a/examples/inception/prepare_config.py
+++ b/examples/inception/prepare_config.py
@@ -8,9 +8,8 @@ from pathlib import Path
 
 
 def resolve_windows_config():
-    # pylint: disable=redefined-outer-name
 
-    with Path("inception_config.json").open("r") as f:
+    with Path("inception_config.json").open() as f:
         snpe_windows_config = json.load(f)
 
     del snpe_windows_config["passes"]["snpe_quantization"]

--- a/examples/phi2/requirements.txt
+++ b/examples/phi2/requirements.txt
@@ -1,4 +1,4 @@
 einops
 onnx>=1.15.0
-transformers>=4.36.2
 onnxscript>=0.1.0.dev20240126
+transformers>=4.36.2

--- a/examples/test/test_snpe_toolkit.py
+++ b/examples/test/test_snpe_toolkit.py
@@ -57,6 +57,8 @@ def setup_resource():
     run_subprocess(cmd=" ".join(install_cmd), check=True)
     retry_func(run_subprocess, kwargs={"cmd": "python download_files.py", "check": True})
 
+    run_subprocess(cmd="python prepare_config.py", check=True)
+
 
 def test_inception_snpe(tmp_path):
     from olive.workflows import run as olive_run

--- a/examples/vgg/README.md
+++ b/examples/vgg/README.md
@@ -32,6 +32,15 @@ To download the necessary data and model files:
 python download_files.py
 ```
 
+## Prepare the configuration file
+The configuration file `vgg_config.json` contains the parameters for the conversion and quantization.
+But the quantization is only supported for `x64-Linux` platform. To run the optimization on Windows, please remove the `quantization` section from the configuration file.
+
+Or you can just run following command to generate the configuration file:
+```sh
+python prepare_config.py
+```
+
 ## Run sample
 Run the conversion and quantization locally. Only supports `x64-Linux`.
 ```

--- a/examples/vgg/prepare_config.py
+++ b/examples/vgg/prepare_config.py
@@ -8,9 +8,8 @@ from pathlib import Path
 
 
 def resolve_windows_config():
-    # pylint: disable=redefined-outer-name
 
-    with Path("vgg_config.json").open("r") as f:
+    with Path("vgg_config.json").open() as f:
         snpe_windows_config = json.load(f)
 
     del snpe_windows_config["passes"]["snpe_quantization"]

--- a/examples/vgg/prepare_config.py
+++ b/examples/vgg/prepare_config.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import json
+import platform
+from pathlib import Path
+
+
+def resolve_windows_config():
+    # pylint: disable=redefined-outer-name
+
+    with Path("vgg_config.json").open("r") as f:
+        snpe_windows_config = json.load(f)
+
+    del snpe_windows_config["passes"]["snpe_quantization"]
+    with Path("vgg_config.json").open("w") as f:
+        json.dump(snpe_windows_config, f, indent=4)
+
+
+if __name__ == "__main__":
+    if platform.system() == "Windows":
+        resolve_windows_config()

--- a/olive/platform_sdk/qualcomm/runner.py
+++ b/olive/platform_sdk/qualcomm/runner.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 import time
+from pathlib import Path
 
 from olive.common.utils import run_subprocess
 from olive.platform_sdk.qualcomm.qnn.env import QNNSDKEnv
@@ -34,6 +35,19 @@ class SDKRunner:
             self.sdk_env = QNNSDKEnv(use_dev_tools=self.use_dev_tools)
 
     def run(self, cmd: str, use_olive_env: bool = True):
+        import platform
+
+        if platform.system() == "Windows" and cmd.startswith(("snpe-", "qnn-")):
+            logger.debug(f"Resolving command {cmd} on Windows.")
+            cmd_path = Path(self.sdk_env.sdk_root_path) / "bin" / self.sdk_env.target_arch
+            cmd_name = cmd.split(" ")[0]
+            if (cmd_path / cmd_name).exists():
+                cmd = str(cmd_path / cmd_name) + cmd[len(cmd_name) :]
+                with (cmd_path / cmd_name).open("r") as f:
+                    first_line = f.readline()
+                    if "python" in first_line:
+                        cmd = f"python {cmd}"
+
         env = self.sdk_env.env if use_olive_env else None
         for run in range(self.runs):
             run_log_msg = "" if self.runs == 1 else f" (run {run + 1}/{self.runs})"

--- a/olive/platform_sdk/qualcomm/runner.py
+++ b/olive/platform_sdk/qualcomm/runner.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-import platform
 import time
 from pathlib import Path
 
@@ -36,6 +35,8 @@ class SDKRunner:
             self.sdk_env = QNNSDKEnv(use_dev_tools=self.use_dev_tools)
 
     def _resolve_cmd(self, cmd: str):
+        import platform
+
         if platform.system() == "Windows" and cmd.startswith(("snpe-", "qnn-")):
             logger.debug(f"Resolving command {cmd} on Windows.")
             cmd_path = Path(self.sdk_env.sdk_root_path) / "bin" / self.sdk_env.target_arch

--- a/olive/platform_sdk/qualcomm/snpe/env.py
+++ b/olive/platform_sdk/qualcomm/snpe/env.py
@@ -17,7 +17,6 @@ class SNPESDKEnv(SDKEnv):
 
     @property
     def env(self):
-        os_env = os.environ.copy()
         env = super().env
         target_arch = self.target_arch
         sdk_root_path = self.sdk_root_path
@@ -37,6 +36,7 @@ class SNPESDKEnv(SDKEnv):
             env["PATH"] = python_env_bin_path + delimiter + env["PATH"]
 
         if platform.system() == "Windows":
+            os_env = os.environ.copy()
             os_env.update(env)
             env = os_env
             if target_arch == SDKTargetDevice.arm64x_windows:

--- a/olive/platform_sdk/qualcomm/snpe/env.py
+++ b/olive/platform_sdk/qualcomm/snpe/env.py
@@ -39,13 +39,13 @@ class SNPESDKEnv(SDKEnv):
         if platform.system() == "Windows":
             os_env.update(env)
             env = os_env
+            if target_arch == SDKTargetDevice.arm64x_windows:
+                bin_path = str(Path(f"{sdk_root_path}/olive-arm-win"))
+                if not Path(bin_path).exists():
+                    raise FileNotFoundError(
+                        f"Path {bin_path} does not exist. Please run"
+                        " 'python -m olive.platform_sdk.qualcomm.configure --py_version 3.8 --sdk snpe' to add the"
+                        " missing folder"
+                    )
 
-        if platform.system() == "Windows" and target_arch == SDKTargetDevice.arm64x_windows:
-            bin_path = str(Path(f"{sdk_root_path}/olive-arm-win"))
-            if not Path(bin_path).exists():
-                raise FileNotFoundError(
-                    f"Path {bin_path} does not exist. Please run"
-                    " 'python -m olive.platform_sdk.qualcomm.configure --py_version 3.8 --sdk snpe' to add the"
-                    " missing folder"
-                )
         return env

--- a/olive/platform_sdk/qualcomm/snpe/tools/dev.py
+++ b/olive/platform_sdk/qualcomm/snpe/tools/dev.py
@@ -38,6 +38,7 @@ def get_dlc_io_config(dlc_path: str, input_names: List[str], output_names: List[
     input_names: list of input names of source model.
     output_names: list of output names of source model.
     """
+    # ruff: noqa: R1732
     tmp_folder = tempfile.TemporaryDirectory()
     tmp_csv = Path(tmp_folder.name) / "dlc_info.csv"
     dlc_info = get_dlc_info(dlc_path, csv_path=str(tmp_csv))

--- a/olive/platform_sdk/qualcomm/snpe/tools/dev.py
+++ b/olive/platform_sdk/qualcomm/snpe/tools/dev.py
@@ -38,8 +38,9 @@ def get_dlc_io_config(dlc_path: str, input_names: List[str], output_names: List[
     input_names: list of input names of source model.
     output_names: list of output names of source model.
     """
-    tmp_csv = tempfile.NamedTemporaryFile(suffix=".csv")  # pylint: disable=consider-using-with
-    dlc_info = get_dlc_info(dlc_path, csv_path=tmp_csv.name)
+    tmp_folder = tempfile.TemporaryDirectory()
+    tmp_csv = Path(tmp_folder.name) / "dlc_info.csv"
+    dlc_info = get_dlc_info(dlc_path, csv_path=str(tmp_csv))
 
     # add the :0 suffix to the input/output names if present in the DLC
     # SNPE adds this suffix to the input/output names in the DLC if the source model is TensorFlow
@@ -49,7 +50,7 @@ def get_dlc_io_config(dlc_path: str, input_names: List[str], output_names: List[
 
     input_dims = {}
     output_dims = {}
-    with Path(tmp_csv.name).open() as f:
+    with tmp_csv.open() as f:
         out = csv.reader(f)
         for row in out:
             if len(row) == 8:
@@ -66,7 +67,8 @@ def get_dlc_io_config(dlc_path: str, input_names: List[str], output_names: List[
                 # input name in this format for versions 2.x
                 if name in input_names:
                     input_dims[name] = list(map(int, shape.split(",")))
-    tmp_csv.close()
+
+    tmp_folder.cleanup()
 
     return {
         "input_names": input_names,

--- a/olive/platform_sdk/qualcomm/snpe/tools/dev.py
+++ b/olive/platform_sdk/qualcomm/snpe/tools/dev.py
@@ -38,37 +38,35 @@ def get_dlc_io_config(dlc_path: str, input_names: List[str], output_names: List[
     input_names: list of input names of source model.
     output_names: list of output names of source model.
     """
-    tmp_folder = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-    tmp_csv = Path(tmp_folder.name) / "dlc_info.csv"
-    dlc_info = get_dlc_info(dlc_path, csv_path=str(tmp_csv))
+    with tempfile.TemporaryDirectory() as tmp_folder:
+        tmp_csv = Path(tmp_folder) / "dlc_info.csv"
+        dlc_info = get_dlc_info(dlc_path, csv_path=str(tmp_csv))
 
-    # add the :0 suffix to the input/output names if present in the DLC
-    # SNPE adds this suffix to the input/output names in the DLC if the source model is TensorFlow
-    if f"{input_names[0]}:0" in dlc_info:
-        input_names = [f"{name}:0" for name in input_names]
-        output_names = [f"{name}:0" for name in output_names]
+        # add the :0 suffix to the input/output names if present in the DLC
+        # SNPE adds this suffix to the input/output names in the DLC if the source model is TensorFlow
+        if f"{input_names[0]}:0" in dlc_info:
+            input_names = [f"{name}:0" for name in input_names]
+            output_names = [f"{name}:0" for name in output_names]
 
-    input_dims = {}
-    output_dims = {}
-    with tmp_csv.open() as f:
-        out = csv.reader(f)
-        for row in out:
-            if len(row) == 8:
-                _, name, _, input_item, output, shape, _, _ = tuple(row)
-                # version 2.x has 'name type'
-                output = output.split(" ")[0]
-                # input name in this format for versions 1.x
-                if name == input_item and name == output and name and name in input_names:
-                    input_dims[name] = list(map(int, shape.split("x")))
-                elif output in output_names:
-                    output_dims[output] = list(map(int, shape.split("x")))
-            if len(row) == 3:
-                name, shape, _ = tuple(row)
-                # input name in this format for versions 2.x
-                if name in input_names:
-                    input_dims[name] = list(map(int, shape.split(",")))
-
-    tmp_folder.cleanup()
+        input_dims = {}
+        output_dims = {}
+        with tmp_csv.open() as f:
+            out = csv.reader(f)
+            for row in out:
+                if len(row) == 8:
+                    _, name, _, input_item, output, shape, _, _ = tuple(row)
+                    # version 2.x has 'name type'
+                    output = output.split(" ")[0]
+                    # input name in this format for versions 1.x
+                    if name == input_item and name == output and name and name in input_names:
+                        input_dims[name] = list(map(int, shape.split("x")))
+                    elif output in output_names:
+                        output_dims[output] = list(map(int, shape.split("x")))
+                if len(row) == 3:
+                    name, shape, _ = tuple(row)
+                    # input name in this format for versions 2.x
+                    if name in input_names:
+                        input_dims[name] = list(map(int, shape.split(",")))
 
     return {
         "input_names": input_names,

--- a/olive/platform_sdk/qualcomm/snpe/tools/dev.py
+++ b/olive/platform_sdk/qualcomm/snpe/tools/dev.py
@@ -38,8 +38,7 @@ def get_dlc_io_config(dlc_path: str, input_names: List[str], output_names: List[
     input_names: list of input names of source model.
     output_names: list of output names of source model.
     """
-    # ruff: noqa: R1732
-    tmp_folder = tempfile.TemporaryDirectory()
+    tmp_folder = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
     tmp_csv = Path(tmp_folder.name) / "dlc_info.csv"
     dlc_info = get_dlc_info(dlc_path, csv_path=str(tmp_csv))
 

--- a/test/unit_test/snpe/test_adb_run.py
+++ b/test/unit_test/snpe/test_adb_run.py
@@ -55,16 +55,19 @@ def test_run_snpe_command():
         if platform.system() == "Linux":
             env = {
                 "LD_LIBRARY_PATH": "/snpe/lib/x86_64-linux-clang",
-                "PATH": "/snpe/bin/x86_64-linux-clang:/usr/bin",
+                "PATH": f"/snpe/bin/x86_64-linux-clang:/usr/bin:{os.environ['PATH']}",
                 "PYTHONPATH": "/snpe/lib/python",
                 "SDK_ROOT": "/snpe",
             }
         else:
             env = {
-                "PATH": "C:\\snpe\\bin\\x86_64-windows-msvc;C:\\snpe\\lib\\x86_64-windows-msvc",
+                "PATH": f"C:\\snpe\\bin\\x86_64-windows-msvc;C:\\snpe\\lib\\x86_64-windows-msvc;{os.environ['PATH']}",
                 "SDK_ROOT": "C:\\snpe",
                 "PYTHONPATH": "C:\\snpe\\lib\\python",
             }
+            os_env = os.environ.copy()
+            os_env.update(env)
+            env = os_env
 
         mock_run_subprocess.assert_called_once_with(
             "snpe-net-run --container xxxx".split(),

--- a/test/unit_test/snpe/test_adb_run.py
+++ b/test/unit_test/snpe/test_adb_run.py
@@ -45,10 +45,11 @@ def test_run_snpe_command():
 
     with patch.object(Path, "exists") as mock_exists, patch.object(Path, "glob") as mock_glob, patch(
         "shutil.which"
-    ) as mock_witch, patch("subprocess.run") as mock_run_subprocess:
+    ) as mock_witch, patch.object(Path, "open") as open_file, patch("subprocess.run") as mock_run_subprocess:
         mock_exists.return_value = True
         mock_glob.return_value = [Path("lib") / target_arch]
         mock_witch.side_effect = lambda x, path: x
+        open_file.return_value.__enter__.return_value.readline.return_value = "python"
         mock_run_subprocess.return_value = CompletedProcess(None, returncode=0, stdout=b"stdout", stderr=b"stderr")
         runner = SDKRunner(platform="SNPE")
         stdout, _ = runner.run(cmd="snpe-net-run --container xxxx")
@@ -59,6 +60,7 @@ def test_run_snpe_command():
                 "PYTHONPATH": "/snpe/lib/python",
                 "SDK_ROOT": "/snpe",
             }
+            cmd = "snpe-net-run --container xxxx"
         else:
             env = {
                 "PATH": f"C:\\snpe\\bin\\x86_64-windows-msvc;C:\\snpe\\lib\\x86_64-windows-msvc;{os.environ['PATH']}",
@@ -68,9 +70,10 @@ def test_run_snpe_command():
             os_env = os.environ.copy()
             os_env.update(env)
             env = os_env
+            cmd = "python C:\\snpe\\bin\\x86_64-windows-msvc\\snpe-net-run --container xxxx"
 
         mock_run_subprocess.assert_called_once_with(
-            "snpe-net-run --container xxxx".split(),
+            cmd.split(),
             capture_output=True,
             env=env,
             cwd=None,


### PR DESCRIPTION
## Describe your changes
To complete the SNPE support in windows. 
Previously Olive only support to run SNPE toolkit in windows. In this PR, I tried to:
1. Test the SNPE toolkit in windows and add the required env variables for SNPE to run. Several differences between run in windows and linux:
  - In windows, only the executable file can be find if it's parent folder in system PATH. That need olive to resolve the full file path to run for those snpe-tools which are python file but not .exe.
  - In windows, to ensure Python.exe can be initialized successfully, olive need to copy the SYSTEMROOT and other env variables to run the cmd. https://stackoverflow.com/questions/58997105/fatal-python-error-failed-to-get-random-numbers-to-initialize-python
2. Enable windows snpe toolkit e2e tests case with Inception model.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
