### PR TITLE
Fix mobilenet README

### DIFF
--- a/examples/mobilenet/README.md
+++ b/examples/mobilenet/README.md
@@ -40,9 +40,9 @@ python -m pip install ort-nightly-qnn --extra-index-url https://aiinfra.pkgs.vis
 deactivate
 ```
 
-Set the environment variable `QNN_EP_ENV` to the directory where the python executable is located:
+Set the environment variable `QNN_ENV_PATH` to the directory where the python executable is located:
 ```bash
-set QNN_EP_ENV=C:\path\to\qnn-ep-env\Scripts
+set QNN_ENV_PATH=C:\path\to\qnn-ep-env\Scripts
 ```
 
 **Note:** Using a virtual environment is optional but recommended to better manage the dependencies.
@@ -61,7 +61,7 @@ Run the following command to quantize the model and evaluate it on the NPU:
 python mobilenet_qnn_ep.py --evaluate
 ```
 
-**NOTE:** You can also only dump the workflow configuration file by adding the `--only_config` flag to the command.
+**NOTE:** You can also only dump the workflow configuration file by adding the `--config_only` flag to the command.
 
 The configuration file will be saved as `mobilenet_qnn_ep_{eval|no_eval}.json` in the current directory and can be run using the Olive CLI.
 ```bash


### PR DESCRIPTION
## Describe your changes
Fixes the following errors in the mobilenet README instructions:
- Rename `QNN_EP_ENV` to `QNN_ENV_PATH`
- Rename `--only_config` to `--config_only`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
