### PR TITLE
🏷️  Simplify run_subprocess log to avoid potential logging bug

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -37,7 +37,7 @@ def run_subprocess(cmd, env=None, cwd=None, check=False):
             f"Failed to run {cmd} with returncode {e.returncode}!",
             f"Stderr: {e.stderr.decode('utf-8')}",
             f"Stdout: {e.stdout.decode('utf-8')}",
-            f"Env: {str(env).encode(errors='ignore').decode()}",
+            f"Env: {env}",
         ]
         logger.error("\n".join(err_msg))  # noqa: TRY400
         raise

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -18,8 +18,8 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def run_subprocess(cmd, env=None, cwd=None, check=False):  # pragma: no cover
-    logger.debug(f"Running command: {cmd} with env: {env}")
+def run_subprocess(cmd, env=None, cwd=None, check=False):
+    logger.debug("Running command: %s", cmd)
 
     assert isinstance(cmd, (str, list)), f"cmd must be a string or a list, got {type(cmd)}."
     windows = platform.system() == "Windows"

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -37,7 +37,7 @@ def run_subprocess(cmd, env=None, cwd=None, check=False):
             f"Failed to run {cmd} with returncode {e.returncode}!",
             f"Stderr: {e.stderr.decode('utf-8')}",
             f"Stdout: {e.stdout.decode('utf-8')}",
-            f"Env: {env}",
+            f"Env: {str(env).encode(errors='ignore').decode()}",
         ]
         logger.error("\n".join(err_msg))  # noqa: TRY400
         raise

--- a/olive/platform_sdk/qualcomm/runner.py
+++ b/olive/platform_sdk/qualcomm/runner.py
@@ -38,7 +38,7 @@ class SDKRunner:
         import platform
 
         if platform.system() == "Windows" and cmd.startswith(("snpe-", "qnn-")):
-            logger.debug(f"Resolving command {cmd} on Windows.")
+            logger.debug("Resolving command %s on Windows.", cmd)
             cmd_path = Path(self.sdk_env.sdk_root_path) / "bin" / self.sdk_env.target_arch
             cmd_name = cmd.split(" ")[0]
             if (cmd_path / cmd_name).exists():
@@ -50,7 +50,7 @@ class SDKRunner:
                             cmd = f"python {cmd}"
                 except UnicodeDecodeError as e:
                     logger.warning(
-                        f"Failed to read the first line of {cmd_name}: {e}. Will ignore to wrap it with python."
+                        "Failed to read the first line of %s: %s. Will ignore to wrap it with python.", cmd_name, e
                     )
 
         return cmd
@@ -61,7 +61,7 @@ class SDKRunner:
         env = self.sdk_env.env if use_olive_env else None
         for run in range(self.runs):
             run_log_msg = "" if self.runs == 1 else f" (run {run + 1}/{self.runs})"
-            logger.debug(f"Running {self.platform} command{run_log_msg}: {cmd}, with env: {env}")
+            logger.debug("Running %s command%s: ", self.platform, run_log_msg)
             _, stdout, stderr = run_subprocess(cmd, env, check=True)
             if self.sleep > 0 and run < self.runs - 1:
                 time.sleep(self.sleep)


### PR DESCRIPTION
## Describe your changes
1. Remove env from run_subprocess's debug logging to avoid potential l[ogging bug.](https://aiinfra.visualstudio.com/PublicPackages/_build/results?buildId=415082&view=logs&j=04f3f8bd-f6ad-546f-a3e7-a621004c3b55&t=a3ec9bd6-ecbf-5027-baca-9daffad9c3e0) The bug is caused by multitudinous path info which may trigger the UnicodeEncodeError.
2. Ignore the missed diag log files and just throw a error log, as the diag logs are used only for latencies measurement. And sometimes, the SNPEDiag_\d+.log cannot match the value of `runs`. For example:
    - if `runs` is 3, the diag log may be `SNPEDiag_0.log, SNPEDiag_3.log, SNPEDiag_4.log`. or  missed one of the log.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
