### PR TITLE
🍨 Inc quanti dataloader fix

### DIFF
--- a/test/unit_test/passes/inc/test_inc_quantization.py
+++ b/test/unit_test/passes/inc/test_inc_quantization.py
@@ -4,12 +4,14 @@
 # --------------------------------------------------------------------------
 import platform
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 from torchvision import transforms
 from torchvision.datasets import CIFAR10
 
+from olive.data.config import DataConfig
 from olive.model import PyTorchModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.conversion import OnnxConversion
@@ -84,6 +86,29 @@ def test_inc_weight_only_quantization(tmp_path):
     del p
     # create IncStaticQuantization pass
     p = create_pass_from_dict(IncStaticQuantization, config, disable_search=True)
+    # execute
+    quantized_model = p.run(ov_model, None, output_folder)
+    # assert
+    assert quantized_model.model_path.endswith(".onnx")
+    assert Path(quantized_model.model_path).exists()
+    assert Path(quantized_model.model_path).is_file()
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Skip test on Windows. neural-compressor import is hanging on Windows."
+)
+@patch.dict("neural_compressor.quantization.STRATEGIES", {"auto": MagicMock()})
+@patch("olive.passes.onnx.inc_quantization.model_proto_to_olive_model")
+def test_inc_quantization_with_data_config(mock_model_saver, tmp_path):
+    ov_model = get_onnx_model(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    config = {"approach": "static", "data_dir": data_dir, "data_config": DataConfig()}
+    output_folder = str(tmp_path / "quantized")
+
+    mock_model_saver.return_value = ov_model
+    # create IncQuantization pass
+    p = create_pass_from_dict(IncQuantization, config, disable_search=True)
     # execute
     quantized_model = p.run(ov_model, None, output_folder)
     # assert


### PR DESCRIPTION
## Describe your changes

Inc quantization's calibration dataloader input requires (input, label) which is data_config's data_loader.
This PR is used to fix the bug when user provide data_config bug not dataloader_func.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
