### PR TITLE
use host_device for TorchTRTConversion

### DIFF
--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -79,10 +79,7 @@ def update_azureml_config(olive_config):
         "workspace_name": workspace_name,
         # pipeline agents have managed identities which take precedence over the Azure CLI credentials
         # so we need to exclude managed identity credentials
-        "default_auth_params": {
-            "exclude_managed_identity_credential": True,
-            "exclude_shared_token_cache_credential": True,
-        },
+        "default_auth_params": {"exclude_managed_identity_credential": True},
     }
 
 

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -79,7 +79,10 @@ def update_azureml_config(olive_config):
         "workspace_name": workspace_name,
         # pipeline agents have managed identities which take precedence over the Azure CLI credentials
         # so we need to exclude managed identity credentials
-        "default_auth_params": {"exclude_managed_identity_credential": True},
+        "default_auth_params": {
+            "exclude_managed_identity_credential": True,
+            "exclude_shared_token_cache_credential": True,
+        },
     }
 
 

--- a/olive/azureml/azureml_client.py
+++ b/olive/azureml/azureml_client.py
@@ -133,7 +133,7 @@ class AzureMLClientConfig(ConfigBase):
             credential.get_token("https://management.azure.com/.default")
             logger.debug("Using DefaultAzureCredential")
         except Exception:
-            logger.debug("Using InteractiveBrowserCredential since of default credential errors", exc_info=True)
+            logger.warning("Using InteractiveBrowserCredential since of default credential errors", exc_info=True)
             # Fall back to InteractiveBrowserCredential in case DefaultAzureCredential not work
             credential = InteractiveBrowserCredential()
 

--- a/olive/azureml/azureml_client.py
+++ b/olive/azureml/azureml_client.py
@@ -133,8 +133,8 @@ class AzureMLClientConfig(ConfigBase):
             credential.get_token("https://management.azure.com/.default")
             logger.debug("Using DefaultAzureCredential")
         except Exception:
+            logger.debug("Using InteractiveBrowserCredential since of default credential errors", exc_info=True)
             # Fall back to InteractiveBrowserCredential in case DefaultAzureCredential not work
             credential = InteractiveBrowserCredential()
-            logger.debug("Using InteractiveBrowserCredential")
 
         return credential

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -69,7 +69,9 @@ class TorchTRTConversion(Pass):
     def validate_search_point(
         self, search_point: Dict[str, Any], accelerator_spec: AcceleratorSpec, with_fixed_value: bool = False
     ) -> bool:
-        if accelerator_spec.accelerator_type != Device.GPU:
+        # since the run will leverage the host device to move the model to device,
+        # we need to check if the host device is GPU
+        if self.host_device != Device.GPU:
             logger.info("TorchTRTConversion only supports GPU.")
             return False
         return True


### PR DESCRIPTION
## Describe your changes
in TorchTRTConversion, use host_device for conversion instead of target device.
The TorchTRTConversion need move the pytorch model to cuda by using https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.to at https://github.com/microsoft/Olive/blob/main/olive/passes/pytorch/torch_trt_conversion.py#L110.

Therefore, we need use host_device instead of target device for conversion

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
