### PR TITLE
🅰️ AutoOpt disable search when no evaluator

### DIFF
--- a/olive/auto_optimizer/regulate_mixins.py
+++ b/olive/auto_optimizer/regulate_mixins.py
@@ -36,7 +36,10 @@ class RegulatePassConfigMixin:
                 for p in pf:
                     if p not in pass_config:
                         pass_config.update({p: {"type": p, "config": {}}})
-
+        # disable pass search when search strategy is None/False
+        if not self.evaluator_config:
+            for pass_name in pass_config:
+                pass_config[pass_name]["disable_search"] = True
         return pass_config, pass_flows
 
     def _regulate_fp16(self, pass_config, pass_flows):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -90,14 +90,18 @@ class RunConfig(ConfigBase):
 
     @validator("engine", pre=True, always=True)
     def default_engine_config(cls, v):
-        return v or {}
+        if v is None:
+            v = {}
+        return v
 
     @validator("data_configs", pre=True, always=True)
     def insert_input_model_data_config(cls, v, values):
         if "input_model" not in values:
             raise ValueError("Invalid input model")
 
-        v = v or {}
+        if not v:
+            # if data_configs is None, create an empty dict
+            v = {}
 
         if INPUT_MODEL_DATA_CONFIG in v:
             raise ValueError(f"Data config name {INPUT_MODEL_DATA_CONFIG} is reserved. Please use another name.")
@@ -247,7 +251,9 @@ class RunConfig(ConfigBase):
 
     @validator("auto_optimizer_config", always=True)
     def validate_auto_optimizer_config(cls, v, values):
-        return v or AutoOptimizerConfig()
+        if not v:
+            v = AutoOptimizerConfig()
+        return v
 
 
 def _resolve_config_str(v, values, alias, component_name):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -90,18 +90,14 @@ class RunConfig(ConfigBase):
 
     @validator("engine", pre=True, always=True)
     def default_engine_config(cls, v):
-        if v is None:
-            v = {}
-        return v
+        return v or {}
 
     @validator("data_configs", pre=True, always=True)
     def insert_input_model_data_config(cls, v, values):
         if "input_model" not in values:
             raise ValueError("Invalid input model")
 
-        if not v:
-            # if data_configs is None, create an empty dict
-            v = {}
+        v = v or {}
 
         if INPUT_MODEL_DATA_CONFIG in v:
             raise ValueError(f"Data config name {INPUT_MODEL_DATA_CONFIG} is reserved. Please use another name.")
@@ -251,9 +247,7 @@ class RunConfig(ConfigBase):
 
     @validator("auto_optimizer_config", always=True)
     def validate_auto_optimizer_config(cls, v, values):
-        if not values["passes"] and not v:
-            return AutoOptimizerConfig()
-        return v
+        return v or AutoOptimizerConfig()
 
 
 def _resolve_config_str(v, values, alias, component_name):

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -249,6 +249,12 @@ class RunConfig(ConfigBase):
                 )
         return v
 
+    @validator("auto_optimizer_config", always=True)
+    def validate_auto_optimizer_config(cls, v, values):
+        if not values["passes"] and not v:
+            return AutoOptimizerConfig()
+        return v
+
 
 def _resolve_config_str(v, values, alias, component_name):
     """Resolve string value for alias in v to corresponding component config in values.

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -165,8 +165,10 @@ def run_engine(config: RunConfig, data_root: str = None):
 
         AzureMLSystem.olive_config = config.to_json()
 
-    no_evaluation = engine.evaluator_config is None and all(
-        pass_config.evaluator is None for pass_config in config.passes.values()
+    no_evaluation = (
+        engine.evaluator_config is None
+        and config.passes
+        and all(pass_config.evaluator is None for pass_config in config.passes.values())
     )
     accelerator_specs = create_accelerators(
         engine.target_config, config.engine.execution_providers, skip_supported_eps_check=no_evaluation

--- a/test/unit_test/auto_optimizer/test_auto_optimizer.py
+++ b/test/unit_test/auto_optimizer/test_auto_optimizer.py
@@ -131,3 +131,15 @@ class TestAutoOptimizer:
             accelerator, ep, precision = k_list[0], k_list[1], k_list[2]
             rls_pf = get_pass_flows_by_accelerator_ep_precision(0, accelerator, ep, precision)
             assert sorted(rls_pf) == sorted(pf)
+
+    def test_pass_config_when_no_evaluator(self):
+        auto_optimizer = AutoOptimizer(
+            input_model_config=self.input_model_config,
+            evaluator_config=None,
+            accelerator_spec=DEFAULT_CPU_ACCELERATOR,
+            auto_optimizer_config=None,
+            data_configs=self.data_configs,
+        )
+        pass_config, _ = auto_optimizer.suggest()
+        for pass_name in pass_config:
+            assert pass_config[pass_name]["disable_search"] is True


### PR DESCRIPTION
## Describe your changes
This PR is used for:
1. If there no passes given, enable AutoOpt be default.
2. If the evaluation config is given, in AutoOpt case, we should set disable_search as True.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
