### PR TITLE
Add `SpecialParamValue` to pass config param type, Dynamic quantization UT

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -332,6 +332,9 @@ class OnnxQuantization(Pass):
             assert (
                 config["dataloader_func"] or config["data_config"]
             ), "dataloader_func or data_config is required for static quantization."
+            # whether to prepare qnn config
+            if config["prepare_qnn_config"] and version.parse(OrtVersion) < version.parse("1.17.0"):
+                raise OlivePassError("prepare_qnn_config is only supported for onnxruntime-qnn>=1.17.0")
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
@@ -364,10 +367,6 @@ class OnnxQuantization(Pass):
             else:
                 logger.info("Already processed model for quantization, skipping preprocessing")
                 model = ONNXModelHandler(LocalFile({"path": preprocessed_temp_model_path}))
-
-        # whether to prepare qnn config
-        if run_config.get("prepare_qnn_config", False) and version.parse(OrtVersion) < version.parse("1.17.0"):
-            raise OlivePassError("prepare_qnn_config is only supported for onnxruntime-qnn>=1.17.0")
 
         # keys not needed for quantization
         to_delete = [

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -8,7 +8,7 @@ from typing import Callable, Dict, Optional, Type, Union
 
 from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, validate_object, validate_resource_path
 from olive.common.pydantic_v1 import create_model, validator
-from olive.strategy.search_parameter import SearchParameter, json_to_search_parameter
+from olive.strategy.search_parameter import SearchParameter, SpecialParamValue, json_to_search_parameter
 
 
 class PassParamDefault(str, Enum):
@@ -117,7 +117,14 @@ def create_config_class(
             config[param] = (type_, ...)
             continue
 
-        type_ = Optional[Union[type_, SearchParameter, PassParamDefault]]
+        # Value can be one of
+        # 1. Instance of type_ if search is disabled or searchable_values is None
+        # 2. Search Parameter if search is enabled and searchable_values is not None
+        # 3. PassParamDefault if value is set to "DEFAULT_VALUE" or "SEARCHABLE_VALUES"
+        # 4. SpecialParamValue.IGNORED if the param is ignored for a specific search point. This is used to ignore
+        #    parameters that are only used conditional on other parameters. Such as static quantization parameters
+        #    that are only used if the quantization mode is static.
+        type_ = Optional[Union[type_, SearchParameter, PassParamDefault, SpecialParamValue]]
         if not disable_search and param_config.searchable_values is not None:
             config[param] = (type_, param_config.searchable_values)
         else:

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -33,7 +33,7 @@ def dummpy_dataloader_func(data_dir, batch_size, *args, **kwargs):
 
 
 @pytest.mark.parametrize("calibrate_method", ["MinMax", "Entropy", "Percentile"])
-def test_quantization(calibrate_method, tmp_path):
+def test_static_quantization(calibrate_method, tmp_path):
     input_model = get_onnx_model()
     config = {
         "quant_mode": "static",
@@ -50,6 +50,20 @@ def test_quantization(calibrate_method, tmp_path):
     p = create_pass_from_dict(OnnxQuantization, config, disable_search=True)
     out = p.run(input_model, None, tmp_path)
     assert out is not None
+
+
+def test_dynamic_quantization(tmp_path):
+    input_model = get_onnx_model()
+    config = {"quant_mode": "dynamic"}
+    p = create_pass_from_dict(OnnxQuantization, config, disable_search=True)
+
+    if version.parse(OrtVersion) >= version.parse("1.17.0"):
+        # there is a bug in ort quantizer after version 1.17.0
+        with pytest.raises(TypeError, match="missing 1 required positional argument: 'initial_type'"):
+            out = p.run(input_model, None, tmp_path)
+    else:
+        out = p.run(input_model, None, tmp_path)
+        assert out is not None
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Describe your changes
This PR fixes a bug in the type of a pass config param where it can be `SpecialParamValue` but this enum was not added to the type. 
This case happens for `ONNXQuantization` pass where the values for `static_option_config` params are set to `SpecialParamValue.IGNORED` when `quant_mode` is `dynamic`. The bug was not caught earlier since all previous optional params were of type string, so it automatically passed the string validation. We also didn't have a dynamic quantization unit test. 

Added a unit test for dynamic quantization. However, there is a bug in ORT>=1.17.0 because of which the dynamic quantizer fails. so added a check for the failure for the affected versions.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
