### PR TITLE
CI: Exclude managed identity from azureml client credentials

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -58,9 +58,6 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
-        AZURE_TENANT_ID: $(azure-tenant-id)
-        AZURE_CLIENT_ID: $(olive-rg-sp-id)
-        AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
 
     - task: ComponentGovernanceComponentDetection@0
       inputs:

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -64,9 +64,6 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
-        AZURE_TENANT_ID: $(azure-tenant-id)
-        AZURE_CLIENT_ID: $(olive-rg-sp-id)
-        AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
   - ${{ else }}:
     - task: AzureCLI@1
       inputs:
@@ -84,9 +81,6 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
-        AZURE_TENANT_ID: $(azure-tenant-id)
-        AZURE_CLIENT_ID: $(olive-rg-sp-id)
-        AZURE_CLIENT_SECRET: $(olive-rg-sp-secret)
 
   - task: CredScan@3
     displayName: 'Run CredScan'

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -77,6 +77,8 @@ def update_azureml_config(olive_config):
         "subscription_id": subscription_id,
         "resource_group": resource_group,
         "workspace_name": workspace_name,
+        # pipeline agents have managed identities which take precedence over the Azure CLI credentials
+        # so we need to exclude managed identity credentials
         "default_auth_params": {"exclude_managed_identity_credential": True},
     }
 

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -77,6 +77,7 @@ def update_azureml_config(olive_config):
         "subscription_id": subscription_id,
         "resource_group": resource_group,
         "workspace_name": workspace_name,
+        "default_auth_params": {"exclude_managed_identity_credential": True},
     }
 
 

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -176,7 +176,8 @@ def normalize_data_path(data_root: Union[str, Path], data_dir: Union[str, Path, 
             # change the data_root to azureml:/, which is not a valid path
             data_full_path = os.path.join(data_root, data_dir_str).replace("\\", "/")
         else:
-            data_full_path = data_dir_str
+            # will keep this as is so that we don't lose information inside ResourcePath
+            data_full_path = data_dir
 
     return create_resource_path(data_full_path)
 

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -461,14 +461,13 @@ class AzureMLDatastore(ResourcePath):
 
     def get_aml_client_config(self) -> AzureMLClientConfig:
         if self.config.datastore_url:
-            subscription_id = re.split("/subscriptions/", self.config.datastore_url)[-1].split("/")[0]
-            resource_group = re.split("/resourcegroups/", self.config.datastore_url)[-1].split("/")[0]
-            workspace_name = re.split("/workspaces/", self.config.datastore_url)[-1].split("/")[0]
-            return AzureMLClientConfig(
-                subscription_id=subscription_id,
-                resource_group=resource_group,
-                workspace_name=workspace_name,
-            )
+            # datastore_url is always created by validator
+            # so we should start with azureml_client if it is already there
+            client_config = self.config.azureml_client.dict() if self.config.azureml_client else {}
+            client_config["subscription_id"] = re.split("/subscriptions/", self.config.datastore_url)[-1].split("/")[0]
+            client_config["resource_group"] = re.split("/resourcegroups/", self.config.datastore_url)[-1].split("/")[0]
+            client_config["workspace_name"] = re.split("/workspaces/", self.config.datastore_url)[-1].split("/")[0]
+            return AzureMLClientConfig.parse_obj(client_config)
         return self.config.azureml_client
 
     def save_to_dir(self, dir_path: Union[Path, str], name: str = None, overwrite: bool = False) -> str:

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -451,7 +451,10 @@ class AzureMLDatastore(ResourcePath):
                 "azureml-fsspec is not installed. Please install azureml-fsspec to use AzureMLDatastore resource path."
             ) from None
         if fsspec is None:
-            fsspec = AzureMachineLearningFileSystem(self.get_path())
+            # provide mlclient so that it is used for authentication
+            fsspec = AzureMachineLearningFileSystem(
+                self.get_path(), ml_client=self.get_aml_client_config().create_client()
+            )
         return fsspec.info(self.get_relative_path()).get("type") == "file"
 
     def get_relative_path(self) -> str:
@@ -484,7 +487,8 @@ class AzureMLDatastore(ResourcePath):
         azureml_client_config = self.get_aml_client_config()
 
         # azureml file system
-        fs = AzureMachineLearningFileSystem(self.get_path())
+        # provide mlclient so that it is used for authentication
+        fs = AzureMachineLearningFileSystem(self.get_path(), ml_client=azureml_client_config.create_client())
         relative_path = Path(self.get_relative_path())
         is_file = self.is_file(fs)
         # path to save the resource to

--- a/test/integ_test/utils.py
+++ b/test/integ_test/utils.py
@@ -26,6 +26,9 @@ def get_olive_workspace_config():
         "subscription_id": subscription_id,
         "resource_group": resource_group,
         "workspace_name": workspace_name,
+        # pipeline agents have managed identities which take precedence over the Azure CLI credentials
+        # so we need to exclude managed identity credentials
+        "default_auth_params": {"exclude_managed_identity_credential": True},
     }
 
 


### PR DESCRIPTION
## Describe your changes
Our pipeline agents have their own managed identities which take precedence over the AzureCLI task's own credentials. However, these managed identities don't have permissions to run jobs on our workspace. 

Exclude managed identity for credential so that we don't have to use the workaround with environment variables.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
