### PR TITLE
GenAIModelExporter: Update arguments to `create_model`

### DIFF
--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -10,8 +10,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict
 
-from onnx import TensorProto
-
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec, Device
 from olive.model import ONNXModelHandler, PyTorchModelHandler
 from olive.model.utils import resolve_onnx_path
@@ -67,13 +65,6 @@ class GenAIModelExporter(Pass):
             "Valid precision + execution provider combinations are: FP32 CPU, FP32 CUDA, FP16 CUDA, INT4 CPU, INT4 CUDA"
         )
 
-        # Set input/output precision of ONNX model
-        io_dtype = (
-            TensorProto.FLOAT
-            if precision in {"int8", "fp32"} or (precision == "int4" and device == Device.CPU)
-            else TensorProto.FLOAT16
-        )
-
         # Select cache location based on priority
         # HF_CACHE (HF >= v5) -> TRANSFORMERS_CACHE (HF < v5) -> local dir
         cache_dir = os.environ.get("HF_HOME", None)
@@ -82,13 +73,15 @@ class GenAIModelExporter(Pass):
         if not cache_dir:
             cache_dir = output_model_filepath.parent / "genai_cache_dir"
 
+        # currently we only support regular hf models so we can pass the name_or_path directly to model_name
+        # could also check if it is a locally saved model and pass the path to input_path but it is not necessary
         create_model(
-            model_name_or_path=str(model.hf_config.model_name),
+            model_name=str(model.model_path or model.hf_config.model_name),
+            input_path="",  # empty string for now
             output_dir=str(output_model_filepath.parent),
             precision=str(precision),
             execution_provider=str(device),
             cache_dir=str(cache_dir),
-            io_dtype=io_dtype,
             filename=str(output_model_filepath.name),
         )
 


### PR DESCRIPTION
## Describe your changes
The arguments passed to the model builder tool is not up to date with the released version. It is only on par with a pre-release commit.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
#1042