### PR TITLE
Refactor engine to use SystemConfig instead of OliveSystem to create the accelerator specs

### DIFF
--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -101,7 +101,7 @@ engine_config = {
     }
 }
 
-engine = Engine(engine_config, evaluator_config=evaluator_config, host=local_system)
+engine = Engine(engine_config, evaluator_config=evaluator_config)
 ```
 
 ## Register Passes

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -78,6 +78,29 @@ def hash_file(filename):  # pragma: no cover
         return hash_io_stream(f)
 
 
+def hash_update_from_file(filename, hash_value):
+    assert Path(filename).is_file()
+    with open(str(filename), "rb") as f:  # noqa: PTH123
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_value.update(chunk)
+    return hash_value
+
+
+def hash_update_from_dir(directory, hash_value):
+    assert Path(directory).is_dir()
+    for path in sorted(Path(directory).iterdir(), key=lambda p: str(p).lower()):
+        hash_value.update(path.name.encode())
+        if path.is_file():
+            hash_value = hash_update_from_file(path, hash_value)
+        elif path.is_dir():
+            hash_value = hash_update_from_dir(path, hash_value)
+    return hash_value
+
+
+def hash_dir(directory):
+    return hash_update_from_dir(directory, hashlib.md5()).hexdigest()
+
+
 def hash_dict(dictionary):  # pragma: no cover
     md5_hash = hashlib.md5()
     encoded_dictionary = json.dumps(dictionary, sort_keys=True).encode()

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -891,7 +891,7 @@ class Engine:
                     start_time=run_cache.get("run_start_time", 0),
                     end_time=run_cache.get("run_end_time", 0),
                 )
-                logger.info(f"Loaded model from cache: {output_model_id} from f{self._run_cache_path}")
+                logger.info(f"Loaded model from cache: {output_model_id} from {self._run_cache_path}")
                 return output_model_config, output_model_id
 
         # new model id

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -922,7 +922,11 @@ class Engine:
 
             # For perf-tuning, we need the model evaluation happens in target even if it is a pass.
             # TODO(myguo): consider more better way to handle System doesn't support run pass like DockerSystem
-            if isinstance(p, OrtPerfTuning) and isinstance(host, LocalSystem):
+            if (
+                isinstance(p, OrtPerfTuning)
+                and isinstance(host, LocalSystem)
+                and not isinstance(self.target, LocalSystem)
+            ):
                 p.set_target(self.target)
 
             output_model_config = host.run_pass(p, input_model_config, data_root, output_model_path, pass_search_point)

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -113,6 +113,7 @@ class Engine:
         if self._config.clean_evaluation_cache:
             cache_utils.clean_evaluation_cache(cache_dir)
 
+        logger.info("Using cache directory: %s", cache_dir)
         self._model_cache_path, self._run_cache_path, self._evaluation_cache_path, _ = cache_utils.get_cache_sub_dirs(
             cache_dir
         )
@@ -890,7 +891,7 @@ class Engine:
                     start_time=run_cache.get("run_start_time", 0),
                     end_time=run_cache.get("run_end_time", 0),
                 )
-                logger.info(f"Loaded model from cache: {output_model_id}")
+                logger.info(f"Loaded model from cache: {output_model_id} from f{self._run_cache_path}")
                 return output_model_config, output_model_id
 
         # new model id

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -22,6 +22,7 @@ from olive.exception import EXCEPTIONS_TO_RAISE, OlivePassError
 from olive.model import ModelConfig
 from olive.strategy.search_strategy import SearchStrategy
 from olive.systems.common import SystemType
+from olive.systems.local import LocalSystem
 from olive.systems.olive_system import OliveSystem
 from olive.systems.system_config import LocalTargetUserConfig, SystemConfig
 from olive.systems.utils import create_new_system_with_cache
@@ -917,6 +918,13 @@ class Engine:
 
         run_start_time = datetime.now().timestamp()
         try:
+            from olive.passes.onnx.perf_tuning import OrtPerfTuning
+
+            # For perf-tuning, we need the model evaluation happens in target even if it is a pass.
+            # TODO(myguo): consider more better way to handle System doesn't support run pass like DockerSystem
+            if isinstance(p, OrtPerfTuning) and isinstance(host, LocalSystem):
+                p.set_target(self.target)
+
             output_model_config = host.run_pass(p, input_model_config, data_root, output_model_path, pass_search_point)
         except OlivePassError:
             logger.exception("Pass run_pass failed")

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -267,6 +267,7 @@ class Engine:
         outputs = {}
 
         for accelerator_spec in accelerator_specs:
+            logger.info("Running Olive on accelerator: %s", accelerator_spec)
             with self.create_managed_environment(accelerator_spec):
                 run_result = self.run_accelerator(
                     input_model_config,
@@ -338,6 +339,7 @@ class Engine:
                     return results
 
             if self.no_search:
+                logger.debug("Running Olive in no-search mode ...")
                 output_footprint = self.run_no_search(
                     input_model_config,
                     input_model_id,
@@ -347,6 +349,7 @@ class Engine:
                     output_name,
                 )
             else:
+                logger.debug("Running Olive in search mode ...")
                 output_footprint = self.run_search(
                     input_model_config,
                     input_model_id,
@@ -364,6 +367,7 @@ class Engine:
         output_fp_path = output_dir / f"{prefix_output_name}_footprints.json"
         logger.info(f"Save footprint to {output_fp_path}")
         self.footprints[accelerator_spec].to_file(output_fp_path)
+        logger.debug("run_accelerator done")
         return output_footprint
 
     def setup_passes(self, accelerator_spec: "AcceleratorSpec"):
@@ -829,6 +833,7 @@ class Engine:
                 # skip evaluation if no search and no evaluator
                 signal = None
             else:
+                logger.info("Run model evaluation for the final model...")
                 signal = self._evaluate_model(model_config, model_id, data_root, evaluator_config, accelerator_spec)
             logger.debug(f"Signal: {signal}")
         else:

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -1043,6 +1043,7 @@ class Engine:
         def create_system(config: "SystemConfig", accelerator_spec):
             assert config, "System config is not provided"
             if getattr(config.config, "olive_managed_env", False):
+                logger.debug(f"Creating new system {config.type} with cache {accelerator_spec.execution_provider}")
                 return create_new_system_with_cache(config, accelerator_spec)
             else:
                 return config.create_system()

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -1061,9 +1061,12 @@ class Engine:
         def create_system(config: "SystemConfig", accelerator_spec):
             assert config, "System config is not provided"
             if config.olive_managed_env:
-                logger.debug(f"Creating new system {config.type} with EP {accelerator_spec.execution_provider}")
+                logger.debug(
+                    "Creating olive_managed_env %s with EP %s", config.type, accelerator_spec.execution_provider
+                )
                 return create_new_system_with_cache(config, accelerator_spec)
             else:
+                logger.debug("create native OliveSystem %s", config.type)
                 return config.create_system()
 
         if not self.target:

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -184,7 +184,7 @@ def create_accelerators(
     is_cpu_available = "cpu" in [accelerator.lower() for accelerator in accelerators]
     for accelerator in accelerators:
         device = Device(accelerator.lower())
-        if getattr(system_config.config, "olive_managed_env", False):
+        if system_config.olive_managed_env:
             available_eps = AcceleratorLookup.get_managed_supported_execution_providers(device)
         elif system_config.type in (SystemType.Local, SystemType.PythonEnvironment) and not skip_supported_eps_check:
             # don't need to check the supported execution providers if there is no evaluation

--- a/olive/model/utils/onnx_utils.py
+++ b/olive/model/utils/onnx_utils.py
@@ -109,7 +109,7 @@ def check_and_normalize_provider_args(
     provider_name_to_options = collections.OrderedDict()
 
     def set_provider_options(name, options):
-        if name not in available_provider_names:
+        if available_provider_names and name not in available_provider_names:
             logger.warning(
                 "Specified provider '%s' is not in available provider names.Available providers: '%s'",
                 name,

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -97,96 +97,6 @@ def valid_config(tuning_combos, config):
     return True
 
 
-def tune_onnx_model(accelerator, target, model, data_root, config):
-    latency_user_config = {}
-    # which should be the same as the config in the metric
-    config_dict = config.dict()
-
-    # data_dir/dataloader_func will be passed to the metric as perf_tuning will leverage
-    # the latency metric to run tune
-    for eval_config in get_user_config_properties_from_metric_type(MetricType.LATENCY):
-        if eval_config in config_dict:
-            latency_user_config[eval_config] = config_dict.get(eval_config)
-    if config_dict.get("dataloader_func_kwargs"):
-        latency_user_config["func_kwargs"] = {"dataloader_func": config_dict.get("dataloader_func_kwargs")}
-    latency_sub_types = [{"name": LatencySubType.AVG}]
-    latency_metric_config = {
-        "name": "latency",
-        "type": MetricType.LATENCY,
-        "sub_types": latency_sub_types,
-        "user_config": latency_user_config,
-        "data_config": config_dict.get("data_config"),
-    }
-    latency_metric = Metric(**latency_metric_config)
-
-    # TODO(myguo): from the time being, the baseline evaluation doesn't enable enable_cuda_graph.
-    # do we need enable it?
-    io_bind = config.io_bind
-    pretuning_inference_result = get_benchmark(
-        accelerator, target, model, data_root, latency_metric, config, io_bind=io_bind, tuning_result=None
-    )
-
-    tuning_op_result = pretuning_inference_result.get("tuning_op_result")
-    tuning_results = []
-    for provider, execution_mode, opt_level in generate_tuning_combos(config):
-        provider, options = populate_provider_options(provider, config)  # noqa: PLW2901
-        if provider == "CUDAExecutionProvider":
-            # if enable_cuda_graph is True but the io_bind is False, the following errors will be raised.
-            # onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : CUDA failure 700:
-            #    an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ;
-            #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_graph.cc ; line=49 ;
-            #    expr=cudaGraphLaunch(graph_exec_, stream_);
-            # [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDA failure 700:
-            #    an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ;
-            #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=286 ;
-            #    expr=cudaStreamDestroy(stream_);
-            # [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDNN failure 4:
-            #    CUDNN_STATUS_INTERNAL_ERROR ; GPU=0 ; hostname=c93f1847c000000 ;
-            #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=181 ;
-            #    expr=cudnnDestroy(cudnn_handle_);
-            io_bind = True
-        elif provider == "CPUExecutionProvider":
-            io_bind = False
-
-        tuning_combo = (([provider], [options]), execution_mode, opt_level, io_bind)
-
-        # TODO(myguo): we need disable the following check when we enable cache in perf tuning.
-        if provider != accelerator.execution_provider and not config.force_evaluate_other_eps:
-            logger.warning(
-                "Ignore perf tuning for EP %s since current pass EP is %s", provider, accelerator.execution_provider
-            )
-            continue
-        tuning_item = ["provider", "execution_mode", "ort_opt_level", "io_bind"]
-        if not valid_config(tuning_combo, config):
-            continue
-        logger.info("Run tuning for: %s", list(zip(tuning_item, tuning_combo)))
-        tuning_results.extend(
-            threads_num_tuning(
-                accelerator, target, model, data_root, latency_metric, config, *tuning_combo, tuning_op_result
-            )
-        )
-
-    for tuning_result in tuning_results:
-        logger.debug("Tuning result for %s: %s", tuning_result["test_name"], tuning_result["latency_ms"])
-
-    best_result = parse_tuning_result(*tuning_results, pretuning_inference_result)
-    logger.info("Best result: %s", best_result)
-    # Both baseline and pertuning result should have the execution provider in the test_results.
-    assert "execution_provider" in best_result, "execution_provider should be in best_result"
-    optimized_model = copy.copy(model)
-    optimized_model.inference_settings = {
-        "execution_provider": best_result["execution_provider"],
-        "provider_options": best_result["provider_options"],
-        "io_bind": best_result["io_bind"],
-        "tuning_op_result": best_result.get("tuning_op_result"),
-    }
-    session_options = best_result.get("session_options")
-    if session_options is not None:
-        optimized_model.inference_settings["session_options"] = session_options
-
-    return optimized_model
-
-
 def populate_provider_options(execution_provider, config):
     if isinstance(execution_provider, (tuple, list)):
         assert len(execution_provider) == 2, "execution_provider should be a tuple with execution provider and options"
@@ -204,165 +114,6 @@ def populate_provider_options(execution_provider, config):
         provider_options["enable_cuda_graph"] = config.enable_cuda_graph
 
     return provider, provider_options
-
-
-def threads_num_tuning(
-    accelerator,
-    target,
-    model,
-    data_root,
-    latency_metric,
-    config,
-    providers,
-    execution_mode,
-    ort_opt_level,
-    io_bind,
-    tuning_op_result,
-):
-    tuning_results = []
-    provider, options = providers
-
-    test_params = {
-        "execution_provider": provider,
-        "provider_options": options,
-        "session_options": {
-            "execution_mode": execution_mode,
-            "graph_optimization_level": ort_opt_level,
-        },
-    }
-
-    if config.extra_session_config:
-        test_params["session_options"]["extra_session_config"] = config.extra_session_config
-
-    try:
-        for inter in config.inter_thread_num_list:
-            if inter is not None:
-                test_params["session_options"]["inter_op_num_threads"] = inter
-            for intra in config.intra_thread_num_list:
-                if intra is not None:
-                    test_params["session_options"]["intra_op_num_threads"] = intra
-                tuning_result = threads_num_binary_search(
-                    accelerator,
-                    target,
-                    model,
-                    data_root,
-                    latency_metric,
-                    config,
-                    test_params,
-                    io_bind,
-                    tuning_op_result,
-                )
-                tuning_results.extend(tuning_result)
-    except EXCEPTIONS_TO_RAISE:
-        raise
-    except Exception:
-        logger.exception(
-            "Optimization failed for tuning combo %s",
-            (providers, execution_mode, ort_opt_level, io_bind),
-        )
-
-    return tuning_results
-
-
-def threads_num_binary_search(
-    accelerator, target, model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result
-):
-    """Binary search based benchmark for inter_op_num_threads and intra_op_num_threads."""
-    import onnxruntime as ort
-    import psutil
-
-    # prepare the inter_op_num_threads/intra_op_num_threads to be tune.
-    extra_session_config = test_params["session_options"].get("extra_session_config")
-    if extra_session_config:
-        affinity_str = extra_session_config.get("session.intra_op_thread_affinities")
-        if affinity_str:
-            test_params["session_options"]["intra_op_num_threads"] = get_thread_affinity_nums(affinity_str) + 1
-            threads_names = ["inter_op_num_threads"]
-    elif test_params["session_options"].get("execution_mode") == ort.ExecutionMode.ORT_SEQUENTIAL:
-        threads_names = ["intra_op_num_threads"]
-    else:
-        threads_names = ["inter_op_num_threads", "intra_op_num_threads"]
-
-    if (
-        test_params["session_options"].get("inter_op_num_threads") is not None
-        and test_params["session_options"].get("intra_op_num_threads") is not None
-    ):
-        # If user specify both inter_op_num_threads and intra_op_num_threads, we will not do tuning
-        test_result = get_benchmark(
-            accelerator, target, model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result
-        )
-        return [test_result]
-
-    tuning_results = []
-
-    def benchmark_with_threads_num(threads_name, threads_num):
-        test_params["session_options"][threads_name] = threads_num
-        test_result = get_benchmark(
-            accelerator, target, model, data_root, latency_metric, config, test_params, io_bind, tuning_op_result
-        )
-        tuning_results.append(test_result)
-        return test_result["latency_ms"]
-
-    for threads_name in threads_names:
-        # set the upper bound and lower bound for binary search
-        thread_num = test_params["session_options"].get(threads_name)
-        if thread_num is not None:
-            upper_threads_num = thread_num
-            lower_threads_num = thread_num
-        else:
-            upper_threads_num = config.cpu_cores or psutil.cpu_count(logical=False)
-            lower_threads_num = 1
-
-        current_threads_num = lower_threads_num
-        best_latency = None
-        best_threads_num = None
-
-        while lower_threads_num < upper_threads_num:
-            benchmark_latency = benchmark_with_threads_num(threads_name, current_threads_num)
-
-            if best_latency is None:
-                # the first time run benchmark, then change next to the upper bound
-                best_latency = benchmark_latency
-                best_threads_num = current_threads_num
-                current_threads_num = upper_threads_num
-            elif best_latency < benchmark_latency:
-                mid_threads_num = lower_threads_num + (upper_threads_num - lower_threads_num) // 2
-                # the current benchmark is worse than best benchmark result.
-                # Just keep the best_latency and best_threads_num
-                if best_threads_num < current_threads_num:
-                    # update the upper bound to middle if best benchmark is in lower side.
-                    upper_threads_num = mid_threads_num
-                    next_thread_num = upper_threads_num
-                else:
-                    # update the lower bound to middle if best benchmark is in upper side.
-                    # The benchmark result is worse than best benchmark and
-                    # the thread num last time used is larger than current
-                    lower_threads_num = mid_threads_num + 1
-                    next_thread_num = lower_threads_num
-
-                current_threads_num = next_thread_num
-            else:
-                mid_threads_num = lower_threads_num + (upper_threads_num - lower_threads_num) // 2
-
-                # the current benchmark result is better than best benchmark result
-                if best_threads_num < current_threads_num:
-                    # If the thread number is in lower side, update the lower bound to middle
-                    lower_threads_num = mid_threads_num + 1
-                    next_thread_num = lower_threads_num
-                else:
-                    # If the thread number is in upper side, update the upper bound to middle
-                    upper_threads_num = mid_threads_num
-                    next_thread_num = upper_threads_num
-
-                # Update the best_latency and best_threads_num for next comparison
-                best_latency = benchmark_latency
-                best_threads_num = current_threads_num
-                current_threads_num = next_thread_num
-
-        # Pin the best threads num for inter_op_num_threads/intra_op_num_threads for next tuning config
-        test_params["session_options"][threads_name] = best_threads_num
-
-    return tuning_results
 
 
 def generate_test_name(test_params, io_bind):
@@ -432,83 +183,6 @@ def enable_rocm_op_tuning(inference_settings, input_tuning_result, tuning_result
         # Only set the tuning_op_result for ROCM. In this case, the tuning_result_file is not None.
         if tuning_op_result:
             inference_settings["tuning_op_result"] = tuning_op_result
-
-
-def get_benchmark(
-    accelerator,
-    target: "OliveSystem",
-    model,
-    data_root,
-    latency_metric,
-    config,
-    test_params=None,
-    io_bind=False,
-    tuning_result=None,
-):
-    import onnxruntime as ort
-
-    from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
-    from olive.model.config.model_config import ModelConfig
-
-    # prepare the inference_settings for metrics.
-    tuning_result_file = None
-    if test_params:
-        assert "provider_options" in test_params, "provider_options should be in test_params"
-        inference_settings = test_params
-    else:
-        inference_settings = copy.deepcopy(model.inference_settings) if model.inference_settings else {}
-        # put the execution_provider and provider_options in inference_settings for baseline evaluation
-        execution_providers, provider_options = check_and_normalize_provider_args(
-            config.providers_list, None, ort.get_available_providers()
-        )
-        inference_settings["execution_provider"] = execution_providers
-        inference_settings["provider_options"] = provider_options
-
-    if config.enable_profiling:
-        if "session_options" not in inference_settings:
-            inference_settings["session_options"] = {}
-        inference_settings["session_options"]["enable_profiling"] = True
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        enable_rocm_op_tuning(inference_settings, tuning_result, temp_dir)
-        # set the session_options for metrics so that the evalute will use them by default
-        latency_metric.user_config.io_bind = io_bind
-        latency_metric.user_config.inference_settings = {"onnx": inference_settings}
-
-        session_name = generate_test_name(test_params, io_bind)
-        logger.debug(f"Run benchmark for: {session_name}")
-        joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
-
-        start_time = time.perf_counter()
-        # TODO(myguo): consider set the ep in accelrator to None for local system
-        if target:
-            model_config = ModelConfig.from_json(model.to_json())
-            metric_result = target.evaluate_model(model_config, data_root, [latency_metric], accelerator)
-        else:
-            evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-            metric_result = evaluator.evaluate(model, data_root, [latency_metric], config.device, None)
-
-        end_time = time.perf_counter()
-        latency_ms = metric_result[joint_key].value
-        logger.debug(f"It takes {(end_time - start_time):.5f} seconds to benchmark for: {session_name}")
-
-        session_options = inference_settings.get("session_options")
-
-        tuning_op_result = None
-        tuning_result_file = inference_settings.get("tuning_result_file")
-        if tuning_result_file:
-            with Path(tuning_result_file).open() as f:
-                tuning_op_result = json.load(f)
-
-        return {
-            "test_name": session_name,
-            "io_bind": io_bind,
-            "latency_ms": latency_ms,
-            "execution_provider": inference_settings["execution_provider"],
-            "provider_options": inference_settings["provider_options"],
-            "session_options": session_options if session_options else {},
-            "tuning_op_result": tuning_op_result,
-        }
 
 
 def parse_tuning_result(*tuning_results):
@@ -636,4 +310,323 @@ class OrtPerfTuning(Pass):
         # TODO(jambayk): decide on whether to ignore the output_model_path
         # if we want to ignore it, we can just return the model
         # otherwise save or symlink the original model to the output_model_path
-        return tune_onnx_model(self.accelerator_spec, self.target, model, data_root, config)
+        runner = PerfTuningRunner(self.accelerator_spec, self.target, config, data_root)
+        return runner.tune_onnx_model(model)
+
+
+class PerfTuningRunner:
+
+    def __init__(
+        self, accelerator_spec: AcceleratorSpec, target: "OliveSystem", config: Dict[str, Any], data_root: str = None
+    ):
+        assert accelerator_spec, "accelerator_spec should not be None"
+        assert config, "config should not be None"
+
+        self.accelerator_spec = accelerator_spec
+        self.target = target
+        self.config = config
+        self.data_root = data_root
+
+    def tune_onnx_model(self, model):
+        latency_user_config = {}
+        # which should be the same as the config in the metric
+        config_dict = self.config.dict()
+
+        # data_dir/dataloader_func will be passed to the metric as perf_tuning will leverage
+        # the latency metric to run tune
+        for eval_config in get_user_config_properties_from_metric_type(MetricType.LATENCY):
+            if eval_config in config_dict:
+                latency_user_config[eval_config] = config_dict.get(eval_config)
+        if config_dict.get("dataloader_func_kwargs"):
+            latency_user_config["func_kwargs"] = {"dataloader_func": config_dict.get("dataloader_func_kwargs")}
+        latency_sub_types = [{"name": LatencySubType.AVG}]
+        latency_metric_config = {
+            "name": "latency",
+            "type": MetricType.LATENCY,
+            "sub_types": latency_sub_types,
+            "user_config": latency_user_config,
+            "data_config": config_dict.get("data_config"),
+        }
+        latency_metric = Metric(**latency_metric_config)
+
+        # TODO(myguo): from the time being, the baseline evaluation doesn't enable enable_cuda_graph.
+        # do we need enable it?
+        io_bind = self.config.io_bind
+        pretuning_inference_result = self.get_benchmark(model, latency_metric, io_bind=io_bind, tuning_result=None)
+
+        tuning_op_result = pretuning_inference_result.get("tuning_op_result")
+        tuning_results = []
+        for provider, execution_mode, opt_level in generate_tuning_combos(self.config):
+            provider, options = populate_provider_options(provider, self.config)  # noqa: PLW2901
+            if provider == "CUDAExecutionProvider":
+                # if enable_cuda_graph is True but the io_bind is False, the following errors will be raised.
+                # onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : CUDA failure 700:
+                #    an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ;
+                #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_graph.cc ; line=49 ;
+                #    expr=cudaGraphLaunch(graph_exec_, stream_);
+                # [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDA failure 700:
+                #    an illegal memory access was encountered ; GPU=0 ; hostname=c93f1847c000000 ;
+                #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=286 ;
+                #    expr=cudaStreamDestroy(stream_);
+                # [E:onnxruntime:Default, cuda_call.cc:116 CudaCall] CUDNN failure 4:
+                #    CUDNN_STATUS_INTERNAL_ERROR ; GPU=0 ; hostname=c93f1847c000000 ;
+                #    file=/onnxruntime_src/onnxruntime/core/providers/cuda/cuda_execution_provider.cc ; line=181 ;
+                #    expr=cudnnDestroy(cudnn_handle_);
+                io_bind = True
+            elif provider == "CPUExecutionProvider":
+                io_bind = False
+
+            tuning_combo = (([provider], [options]), execution_mode, opt_level, io_bind)
+
+            # TODO(myguo): we need disable the following check when we enable cache in perf tuning.
+            if provider != self.accelerator_spec.execution_provider and not self.config.force_evaluate_other_eps:
+                logger.warning(
+                    "Ignore perf tuning for EP %s since current pass EP is %s",
+                    provider,
+                    self.accelerator_spec.execution_provider,
+                )
+                continue
+            tuning_item = ["provider", "execution_mode", "ort_opt_level", "io_bind"]
+            if not valid_config(tuning_combo, self.config):
+                continue
+            logger.info("Run tuning for: %s", list(zip(tuning_item, tuning_combo)))
+            tuning_results.extend(self.threads_num_tuning(model, latency_metric, *tuning_combo, tuning_op_result))
+
+        for tuning_result in tuning_results:
+            logger.debug("Tuning result for %s: %s", tuning_result["test_name"], tuning_result["latency_ms"])
+
+        best_result = parse_tuning_result(*tuning_results, pretuning_inference_result)
+        logger.info("Best result: %s", best_result)
+        # Both baseline and pertuning result should have the execution provider in the test_results.
+        assert "execution_provider" in best_result, "execution_provider should be in best_result"
+        optimized_model = copy.copy(model)
+        optimized_model.inference_settings = {
+            "execution_provider": best_result["execution_provider"],
+            "provider_options": best_result["provider_options"],
+            "io_bind": best_result["io_bind"],
+            "tuning_op_result": best_result.get("tuning_op_result"),
+        }
+        session_options = best_result.get("session_options")
+        if session_options is not None:
+            optimized_model.inference_settings["session_options"] = session_options
+
+        return optimized_model
+
+    def get_benchmark(
+        self,
+        model,
+        latency_metric,
+        test_params=None,
+        io_bind=False,
+        tuning_result=None,
+    ):
+        import onnxruntime as ort
+
+        from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
+        from olive.model.config.model_config import ModelConfig
+
+        # prepare the inference_settings for metrics.
+        tuning_result_file = None
+        if test_params:
+            assert "provider_options" in test_params, "provider_options should be in test_params"
+            inference_settings = test_params
+        else:
+            inference_settings = copy.deepcopy(model.inference_settings) if model.inference_settings else {}
+            # put the execution_provider and provider_options in inference_settings for baseline evaluation
+            execution_providers, provider_options = check_and_normalize_provider_args(
+                self.config.providers_list, None, ort.get_available_providers()
+            )
+            inference_settings["execution_provider"] = execution_providers
+            inference_settings["provider_options"] = provider_options
+
+        if self.config.enable_profiling:
+            if "session_options" not in inference_settings:
+                inference_settings["session_options"] = {}
+            inference_settings["session_options"]["enable_profiling"] = True
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            enable_rocm_op_tuning(inference_settings, tuning_result, temp_dir)
+            # set the session_options for metrics so that the evalute will use them by default
+            latency_metric.user_config.io_bind = io_bind
+            latency_metric.user_config.inference_settings = {"onnx": inference_settings}
+
+            session_name = generate_test_name(test_params, io_bind)
+            logger.debug(f"Run benchmark for: {session_name}")
+            joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
+
+            start_time = time.perf_counter()
+            # TODO(myguo): consider set the ep in accelrator to None for local system
+            if self.target:
+                model_config = ModelConfig.from_json(model.to_json())
+                metric_result = self.target.evaluate_model(
+                    model_config, self.data_root, [latency_metric], self.accelerator_spec
+                )
+            else:
+                evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
+                metric_result = evaluator.evaluate(model, self.data_root, [latency_metric], self.config.device, None)
+
+            end_time = time.perf_counter()
+            latency_ms = metric_result[joint_key].value
+            logger.debug(f"It takes {(end_time - start_time):.5f} seconds to benchmark for: {session_name}")
+
+            session_options = inference_settings.get("session_options")
+
+            tuning_op_result = None
+            tuning_result_file = inference_settings.get("tuning_result_file")
+            if tuning_result_file:
+                with Path(tuning_result_file).open() as f:
+                    tuning_op_result = json.load(f)
+
+            return {
+                "test_name": session_name,
+                "io_bind": io_bind,
+                "latency_ms": latency_ms,
+                "execution_provider": inference_settings["execution_provider"],
+                "provider_options": inference_settings["provider_options"],
+                "session_options": session_options if session_options else {},
+                "tuning_op_result": tuning_op_result,
+            }
+
+    def threads_num_tuning(
+        self,
+        model,
+        latency_metric,
+        providers,
+        execution_mode,
+        ort_opt_level,
+        io_bind,
+        tuning_op_result,
+    ):
+        tuning_results = []
+        provider, options = providers
+
+        test_params = {
+            "execution_provider": provider,
+            "provider_options": options,
+            "session_options": {
+                "execution_mode": execution_mode,
+                "graph_optimization_level": ort_opt_level,
+            },
+        }
+
+        if self.config.extra_session_config:
+            test_params["session_options"]["extra_session_config"] = self.config.extra_session_config
+
+        try:
+            for inter in self.config.inter_thread_num_list:
+                if inter is not None:
+                    test_params["session_options"]["inter_op_num_threads"] = inter
+                for intra in self.config.intra_thread_num_list:
+                    if intra is not None:
+                        test_params["session_options"]["intra_op_num_threads"] = intra
+                    tuning_result = self.threads_num_binary_search(
+                        model,
+                        latency_metric,
+                        test_params,
+                        io_bind,
+                        tuning_op_result,
+                    )
+                    tuning_results.extend(tuning_result)
+        except EXCEPTIONS_TO_RAISE:
+            raise
+        except Exception:
+            logger.exception(
+                "Optimization failed for tuning combo %s",
+                (providers, execution_mode, ort_opt_level, io_bind),
+            )
+
+        return tuning_results
+
+    def threads_num_binary_search(self, model, latency_metric, test_params, io_bind, tuning_op_result):
+        """Binary search based benchmark for inter_op_num_threads and intra_op_num_threads."""
+        import onnxruntime as ort
+        import psutil
+
+        # prepare the inter_op_num_threads/intra_op_num_threads to be tune.
+        extra_session_config = test_params["session_options"].get("extra_session_config")
+        if extra_session_config:
+            affinity_str = extra_session_config.get("session.intra_op_thread_affinities")
+            if affinity_str:
+                test_params["session_options"]["intra_op_num_threads"] = get_thread_affinity_nums(affinity_str) + 1
+                threads_names = ["inter_op_num_threads"]
+        elif test_params["session_options"].get("execution_mode") == ort.ExecutionMode.ORT_SEQUENTIAL:
+            threads_names = ["intra_op_num_threads"]
+        else:
+            threads_names = ["inter_op_num_threads", "intra_op_num_threads"]
+
+        if (
+            test_params["session_options"].get("inter_op_num_threads") is not None
+            and test_params["session_options"].get("intra_op_num_threads") is not None
+        ):
+            # If user specify both inter_op_num_threads and intra_op_num_threads, we will not do tuning
+            test_result = self.get_benchmark(model, latency_metric, test_params, io_bind, tuning_op_result)
+            return [test_result]
+
+        tuning_results = []
+
+        def benchmark_with_threads_num(threads_name, threads_num):
+            test_params["session_options"][threads_name] = threads_num
+            test_result = self.get_benchmark(model, latency_metric, test_params, io_bind, tuning_op_result)
+            tuning_results.append(test_result)
+            return test_result["latency_ms"]
+
+        for threads_name in threads_names:
+            # set the upper bound and lower bound for binary search
+            thread_num = test_params["session_options"].get(threads_name)
+            if thread_num is not None:
+                upper_threads_num = thread_num
+                lower_threads_num = thread_num
+            else:
+                upper_threads_num = self.config.cpu_cores or psutil.cpu_count(logical=False)
+                lower_threads_num = 1
+
+            current_threads_num = lower_threads_num
+            best_latency = None
+            best_threads_num = None
+
+            while lower_threads_num < upper_threads_num:
+                benchmark_latency = benchmark_with_threads_num(threads_name, current_threads_num)
+
+                if best_latency is None:
+                    # the first time run benchmark, then change next to the upper bound
+                    best_latency = benchmark_latency
+                    best_threads_num = current_threads_num
+                    current_threads_num = upper_threads_num
+                elif best_latency < benchmark_latency:
+                    mid_threads_num = lower_threads_num + (upper_threads_num - lower_threads_num) // 2
+                    # the current benchmark is worse than best benchmark result.
+                    # Just keep the best_latency and best_threads_num
+                    if best_threads_num < current_threads_num:
+                        # update the upper bound to middle if best benchmark is in lower side.
+                        upper_threads_num = mid_threads_num
+                        next_thread_num = upper_threads_num
+                    else:
+                        # update the lower bound to middle if best benchmark is in upper side.
+                        # The benchmark result is worse than best benchmark and
+                        # the thread num last time used is larger than current
+                        lower_threads_num = mid_threads_num + 1
+                        next_thread_num = lower_threads_num
+
+                    current_threads_num = next_thread_num
+                else:
+                    mid_threads_num = lower_threads_num + (upper_threads_num - lower_threads_num) // 2
+
+                    # the current benchmark result is better than best benchmark result
+                    if best_threads_num < current_threads_num:
+                        # If the thread number is in lower side, update the lower bound to middle
+                        lower_threads_num = mid_threads_num + 1
+                        next_thread_num = lower_threads_num
+                    else:
+                        # If the thread number is in upper side, update the upper bound to middle
+                        upper_threads_num = mid_threads_num
+                        next_thread_num = upper_threads_num
+
+                    # Update the best_latency and best_threads_num for next comparison
+                    best_latency = benchmark_latency
+                    best_threads_num = current_threads_num
+                    current_threads_num = next_thread_num
+
+            # Pin the best threads num for inter_op_num_threads/intra_op_num_threads for next tuning config
+            test_params["session_options"][threads_name] = best_threads_num
+
+        return tuning_results

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
 import copy
 import itertools
 import json
@@ -433,8 +432,12 @@ class PerfTuningRunner:
         else:
             inference_settings = copy.deepcopy(model.inference_settings) if model.inference_settings else {}
             # put the execution_provider and provider_options in inference_settings for baseline evaluation
+            if self.target is None:
+                available_eps = ort.get_available_providers()
+            else:
+                available_eps = None
             execution_providers, provider_options = check_and_normalize_provider_args(
-                self.config.providers_list, None, ort.get_available_providers()
+                self.config.providers_list, None, available_eps
             )
             inference_settings["execution_provider"] = execution_providers
             inference_settings["provider_options"] = provider_options

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -134,10 +134,17 @@ class AzureMLSystem(OliveSystem):
     def _create_environment(self, docker_config: AzureMLDockerConfig):
         if docker_config.build_context_path:
             return Environment(
-                build=BuildContext(dockerfile_path=docker_config.dockerfile, path=docker_config.build_context_path)
+                name=docker_config.name,
+                version=docker_config.version,
+                build=BuildContext(dockerfile_path=docker_config.dockerfile, path=docker_config.build_context_path),
             )
         if docker_config.base_image:
-            return Environment(image=docker_config.base_image, conda_file=docker_config.conda_file_path)
+            return Environment(
+                name=docker_config.name,
+                version=docker_config.version,
+                image=docker_config.base_image,
+                conda_file=docker_config.conda_file_path,
+            )
         raise ValueError("Please specify DockerConfig.")
 
     def _assert_not_none(self, obj):

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -109,6 +109,7 @@ class AzureMLSystem(OliveSystem):
             aml_docker_config = validate_config(aml_docker_config, AzureMLDockerConfig)
             self.environment = self._create_environment(aml_docker_config)
         self.env_vars = self._get_hf_token_env(self.azureml_client_config.keyvault_name) if self.hf_token else None
+        self.temp_dirs = []
 
     def _get_hf_token_env(self, keyvault_name: str):
         if keyvault_name is None:
@@ -703,4 +704,8 @@ class AzureMLSystem(OliveSystem):
         return cmd(**args)
 
     def remove(self):
-        logger.info("AzureML system does not need system removal")
+        if self.temp_dirs:
+            logger.info("AzureML system cleanup temp dirs.")
+            for temp_dir in self.temp_dirs:
+                temp_dir.cleanup()
+            self.temp_dirs = []

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -102,6 +102,7 @@ class AzureMLSystem(OliveSystem):
         if not aml_docker_config and not aml_environment_config:
             raise ValueError("either aml_docker_config or aml_environment_config should be provided.")
 
+        self.environment = None
         if aml_environment_config:
             from azure.core.exceptions import ResourceNotFoundError
 
@@ -112,7 +113,7 @@ class AzureMLSystem(OliveSystem):
                 if not aml_docker_config:
                     raise
 
-        if aml_docker_config:
+        if self.environment is None and aml_docker_config:
             aml_docker_config = validate_config(aml_docker_config, AzureMLDockerConfig)
             self.environment = self._create_environment(aml_docker_config)
         self.env_vars = self._get_hf_token_env(self.azureml_client_config.keyvault_name) if self.hf_token else None

--- a/olive/systems/common.py
+++ b/olive/systems/common.py
@@ -22,6 +22,8 @@ class AzureMLDockerConfig(ConfigBase):
     dockerfile: Optional[str] = None
     build_context_path: Optional[Union[Path, str]] = None
     conda_file_path: Optional[Union[Path, str]] = None
+    name: Optional[str] = None
+    version: Optional[str] = None
 
     @validator("dockerfile", "build_context_path", always=True)
     def _validate_one_of_dockerfile_or_base_image(cls, v, values):

--- a/olive/systems/common.py
+++ b/olive/systems/common.py
@@ -47,19 +47,11 @@ class AzureMLEnvironmentConfig(ConfigBase):
 
 class LocalDockerConfig(ConfigBase):
     image_name: str
-    base_image: Optional[str] = None
-    requirements_file_path: Optional[str] = None
     dockerfile: Optional[str] = None
     build_context_path: Optional[Union[Path, str]] = None
     build_args: Optional[dict] = None
     run_params: Optional[dict] = None
 
-    @validator("build_context_path", "requirements_file_path")
+    @validator("build_context_path")
     def _get_abspath(cls, v):
         return str(Path(v).resolve()) if v else None
-
-    @validator("dockerfile", always=True)
-    def _validate_one_of_dockerfile_or_base_image(cls, v, values):
-        if v is None and values.get("requirements_file_path") is None:
-            raise ValueError("One of build_context_path/dockerfile or requirements_file_path must be provided")
-        return v

--- a/olive/systems/docker/Dockerfile.cpu
+++ b/olive/systems/docker/Dockerfile.cpu
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
 
 RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime==1.15.1 olive-ai
+RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime olive-ai
 
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/olive/systems/docker/Dockerfile.gpu
+++ b/olive/systems/docker/Dockerfile.gpu
@@ -15,7 +15,7 @@ RUN v="8.4.1-1+cuda11.6" &&\
         libnvinfer-dev=${v} libnvonnxparsers-dev=${v} libnvparsers-dev=${v} libnvinfer-plugin-dev=${v} \
         python3-libnvinfer=${v} libnvinfer-samples=${v}
 
-RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime-gpu==1.15.1 olive-ai
+RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime-gpu olive-ai
 
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/olive/systems/docker/Dockerfile.openvino
+++ b/olive/systems/docker/Dockerfile.openvino
@@ -1,15 +1,20 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 # mcr image https://github.com/microsoft/mcr
 # tag list https://mcr.microsoft.com/v2/azureml/openmpi4.1.0-ubuntu20.04/tags/list
 FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
 
-ARG OPENVINO_VERSION=2023.0.0
+ARG OPENVINO_VERSION=2023.3.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && ACCEPT_EULA=Y apt-get -y upgrade
 RUN apt-get install -y --no-install-recommends wget gnupg
 
 RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime-openvino==1.15.0 olive-ai
+RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime-openvino olive-ai
 
 ENV INTEL_OPENVINO_DIR /opt/intel/openvino_${OPENVINO_VERSION}
 ENV LD_LIBRARY_PATH $INTEL_OPENVINO_DIR/runtime/lib/intel64:$INTEL_OPENVINO_DIR/runtime/3rdparty/tbb/lib:/usr/local/openblas/lib:$LD_LIBRARY_PATH
@@ -19,9 +24,9 @@ ENV IE_PLUGINS_PATH $INTEL_OPENVINO_DIR/runtime/lib/intel64
 
 # Install OpenVINO
 RUN cd /opt && mkdir -p intel && cd intel && \
-    wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_ubuntu20_2023.0.0.10926.b4452d56304_x86_64.tgz && \
-    tar xzf l_openvino_toolkit_ubuntu20_2023.0.0.10926.b4452d56304_x86_64.tgz && rm -rf l_openvino_toolkit_ubuntu20_2023.0.0.10926.b4452d56304_x86_64.tgz && \
-    mv l_openvino_toolkit_ubuntu20_2023.0.0.10926.b4452d56304_x86_64 openvino_2023.0.0 && \
+    wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.3/linux/l_openvino_toolkit_ubuntu20_2023.3.0.13775.ceeafaf64f3_x86_64.tgz && \
+    tar xzf l_openvino_toolkit_ubuntu20_2023.3.0.13775.ceeafaf64f3_x86_64.tgz && rm -rf l_openvino_toolkit_ubuntu20_2023.3.0.13775.ceeafaf64f3_x86_64.tgz && \
+    mv l_openvino_toolkit_ubuntu20_2023.3.0.13775.ceeafaf64f3_x86_64 openvino_2023.3.0 && \
     cd $INTEL_OPENVINO_DIR/install_dependencies && ./install_openvino_dependencies.sh -y
 
 WORKDIR /root

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -60,46 +60,41 @@ class DockerSystem(OliveSystem):
             logger.info(f"Image {local_docker_config.image_name} found")
 
         except docker.errors.ImageNotFound:
-            if local_docker_config.build_context_path and local_docker_config.dockerfile:
-                build_context_path = local_docker_config.build_context_path
-                logger.info(f"Building image from Dockerfile {build_context_path}/{local_docker_config.dockerfile}")
+            with tempfile.TemporaryDirectory() as tempdir:
+                build_context_path = tempdir
+                if local_docker_config.build_context_path and local_docker_config.dockerfile:
+                    dockerfile = local_docker_config.dockerfile
+                    dockerfile_path = Path(local_docker_config.build_context_path) / dockerfile
+                else:
+                    dockerfile = self.BASE_DOCKERFILE
+                    dockerfile_path = Path(__file__).resolve().parent / self.BASE_DOCKERFILE
+
+                shutil.copy2(dockerfile_path, build_context_path)
+                if local_docker_config.requirements_file_path:
+                    shutil.copyfile(
+                        local_docker_config.requirements_file_path, Path(build_context_path) / "requirements.txt"
+                    )
+                else:
+                    with (Path(build_context_path) / "requirements.txt").open("w"):
+                        pass
+
+                logger.info(
+                    f"Building image from Dockerfile {build_context_path}/{local_docker_config.dockerfile}"
+                    f" with buildargs {local_docker_config.build_args} "
+                )
                 try:
                     self.image, build_logs = self.docker_client.images.build(
                         path=build_context_path,
-                        dockerfile=local_docker_config.dockerfile,
+                        dockerfile=dockerfile,
                         tag=local_docker_config.image_name,
                         buildargs=local_docker_config.build_args,
                     )
                     logger.info(f"Image {local_docker_config.image_name} build successfully.")
                     _print_docker_logs(build_logs, logging.DEBUG)
                 except BuildError as e:
-                    logger.exception("Image build failed with error")
+                    logger.exception("Image build failed with error.")
                     _print_docker_logs(e.build_log, logging.ERROR)
                     raise
-            elif local_docker_config.requirements_file_path:
-                logger.info(
-                    f"Building image from Olive default Dockerfile with buildargs {local_docker_config.build_args} "
-                    f"requirements.txt {local_docker_config.requirements_file_path}"
-                )
-                dockerfile_path = str(Path(__file__).resolve().parent / self.BASE_DOCKERFILE)
-                with tempfile.TemporaryDirectory() as tempdir:
-                    build_context_path = tempdir
-                    shutil.copy2(dockerfile_path, build_context_path)
-                    shutil.copy2(local_docker_config.requirements_file_path, build_context_path)
-
-                    try:
-                        self.image, build_logs = self.docker_client.images.build(
-                            path=build_context_path,
-                            dockerfile=self.BASE_DOCKERFILE,
-                            tag=local_docker_config.image_name,
-                            buildargs=local_docker_config.build_args,
-                        )
-                        logger.info(f"Image {local_docker_config.image_name} build successfully.")
-                        _print_docker_logs(build_logs, logging.DEBUG)
-                    except BuildError as e:
-                        logger.exception("Image build failed with error.")
-                        _print_docker_logs(e.build_log, logging.ERROR)
-                        raise
 
     def run_pass(
         self,

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -64,12 +64,12 @@ class DockerSystem(OliveSystem):
                 build_context_path = tempdir
                 if local_docker_config.build_context_path and local_docker_config.dockerfile:
                     dockerfile = local_docker_config.dockerfile
-                    dockerfile_path = Path(local_docker_config.build_context_path) / dockerfile
+                    shutil.copytree(local_docker_config.build_context_path, build_context_path, dirs_exist_ok=True)
                 else:
                     dockerfile = self.BASE_DOCKERFILE
                     dockerfile_path = Path(__file__).resolve().parent / self.BASE_DOCKERFILE
+                    shutil.copy2(dockerfile_path, build_context_path)
 
-                shutil.copy2(dockerfile_path, build_context_path)
                 if local_docker_config.requirements_file_path:
                     shutil.copyfile(
                         local_docker_config.requirements_file_path, Path(build_context_path) / "requirements.txt"

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -35,12 +35,12 @@ class DockerSystem(OliveSystem):
 
     def __init__(
         self,
-        local_docker_config: Union[Dict[str, Any], LocalDockerConfig] = None,
+        local_docker_config: Union[Dict[str, Any], LocalDockerConfig],
         accelerators: List[str] = None,
         is_dev: bool = False,
         olive_managed_env: bool = False,
-        requirements_file: Union[Path, str] = None,
         hf_token: bool = None,
+        **kwargs,  # used to hold the rest of the arguments like requirements_file which is not used by dockersystem
     ):
         super().__init__(
             accelerators=accelerators,
@@ -49,58 +49,57 @@ class DockerSystem(OliveSystem):
         )
         logger.info("Initializing Docker System...")
         self.is_dev = is_dev
-        self.requirements_file = requirements_file
-        if local_docker_config and olive_managed_env:
-            raise ValueError("Olive managed environment is not supported if local_docker_config is provided.")
-        if local_docker_config:
-            self.docker_client = docker.from_env()
-            local_docker_config = validate_config(local_docker_config, LocalDockerConfig)
-            self.run_params = local_docker_config.run_params
-            try:
-                self.image = self.docker_client.images.get(local_docker_config.image_name)
-                logger.info(f"Image {local_docker_config.image_name} found")
+        self.docker_client = docker.from_env()
+        if local_docker_config is None:
+            raise ValueError("local_docker_config cannot be None.")
 
-            except docker.errors.ImageNotFound:
-                if local_docker_config.build_context_path and local_docker_config.dockerfile:
-                    build_context_path = local_docker_config.build_context_path
-                    logger.info(f"Building image from Dockerfile {build_context_path}/{local_docker_config.dockerfile}")
+        local_docker_config = validate_config(local_docker_config, LocalDockerConfig)
+        self.run_params = local_docker_config.run_params
+        try:
+            self.image = self.docker_client.images.get(local_docker_config.image_name)
+            logger.info(f"Image {local_docker_config.image_name} found")
+
+        except docker.errors.ImageNotFound:
+            if local_docker_config.build_context_path and local_docker_config.dockerfile:
+                build_context_path = local_docker_config.build_context_path
+                logger.info(f"Building image from Dockerfile {build_context_path}/{local_docker_config.dockerfile}")
+                try:
+                    self.image, build_logs = self.docker_client.images.build(
+                        path=build_context_path,
+                        dockerfile=local_docker_config.dockerfile,
+                        tag=local_docker_config.image_name,
+                        buildargs=local_docker_config.build_args,
+                    )
+                    logger.info(f"Image {local_docker_config.image_name} build successfully.")
+                    _print_docker_logs(build_logs, logging.DEBUG)
+                except BuildError as e:
+                    logger.exception("Image build failed with error")
+                    _print_docker_logs(e.build_log, logging.ERROR)
+                    raise
+            elif local_docker_config.requirements_file_path:
+                logger.info(
+                    f"Building image from Olive default Dockerfile with buildargs {local_docker_config.build_args} "
+                    f"requirements.txt {local_docker_config.requirements_file_path}"
+                )
+                dockerfile_path = str(Path(__file__).resolve().parent / self.BASE_DOCKERFILE)
+                with tempfile.TemporaryDirectory() as tempdir:
+                    build_context_path = tempdir
+                    shutil.copy2(dockerfile_path, build_context_path)
+                    shutil.copy2(local_docker_config.requirements_file_path, build_context_path)
+
                     try:
                         self.image, build_logs = self.docker_client.images.build(
                             path=build_context_path,
-                            dockerfile=local_docker_config.dockerfile,
+                            dockerfile=self.BASE_DOCKERFILE,
                             tag=local_docker_config.image_name,
                             buildargs=local_docker_config.build_args,
                         )
                         logger.info(f"Image {local_docker_config.image_name} build successfully.")
                         _print_docker_logs(build_logs, logging.DEBUG)
                     except BuildError as e:
-                        logger.exception("Image build failed with error")
+                        logger.exception("Image build failed with error.")
                         _print_docker_logs(e.build_log, logging.ERROR)
                         raise
-                elif local_docker_config.requirements_file_path:
-                    logger.info(
-                        f"Building image from Olive default Dockerfile with buildargs {local_docker_config.build_args} "
-                        f"requirements.txt {local_docker_config.requirements_file_path}"
-                    )
-                    dockerfile_path = str(Path(__file__).resolve().parent / self.BASE_DOCKERFILE)
-                    with tempfile.TemporaryDirectory() as tempdir:
-                        build_context_path = tempdir
-                        shutil.copy2(dockerfile_path, build_context_path)
-                        shutil.copy2(local_docker_config.requirements_file_path, build_context_path)
-
-                        try:
-                            self.image, build_logs = self.docker_client.images.build(
-                                path=build_context_path,
-                                dockerfile=self.BASE_DOCKERFILE,
-                                tag=local_docker_config.image_name,
-                                buildargs=local_docker_config.build_args,
-                            )
-                            logger.info(f"Image {local_docker_config.image_name} build successfully.")
-                            _print_docker_logs(build_logs, logging.DEBUG)
-                        except BuildError as e:
-                            logger.exception("Image build failed with error.")
-                            _print_docker_logs(e.build_log, logging.ERROR)
-                            raise
 
     def run_pass(
         self,

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -123,4 +123,8 @@ class SystemConfig(ConfigBase):
             raise ValueError("azureml_client is required for AzureML system")
         return system_class(**self.config.dict())
 
+    @property
+    def olive_managed_env(self):
+        return getattr(self.config, "olive_managed_env", False)
+
     __hash__ = object.__hash__

--- a/olive/systems/system_config.py
+++ b/olive/systems/system_config.py
@@ -18,6 +18,8 @@ class TargetUserConfig(ConfigBase):
     accelerators: List[str] = None
     hf_token: bool = None
 
+    __hash__ = object.__hash__
+
 
 class LocalTargetUserConfig(TargetUserConfig):
     pass
@@ -120,3 +122,5 @@ class SystemConfig(ConfigBase):
         if system_class.system_type == SystemType.AzureML and not self.config.azureml_client_config:
             raise ValueError("azureml_client is required for AzureML system")
         return system_class(**self.config.dict())
+
+    __hash__ = object.__hash__

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -126,6 +126,7 @@ def create_new_system(system_config, accelerator):
             },
             accelerators=[accelerator.accelerator_type],
             is_dev=system_config.config.is_dev,
+            olive_managed_env=True,
         )
 
     elif system_config.type == SystemType.AzureML:
@@ -150,6 +151,7 @@ def create_new_system(system_config, accelerator):
                 "build_context_path": build_context_path,
             },
             is_dev=system_config.config.is_dev,
+            olive_managed_env=True,
         )
 
     else:

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -118,18 +118,19 @@ def create_new_system(system_config, accelerator):
         from olive.systems.docker import DockerSystem
 
         dockerfile = provider_dockerfile_mapping.get(accelerator.execution_provider, "Dockerfile.cpu")
+        # TODO(myguo): create a temp dir for the build context
         new_system = DockerSystem(
             local_docker_config={
                 "image_name": f"olive_{accelerator.execution_provider[:-17].lower()}",
-                "requirements_file_path": (
-                    str(system_config.config.requirements_file) if system_config.config.requirements_file else None
-                ),
                 "dockerfile": dockerfile,
                 "build_context_path": Path(__file__).parent / "docker",
             },
             accelerators=[accelerator.accelerator_type],
             is_dev=system_config.config.is_dev,
             olive_managed_env=True,
+            requirements_file=(
+                str(system_config.config.requirements_file) if system_config.config.requirements_file else None
+            ),
         )
 
     elif system_config.type == SystemType.AzureML:

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -64,11 +64,11 @@ def get_common_args(raw_args):
 
 
 @lru_cache(maxsize=8)
-def create_new_system_with_cache(origin_system, accelerator):
-    return create_new_system(origin_system, accelerator)
+def create_new_system_with_cache(system_config, accelerator):
+    return create_new_system(system_config, accelerator)
 
 
-def create_new_system(origin_system, accelerator):
+def create_new_system(system_config, accelerator):
     # pylint: disable=consider-using-with
     provider_dockerfile_mapping = {
         "CPUExecutionProvider": "Dockerfile.cpu",
@@ -78,10 +78,10 @@ def create_new_system(origin_system, accelerator):
     }
 
     # create a new system with the same type as the origin system
-    if origin_system.system_type == SystemType.Local:
+    if system_config.type == SystemType.Local:
         raise NotImplementedError("olive_managed_env is not supported for LocalSystem")
 
-    elif origin_system.system_type == SystemType.PythonEnvironment:
+    elif system_config.type == SystemType.PythonEnvironment:
         import os
         import platform
         import venv
@@ -106,53 +106,53 @@ def create_new_system(origin_system, accelerator):
         new_system = PythonEnvironmentSystem(
             python_environment_path=python_environment_path,
             accelerators=[accelerator.accelerator_type],
-            environment_variables=origin_system.config.environment_variables,
-            prepend_to_path=origin_system.config.prepend_to_path,
+            environment_variables=system_config.config.environment_variables,
+            prepend_to_path=system_config.config.prepend_to_path,
             olive_managed_env=True,
-            requirements_file=origin_system.config.requirements_file,
+            requirements_file=system_config.config.requirements_file,
         )
         new_system.install_requirements(accelerator)
 
-    elif origin_system.system_type == SystemType.Docker:
+    elif system_config.type == SystemType.Docker:
         from olive.systems.docker import DockerSystem
 
         dockerfile = provider_dockerfile_mapping.get(accelerator.execution_provider, "Dockerfile.cpu")
         new_system = DockerSystem(
             local_docker_config={
                 "image_name": f"olive_{accelerator.execution_provider[:-17].lower()}",
-                "requirements_file_path": str(origin_system.requirements_file),
+                "requirements_file_path": str(system_config.config.requirements_file),
                 "dockerfile": dockerfile,
                 "build_context_path": Path(__file__).parent / "docker",
             },
             accelerators=[accelerator.accelerator_type],
-            is_dev=origin_system.is_dev,
+            is_dev=system_config.config.is_dev,
         )
 
-    elif origin_system.system_type == SystemType.AzureML:
+    elif system_config.type == SystemType.AzureML:
         from olive.systems.azureml import AzureMLSystem
 
         dockerfile = provider_dockerfile_mapping.get(accelerator.execution_provider, "Dockerfile.cpu")
         build_context_path = Path(__file__).parent / "docker"
 
-        if origin_system.requirements_file:
-            shutil.copyfile(origin_system.requirements_file, build_context_path / "requirements.txt")
+        if system_config.config.requirements_file:
+            shutil.copyfile(system_config.config.requirements_file, build_context_path / "requirements.txt")
         else:
             with (build_context_path / "requirements.txt").open("w"):
                 pass
 
         new_system = AzureMLSystem(
-            azureml_client_config=origin_system.azureml_client_config,
-            aml_compute=origin_system.compute,
-            instance_count=origin_system.instance_count,
+            azureml_client_config=system_config.config.azureml_client_config,
+            aml_compute=system_config.config.compute,
+            instance_count=system_config.config.instance_count,
             accelerators=[accelerator.accelerator_type],
             aml_docker_config={
                 "dockerfile": dockerfile,
                 "build_context_path": build_context_path,
             },
-            is_dev=origin_system.is_dev,
+            is_dev=system_config.config.is_dev,
         )
 
     else:
-        raise NotImplementedError(f"System type {origin_system.system_type} is not supported")
+        raise NotImplementedError(f"System type {system_config.type} is not supported")
 
     return new_system

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -146,13 +146,18 @@ def create_new_system(system_config, accelerator):
                 pass
 
         env_hash = hash_dir(build_context_path)
+        name = f"olive-managed-env-{env_hash}"
         new_system = AzureMLSystem(
             azureml_client_config=system_config.config.azureml_client_config,
             aml_compute=system_config.config.aml_compute,
             instance_count=system_config.config.instance_count,
             accelerators=[accelerator.accelerator_type],
+            aml_environment_config={
+                "name": name,
+                "label": "latest",
+            },
             aml_docker_config={
-                "name": f"olive-managed-env-{env_hash}",
+                "name": name,
                 "dockerfile": dockerfile,
                 "build_context_path": build_context_path,
             },

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -10,6 +10,7 @@ import tempfile
 from functools import lru_cache
 from pathlib import Path
 
+from olive.common.utils import hash_dir
 from olive.systems.common import SystemType
 
 logger = logging.getLogger(__name__)
@@ -144,13 +145,14 @@ def create_new_system(system_config, accelerator):
             with (build_context_path / "requirements.txt").open("w"):
                 pass
 
+        env_hash = hash_dir(build_context_path)
         new_system = AzureMLSystem(
             azureml_client_config=system_config.config.azureml_client_config,
             aml_compute=system_config.config.aml_compute,
             instance_count=system_config.config.instance_count,
             accelerators=[accelerator.accelerator_type],
             aml_docker_config={
-                "name": "olive-managed-env",
+                "name": f"olive-managed-env-{env_hash}",
                 "dockerfile": dockerfile,
                 "build_context_path": build_context_path,
             },

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -134,12 +134,12 @@ def create_new_system(system_config, accelerator):
 
         dockerfile = provider_dockerfile_mapping.get(accelerator.execution_provider, "Dockerfile.cpu")
         temp_dir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-        temp_dir_path = Path(temp_dir.name)
-        shutil.copy2(str(Path(__file__).parent / "docker" / dockerfile), temp_dir_path)
+        build_context_path = Path(temp_dir.name)
+        shutil.copy2(str(Path(__file__).parent / "docker" / dockerfile), build_context_path)
         if system_config.config.requirements_file:
-            shutil.copy2(system_config.config.requirements_file, temp_dir_path)
+            shutil.copyfile(system_config.config.requirements_file, build_context_path / "requirements.txt")
         else:
-            with (temp_dir_path / "requirements.txt").open("w"):
+            with (build_context_path / "requirements.txt").open("w"):
                 pass
 
         new_system = AzureMLSystem(
@@ -149,7 +149,7 @@ def create_new_system(system_config, accelerator):
             accelerators=[accelerator.accelerator_type],
             aml_docker_config={
                 "dockerfile": dockerfile,
-                "build_context_path": temp_dir_path,
+                "build_context_path": build_context_path,
             },
             is_dev=system_config.config.is_dev,
             olive_managed_env=True,

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -150,6 +150,7 @@ def create_new_system(system_config, accelerator):
             instance_count=system_config.config.instance_count,
             accelerators=[accelerator.accelerator_type],
             aml_docker_config={
+                "name": "olive-managed-env",
                 "dockerfile": dockerfile,
                 "build_context_path": build_context_path,
             },

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -120,7 +120,9 @@ def create_new_system(system_config, accelerator):
         new_system = DockerSystem(
             local_docker_config={
                 "image_name": f"olive_{accelerator.execution_provider[:-17].lower()}",
-                "requirements_file_path": str(system_config.config.requirements_file),
+                "requirements_file_path": (
+                    str(system_config.config.requirements_file) if system_config.config.requirements_file else None
+                ),
                 "dockerfile": dockerfile,
                 "build_context_path": Path(__file__).parent / "docker",
             },

--- a/olive/systems/utils.py
+++ b/olive/systems/utils.py
@@ -142,7 +142,7 @@ def create_new_system(system_config, accelerator):
 
         new_system = AzureMLSystem(
             azureml_client_config=system_config.config.azureml_client_config,
-            aml_compute=system_config.config.compute,
+            aml_compute=system_config.config.aml_compute,
             instance_count=system_config.config.instance_count,
             accelerators=[accelerator.accelerator_type],
             aml_docker_config={

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -157,7 +157,7 @@ def run_engine(config: RunConfig, data_root: str = None):
         pass_config.evaluator is None for pass_config in config.passes.values()
     )
     accelerator_specs = create_accelerators(
-        engine.target, config.engine.execution_providers, skip_supported_eps_check=no_evaluation
+        engine.target_config, config.engine.execution_providers, skip_supported_eps_check=no_evaluation
     )
 
     pass_list = []

--- a/test/multiple_ep/test_aml_system.py
+++ b/test/multiple_ep/test_aml_system.py
@@ -57,8 +57,14 @@ class TestOliveAzureMLSystem:
 
         metric = get_latency_metric()
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
+        config = {
+            "cache_dir": "aml_cache",
+        }
         engine = Engine(
-            target_config=self.system_config, host_config=self.system_config, evaluator_config=evaluator_config
+            config=config,
+            target_config=self.system_config,
+            host_config=self.system_config,
+            evaluator_config=evaluator_config,
         )
         accelerator_specs = create_accelerators(self.system_config, self.execution_providers)
         engine.register(OrtPerfTuning)

--- a/test/multiple_ep/test_aml_system.py
+++ b/test/multiple_ep/test_aml_system.py
@@ -26,18 +26,21 @@ class TestOliveAzureMLSystem:
         from test.multiple_ep.utils import download_data, download_models, get_onnx_model
 
         from olive.azureml.azureml_client import AzureMLClientConfig
-        from olive.systems.azureml.aml_system import AzureMLSystem
+        from olive.systems.system_config import AzureMLTargetUserConfig, SystemConfig
 
         aml_compute = "cpu-cluster"
         azureml_client_config = AzureMLClientConfig(**get_olive_workspace_config())
 
-        self.system = AzureMLSystem(
-            azureml_client_config=azureml_client_config,
-            aml_compute=aml_compute,
-            accelerators=["cpu"],
-            olive_managed_env=True,
-            requirements_file=Path(__file__).parent / "requirements.txt",
-            is_dev=True,
+        self.system_config = SystemConfig(
+            system_type="AzureML",
+            target_user_config=AzureMLTargetUserConfig(
+                azureml_client_config=azureml_client_config,
+                aml_compute=aml_compute,
+                accelerators=["cpu"],
+                olive_managed_env=True,
+                requirements_file=Path(__file__).parent / "requirements.txt",
+                is_dev=True,
+            ),
         )
 
         self.execution_providers = ["CPUExecutionProvider", "OpenVINOExecutionProvider"]
@@ -54,8 +57,10 @@ class TestOliveAzureMLSystem:
 
         metric = get_latency_metric()
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
-        engine = Engine(target=self.system, host=self.system, evaluator_config=evaluator_config)
-        accelerator_specs = create_accelerators(self.system, self.execution_providers)
+        engine = Engine(
+            target_config=self.system_config, host_config=self.system_config, evaluator_config=evaluator_config
+        )
+        accelerator_specs = create_accelerators(self.system_config, self.execution_providers)
         engine.register(OrtPerfTuning)
         output = engine.run(self.input_model_config, accelerator_specs, output_dir=output_dir)
         cpu_res = next(iter(output[DEFAULT_CPU_ACCELERATOR].nodes.values()))

--- a/test/multiple_ep/test_aml_system.py
+++ b/test/multiple_ep/test_aml_system.py
@@ -32,8 +32,8 @@ class TestOliveAzureMLSystem:
         azureml_client_config = AzureMLClientConfig(**get_olive_workspace_config())
 
         self.system_config = SystemConfig(
-            system_type="AzureML",
-            target_user_config=AzureMLTargetUserConfig(
+            type="AzureML",
+            config=AzureMLTargetUserConfig(
                 azureml_client_config=azureml_client_config,
                 aml_compute=aml_compute,
                 accelerators=["cpu"],

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -55,7 +55,10 @@ class TestOliveManagedDockerSystem:
         metric = get_latency_metric()
         set_default_logger_severity(0)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
-        engine = Engine(target_config=self.system_config, evaluator_config=evaluator_config)
+        config = {
+            "cache_dir": "docker_cache",
+        }
+        engine = Engine(config=config, target_config=self.system_config, evaluator_config=evaluator_config)
         accelerator_specs = create_accelerators(self.system_config, self.execution_providers)
         engine.register(OrtPerfTuning)
         output = engine.run(self.input_model_config, accelerator_specs, output_dir=output_dir)

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -10,6 +10,7 @@ from olive.engine import Engine
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import Device
 from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec, create_accelerators
+from olive.logging import set_default_logger_severity
 from olive.model import ModelConfig
 from olive.passes.onnx import OrtPerfTuning
 
@@ -46,6 +47,7 @@ class TestOliveManagedDockerSystem:
         output_dir = tmpdir
 
         metric = get_latency_metric()
+        set_default_logger_severity(0)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
         engine = Engine(target_config=self.system_config, evaluator_config=evaluator_config)
         accelerator_specs = create_accelerators(self.system_config, self.execution_providers)

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 import platform
+from pathlib import Path
 
 import pytest
 
@@ -31,6 +32,7 @@ class TestOliveManagedDockerSystem:
             type="Docker",
             config=DockerTargetUserConfig(
                 accelerators=["cpu"],
+                requirements_file=Path(__file__).parent / "requirements.txt",
                 olive_managed_env=True,
                 is_dev=True,
             ),

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 import platform
 
 import pytest
@@ -41,7 +42,10 @@ class TestOliveManagedDockerSystem:
         )
         download_data()
 
-    def test_run_pass_evaluate(self, tmpdir):
+    def test_run_pass_evaluate(self, tmpdir, caplog):
+        logger = logging.getLogger("olive")
+        logger.propagate = True
+
         from test.multiple_ep.utils import get_latency_metric
 
         output_dir = tmpdir
@@ -63,3 +67,5 @@ class TestOliveManagedDockerSystem:
         )
         assert cpu_res.metrics.value.__root__
         assert openvino_res.metrics.value.__root__
+        assert "Creating new system Docker with EP CPUExecutionProvider" in caplog.text
+        assert "Creating new system Docker with EP CPUExecutionProvider" in caplog.text

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -72,5 +72,5 @@ class TestOliveManagedDockerSystem:
         )
         assert cpu_res.metrics.value.__root__
         assert openvino_res.metrics.value.__root__
-        assert "Creating new system Docker with EP CPUExecutionProvider" in caplog.text
-        assert "Creating new system Docker with EP OpenVINOExecutionProvider" in caplog.text
+        assert "Creating olive_managed_env SystemType.Docker with EP CPUExecutionProvider" in caplog.text
+        assert "Creating olive_managed_env SystemType.Docker with EP OpenVINOExecutionProvider" in caplog.text

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -68,4 +68,4 @@ class TestOliveManagedDockerSystem:
         assert cpu_res.metrics.value.__root__
         assert openvino_res.metrics.value.__root__
         assert "Creating new system Docker with EP CPUExecutionProvider" in caplog.text
-        assert "Creating new system Docker with EP CPUExecutionProvider" in caplog.text
+        assert "Creating new system Docker with EP OpenVINOExecutionProvider" in caplog.text

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -26,8 +26,8 @@ class TestOliveManagedDockerSystem:
 
         # use the olive managed Docker system as the test environment
         self.system_config = SystemConfig(
-            system_type="Docker",
-            target_user_config=DockerTargetUserConfig(
+            type="Docker",
+            config=DockerTargetUserConfig(
                 accelerators=["cpu"],
                 olive_managed_env=True,
                 is_dev=True,

--- a/test/multiple_ep/test_python_env_system.py
+++ b/test/multiple_ep/test_python_env_system.py
@@ -70,8 +70,14 @@ class TestOliveManagedPythonEnvironmentSystem:
 
         metric = get_latency_metric(LatencySubType.AVG)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
+        config = {
+            "cache_dir": "python_env_cache",
+        }
         engine = Engine(
-            target_config=self.system_config, host_config=self.system_config, evaluator_config=evaluator_config
+            config=config,
+            target_config=self.system_config,
+            host_config=self.system_config,
+            evaluator_config=evaluator_config,
         )
         accelerator_specs = create_accelerators(self.system_config, self.execution_providers)
         engine.register(OrtPerfTuning)

--- a/test/multiple_ep/test_python_env_system.py
+++ b/test/multiple_ep/test_python_env_system.py
@@ -28,8 +28,8 @@ class TestOliveManagedPythonEnvironmentSystem:
     def test_run_pass_evaluate_windows(self, tmpdir):
         # use the olive managed python environment as the test environment
         self.system_config = SystemConfig(
-            system_type="PythonEnvironment",
-            target_user_config=PythonEnvironmentTargetUserConfig(
+            type="PythonEnvironment",
+            config=PythonEnvironmentTargetUserConfig(
                 accelerators=["gpu"],
                 olive_managed_env=True,
             ),
@@ -59,8 +59,8 @@ class TestOliveManagedPythonEnvironmentSystem:
     def test_run_pass_evaluate_linux(self, tmpdir):
         # use the olive managed python environment as the test environment
         self.system_config = SystemConfig(
-            system_type="PythonEnvironment",
-            target_user_config=PythonEnvironmentTargetUserConfig(
+            type="PythonEnvironment",
+            config=PythonEnvironmentTargetUserConfig(
                 accelerators=["cpu"],
                 olive_managed_env=True,
             ),

--- a/test/multiple_ep/test_python_env_system.py
+++ b/test/multiple_ep/test_python_env_system.py
@@ -13,7 +13,7 @@ from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import Device
 from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec, create_accelerators
 from olive.passes.onnx import OrtPerfTuning
-from olive.systems.python_environment import PythonEnvironmentSystem
+from olive.systems.system_config import PythonEnvironmentTargetUserConfig, SystemConfig
 
 # pylint: disable=attribute-defined-outside-init
 
@@ -27,17 +27,22 @@ class TestOliveManagedPythonEnvironmentSystem:
     @pytest.mark.skip(reason="No machine to test DML execution provider")
     def test_run_pass_evaluate_windows(self, tmpdir):
         # use the olive managed python environment as the test environment
-        self.system = PythonEnvironmentSystem(
-            accelerators=["gpu"],
-            olive_managed_env=True,
+        self.system_config = SystemConfig(
+            system_type="PythonEnvironment",
+            target_user_config=PythonEnvironmentTargetUserConfig(
+                accelerators=["gpu"],
+                olive_managed_env=True,
+            ),
         )
         self.execution_providers = ["DmlExecutionProvider", "OpenVINOExecutionProvider"]
         output_dir = tmpdir
 
         metric = get_latency_metric(LatencySubType.AVG)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
-        engine = Engine(target=self.system, host=self.system, evaluator_config=evaluator_config)
-        accelerator_specs = create_accelerators(self.system, self.execution_providers)
+        engine = Engine(
+            target_config=self.system_config, host_config=self.system_config, evaluator_config=evaluator_config
+        )
+        accelerator_specs = create_accelerators(self.system_config, self.execution_providers)
 
         engine.register(OrtPerfTuning)
         output = engine.run(
@@ -53,17 +58,22 @@ class TestOliveManagedPythonEnvironmentSystem:
     @pytest.mark.skipif(platform.system() == "Windows", reason="Test for Linux only")
     def test_run_pass_evaluate_linux(self, tmpdir):
         # use the olive managed python environment as the test environment
-        self.system = PythonEnvironmentSystem(
-            accelerators=["cpu"],
-            olive_managed_env=True,
+        self.system_config = SystemConfig(
+            system_type="PythonEnvironment",
+            target_user_config=PythonEnvironmentTargetUserConfig(
+                accelerators=["cpu"],
+                olive_managed_env=True,
+            ),
         )
         self.execution_providers = ["CPUExecutionProvider", "OpenVINOExecutionProvider"]
         output_dir = tmpdir
 
         metric = get_latency_metric(LatencySubType.AVG)
         evaluator_config = OliveEvaluatorConfig(metrics=[metric])
-        engine = Engine(target=self.system, host=self.system, evaluator_config=evaluator_config)
-        accelerator_specs = create_accelerators(self.system, self.execution_providers)
+        engine = Engine(
+            target_config=self.system_config, host_config=self.system_config, evaluator_config=evaluator_config
+        )
+        accelerator_specs = create_accelerators(self.system_config, self.execution_providers)
         engine.register(OrtPerfTuning)
         output = engine.run(
             self.input_model_config, accelerator_specs, output_dir=output_dir, evaluate_input_model=True

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -16,7 +16,7 @@ from olive.evaluator.olive_evaluator import OliveEvaluator, OnnxEvaluator
 from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR, DEFAULT_GPU_CUDA_ACCELERATOR, AcceleratorSpec, Device
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OrtPerfTuning
-from olive.passes.onnx.perf_tuning import PERFTUNING_BASELINE, generate_test_name
+from olive.passes.onnx.perf_tuning import PERFTUNING_BASELINE, PerfTuningRunner, generate_test_name
 
 
 @pytest.mark.parametrize(
@@ -231,7 +231,7 @@ def test_ort_perf_tuning_pass_with_dynamic_shapes(mock_get_io_config, tmp_path):
     assert "ones() received an invalid combination of arguments" in str(e.value)
 
 
-@patch("olive.passes.onnx.perf_tuning.threads_num_binary_search")
+@patch.object(PerfTuningRunner, "threads_num_binary_search")
 def test_ort_perf_tuning_pass_with_import_error(threads_num_binary_search_mock, tmp_path):
     threads_num_binary_search_mock.side_effect = ModuleNotFoundError("test")
 

--- a/test/unit_test/passes/onnx/test_perf_tuning.py
+++ b/test/unit_test/passes/onnx/test_perf_tuning.py
@@ -17,6 +17,7 @@ from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR, DEFAULT_GPU_CUDA
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx import OrtPerfTuning
 from olive.passes.onnx.perf_tuning import PERFTUNING_BASELINE, PerfTuningRunner, generate_test_name
+from olive.systems.local import LocalSystem
 
 
 @pytest.mark.parametrize(
@@ -350,3 +351,14 @@ def test_rocm_tuning_enable(get_available_providers_mock, inference_session_mock
     set_tuning_result_count = 3 * set_tuning_result_binary_search_count_per_iteration
     assert mock.set_tuning_results.call_count >= set_tuning_result_count
     assert mock.get_tuning_results.call_count == mock.set_tuning_results.call_count + 1
+
+
+def test_perf_tuning_with_target(tmp_path):
+    # setup
+    input_model = get_onnx_model()
+    p = create_pass_from_dict(OrtPerfTuning, {}, disable_search=True)
+    output_folder = str(tmp_path / "onnx")
+
+    # execute
+    p.set_target(LocalSystem())
+    p.run(input_model, None, output_folder)

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -16,6 +16,7 @@ import pytest
 from azure.ai.ml import Input, Output
 from azure.ai.ml.constants import AssetTypes
 from azure.ai.ml.entities import UserIdentityConfiguration
+from azure.core.exceptions import ResourceNotFoundError
 
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.data.config import DataConfig
@@ -751,7 +752,7 @@ def test_create_managed_env(create_client_mock):
     from olive.systems.utils import create_new_system
 
     ml_client = MagicMock()
-    ml_client.environments.get.return_value = MagicMock()
+    ml_client.environments.get.side_effect = ResourceNotFoundError()
     ml_client.environments.get.__name__ = "get"
     create_client_mock.return_value = ml_client
 
@@ -770,6 +771,11 @@ def test_create_managed_env(create_client_mock):
     )
     system = create_new_system(system_config, DEFAULT_CPU_ACCELERATOR)
     assert system.olive_managed_env
+
+    ml_client = MagicMock()
+    ml_client.environments.get.return_value = MagicMock()
+    ml_client.environments.get.__name__ = "get"
+    create_client_mock.return_value = ml_client
 
     system_config = SystemConfig(
         type="AzureML",

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -743,3 +743,46 @@ def test__get_enironment_from_config(mock_retry_func):
 
     # assert
     assert expected_env == system.environment
+
+
+@patch.object(AzureMLClientConfig, "create_client")
+def test_create_managed_env(create_client_mock):
+    from olive.systems.system_config import AzureMLTargetUserConfig, SystemConfig
+    from olive.systems.utils import create_new_system
+
+    ml_client = MagicMock()
+    ml_client.environments.get.return_value = MagicMock()
+    ml_client.environments.get.__name__ = "get"
+    create_client_mock.return_value = ml_client
+
+    docker_config = AzureMLDockerConfig(
+        base_image="base_image",
+        conda_file_path="conda_file_path",
+    )
+    system_config = SystemConfig(
+        type="AzureML",
+        config=AzureMLTargetUserConfig(
+            azureml_client_config=AzureMLClientConfig(),
+            aml_compute="aml_compute",
+            aml_docker_config=docker_config,
+            olive_managed_env=True,
+        ),
+    )
+    system = create_new_system(system_config, DEFAULT_CPU_ACCELERATOR)
+    assert system.olive_managed_env
+
+    system_config = SystemConfig(
+        type="AzureML",
+        config=AzureMLTargetUserConfig(
+            azureml_client_config=AzureMLClientConfig(),
+            aml_compute="aml_compute",
+            aml_environment_config=AzureMLEnvironmentConfig(
+                name="name",
+                version="version",
+                label="label",
+            ),
+            olive_managed_env=False,
+        ),
+    )
+    system = system_config.create_system()
+    assert not system.olive_managed_env

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -81,13 +81,12 @@ class TestDockerSystem:
         mock_from_env.return_value = mock_docker_client
         docker_config = LocalDockerConfig(
             image_name="image_name",
-            requirements_file_path="requirements_file_path",
         )
         mock_docker_client.images.get.side_effect = docker.errors.ImageNotFound("msg")
         mock_docker_client.images.build.return_value = (MagicMock(), [{"stream": "Successfully built mock_image_id"}])
 
         # execute
-        docker_system = DockerSystem(docker_config, is_dev=True)
+        docker_system = DockerSystem(docker_config, is_dev=True, requirements_file="requirements_file")
 
         # assert
         mock_docker_client.images.build.assert_called_once_with(

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -37,9 +37,14 @@ class TestDockerSystem:
         assert docker_system.image == mock_image
         mock_docker_client.images.get.assert_called_once_with(docker_config.image_name)
 
+    @patch("olive.systems.docker.docker_system.shutil.copy2")
+    @patch("olive.systems.docker.docker_system.shutil.copytree")
     @patch("olive.systems.docker.docker_system.docker.from_env")
-    def test__init_image_dockerfile_build(self, mock_from_env):
+    @patch("olive.systems.docker.docker_system.tempfile.TemporaryDirectory")
+    def test__init_image_dockerfile_build(self, mock_tempdir, mock_from_env, mock_copytree, mock_copy2, tmpdir):
         # setup
+        mock_tempdir.return_value.__enter__.return_value = tmpdir
+
         import docker
 
         mock_docker_client = MagicMock()
@@ -54,17 +59,19 @@ class TestDockerSystem:
         DockerSystem(docker_config, is_dev=True)
 
         # assert
+        expected_build_context_path = tmpdir
         mock_docker_client.images.build.assert_called_once_with(
-            path=docker_config.build_context_path,
+            path=expected_build_context_path,
             dockerfile=docker_config.dockerfile,
             tag=docker_config.image_name,
             buildargs=docker_config.build_args,
         )
 
     @patch("olive.systems.docker.docker_system.shutil.copy2")
+    @patch("olive.systems.docker.docker_system.shutil.copyfile")
     @patch("olive.systems.docker.docker_system.docker.from_env")
     @patch("olive.systems.docker.docker_system.tempfile.TemporaryDirectory")
-    def test__init_image_requirements_file_build(self, mock_tempdir, mock_from_env, mock_copy, tmpdir):
+    def test__init_image_requirements_file_build(self, mock_tempdir, mock_from_env, mock_copyfile, mock_copy, tmpdir):
         # setup
         import docker
 

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -311,11 +311,17 @@ class TestPythonEnvironmentSystem:
 
     @patch("olive.systems.utils.create_new_system")
     def test_create_new_system_with_cache(self, mock_create_new_system):
+        from olive.systems.system_config import PythonEnvironmentTargetUserConfig, SystemConfig
         from olive.systems.utils import create_new_system_with_cache
 
-        origin_system = PythonEnvironmentSystem(olive_managed_env=True)
-        create_new_system_with_cache(origin_system, DEFAULT_CPU_ACCELERATOR)
-        create_new_system_with_cache(origin_system, DEFAULT_CPU_ACCELERATOR)
+        system_config = SystemConfig(
+            type="PythonEnvironment",
+            config=PythonEnvironmentTargetUserConfig(
+                olive_managed_env=True,
+            ),
+        )
+        create_new_system_with_cache(system_config, DEFAULT_CPU_ACCELERATOR)
+        create_new_system_with_cache(system_config, DEFAULT_CPU_ACCELERATOR)
         assert mock_create_new_system.call_count == 1
         create_new_system_with_cache.cache_clear()
         assert create_new_system_with_cache.cache_info().currsize == 0

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -325,3 +325,16 @@ class TestPythonEnvironmentSystem:
         assert mock_create_new_system.call_count == 1
         create_new_system_with_cache.cache_clear()
         assert create_new_system_with_cache.cache_info().currsize == 0
+
+    def test_create_managed_env(self):
+        from olive.systems.system_config import PythonEnvironmentTargetUserConfig, SystemConfig
+        from olive.systems.utils import create_new_system
+
+        system_config = SystemConfig(
+            type="PythonEnvironment",
+            config=PythonEnvironmentTargetUserConfig(
+                olive_managed_env=True,
+            ),
+        )
+        system = create_new_system(system_config, DEFAULT_CPU_ACCELERATOR)
+        assert system.olive_managed_env


### PR DESCRIPTION
## Describe your changes
* The PR just do code refactoring to facilitate the ep refactor work item to put it into system.
* In this PR, we deliberately delay the OliveSystem creation only when execution. When create accelerator spec, we will use system config to create the accelerator specs
* This PR also fix the multiple EPs evaluation bug when the host is local but target is DockerSystem. If the target is DockerSystem and host is local. the perftuning run pass need to be run in target instead of like other pass. From the time being, I choose a hack way to set the target for perf tuning pass. We need consider more better way to handle the case after this PR.
* For managed AzureMLSystem, we will first query the azureml env. If it doesn't exist, a new one will be created.
* simplify the logic of DockerSystem.
* Cleanup LocalDockerConfig.requirements_file_path since the DockerTargetUserConfig has already one
* unpin the ort version in dockerfiles used by multiple EP.
* refactor perftuning to uses PerfTuningRunner to host the underlying perf tuning logic.
## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
