### PR TITLE
use sys.executable instead of python

### DIFF
--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -7,6 +7,7 @@ import json
 import logging
 import platform
 import shutil
+import sys
 import tempfile
 import urllib.request
 from collections import OrderedDict
@@ -249,12 +250,12 @@ def _package_onnxruntime_packages(tempdir, pf_footprint: "Footprint"):
     try:
         # Download Python onnxruntime package
         NIGHTLY_PYTHON_COMMAND = Template(
-            "python -m pip download -i "
+            f"{sys.executable} -m pip download -i "
             "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ "
             "$package_name==$ort_version --no-deps -d $python_download_path"
         )
         STABLE_PYTHON_COMMAND = Template(
-            "python -m pip download $package_name==$ort_version --no-deps -d $python_download_path"
+            f"{sys.executable} -m pip download $package_name==$ort_version --no-deps -d $python_download_path"
         )
         python_download_path = tempdir / "ONNXRuntimePackages" / "python"
         python_download_path.mkdir(parents=True, exist_ok=True)
@@ -309,7 +310,7 @@ def _download_ort_extensions_package(use_ort_extensions: bool, download_path: st
             system = platform.system()
             if system == "Windows":
                 download_command = (
-                    "python -m pip download -i "
+                    f"{sys.executable} -m pip download -i "
                     "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ "
                     f"onnxruntime-extensions=={version} --no-deps -d {download_path}"
                 )
@@ -320,7 +321,9 @@ def _download_ort_extensions_package(use_ort_extensions: bool, download_path: st
                     "Skip packaging ONNXRuntime-Extensions package. Please manually install ONNXRuntime-Extensions."
                 )
         else:
-            download_command = f"python -m pip download onnxruntime-extensions=={version} --no-deps -d {download_path}"
+            download_command = (
+                f"{sys.executable} -m pip download onnxruntime-extensions=={version} --no-deps -d {download_path}"
+            )
             run_subprocess(download_command)
 
 

--- a/olive/platform_sdk/qualcomm/runner.py
+++ b/olive/platform_sdk/qualcomm/runner.py
@@ -56,7 +56,7 @@ class SDKRunner:
                     )
         if isinstance(cmd, str):
             cmd = shlex.split(cmd, posix=(platform.system() != "Windows"))
-            cmd[0] = shutil.which(cmd[0], path=self.sdk_env.env.get("PATH", None) or cmd[0])
+            cmd[0] = shutil.which(cmd[0], path=self.sdk_env.env.get("PATH")) or cmd[0]
         return cmd
 
     def run(self, cmd: str, use_olive_env: bool = True):

--- a/olive/platform_sdk/qualcomm/runner.py
+++ b/olive/platform_sdk/qualcomm/runner.py
@@ -54,9 +54,9 @@ class SDKRunner:
                     logger.warning(
                         "Failed to read the first line of %s: %s. Will ignore to wrap it with python.", cmd_name, e
                     )
-            if isinstance(cmd, str):
-                cmd = shlex.split(cmd, posix=(platform.system() != "Windows"))
-                cmd[0] = shutil.which(cmd[0], path=self.sdk_env.env.get("PATH", None) or cmd[0])
+        if isinstance(cmd, str):
+            cmd = shlex.split(cmd, posix=(platform.system() != "Windows"))
+            cmd[0] = shutil.which(cmd[0], path=self.sdk_env.env.get("PATH", None) or cmd[0])
         return cmd
 
     def run(self, cmd: str, use_olive_env: bool = True):

--- a/olive/systems/isolated_ort/isolated_ort_system.py
+++ b/olive/systems/isolated_ort/isolated_ort_system.py
@@ -5,6 +5,7 @@
 import collections
 import json
 import logging
+import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
@@ -128,7 +129,7 @@ class IsolatedORTEvaluator(OliveEvaluator, OnnxEvaluatorMixin, framework="ort_in
         output_dir: Union[str, Path],
     ):
         command = [
-            "python",
+            sys.executable,
             str(self.inference_runner_path),
             "--config_path",
             str(config_path),

--- a/olive/systems/isolated_ort/isolated_ort_system.py
+++ b/olive/systems/isolated_ort/isolated_ort_system.py
@@ -46,7 +46,7 @@ class IsolatedORTSystem(OliveSystem):
         if python_environment_path is None:
             raise ValueError("python_environment_path is required for PythonEnvironmentSystem.")
 
-        super().__init__(accelerators=accelerators, olive_managed_env=False)
+        super().__init__(accelerators=accelerators, olive_managed_env=False, hf_token=hf_token)
         self.config = IsolatedORTTargetUserConfig(
             python_environment_path=python_environment_path,
             environment_variables=environment_variables,

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -41,6 +42,9 @@ class PythonEnvironmentSystem(OliveSystem):
         requirements_file: Union[Path, str] = None,
         hf_token: bool = None,
     ):
+        if python_environment_path is None:
+            raise ValueError("python_environment_path is required for PythonEnvironmentSystem.")
+
         super().__init__(accelerators=accelerators, olive_managed_env=olive_managed_env)
         self.config = PythonEnvironmentTargetUserConfig(
             python_environment_path=python_environment_path,
@@ -64,6 +68,7 @@ class PythonEnvironmentSystem(OliveSystem):
             else:
                 self.environ["TMPDIR"] = tempfile.TemporaryDirectory().name  # pylint: disable=consider-using-with
 
+        self.executable = shutil.which("python", path=self.environ["PATH"])
         # available eps. This will be populated the first time self.get_supported_execution_providers() is called.
         # used for caching the available eps
         self.available_eps = None
@@ -79,7 +84,7 @@ class PythonEnvironmentSystem(OliveSystem):
             tmp_dir_path = Path(tmp_dir).resolve()
 
             # command to run
-            command = [sys.executable, str(script_path)]
+            command = [self.executable, str(script_path)]
 
             # write config jsons to files
             for key, config_json in config_jsons.items():

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import platform
+import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
@@ -78,7 +79,7 @@ class PythonEnvironmentSystem(OliveSystem):
             tmp_dir_path = Path(tmp_dir).resolve()
 
             # command to run
-            command = ["python", str(script_path)]
+            command = [sys.executable, str(script_path)]
 
             # write config jsons to files
             for key, config_json in config_jsons.items():
@@ -171,13 +172,15 @@ class PythonEnvironmentSystem(OliveSystem):
         packages.append(onnxruntime_package)
 
         _, stdout, _ = run_subprocess(
-            f"pip install --cache-dir {self.environ['TMPDIR']} {' '.join(packages)}",
+            f"{sys.executable} -m pip install --cache-dir {self.environ['TMPDIR']} {' '.join(packages)}",
             env=self.environ,
             check=True,
         )
         log_stdout(stdout)
 
-        _, stdout, _ = run_subprocess(f"pip show {onnxruntime_package}", env=self.environ, check=True)
+        _, stdout, _ = run_subprocess(
+            f"{sys.executable} -m pip show {onnxruntime_package}", env=self.environ, check=True
+        )
         log_stdout(stdout)
 
     def remove(self):

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -44,7 +44,7 @@ class PythonEnvironmentSystem(OliveSystem):
         if python_environment_path is None:
             raise ValueError("python_environment_path is required for PythonEnvironmentSystem.")
 
-        super().__init__(accelerators=accelerators, olive_managed_env=olive_managed_env)
+        super().__init__(accelerators=accelerators, olive_managed_env=olive_managed_env, hf_token=hf_token)
         self.config = PythonEnvironmentTargetUserConfig(
             python_environment_path=python_environment_path,
             environment_variables=environment_variables,

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -188,8 +188,6 @@ class PythonEnvironmentSystem(OliveSystem):
         log_stdout(stdout)
 
     def remove(self):
-        import shutil
-
         vitual_env_path = Path(self.config.python_environment_path).resolve().parent
 
         try:

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -7,7 +7,6 @@ import logging
 import os
 import platform
 import shutil
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
@@ -177,14 +176,14 @@ class PythonEnvironmentSystem(OliveSystem):
         packages.append(onnxruntime_package)
 
         _, stdout, _ = run_subprocess(
-            f"{sys.executable} -m pip install --cache-dir {self.environ['TMPDIR']} {' '.join(packages)}",
+            f"{self.executable} -m pip install --cache-dir {self.environ['TMPDIR']} {' '.join(packages)}",
             env=self.environ,
             check=True,
         )
         log_stdout(stdout)
 
         _, stdout, _ = run_subprocess(
-            f"{sys.executable} -m pip show {onnxruntime_package}", env=self.environ, check=True
+            f"{self.executable} -m pip show {onnxruntime_package}", env=self.environ, check=True
         )
         log_stdout(stdout)
 

--- a/olive/systems/utils/misc.py
+++ b/olive/systems/utils/misc.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tempfile
 from copy import deepcopy
 from functools import lru_cache
@@ -152,7 +153,7 @@ def run_available_providers_runner(environ: Dict) -> List[str]:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_path = Path(temp_dir).resolve() / "available_eps.json"
         run_subprocess(
-            f"python {runner_path} --output_path {output_path}",
+            f"{sys.executable} {runner_path} --output_path {output_path}",
             env=environ,
             check=True,
         )

--- a/olive/systems/utils/misc.py
+++ b/olive/systems/utils/misc.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import shutil
-import sys
 import tempfile
 from copy import deepcopy
 from functools import lru_cache
@@ -150,10 +149,11 @@ def create_new_environ(
 def run_available_providers_runner(environ: Dict) -> List[str]:
     """Run the available providers runner script with the given environment and return the available providers."""
     runner_path = Path(__file__).parent / "available_providers_runner.py"
+    python_path = shutil.which("python", path=environ["PATH"])
     with tempfile.TemporaryDirectory() as temp_dir:
         output_path = Path(temp_dir).resolve() / "available_eps.json"
         run_subprocess(
-            f"{sys.executable} {runner_path} --output_path {output_path}",
+            f"{python_path} {runner_path} --output_path {output_path}",
             env=environ,
             check=True,
         )

--- a/test/unit_test/systems/isolated_ort/test_isolated_ort_system.py
+++ b/test/unit_test/systems/isolated_ort/test_isolated_ort_system.py
@@ -43,7 +43,7 @@ class TestIsolatedORTSystemConfig:
 
     def test_invalid_isolated_system_config(self):
         config = {"type": "IsolatedORT", "config": {"python_environment_path": "invalid_path"}}
-        with pytest.raises(ValueError, match="Python path invalid_path does not exist"):
+        with pytest.raises(ValueError, match=f"Python path {Path('invalid_path').resolve()} does not exist"):
             SystemConfig.parse_obj(config)
 
 

--- a/test/unit_test/systems/isolated_ort/test_isolated_ort_system.py
+++ b/test/unit_test/systems/isolated_ort/test_isolated_ort_system.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 import torch
 
+from olive.common.pydantic_v1 import ValidationError
 from olive.common.utils import run_subprocess
 from olive.constants import Framework
 from olive.evaluator.metric import AccuracySubType, LatencySubType
@@ -24,8 +25,26 @@ from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.systems.isolated_ort import IsolatedORTSystem
 from olive.systems.isolated_ort.inference_runner import main as inference_runner_main
 from olive.systems.isolated_ort.isolated_ort_system import IsolatedORTEvaluator
+from olive.systems.system_config import IsolatedORTTargetUserConfig, SystemConfig
 
 # pylint: disable=attribute-defined-outside-init, protected-access
+
+
+class TestIsolatedORTSystemConfig:
+    def test_isolated_system_config(self):
+        config = {"type": "IsolatedORT", "config": {"python_environment_path": Path(sys.executable).parent}}
+        system_config = SystemConfig.parse_obj(config)
+        assert isinstance(system_config.config, IsolatedORTTargetUserConfig)
+
+    def test_missing_isolated_system_config(self):
+        config = {"type": "IsolatedORT", "config": {}}
+        with pytest.raises(ValidationError):
+            SystemConfig.parse_obj(config)
+
+    def test_invalid_isolated_system_config(self):
+        config = {"type": "IsolatedORT", "config": {"python_environment_path": "invalid_path"}}
+        with pytest.raises(ValueError, match="Python path invalid_path does not exist"):
+            SystemConfig.parse_obj(config)
 
 
 class TestIsolatedORTSystem:
@@ -86,8 +105,10 @@ class TestIsolatedORTEvaluator:
         else:
             python_environment_path = f"{venv_path}/bin"
         self.system = IsolatedORTSystem(python_environment_path)
+
+        python_path = shutil.which("python", path=python_environment_path)
         # install only onnxruntime
-        run_subprocess(["python", "-m", "pip", "install", "onnxruntime"], env=self.system.environ)
+        run_subprocess([python_path, "-m", "pip", "install", "onnxruntime"], env=self.system.environ)
 
         self.evaluator = IsolatedORTEvaluator(self.system.environ)
         self.onnx_evaluator = OnnxEvaluator()

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -53,9 +53,11 @@ class TestPythonEnvironmentSystem:
         # install only onnxruntime
         run_subprocess([python_path, "-m", "pip", "install", "onnxruntime"], env=self.system.environ)
 
-        import onnxruntime as ort
-
-        assert set(self.system.get_supported_execution_providers()) == set(ort.get_available_providers())
+        # for GPU ort, the get_available_providers will return ["CUDAExecutionProvider", "DmlExecutionProvider"]
+        assert set(self.system.get_supported_execution_providers()) == {
+            "AzureExecutionProvider",
+            "CPUExecutionProvider",
+        }
 
     @patch("olive.systems.python_environment.python_environment_system.run_subprocess")
     @patch("olive.systems.python_environment.python_environment_system.tempfile.TemporaryDirectory")

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from olive.common.utils import run_subprocess
 from olive.evaluator.metric import MetricResult, joint_metric_key
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.model import ModelConfig
@@ -48,6 +49,10 @@ class TestPythonEnvironmentSystem:
         shutil.rmtree(venv_path)
 
     def test_get_supported_execution_providers(self):
+        python_path = shutil.which("python", path=self.python_environment_path)
+        # install only onnxruntime
+        run_subprocess([python_path, "-m", "pip", "install", "onnxruntime"], env=self.system.environ)
+
         import onnxruntime as ort
 
         assert set(self.system.get_supported_execution_providers()) == set(ort.get_available_providers())


### PR DESCRIPTION
## Describe your changes
* according to the best practice https://docs.python.org/3/library/subprocess.html#popen-constructor, we should use sys.executable instead of python to specify the full path of executable.
* for other program, prefer specify the full path by calling `[shutil.which()](https://docs.python.org/3/library/shutil.html#shutil.which) to expand the full path of the program.
![image](https://github.com/microsoft/Olive/assets/817030/5608189a-2f73-4b78-86e1-89137f6eca90)


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
