### PR TITLE
CI: Use managed identity for Azure authentication

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -43,11 +43,7 @@ jobs:
       displayName: Set exampleRequirements
       condition: eq(variables['exampleRequirements'], '')
 
-    - task: AzureCLI@1
-      inputs:
-        azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
-        scriptLocation: 'inlineScript'
-        inlineScript: |
+    - script: |
           python -m pip install pytest
           python -m pip install azure-storage-blob tabulate
           python -m pip install -r $(Build.SourcesDirectory)/examples/$(exampleFolder)/$(exampleRequirements)
@@ -58,6 +54,7 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
+        WORKSPACE_CLIENT_ID: $(olive-1es-identity-client-id)
 
     - task: ComponentGovernanceComponentDetection@0
       inputs:

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -54,7 +54,7 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
-        WORKSPACE_CLIENT_ID: $(olive-1es-identity-client-id)
+        MANAGED_IDENTITY_CLIENT_ID: $(olive-1es-identity-client-id)
 
     - task: ComponentGovernanceComponentDetection@0
       inputs:

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -60,7 +60,7 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
-        WORKSPACE_CLIENT_ID: $(olive-1es-identity-client-id)
+        MANAGED_IDENTITY_CLIENT_ID: $(olive-1es-identity-client-id)
   - ${{ else }}:
     - script: |
           python -m pip install pytest
@@ -74,7 +74,7 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
-        WORKSPACE_CLIENT_ID: $(olive-1es-identity-client-id)
+        MANAGED_IDENTITY_CLIENT_ID: $(olive-1es-identity-client-id)
 
   - task: CredScan@3
     displayName: 'Run CredScan'

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -46,11 +46,7 @@ jobs:
       displayName: Install ${{ parameters.onnxruntime }}
 
   - ${{ if and(eq(variables.WINDOWS, 'True'), eq(variables.testType, 'multiple_ep')) }}:
-    - task: AzureCLI@1
-      inputs:
-        azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
-        scriptLocation: 'inlineScript'
-        inlineScript: |
+    - script: |
           call python -m pip install pytest
           call curl --output openvino_toolkit.zip https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0.1/windows/w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64.zip
           call 7z x openvino_toolkit.zip
@@ -64,12 +60,9 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
+        WORKSPACE_CLIENT_ID: $(olive-1es-identity-client-id)
   - ${{ else }}:
-    - task: AzureCLI@1
-      inputs:
-        azureSubscription: $(OLIVE_RG_SERVICE_CONNECTION)
-        scriptLocation: 'inlineScript'
-        inlineScript: |
+    - script: |
           python -m pip install pytest
           python -m pip install -r $(Build.SourcesDirectory)/test/$(requirements_file)
 
@@ -81,6 +74,7 @@ jobs:
         WORKSPACE_SUBSCRIPTION_ID: $(workspace-subscription-id)
         WORKSPACE_RESOURCE_GROUP: $(workspace-resource-group)
         WORKSPACE_NAME: $(workspace-name)
+        WORKSPACE_CLIENT_ID: $(olive-1es-identity-client-id)
 
   - task: CredScan@3
     displayName: 'Run CredScan'

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -73,13 +73,16 @@ def update_azureml_config(olive_config):
     if workspace_name is None:
         raise Exception("Please set the environment variable WORKSPACE_NAME")
 
+    client_id = os.environ.get("WORKSPACE_CLIENT_ID")
+    if client_id is None:
+        raise Exception("Please set the environment variable WORKSPACE_CLIENT_ID")
+
     olive_config["azureml_client"] = {
         "subscription_id": subscription_id,
         "resource_group": resource_group,
         "workspace_name": workspace_name,
-        # pipeline agents have managed identities which take precedence over the Azure CLI credentials
-        # so we need to exclude managed identity credentials
-        "default_auth_params": {"exclude_managed_identity_credential": True},
+        # pipeline agents have multiple managed identities, so we need to specify the client_id
+        "default_auth_params": {"client_id": client_id},
     }
 
 

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -73,9 +73,9 @@ def update_azureml_config(olive_config):
     if workspace_name is None:
         raise Exception("Please set the environment variable WORKSPACE_NAME")
 
-    client_id = os.environ.get("WORKSPACE_CLIENT_ID")
+    client_id = os.environ.get("MANAGED_IDENTITY_CLIENT_ID")
     if client_id is None:
-        raise Exception("Please set the environment variable WORKSPACE_CLIENT_ID")
+        raise Exception("Please set the environment variable MANAGED_IDENTITY_CLIENT_ID")
 
     olive_config["azureml_client"] = {
         "subscription_id": subscription_id,

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -82,7 +82,7 @@ def update_azureml_config(olive_config):
         "resource_group": resource_group,
         "workspace_name": workspace_name,
         # pipeline agents have multiple managed identities, so we need to specify the client_id
-        "default_auth_params": {"client_id": client_id},
+        "default_auth_params": {"managed_identity_client_id": client_id},
     }
 
 

--- a/test/integ_test/utils.py
+++ b/test/integ_test/utils.py
@@ -31,7 +31,7 @@ def get_olive_workspace_config():
         "resource_group": resource_group,
         "workspace_name": workspace_name,
         # pipeline agents have multiple managed identities, so we need to specify the client_id
-        "default_auth_params": {"client_id": client_id},
+        "default_auth_params": {"managed_identity_client_id": client_id},
     }
 
 

--- a/test/integ_test/utils.py
+++ b/test/integ_test/utils.py
@@ -22,13 +22,16 @@ def get_olive_workspace_config():
     if workspace_name is None:
         raise Exception("Please set the environment variable WORKSPACE_NAME")
 
+    client_id = os.environ.get("WORKSPACE_CLIENT_ID")
+    if client_id is None:
+        raise Exception("Please set the environment variable WORKSPACE_CLIENT_ID")
+
     return {
         "subscription_id": subscription_id,
         "resource_group": resource_group,
         "workspace_name": workspace_name,
-        # pipeline agents have managed identities which take precedence over the Azure CLI credentials
-        # so we need to exclude managed identity credentials
-        "default_auth_params": {"exclude_managed_identity_credential": True},
+        # pipeline agents have multiple managed identities, so we need to specify the client_id
+        "default_auth_params": {"client_id": client_id},
     }
 
 

--- a/test/integ_test/utils.py
+++ b/test/integ_test/utils.py
@@ -22,9 +22,9 @@ def get_olive_workspace_config():
     if workspace_name is None:
         raise Exception("Please set the environment variable WORKSPACE_NAME")
 
-    client_id = os.environ.get("WORKSPACE_CLIENT_ID")
+    client_id = os.environ.get("MANAGED_IDENTITY_CLIENT_ID")
     if client_id is None:
-        raise Exception("Please set the environment variable WORKSPACE_CLIENT_ID")
+        raise Exception("Please set the environment variable MANAGED_IDENTITY_CLIENT_ID")
 
     return {
         "subscription_id": subscription_id,


### PR DESCRIPTION
## Describe your changes
The workload federated identity from the service connection is only [valid for 10 minutes](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/troubleshoot-workload-identity?view=azure-devops#error-messages). This is not enough for long running jobs. 
- Instead use user assigned managed identity from the 1es pool agent for authentication.
- Change `AzureCLI` task to `script` since we don't need the az login using the service connection anymore.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
