### PR TITLE
☂️ Make `data_config` optional for SNPE quantization

### DIFF
--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -51,7 +51,6 @@ class SNPEQuantization(Pass):
             ),
             "data_config": PassConfigParam(
                 type_=Union[DataConfig, Dict],
-                required=True,
                 description="Data config for quantization, required if dataloader_func is None",
             ),
             "use_enhanced_quantizer": PassConfigParam(

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -242,14 +242,14 @@ def run(
         package_config = OlivePackageConfig.get_default_config_path()
 
     # we use parse_file and parse_obj to be safe. If implemented as expected, both should be equivalent.
-    logger.info("Loading Olive module configuration: %s", package_config)
     if isinstance(package_config, (str, Path)):
+        logger.info("Loading Olive module configuration from: %s", package_config)
         package_config = OlivePackageConfig.parse_file(package_config)
     else:
         package_config = OlivePackageConfig.parse_obj(package_config)
 
-    logger.info("Loading run configuration: %s", run_config)
     if isinstance(run_config, (str, Path)):
+        logger.info("Loading run configuration from: %s", run_config)
         run_config = RunConfig.parse_file(run_config)
     else:
         run_config = RunConfig.parse_obj(run_config)


### PR DESCRIPTION
## Describe your changes

1. Make `data_config` optional for SNPE quantization as it can accept `dataloder_func` or `data_config`
2. Update run logs to let it output `package_config, run_config` only if they are str or path. Output the object will let the logs look a bit messy.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
