### PR TITLE
Add fast_mode support

### DIFF
--- a/olive/common/onnx_utils.py
+++ b/olive/common/onnx_utils.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import onnx
+
+from olive.model.utils.onnx_utils import resolve_onnx_path
+
+logger = logging.getLogger(__name__)
+
+
+def model_proto_to_file(
+    model: onnx.ModelProto,
+    output_path: Union[str, Path],
+    save_as_external_data: Optional[bool] = False,
+    all_tensors_to_one_file: Optional[bool] = True,
+    external_data_name: Optional[Union[str, Path]] = None,
+    size_threshold: Optional[int] = 1024,
+    convert_attribute: Optional[bool] = False,
+) -> bool:
+    """Save the ONNX model to the specified path.
+
+    :param model: The ONNX model to save.
+    :param output_path: The path to save the ONNX model to.
+    :param save_as_external_data: If True, save tensor data to separate files instead of directly in the ONNX file.
+        Large models (>2GB) may be forced to save external data regardless of the value of this parameter.
+    :param all_tensors_to_one_file: Effective only if save_as_external_data is True. If True, save all tensors to one
+        external file specified by 'external_data_name'. If False, save each tensor to a file named with the tensor
+        name.
+    :param external_data_name: Effective only if all_tensors_to_one_file is True and save_as_external_data is True.
+        If not specified, the external data file will be named with <model_path_name>.data
+
+    :return: True if the model has external data, False otherwise.
+    """
+    output_path = Path(resolve_onnx_path(output_path))
+    if output_path.exists():
+        logger.info("Deleting existing onnx file: %s", output_path)
+        output_path.unlink()
+
+    # parent directory of .onnx file
+    output_dir = output_path.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not save_as_external_data:
+        try:
+            # save model
+            onnx.save_model(model, str(output_path))
+            return False
+        except ValueError as e:
+            # there are different types of error message for large model (>2GB) based on onnx version
+            # just try to save as external data
+            # if it fails, raise the original error
+            try:
+                logger.debug("Model save failed with error: %s. Trying to save as external data.", e)
+                model_proto_to_file(model, output_path, True, all_tensors_to_one_file, external_data_name)
+                logger.warning(
+                    "Model is too large to save as a single file but 'save_as_external_data' is False. Saved tensors"
+                    " as external data regardless."
+                )
+                return True
+            except Exception:
+                raise e from None
+
+    # location for external data
+    external_data_path = output_dir / (external_data_name if external_data_name else f"{output_path.name}.data")
+    location = external_data_path.name if all_tensors_to_one_file else None
+
+    if all_tensors_to_one_file:
+        if external_data_path.exists():
+            # Delete the external data file. Otherwise, data will be appended to existing file.
+            logger.info("Deleting existing external data file: %s", external_data_path)
+            external_data_path.unlink()
+    else:
+        if any(output_dir.iterdir()):
+            raise RuntimeError(f"Output directory ({output_dir}) for external data is not empty.")
+
+    # save model
+    onnx.save_model(
+        model,
+        str(output_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=all_tensors_to_one_file,
+        location=location,
+        size_threshold=size_threshold,
+        convert_attribute=convert_attribute,
+    )
+    return True

--- a/olive/engine/config.py
+++ b/olive/engine/config.py
@@ -26,6 +26,7 @@ class EngineConfig(ConfigBase, extra=Extra.forbid):
     host: SystemConfig = None
     target: SystemConfig = None
     evaluator: OliveEvaluatorConfig = None
+    enable_fast_mode: bool = False
     azureml_client_config: Optional[AzureMLClientConfig] = None
     packaging_config: PackagingConfig = None
     cache_dir: Union[Path, str] = ".olive-cache"

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -252,7 +252,7 @@ def _save_model(
                 # file_name for .onnx file is model.onnx, otherwise keep the original file name
                 model_config = pf_footprint.get_model_config(model_id)
                 onnx_file_name = model_config.get("onnx_file_name")
-                onnx_model = ONNXModelHandler(temp_resource_path, onnx_file_name)
+                onnx_model = ONNXModelHandler(model_path=temp_resource_path, onnx_file_name=onnx_file_name)
                 model_name = Path(onnx_model.model_path).name
                 for file in Path(temp_resource_path.get_path()).iterdir():
                     if file.name == model_name:

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -576,7 +576,7 @@ class OnnxEvaluator(OliveEvaluator, OnnxEvaluatorMixin, framework=Framework.ONNX
             for provider in execution_providers
         ]
 
-        model = ONNXModelHandler(model_path, inference_settings=inference_settings)
+        model = ONNXModelHandler(model_path=model_path, inference_settings=inference_settings)
         dataloader, _, post_func = OnnxEvaluator.get_user_config(model.framework, data_root, metric)
 
         session = model.prepare_session(inference_settings=inference_settings, device=Device.GPU, rank=int(local_rank))
@@ -662,7 +662,7 @@ class OnnxEvaluator(OliveEvaluator, OnnxEvaluatorMixin, framework=Framework.ONNX
             for provider in execution_providers
         ]
 
-        model = ONNXModelHandler(model_path, inference_settings=inference_settings)
+        model = ONNXModelHandler(model_path=model_path, inference_settings=inference_settings)
         dataloader, _, _ = OnnxEvaluator.get_user_config(model.framework, data_root, metric)
         session = model.prepare_session(inference_settings=inference_settings, device=Device.GPU, rank=int(local_rank))
         io_config = model.get_io_config()

--- a/olive/model/config/model_config.py
+++ b/olive/model/config/model_config.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from typing import Any
+
 from olive.common.config_utils import ConfigBase
 from olive.common.pydantic_v1 import validator
 from olive.model.config.registry import get_model_handler, is_valid_model_type
@@ -88,6 +90,8 @@ class ModelConfig(ConfigBase):
 
     type: str
     config: dict
+    # For enable_fast_mode only. Otherwise, it will be None.
+    loaded_model: Any = None
 
     @validator("type")
     def validate_type(cls, v):
@@ -107,3 +111,7 @@ class ModelConfig(ConfigBase):
     def create_model(self):
         cls = get_model_handler(self.type)
         return cls(**self.config)
+
+    def to_json(self, check_object: bool = False) -> dict:
+        self.loaded_model = None
+        return super().to_json(check_object)

--- a/olive/model/handler/base.py
+++ b/olive/model/handler/base.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from olive.constants import Framework, ModelFileFormat
@@ -34,10 +35,12 @@ class OliveModelHandler(ABC, ResourceMixin, IoConfigMixin, JsonMixin, CompositeM
         self,
         framework: Framework,
         model_file_format: ModelFileFormat,
+        model: Optional[object] = None,
         model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         model_attributes: Optional[Dict[str, Any]] = None,
     ):
         self.framework = framework
+        self.model = model
         self.model_file_format = model_file_format
         self.composite_parent = None
         self.model_attributes = model_attributes
@@ -57,7 +60,7 @@ class OliveModelHandler(ABC, ResourceMixin, IoConfigMixin, JsonMixin, CompositeM
         return self.get_resource("model_path")
 
     @abstractmethod
-    def load_model(self, rank: int = None) -> object:
+    def load_model(self, rank: int = None, enable_fast_mode: bool = False) -> object:
         """Load model from disk, return in-memory model object.
 
         Derived class should implement its specific logic if needed.
@@ -73,6 +76,14 @@ class OliveModelHandler(ABC, ResourceMixin, IoConfigMixin, JsonMixin, CompositeM
         rank: Optional[int] = None,
     ):
         """Prepare inference session for Olive model, return in-memory inference session.
+
+        Derived class should implement its specific logic if needed.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_model_to_path(self, save_path: Union[str, Path], model_name: Optional[str] = None):
+        """Save model to disk.
 
         Derived class should implement its specific logic if needed.
         """

--- a/olive/model/handler/composite.py
+++ b/olive/model/handler/composite.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from olive.common.config_utils import serialize_to_json, validate_config
@@ -66,7 +67,10 @@ class CompositeModelHandler(OliveModelHandler):
     def get_model_components(self) -> List[Tuple[str, OliveModelHandler]]:
         return zip(self.model_component_names, self.model_components)
 
-    def load_model(self, rank: int = None):
+    def load_model(self, rank: int = None, enable_fast_mode: bool = False):
+        raise NotImplementedError
+
+    def save_model_to_path(self, save_path: Union[str, Path], model_name: Optional[str] = None):
         raise NotImplementedError
 
     def prepare_session(

--- a/olive/model/handler/mixin/onnx_graph.py
+++ b/olive/model/handler/mixin/onnx_graph.py
@@ -71,7 +71,7 @@ class OnnxGraphMixin:
         # external data is not needed for io config parsing
         # the .onnx model already contains all of the graph information
         # this method works whether the external data is in the same directory or not
-        model = onnx.load(self.model_path, load_external_data=False)
+        model = self.model or onnx.load(self.model_path, load_external_data=False)
         io_config = {
             "input_names": [],
             "input_shapes": [],

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -360,6 +360,9 @@ class DistributedPyTorchModelHandler(OliveModelHandler, HfConfigMixin):
             model_attributes=self.model_attributes,
         )
 
+    def save_model_to_path(self, save_path: Union[str, Path], model_name: Optional[str] = None):
+        raise NotImplementedError
+
     def get_component_model(self, component: HfComponent, rank: int = 0) -> PyTorchModelHandler:
         # TODO(shaahji): Add support for 'HfComponent.component_func'
         hf_config = deepcopy(self.hf_config).dict()

--- a/olive/model/handler/qnn.py
+++ b/olive/model/handler/qnn.py
@@ -77,8 +77,11 @@ class QNNModelHandler(OliveModelHandler):
             raise ValueError(f"Unsupported model file format {self.model_file_format}")
         return model_path
 
-    def load_model(self, rank: int = None):
+    def load_model(self, rank: int = None, enable_fast_mode: bool = False):
         raise NotImplementedError("QNNModelHandler does not support load_model")
+
+    def save_model_to_path(self, save_path: Union[str, Path], model_name: Optional[str] = None):
+        raise NotImplementedError
 
     def prepare_session(
         self,

--- a/olive/model/handler/snpe.py
+++ b/olive/model/handler/snpe.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from olive.common.config_utils import serialize_to_json
@@ -39,7 +40,10 @@ class SNPEModelHandler(OliveModelHandler):
             "output_shapes": output_shapes,
         }
 
-    def load_model(self, rank: int = None):
+    def load_model(self, rank: int = None, enable_fast_mode: bool = False):
+        raise NotImplementedError
+
+    def save_model_to_path(self, save_path: Union[str, Path], model_name: Optional[str] = None):
         raise NotImplementedError
 
     def prepare_session(

--- a/olive/model/handler/tensorflow.py
+++ b/olive/model/handler/tensorflow.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from olive.constants import Framework, ModelFileFormat
@@ -26,7 +27,10 @@ class TensorFlowModelHandler(OliveModelHandler):
             model_attributes=model_attributes,
         )
 
-    def load_model(self, rank: int = None):
+    def load_model(self, rank: int = None, enable_fast_mode: bool = False):
+        raise NotImplementedError
+
+    def save_model_to_path(self, save_path: Union[str, Path], model_name: Optional[str] = None):
         raise NotImplementedError
 
     def prepare_session(

--- a/olive/model/utils/onnx_utils.py
+++ b/olive/model/utils/onnx_utils.py
@@ -5,7 +5,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from olive.model.utils.path_utils import normalize_path_suffix
 
@@ -27,7 +27,7 @@ def resolve_onnx_path(file_or_dir_path: str, model_filename: str = "model.onnx")
     return normalize_path_suffix(file_or_dir_path, model_filename)
 
 
-def get_onnx_file_path(model_path: str, onnx_file_name: Optional[str] = None) -> str:
+def get_onnx_file_path(model_path: Union[str, Path], onnx_file_name: Optional[str] = None) -> str:
     """Get the path to the ONNX model file.
 
     If model_path is a file, it is returned as is. If model_path is a

--- a/olive/passes/onnx/dynamic_to_fixed_shape.py
+++ b/olive/passes/onnx/dynamic_to_fixed_shape.py
@@ -66,10 +66,11 @@ class DynamicToFixedShape(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         from onnxruntime.tools.onnx_model_utils import fix_output_shapes, make_dim_param_fixed, make_input_shape_fixed
 
-        onnx_model = model.load_model()
+        onnx_model = model.load_model(enable_fast_mode=enable_fast_mode)
         output_model_path = resolve_onnx_path(output_model_path)
 
         if config["dim_param"]:
@@ -80,7 +81,7 @@ class DynamicToFixedShape(Pass):
                 make_input_shape_fixed(onnx_model.graph, name, shape)
         # update the output shapes to make them fixed
         fix_output_shapes(onnx_model)
-        return model_proto_to_olive_model(onnx_model, output_model_path, config)
+        return model_proto_to_olive_model(onnx_model, output_model_path, config, enable_fast_mode=enable_fast_mode)
 
 
 def _jointly_validate_configs(cls, values):

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -5,8 +5,6 @@
 from pathlib import Path
 from typing import Any, Dict, List
 
-import onnx
-
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
@@ -48,7 +46,12 @@ class OnnxFloatToFloat16(Pass):
         return config
 
     def _run_for_config(
-        self, model: ONNXModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: ONNXModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         from onnxconverter_common import float16
 
@@ -56,7 +59,7 @@ class OnnxFloatToFloat16(Pass):
 
         config = self._config_class(**config)
 
-        model_fp32 = onnx.load(str(model.model_path))
+        model_fp32 = model.load_model(enable_fast_mode=enable_fast_mode)
         model_fp16 = float16.convert_float_to_float16(
             model_fp32,
             min_positive_val=config.min_positive_val,
@@ -68,4 +71,6 @@ class OnnxFloatToFloat16(Pass):
         )
 
         # save the model to the output path and return the model
-        return model_proto_to_olive_model(model_fp16, output_model_path, config.dict())
+        return model_proto_to_olive_model(
+            model_fp16, output_model_path, config.dict(), enable_fast_mode=enable_fast_mode
+        )

--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -41,7 +41,12 @@ class GenAIModelExporter(Pass):
         }
 
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         from onnxruntime_genai.models.builder import create_model
 
@@ -85,4 +90,4 @@ class GenAIModelExporter(Pass):
             filename=str(output_model_filepath.name),
         )
 
-        return ONNXModelHandler(output_model_filepath.parent, onnx_file_name=output_model_filepath.name)
+        return ONNXModelHandler(model_path=output_model_filepath.parent, onnx_file_name=output_model_filepath.name)

--- a/olive/passes/onnx/insert_beam_search.py
+++ b/olive/passes/onnx/insert_beam_search.py
@@ -316,7 +316,12 @@ class InsertBeamSearch(Pass):
         model.graph.input.insert(1, mask)
 
     def _run_for_config(
-        self, model: OliveModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: OliveModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         from onnxruntime import __version__ as OrtVersion
         from onnxruntime.transformers import onnx_model as ort_onnx_model
@@ -360,4 +365,6 @@ class InsertBeamSearch(Pass):
         )
         # save the model to the output path and return the model
         output_model_path = resolve_onnx_path(output_model_path, "model_with_beam_search.onnx")
-        return model_proto_to_olive_model(combined_model, output_model_path, config, True)
+        return model_proto_to_olive_model(
+            combined_model, output_model_path, config, True, enable_fast_mode=enable_fast_mode
+        )

--- a/olive/passes/onnx/mixed_precision.py
+++ b/olive/passes/onnx/mixed_precision.py
@@ -37,7 +37,12 @@ class OrtMixedPrecision(Pass):
         return config
 
     def _run_for_config(
-        self, model: ONNXModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: ONNXModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         """Convert model to mixed precision.
 
@@ -96,11 +101,13 @@ class OrtMixedPrecision(Pass):
 
         logger.info("auto_mixed_precision parameters: %s", parameters)
         fp16_model = self._convert_float_to_float16(
-            model=model.load_model(), use_symbolic_shape_infer=True, **parameters
+            model=model.load_model(enable_fast_mode=enable_fast_mode), use_symbolic_shape_infer=True, **parameters
         )
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
         config = self._config_class(**config)
-        return model_proto_to_olive_model(fp16_model, output_model_path, config.dict())
+        return model_proto_to_olive_model(
+            fp16_model, output_model_path, config.dict(), enable_fast_mode=enable_fast_mode
+        )
 
     def _convert_float_to_float16(self, model, use_symbolic_shape_infer=True, **kwargs):
         """Convert a model to half (default) or mixed precision.

--- a/olive/passes/onnx/model_optimizer.py
+++ b/olive/passes/onnx/model_optimizer.py
@@ -224,7 +224,12 @@ class OnnxModelOptimizer(Pass):
         return get_external_data_config()
 
     def _run_for_config(
-        self, model: ONNXModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: ONNXModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
@@ -238,4 +243,6 @@ class OnnxModelOptimizer(Pass):
         model_optimizer.fuse_reshape_operations()
 
         # save the model to the output path and return the model
-        return model_proto_to_olive_model(model_optimizer.model, output_model_path, config)
+        return model_proto_to_olive_model(
+            model_optimizer.model, output_model_path, config, enable_fast_mode=enable_fast_mode
+        )

--- a/olive/passes/onnx/moe_experts_distributor.py
+++ b/olive/passes/onnx/moe_experts_distributor.py
@@ -394,7 +394,12 @@ class MoEExpertsDistributor(Pass):
         return {"validate_distributor_config": validator("world_size", allow_reuse=True)(cls._validate_world_size)}
 
     def _run_for_config(
-        self, model: ONNXModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: ONNXModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> DistributedOnnxModelHandler:
         # huggingface/tokenizers: The current process just got forked, after parallelism has already been used.
         # Disabling parallelism to avoid deadlocks...

--- a/olive/passes/onnx/optimum_conversion.py
+++ b/olive/passes/onnx/optimum_conversion.py
@@ -63,7 +63,12 @@ class OptimumConversion(Pass):
         return True
 
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> Union[ONNXModelHandler, CompositeModelHandler]:
         from optimum import version as optimum_version
         from optimum.exporters.onnx import main_export as export_optimum_model

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -44,7 +44,12 @@ class OptimumMerging(Pass):
         return config
 
     def _run_for_config(
-        self, model: CompositeModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: CompositeModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> Union[ONNXModelHandler, CompositeModelHandler]:
         import onnxruntime
 
@@ -74,7 +79,9 @@ class OptimumMerging(Pass):
         # onnx.save will fail if the directory doesn't already exist
         output_model_path = resolve_onnx_path(output_model_path, "decoder_model_merged.onnx")
 
-        olive_model = model_proto_to_olive_model(merged_model, output_model_path, config)
+        olive_model = model_proto_to_olive_model(
+            merged_model, output_model_path, config, enable_fast_mode=enable_fast_mode
+        )
 
         # Doing a dry run of ORT allows us to remove the initializers that were orphaned by the merging step
         sess_options = onnxruntime.SessionOptions()

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -292,7 +292,12 @@ class OrtPerfTuning(Pass):
         }
 
     def _run_for_config(
-        self, model: ONNXModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: ONNXModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         config = self._config_class(**config)
         # TODO(jambayk): decide on whether to ignore the output_model_path

--- a/olive/passes/onnx/pipeline/step_utils.py
+++ b/olive/passes/onnx/pipeline/step_utils.py
@@ -164,7 +164,6 @@ def parse_step_params(model: onnx.ModelProto, step_config: Dict):
 
     params = {}
     for param_name, param_value in step_params.items():
-        # print(param_name, param_value)
         if isinstance(param_value, list):
             resolved_params = []
             for p_v in param_value:

--- a/olive/passes/onnx/qnn_preprocess.py
+++ b/olive/passes/onnx/qnn_preprocess.py
@@ -78,6 +78,7 @@ class QNNPreprocess(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         from onnxruntime import __version__ as OrtVersion
         from packaging import version

--- a/olive/passes/openvino/conversion.py
+++ b/olive/passes/openvino/conversion.py
@@ -69,6 +69,7 @@ class OpenVINOConversion(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> OpenVINOModelHandler:
         try:
             import openvino as ov
@@ -103,6 +104,9 @@ class OpenVINOConversion(Pass):
         }
 
         ov_model = ov.convert_model(**args)
+
+        if enable_fast_mode:
+            return OpenVINOModelHandler(model=ov_model)
 
         model_name = "ov_model"
         output_dir = Path(output_model_path) / config.get("output_model", model_name)

--- a/olive/passes/openvino/quantization.py
+++ b/olive/passes/openvino/quantization.py
@@ -221,7 +221,12 @@ class OpenVINOQuantizationBase(Pass):
 class OpenVINOQuantization(OpenVINOQuantizationBase):
 
     def _run_for_config(
-        self, model: OpenVINOModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: OpenVINOModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> OpenVINOModelHandler:
         try:
             import nncf
@@ -236,6 +241,9 @@ class OpenVINOQuantization(OpenVINOQuantizationBase):
         extra_params = self._get_extra_params(config)
 
         quantized_model = nncf.quantize(model, calibration_dataset, **extra_params)
+
+        if enable_fast_mode:
+            return OpenVINOModelHandler(model=quantized_model)
 
         model_name = "ov_model"
         output_dir = Path(output_model_path) / model_name
@@ -281,7 +289,12 @@ class OpenVINOQuantizationWithAccuracy(OpenVINOQuantizationBase):
         return config
 
     def _run_for_config(
-        self, model: OliveModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: OliveModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> OliveModelHandler:
         try:
             import nncf

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -120,7 +120,12 @@ class GptqQuantizer(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> PyTorchModelHandler:
         from auto_gptq import BaseQuantizeConfig
         from auto_gptq.modeling import BaseGPTQForCausalLM

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -787,7 +787,12 @@ class LoRA(LoRABase):
         return config
 
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> PyTorchModelHandler:
         # convert config to pass config class
         # this will validate the config and convert to the correct types
@@ -843,7 +848,12 @@ class QLoRABase(LoRABase):
         return config
 
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> PyTorchModelHandler:
         # convert config to pass config class
         # this will validate the config and convert to the correct types

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -98,7 +98,12 @@ class QuantizationAwareTraining(Pass):
         }
 
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> PyTorchModelHandler:
         from olive.passes.pytorch.qat_utils import QatTrainer
 

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -92,7 +92,12 @@ class SparseGPT(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> PyTorchModelHandler:
         model_type = model.model_attributes["model_type"]
         if model_type not in supported_models:

--- a/olive/passes/pytorch/tensor_parallel.py
+++ b/olive/passes/pytorch/tensor_parallel.py
@@ -144,7 +144,12 @@ class PyTorchTensorParallel(Pass):
         return 1  # Return 1 for success.
 
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> DistributedPyTorchModelHandler:
         world_size = int(config["world_size"])
         output_model_path = Path(output_model_path)

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -78,7 +78,12 @@ class TorchTRTConversion(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: PyTorchModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> PyTorchModelHandler:
         from olive.passes.pytorch.trt_utils import compile_trt_model
 

--- a/olive/passes/qnn/context_binary_generator.py
+++ b/olive/passes/qnn/context_binary_generator.py
@@ -56,6 +56,7 @@ class QNNContextBinaryGenerator(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> QNNModelHandler:
         main_cmd = "qnn-context-binary-generator"
         runner = QNNSDKRunner(use_dev_tools=True)

--- a/olive/passes/qnn/conversion.py
+++ b/olive/passes/qnn/conversion.py
@@ -69,6 +69,7 @@ class QNNConversion(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> QNNModelHandler:
         if isinstance(model, TensorFlowModelHandler):
             converter_platform = "tensorflow"

--- a/olive/passes/qnn/model_lib_generator.py
+++ b/olive/passes/qnn/model_lib_generator.py
@@ -50,6 +50,7 @@ class QNNModelLibGenerator(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> QNNModelHandler:
         main_cmd = "qnn-model-lib-generator"
         runner = QNNSDKRunner(use_dev_tools=True)

--- a/olive/passes/snpe/conversion.py
+++ b/olive/passes/snpe/conversion.py
@@ -98,6 +98,7 @@ class SNPEConversion(Pass):
         data_root: str,
         config: Dict[str, Any],
         output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> SNPEModelHandler:
         if Path(output_model_path).suffix != ".dlc":
             output_model_path += ".dlc"

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -85,7 +85,12 @@ class SNPEQuantization(Pass):
         }
 
     def _run_for_config(
-        self, model: SNPEModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: SNPEModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> SNPEModelHandler:
         if Path(output_model_path).suffix != ".dlc":
             output_model_path += ".dlc"

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -51,7 +51,12 @@ class SNPEtoONNXConversion(Pass):
         }
 
     def _run_for_config(
-        self, model: SNPEModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+        self,
+        model: SNPEModelHandler,
+        data_root: str,
+        config: Dict[str, Any],
+        output_model_path: str,
+        enable_fast_mode: bool = False,
     ) -> ONNXModelHandler:
         config = self._config_class(**config)
 
@@ -61,4 +66,6 @@ class SNPEtoONNXConversion(Pass):
         onnx_model = dlc_to_onnx(model.model_path, config.dict(), **model.io_config)
 
         # save the model to the output path and return the model
-        return model_proto_to_olive_model(onnx_model, output_model_path, config.dict())
+        return model_proto_to_olive_model(
+            onnx_model, output_model_path, config.dict(), enable_fast_mode=enable_fast_mode
+        )

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -171,6 +171,7 @@ class AzureMLSystem(OliveSystem):
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
+        enable_fast_mode: bool = False,
     ) -> ModelConfig:
         """Run the pass on the model at a specific point in the search space."""
         ml_client = self.azureml_client_config.create_client()

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -109,6 +109,7 @@ class DockerSystem(OliveSystem):
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
+        enable_fast_mode: bool = False,
     ) -> "ModelConfig":
         """Run the pass on the model at a specific point in the search space."""
         with tempfile.TemporaryDirectory() as tempdir:

--- a/olive/systems/isolated_ort/isolated_ort_system.py
+++ b/olive/systems/isolated_ort/isolated_ort_system.py
@@ -65,6 +65,7 @@ class IsolatedORTSystem(OliveSystem):
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
+        enable_fast_mode: bool = False,
     ) -> "ModelConfig":
         """Run the pass on the model at a specific point in the search space."""
         logger.warning("IsolatedORTSystem does not support running passes.")

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorFactory
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from olive.evaluator.metric import Metric, MetricResult
     from olive.passes.olive_pass import Pass
 
+logger = logging.getLogger(__name__)
+
 
 class LocalSystem(OliveSystem):
     system_type = SystemType.Local
@@ -25,11 +28,17 @@ class LocalSystem(OliveSystem):
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
+        enable_fast_mode: bool = False,
     ) -> ModelConfig:
         """Run the pass on the model at a specific point in the search space."""
         model = model_config.create_model()
-        output_model = the_pass.run(model, data_root, output_model_path, point)
-        return ModelConfig.from_json(output_model.to_json())
+        model.model = model_config.loaded_model
+
+        output_model = the_pass.run(model, data_root, output_model_path, point, enable_fast_mode)
+        model_config = ModelConfig.from_json(output_model.to_json())
+        model_config.loaded_model = output_model.model
+
+        return model_config
 
     def evaluate_model(
         self, model_config: ModelConfig, data_root: str, metrics: List["Metric"], accelerator: AcceleratorSpec
@@ -42,6 +51,7 @@ class LocalSystem(OliveSystem):
         execution_providers = accelerator.execution_provider if accelerator else None
 
         model = model_config.create_model()
+        model.model = model_config.loaded_model
         evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
         return evaluator.evaluate(model, data_root, metrics, device=device, execution_providers=execution_providers)
 

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -47,6 +47,7 @@ class OliveSystem(ABC):
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
+        enable_fast_mode: bool = False,
     ) -> "ModelConfig":
         """Run the pass on the model at a specific point in the search space."""
         raise NotImplementedError

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -111,6 +111,7 @@ class PythonEnvironmentSystem(OliveSystem):
         data_root: str,
         output_model_path: str,
         point: Optional[Dict[str, Any]] = None,
+        enable_fast_mode: bool = False,
     ) -> ModelConfig:
         """Run the pass on the model at a specific point in the search space."""
         point = point or {}

--- a/olive/workflows/snpe/convertquantize/convertquantize.py
+++ b/olive/workflows/snpe/convertquantize/convertquantize.py
@@ -46,7 +46,7 @@ def convertquantize(
     model_file = Path(model).resolve()
     if model_file.suffix == ".onnx":
         logger.info("Loading model...")
-        model = ONNXModelHandler(model_file)
+        model = ONNXModelHandler(model_path=model_file)
     elif model_file.suffix == ".pb":
         logger.info("Loading model...")
         model = TensorFlowModelHandler(model_file)

--- a/test/integ_test/evaluator/local_eval/test_local_evaluation.py
+++ b/test/integ_test/evaluator/local_eval/test_local_evaluation.py
@@ -54,8 +54,8 @@ class TestLocalEvaluation:
     def test_evaluate_model(self, type, model_config_func, metric_func, expected_res):  # noqa: A002
         model_config = model_config_func()
         metric = metric_func()
-        model_conf = ModelConfig.parse_obj({"type": type, "config": model_config})
-        actual_res = LocalSystem().evaluate_model(model_conf, None, [metric], DEFAULT_CPU_ACCELERATOR)
+        model = ModelConfig.parse_obj({"type": type, "config": model_config})
+        actual_res = LocalSystem().evaluate_model(model, None, [metric], DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/unit_test/passes/onnx/test_bnb_quantization.py
+++ b/test/unit_test/passes/onnx/test_bnb_quantization.py
@@ -29,7 +29,7 @@ def get_onnx_matmul_model(model_path, model_attributes=None):
         output_names=["output"],
         opset_version=13,
     )
-    return ONNXModelHandler(model_path, model_attributes=model_attributes)
+    return ONNXModelHandler(model_path=model_path, model_attributes=model_attributes)
 
 
 def get_onnx_gemm_model(model_path=None, model_attributes=None):

--- a/test/unit_test/passes/onnx/test_dynamic_to_fixed_shape.py
+++ b/test/unit_test/passes/onnx/test_dynamic_to_fixed_shape.py
@@ -57,7 +57,7 @@ def test_dynamic_to_fixed_shape_validator(pass_config, err_msg):
 def test_dynamic_to_fixed_shape(pass_config, tmp_path):
     dynamic_shape_model_path = tmp_path / "input_model.onnx"
     create_onnx_model_with_dynamic_axis(dynamic_shape_model_path)
-    input_model = ONNXModelHandler(dynamic_shape_model_path)
+    input_model = ONNXModelHandler(model_path=dynamic_shape_model_path)
     input_onnx_model = input_model.load_model()
     assert input_onnx_model.graph.input[0].type.tensor_type.shape.dim[0].dim_param == "batch_size"
     assert input_onnx_model.graph.output[0].type.tensor_type.shape.dim[0].dim_param == "batch_size"

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -524,7 +524,7 @@ class TestAzureMLSystem:
 
         # mock output
         shutil.copy(ONNX_MODEL_PATH, output_dir)
-        mock_conversion_run.return_value = ONNXModelHandler(output_dir / ONNX_MODEL_PATH.name)
+        mock_conversion_run.return_value = ONNXModelHandler(model_path=(output_dir / ONNX_MODEL_PATH.name))
 
         # execute
         args = [

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -34,7 +34,7 @@ class TestLocalSystem:
         self.system.run_pass(p, olive_model, None, output_model_path)
 
         # assert
-        p.run.assert_called_once_with(olive_model.create_model(), None, output_model_path, None)
+        p.run.assert_called_once_with(olive_model.create_model(), None, output_model_path, None, False)
 
     METRIC_TEST_CASE: ClassVar[List[Metric]] = [
         (partial(get_accuracy_metric, AccuracySubType.ACCURACY_SCORE)),


### PR DESCRIPTION
## Describe your changes

_This is only a draft PR._

Add fast_mode support.

For large models, there is a pain point for Olive for now. We constantly save and load model again between pass and pass and between pass and evaluator, which could waste a bunch of time. So we introduce `fast_mode` for Olive workflow.

`fast_mode` will:

- Pass loaded model between pass and pass or between pass and evaluator.
- No cache for intermediate models.
- Save final model.
- Only support local system.
- require latest ort nightly package >= 1.18.0.dev20240405004

Cons:

- Search could be slower than running workflow with cache. Depends on model size and search algorithm.

`fast_mode` should be used for large model + no search for best running time.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
