### PR TITLE
LoRA: Don't save embedding weights

### DIFF
--- a/olive/model/config/hf_config.py
+++ b/olive/model/config/hf_config.py
@@ -203,7 +203,10 @@ class HfFromPretrainedArgs(ConfigWithExtraArgs):
         config = config_cls.from_dict(config_dict, return_unused_kwargs=False)
         # we will do a manual check to see if there are unused kwargs
         # this works since config_cls is created as a dataclass
-        extras = set(config_dict.keys()) - set(config.__dict__.keys())
+        extras = set()
+        for k in config_dict:
+            if not hasattr(config, k):
+                extras.add(k)
         if extras:
             logger.warning("Unused kwargs in quantization_config: %s. Ignoring them", extras)
         return config


### PR DESCRIPTION
## Describe your changes
- Provide `save_embedding_layers=False` to saving the peft model. Otherwise, it defaults to "auto" which checks if the vocab size changed. For models with no pad token, we add a dummy token and increase the embedding size but these are not trained at all. The fine-tuned model can be used without these extra dummy weights and tokens so we don't save them.
- Update the `extra_keys` logic in quant config validation since some attributes were made private and causes incorrect warning log.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
