### PR TITLE
🔑  Update kv cache input type

### DIFF
--- a/examples/phi2/phi2.py
+++ b/examples/phi2/phi2.py
@@ -98,23 +98,23 @@ def get_output_model_path(footprints):
 
 
 def main(raw_args=None):
-    # Check if onnxruntime version is supported
-    # in linux, it requires the
-    # 1. model_type as `phi`
-    # 2. "optimization_options": {"attention_op_type": "MultiHeadAttention"}
-    # in windows, it requires the
-    # 1. model_type as `gpt2`
-    # 2. "optimization_options": {"attention_op_type": "MultiHeadAttention"}
-    # and `phi` and `MultiHeadAttention` requires ort-nightly version >= 1.18.0
-    if version.parse(OrtVersion) < version.parse("1.18.0"):
+    args = get_args(raw_args)
+
+    if not args.optimum_optimization and version.parse(OrtVersion) < version.parse("1.18.0"):
+        # Check if onnxruntime version is supported
+        # in linux, it requires the
+        # 1. model_type as `phi`
+        # 2. "optimization_options": {"attention_op_type": "MultiHeadAttention"}
+        # in windows, it requires the
+        # 1. model_type as `gpt2`
+        # 2. "optimization_options": {"attention_op_type": "MultiHeadAttention"}
+        # and `phi` and `MultiHeadAttention` requires ort-nightly version >= 1.18.0
         raise ValueError(
             "Please use onnxruntime>=1.18.0 for phi2 optimization in Linux, you can refer to "
             "https://onnxruntime.ai/docs/install/#inference-install-table-for-all-languages "
             "for ort-nightly installation. If you are optimizing phi2 model in GPU, only cuda11 "
             "is supported in onnxruntime>=1.18.0"
         )
-
-    args = get_args(raw_args)
 
     json_file_template = "phi2_optimize_template.json"
     with open(json_file_template) as f:


### PR DESCRIPTION
## Describe your changes

1. For phi2 optimization, the transformer optimization keep_io_bytes is False. That means, the input/output of kv should be float16. Update the generation example to fix.
2. optimum conversion does not require ort >=1.18. Update the condition in this PR.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
