### PR TITLE
refactor accelerator normalization

### DIFF
--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -241,7 +241,7 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
                         )
                     else:
                         # User specify both the device and execution providers
-                        pass
+                        logger.debug("The accelerator device and execution providers are specified, skipping deduce.")
         else:
             # for AzureML and Docker System
             if not system_config.config.accelerators:

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -167,7 +167,7 @@ class AcceleratorLookup:
 
 
 def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_check: bool = True) -> "SystemConfig":
-    """Noralize the accelerators in the system config.
+    """Normalize the accelerators in the system config.
 
     * the accelerators is not specified, infer the device/ep based on the installed ORT in case of local/python system.
     * only device is specified, infer the execution providers based on the installed ORT in case of local/python system.
@@ -216,9 +216,9 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
                         inferred_device = AcceleratorLookup.infer_single_device_from_execution_providers(
                             accelerator.execution_providers
                         )
+                        logger.info("the accelerator device is not specified. Inferred device: %s.", inferred_device)
                         accelerator.device = inferred_device
-                    else:
-                        assert accelerator.device, "The device is not specified."
+                    elif not accelerator.execution_providers:
                         # User specify the device but missing the execution providers
                         execution_providers = (
                             AcceleratorLookup.get_execution_providers_for_device_by_available_providers(
@@ -239,6 +239,9 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
                             accelerator.device,
                             accelerator.execution_providers,
                         )
+                    else:
+                        # User specify both the device and execution providers
+                        pass
         else:
             # for AzureML and Docker System
             if not system_config.config.accelerators:

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -229,7 +229,7 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
                         filtered_eps = [ep for ep in system_supported_eps if ep not in execution_providers]
                         if filtered_eps:
                             logger.warning(
-                                "The following execution provider is not supported: %s. "
+                                "The following execution providers are filtered: %s. "
                                 "Please raise issue in Olive site since it might be a bug. ",
                                 ",".join(filtered_eps),
                             )
@@ -286,7 +286,7 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
 
     if ep_not_supported:
         logger.warning(
-            "The following execution provider is not supported: %s. "
+            "The following execution providers are not supported: %s. "
             "Please consider installing an onnxruntime build that contains the relevant execution providers. ",
             ",".join(ep_not_supported),
         )

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -197,7 +197,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             ["CPUExecutionProvider"],
         ),
         (
-            # deduce devide for GPU
+            # deduce device for GPU
             {
                 "type": "LocalSystem",
                 "config": {

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -217,7 +217,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             ["CUDAExecutionProvider", "CPUExecutionProvider"],
         ),
         (
-            # dosn't fill both device and ep.
+            # doesn't fill both device and ep.
             {
                 "type": "LocalSystem",
                 "config": {"accelerators": [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider"]}]},
@@ -323,7 +323,7 @@ def test_normalize_accelerators(
             {"type": "LocalSystem"},
             ["OpenVINOExecutionProvider", "CPUExecutionProvider"],
             AssertionError,
-            "Cannot infer the accelerators from the execution providers",
+            "Cannot infer the devices from the execution providers",
         ),
         (
             {"type": "PythonEnvironment", "config": {"olive_managed_env": True}},
@@ -354,7 +354,7 @@ def test_normalize_accelerators(
             ["CPUExecutionProvider"],
             AssertionError,
             (
-                "Cannot infer the accelerators from the execution providers "
+                "Cannot infer the devices from the execution providers "
                 "['OpenVINOExecutionProvider', 'CPUExecutionProvider']."
             ),
         ),
@@ -368,8 +368,8 @@ def test_normalize_accelerators(
             ["CPUExecutionProvider"],
             AssertionError,
             (
-                "Cannot infer the accelerators from the execution providers "
-                "['QNNExecutionProvider', 'CUDAExecutionProvider']. Multiple accelerators are inferred: ['npu', 'gpu']."
+                "Cannot infer the devices from the execution providers "
+                "['QNNExecutionProvider', 'CUDAExecutionProvider']. Multiple devices are inferred: ['npu', 'gpu']."
             ),
         ),
     ],

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -178,7 +178,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             {"type": "LocalSystem", "config": {"accelerators": [{"device": "cpu"}]}},
             [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider", "CPUExecutionProvider"]}],
             [
-                "The following execution provider is not supported: DmlExecutionProvider.",
+                "The following execution providers are filtered: DmlExecutionProvider.",
                 (
                     "The accelerator execution providers is not specified for cpu. Use the inferred ones. "
                     "['OpenVINOExecutionProvider', 'CPUExecutionProvider']"
@@ -248,7 +248,32 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
                     "execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
                 }
             ],
-            ["The following execution provider is not supported: ROCMExecutionProvider"],
+            ["The following execution providers are not supported: ROCMExecutionProvider"],
+            ["CUDAExecutionProvider", "CPUExecutionProvider"],
+        ),
+        (
+            {
+                "type": "LocalSystem",
+                "config": {
+                    "accelerators": [
+                        {
+                            "device": "gpu",
+                            "execution_providers": [
+                                "ROCMExecutionProvider",
+                                "CUDAExecutionProvider",
+                                "CPUExecutionProvider",
+                            ],
+                        }
+                    ]
+                },
+            },
+            [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+                }
+            ],
+            ["The following execution providers are not supported: ROCMExecutionProvider"],
             ["CUDAExecutionProvider", "CPUExecutionProvider"],
         ),
     ],

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -223,7 +223,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
                 "config": {"accelerators": [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider"]}]},
             },
             [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider"]}],
-            [],
+            ["The accelerator device and execution providers are specified, skipping deduce"],
             ["OpenVINOExecutionProvider", "CPUExecutionProvider"],
         ),
         (
@@ -265,6 +265,7 @@ def test_normalize_accelerators(
     # capture logging
     logger = logging.getLogger("olive")
     logger.propagate = True
+    caplog.set_level(logging.DEBUG, logger="olive")
 
     system_config = validate_config(system_config, SystemConfig)
     python_mock = None

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -29,7 +29,7 @@ from olive.systems.system_config import SystemConfig
 )
 def test_infer_accelerators_from_execution_provider(execution_providers_test):
     execution_providers, expected_accelerators = execution_providers_test
-    actual_rls = AcceleratorLookup.infer_accelerators_from_execution_providers(execution_providers)
+    actual_rls = AcceleratorLookup.infer_devices_from_execution_providers(execution_providers)
     assert actual_rls == expected_accelerators
 
 
@@ -214,8 +214,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             AssertionError,
             (
                 "Cannot infer the accelerators from the execution providers "
-                "['OpenVINOExecutionProvider', 'CPUExecutionProvider']. "
-                "Please specify the accelerator in the accelerator configs."
+                "['OpenVINOExecutionProvider', 'CPUExecutionProvider']."
             ),
         ),
         (
@@ -230,7 +229,6 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             (
                 "Cannot infer the accelerators from the execution providers "
                 "['QNNExecutionProvider', 'CUDAExecutionProvider']. Multiple accelerators are inferred: ['npu', 'gpu']."
-                " Please specify the accelerator in the accelerator configs."
             ),
         ),
     ],

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -9,7 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from olive.common.config_utils import validate_config
-from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec, create_accelerators
+from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec, create_accelerators, normalize_accelerators
 from olive.systems.common import AcceleratorConfig, SystemType
 from olive.systems.python_environment.python_environment_system import PythonEnvironmentSystem
 from olive.systems.system_config import SystemConfig
@@ -38,46 +39,12 @@ def test_infer_accelerators_from_execution_provider(execution_providers_test):
     [
         # LocalSystem
         (
-            {"type": "LocalSystem"},
-            [("cpu", "CPUExecutionProvider")],
-            ["AzureExecutionProvider", "CPUExecutionProvider"],
-        ),
-        (
-            # openvino need device to be specified since it exists in both GPU and CPU
-            {"type": "LocalSystem", "config": {"accelerators": [{"device": "cpu"}]}},
-            [("CPU", "OpenVINOExecutionProvider"), ("cpu", "CPUExecutionProvider")],
-            ["OpenVINOExecutionProvider", "CPUExecutionProvider"],
-        ),
-        (
-            {"type": "LocalSystem"},
-            [("gpu", "TensorrtExecutionProvider"), ("gpu", "CUDAExecutionProvider"), ("gpu", "CPUExecutionProvider")],
-            ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"],
-        ),
-        (
             {
                 "type": "LocalSystem",
                 "config": {"accelerators": [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}]},
             },
             [("cpu", "CPUExecutionProvider")],
             ["CPUExecutionProvider"],
-        ),
-        (
-            {
-                "type": "LocalSystem",
-                "config": {"accelerators": [{"execution_providers": ["CPUExecutionProvider"]}]},
-            },
-            [("cpu", "CPUExecutionProvider")],
-            ["CPUExecutionProvider"],
-        ),
-        (
-            {
-                "type": "LocalSystem",
-                "config": {
-                    "accelerators": [{"execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"]}]
-                },
-            },
-            [("gpu", "CUDAExecutionProvider"), ("gpu", "CPUExecutionProvider")],
-            ["CUDAExecutionProvider", "CPUExecutionProvider"],
         ),
         # PythonEnvironment
         (
@@ -171,6 +138,154 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
 
     accelerators = create_accelerators(system_config, skip_supported_eps_check=False)
     assert accelerators == expected_accelerator_specs
+    if python_mock:
+        python_mock.stop()
+
+
+@pytest.mark.parametrize(
+    ("system_config", "expected_accs", "expected_logs", "available_providers"),
+    [
+        (
+            # fill both device and ep.
+            {"type": "LocalSystem"},
+            [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}],
+            [
+                (
+                    "There is no any accelerator specified. Inferred accelerators: "
+                    "[AcceleratorConfig(device='cpu', execution_providers=['CPUExecutionProvider'])]"
+                )
+            ],
+            ["AzureExecutionProvider", "CPUExecutionProvider"],
+        ),
+        (
+            # fill both device and ep but with GPU
+            {"type": "LocalSystem"},
+            [
+                {
+                    "device": "gpu",
+                    "execution_providers": [
+                        "TensorrtExecutionProvider",
+                        "CUDAExecutionProvider",
+                        "CPUExecutionProvider",
+                    ],
+                }
+            ],
+            [],
+            ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"],
+        ),
+        (
+            # fill the EPs.
+            {"type": "LocalSystem", "config": {"accelerators": [{"device": "cpu"}]}},
+            [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider", "CPUExecutionProvider"]}],
+            [
+                "The following execution provider is not supported: DmlExecutionProvider.",
+                (
+                    "The accelerator execution providers is not specified for cpu. Use the inferred ones. "
+                    "['OpenVINOExecutionProvider', 'CPUExecutionProvider']"
+                ),
+            ],
+            ["OpenVINOExecutionProvider", "CPUExecutionProvider", "DmlExecutionProvider"],
+        ),
+        (
+            # user only specify EPs
+            {
+                "type": "LocalSystem",
+                "config": {"accelerators": [{"execution_providers": ["CPUExecutionProvider"]}]},
+            },
+            [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}],
+            ["the accelerator device is not specified. Inferred device: cpu."],
+            ["CPUExecutionProvider"],
+        ),
+        (
+            # deduce devide for GPU
+            {
+                "type": "LocalSystem",
+                "config": {
+                    "accelerators": [{"execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"]}]
+                },
+            },
+            [
+                {
+                    "device": "gpu",
+                    "execution_providers": [
+                        "CUDAExecutionProvider",
+                        "CPUExecutionProvider",
+                    ],
+                }
+            ],
+            [],
+            ["CUDAExecutionProvider", "CPUExecutionProvider"],
+        ),
+        (
+            # dosn't fill both device and ep.
+            {
+                "type": "LocalSystem",
+                "config": {"accelerators": [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider"]}]},
+            },
+            [{"device": "cpu", "execution_providers": ["OpenVINOExecutionProvider"]}],
+            [],
+            ["OpenVINOExecutionProvider", "CPUExecutionProvider"],
+        ),
+        (
+            # user specify invalid EPs.
+            {
+                "type": "LocalSystem",
+                "config": {
+                    "accelerators": [
+                        {
+                            "execution_providers": [
+                                "ROCMExecutionProvider",
+                                "CUDAExecutionProvider",
+                                "CPUExecutionProvider",
+                            ]
+                        }
+                    ]
+                },
+            },
+            [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+                }
+            ],
+            ["The following execution provider is not supported: ROCMExecutionProvider"],
+            ["CUDAExecutionProvider", "CPUExecutionProvider"],
+        ),
+    ],
+)
+@patch("onnxruntime.get_available_providers")
+def test_normalize_accelerators(
+    get_available_providers_mock,
+    caplog,
+    system_config,
+    expected_accs,
+    expected_logs,
+    available_providers,
+):
+    # capture logging
+    logger = logging.getLogger("olive")
+    logger.propagate = True
+
+    system_config = validate_config(system_config, SystemConfig)
+    python_mock = None
+    if system_config.type == SystemType.Local:
+        get_available_providers_mock.return_value = available_providers
+    elif system_config.type == SystemType.PythonEnvironment:
+        python_mock = patch.object(
+            PythonEnvironmentSystem, "get_supported_execution_providers", return_value=available_providers
+        )
+        python_mock.start()
+
+    normalized_accs = normalize_accelerators(system_config, skip_supported_eps_check=False)
+    assert len(normalized_accs.config.accelerators) == len(expected_accs)
+    for i, acc in enumerate(expected_accs):
+        assert normalized_accs.config.accelerators[i].device == acc["device"]
+        assert normalized_accs.config.accelerators[i].execution_providers == acc["execution_providers"]
+
+    if expected_logs:
+        for log in expected_logs:
+            assert log in caplog.text
+
     if python_mock:
         python_mock.stop()
 


### PR DESCRIPTION
## Describe your changes
* Refactor accelerator normalization logic so that the host system could reuse it when we introduce host device later.
* If user specify EP and device explicitly, the EP will always be override by the available EPs. This PR also fix the bug. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
