### PR TITLE
▶️ Postpone the error raising even if no hf_io_config is available

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -471,7 +471,8 @@ class Engine:
         fp_outputs = self.footprints[accelerator_spec].create_footprints_by_model_ids(output_model_ids)
         # update the output model config
         for model_id, model_config in output_models.items():
-            fp_outputs.nodes[model_id].model_config = model_config
+            # output_model_config could be None if the model is not supported to be saved like CompositeModel
+            fp_outputs.nodes[model_id].model_config = model_config or fp_outputs.nodes[model_id].model_config
 
         return fp_outputs
 

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -471,8 +471,7 @@ class Engine:
         fp_outputs = self.footprints[accelerator_spec].create_footprints_by_model_ids(output_model_ids)
         # update the output model config
         for model_id, model_config in output_models.items():
-            # output_model_config could be None if the model is not supported to be saved like CompositeModel
-            fp_outputs.nodes[model_id].model_config = model_config or fp_outputs.nodes[model_id].model_config
+            fp_outputs.nodes[model_id].model_config = model_config
 
         return fp_outputs
 

--- a/olive/model/utils/hf_utils.py
+++ b/olive/model/utils/hf_utils.py
@@ -139,6 +139,12 @@ def get_hf_model_io_config(model_name: str, task: str, feature: Optional[str] = 
     model_config = get_onnx_config(model_name, task, feature, **kwargs)
     inputs = model_config.inputs
     outputs = model_config.outputs
+    if not inputs or not outputs:
+        # just log a warning and return None, since this is not a critical error
+        # and following pass may not use the io_config, like OptimumConversion
+        logger.warning("No inputs or outputs found from model %s", model_config)
+        return None
+
     io_config = {}
     io_config["input_names"] = list(inputs.keys())
     io_config["output_names"] = list(outputs.keys())


### PR DESCRIPTION
## Describe your changes
For some models, like microsoft/trocr-base-handwritten, the onnx_config can be got from hf_transformers, but there is not input. 
But it can be converted by OptimumConversion. This PR is used to postpone the error raising even if no hf_io_config is available. 


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
