### PR TITLE
[Llama2] Use eager attention implementation

### DIFF
--- a/examples/llama2/llama2_qlora.json
+++ b/examples/llama2/llama2_qlora.json
@@ -7,7 +7,10 @@
             "dummy_inputs_func": "get_merged_decoder_with_past_dummy_inputs",
             "hf_config": {
                 "model_name": "meta-llama/Llama-2-7b-hf",
-                "task": "text-generation"
+                "task": "text-generation",
+                "from_pretrained_args": {
+                    "_attn_implementation": "eager"
+                }
             }
         }
     },

--- a/examples/llama2/llama2_template.json
+++ b/examples/llama2/llama2_template.json
@@ -7,7 +7,10 @@
             "dummy_inputs_func": "get_merged_decoder_with_past_dummy_inputs",
             "hf_config": {
                 "model_name": "<model_name_placeholder>",
-                "model_class": "LlamaForCausalLM"
+                "model_class": "LlamaForCausalLM",
+                "from_pretrained_args": {
+                    "_attn_implementation": "eager"
+                }
             }
         }
     },


### PR DESCRIPTION
## Describe your changes
Latest version of transformers has different attention implementation. Onnx conversion requires `eager` attention implementation to work.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
