### PR TITLE
📤 Output model config fix in run_no_search

### DIFF
--- a/olive/cache.py
+++ b/olive/cache.py
@@ -7,7 +7,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from olive.common.config_utils import serialize_to_json
 from olive.common.utils import hash_dict
@@ -197,7 +197,7 @@ def save_model(
     output_name: Union[str, Path] = None,
     overwrite: bool = False,
     cache_dir: Union[str, Path] = ".olive-cache",
-):
+) -> Optional[Dict]:
     """Save a model from the cache to a given path."""
     # This function should probably be outside of the cache module
     # just to be safe, import lazily to avoid any future circular imports

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -459,6 +459,8 @@ class Engine:
                     overwrite=True,
                     cache_dir=self._config.cache_dir,
                 )
+                # it is not supported to save compositepytorchmodel/compositemodel again
+                # so the output_model_json could be None
                 output_models[pass_output_model_id] = output_model_json
 
             # save the evaluation results to output_dir
@@ -471,7 +473,7 @@ class Engine:
         fp_outputs = self.footprints[accelerator_spec].create_footprints_by_model_ids(output_model_ids)
         # update the output model config
         for model_id, model_config in output_models.items():
-            fp_outputs.nodes[model_id].model_config = model_config
+            fp_outputs.nodes[model_id].model_config = model_config or fp_outputs.nodes[model_id].model_config
 
         return fp_outputs
 

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -473,7 +473,8 @@ class Engine:
         fp_outputs = self.footprints[accelerator_spec].create_footprints_by_model_ids(output_model_ids)
         # update the output model config
         for model_id, model_config in output_models.items():
-            fp_outputs.nodes[model_id].model_config = model_config or fp_outputs.nodes[model_id].model_config
+            if model_config:
+                fp_outputs.nodes[model_id].model_config = model_config
 
         return fp_outputs
 

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -169,7 +169,10 @@ def _package_candidate_models(
         elif model_type.lower() == "openvinomodel":
             model_resource_path.save_to_dir(model_dir, "model", True)
         else:
-            raise ValueError(f"Unsupported model type: {model_type} for packaging")
+            raise ValueError(
+                f"Unsupported model type: {model_type} for packaging,"
+                " you can set `packaging_config` as None to mitigate this issue."
+            )
 
         # Copy Passes configurations
         configuration_path = model_dir / "configurations.json"

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -129,6 +129,19 @@ def get_onnx_model_config():
     return ModelConfig.parse_obj({"type": "ONNXModel", "config": {"model_path": str(ONNX_MODEL_PATH)}})
 
 
+def get_composite_onnx_model_config():
+    onnx_model_config = get_onnx_model_config().dict()
+    return ModelConfig.parse_obj(
+        {
+            "type": "CompositeModel",
+            "config": {
+                "model_components": [onnx_model_config, onnx_model_config],
+                "model_component_names": "test_component_name",
+            },
+        }
+    )
+
+
 def get_onnx_model():
     return ONNXModelHandler(model_path=str(ONNX_MODEL_PATH))
 


### PR DESCRIPTION
## Describe your changes

The case of run_no_search, if the final model output is composite model, the model_config will be None which leads the error output packing.

```json
{
    "input_model":{
        "type": "PyTorchModel",
        "config": {
            "hf_config": {
                "model_name": "microsoft/trocr-base-handwritten",
                "task": "image-to-text"
            }
        }
    },
    "passes": {
        "conversion": {
            "type": "OptimumConversion"
        }
    },
    "engine": {
        "cache_dir": "cache",
        "packaging_config": {
            "type": "Zipfile", <---- should be removed
            "name": "OutputModels" <---- should be removed
        },
        "output_dir" : "models"
    }
}
```

Basically, Olive did not support pack composite model and we should add log to tell user when they encounter similar issues.

This PR is used to fix above issue.




## Checklist before requesting a review
- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
