### PR TITLE
Re-enable bert cpu docker test in CI

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -88,10 +88,9 @@ jobs:
       bert_ptq_cpu_aml:
         exampleFolder: bert
         exampleName: bert_ptq_cpu_aml
-      # enable the docker test for openvino after the ORT-openvino 1.17 is released.
-      # bert_ptq_cpu_docker:
-      #   exampleFolder: bert
-      #   exampleName: bert_ptq_cpu_docker
+      bert_ptq_cpu_docker:
+        exampleFolder: bert
+        exampleName: bert_ptq_cpu_docker
       resnet_ptq_cpu:
         exampleFolder: resnet
         exampleName: resnet_ptq_cpu
@@ -110,16 +109,6 @@ jobs:
       inception_snpe_toolkit:
         exampleFolder: inception
         exampleName: snpe_toolkit
-
-- template: job_templates/olive-example-template.yaml
-  parameters:
-    name: Linux_CI_ORT_116
-    pool: $(OLIVE_POOL_UBUNTU2004)
-    onnxruntime: onnxruntime==1.16.3
-    examples:
-      bert_ptq_cpu_docker:
-        exampleFolder: bert
-        exampleName: bert_ptq_cpu_docker
 
 # # Windows examples test
 - template: job_templates/olive-example-template.yaml


### PR DESCRIPTION
## Describe your changes
Docker pass run has been moved inside the docker system. So the environment running the engine doesn't have any restrictions on the ort version.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
