### PR TITLE
🧞 Fix genai exporter arguments bug and add Genai phi2 example

### DIFF
--- a/examples/llama2/README.md
+++ b/examples/llama2/README.md
@@ -54,23 +54,30 @@ Run the following command to execute the workflow:
 python -m olive.workflows.run --config lamma2_genai.json
 ```
 Snippet below shows an example run of generated llama2 model.
-```
-import onnxruntime_genai as ortgenai
+```python
+import onnxruntime_genai as og
 
-model = ortgenai.Model("llama2-7b-chat-int4-cpu", ortgenai.DeviceType.CPU)
-tokenizer = model.create_tokenizer()
+model = og.Model("model_path")
+tokenizer = og.Tokenizer(model)
+tokenizer_stream = tokenizer.create_stream()
 
-while True:
-    prompt = input("Input: ")
-    input_tokens = tokenizer.encode(prompt)
+prompt = '''def print_prime(n):
+    """
+    Print all primes between 1 and n
+    """'''
 
-    params = ortgenai.GeneratorParams(model)
-    params.max_length = 64
-    params.input_ids = input_tokens
+tokens = tokenizer.encode(prompt)
 
-    output_tokens = model.generate(params)[0]
+params = og.GeneratorParams(model)
+params.set_search_options({"max_length":200})
+params.input_ids = tokens
 
-    print("Output: ", tokenizer.decode(output_tokens))
+output_tokens = model.generate(params)
+
+text = tokenizer.decode(output_tokens)
+
+print("Output:")
+print(text)
 ```
 
 ### Quantization using GPTQ and do text generation using ONNX Runtime with Optimum

--- a/examples/phi2/README.md
+++ b/examples/phi2/README.md
@@ -49,6 +49,78 @@ cuda_int4
 python phi2.py --model_type cuda_int4
 ```
 
+### GenAI Optimization
+For using ONNX runtime GenAI to optimize, follow build and installation instructions [here](https://github.com/microsoft/onnxruntime-genai).
+Run the following command to execute the workflow:
+```bash
+python -m olive.workflows.run --config phi2_genai.json
+```
+This `phi2_genai.json` config file will generate optimized models for `cpu_int4` and `cuda_int4` model types as onnxruntime-gpu support cpu ep and cuda ep both.
+If you only want cpu or cuda model, you can modify the config file by remove the unwanted execution providers.
+```json
+# CPU
+"accelerators": [
+  {
+      "device": "CPU",
+      "execution_providers": [
+          "CPUExecutionProvider",
+      ]
+  }
+]
+# CPU: this is same with above as onnxruntime-gpu support cpu ep
+"accelerators": [
+  {
+      "device": "GPU",
+      "execution_providers": [
+          "CPUExecutionProvider",
+      ]
+  }
+]
+# CUDA
+"accelerators": [
+  {
+      "device": "GPU",
+      "execution_providers": [
+          "CUDAExecutionProvider",
+      ]
+  }
+]
+```
+
+or you can use `ph2.py` to generate optimized models separately by running the following commands:
+```bash
+python phi2.py --model_type cpu_int4 --genai_optimization
+python phi2.py --model_type cuda_int4 --genai_optimization
+```
+
+Snippet below shows an example run of generated phi2 model.
+```python
+import onnxruntime_genai as og
+
+model = og.Model("model_path")
+tokenizer = og.Tokenizer(model)
+tokenizer_stream = tokenizer.create_stream()
+
+prompt = '''def print_prime(n):
+    """
+    Print all primes between 1 and n
+    """'''
+
+tokens = tokenizer.encode(prompt)
+
+params = og.GeneratorParams(model)
+params.set_search_options({"max_length":200})
+params.input_ids = tokens
+
+output_tokens = model.generate(params)
+
+text = tokenizer.decode(output_tokens)
+
+print("Output:")
+print(text)
+```
+
+### Optimum Optimization
 Above commands will generate optimized models with given model_type and save them in the `phi2` folder. These optimized models can be wrapped by ONNXRuntime for inference.
 Besides, for better generation experience, this example also let use use [Optimum](https://huggingface.co/docs/optimum/v1.2.1/en/onnxruntime/modeling_ort) to generate optimized models.
 Then use can call `model.generate` easily to run inference with the optimized model.

--- a/examples/phi2/phi2.py
+++ b/examples/phi2/phi2.py
@@ -79,7 +79,7 @@ def get_args(raw_args):
         "--optimum_optimization",
         action="store_true",
         help="Use optimum optimization",
-    ),
+    )
     parser.add_argument(
         "--genai_optimization",
         action="store_true",
@@ -120,7 +120,7 @@ def main(raw_args=None):
     if not args.model_type and not args.finetune_method:
         raise ValueError("Please specify either model_type or finetune_method")
 
-    model_type = str(args.model_type) or None
+    model_type = str(args.model_type) or ""
 
     if args.genai_optimization:
         json_file_template = "phi2_genai.json"

--- a/examples/phi2/phi2_genai.json
+++ b/examples/phi2/phi2_genai.json
@@ -1,0 +1,42 @@
+{
+    "input_model":{
+        "type": "PyTorchModel",
+        "config": {
+            "hf_config": {
+                "model_name": "microsoft/phi-2",
+                "task": "text-generation"
+            }
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "config": {
+                "accelerators": [
+                    {
+                        "device": "GPU",
+                        "execution_providers": [
+                            "CPUExecutionProvider",
+                            "CUDAExecutionProvider"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "passes": {
+        "genai_exporter": {
+            "type": "GenAIModelExporter",
+            "config": {
+                "precision": "int4"
+            }
+        }
+    },
+    "engine": {
+        "log_severity_level": 0,
+        "host": "local_system",
+        "target": "local_system",
+        "cache_dir": "cache",
+        "output_dir": "models/genai"
+    }
+}

--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -30,6 +30,9 @@ class GenAIModelExporter(Pass):
         FP16 = "fp16"
         INT4 = "int4"
 
+        def __str__(self) -> str:
+            return self.value
+
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
         return {
@@ -52,7 +55,7 @@ class GenAIModelExporter(Pass):
             in AcceleratorLookup.get_execution_providers_for_device(Device.CPU)
             else Device.GPU
         )
-        if precision == self.Precision.FP16 and device == Device.CPU:
+        if precision == GenAIModelExporter.Precision.FP16 and device == Device.CPU:
             logger.info(
                 "FP16 is not supported on CPU. Valid precision + execution"
                 "provider combinations are: FP32 CPU, FP32 CUDA, FP16 CUDA, INT4 CPU, INT4 CUDA"
@@ -78,7 +81,7 @@ class GenAIModelExporter(Pass):
         output_model_filepath = Path(resolve_onnx_path(output_model_path))
 
         precision = config["precision"]
-        execution_provider = (
+        target_execution_provider = (
             "cpu"
             if self.accelerator_spec.execution_provider
             in AcceleratorLookup.get_execution_providers_for_device(Device.CPU)
@@ -98,8 +101,8 @@ class GenAIModelExporter(Pass):
             model_name=str(model.model_path or model.hf_config.model_name),
             input_path="",  # empty string for now
             output_dir=str(output_model_filepath.parent),
-            precision=precision.value,
-            execution_provider=execution_provider,
+            precision=precision,
+            execution_provider=target_execution_provider,
             cache_dir=str(cache_dir),
             filename=str(output_model_filepath.name),
         )


### PR DESCRIPTION
## Describe your changes
1. With the latest onnxruntime-genai, there are a few bugs:
  a. `precision` can only accept string value(int4, fp16, fp32) but not the 
   ![image](https://github.com/microsoft/Olive/assets/13343117/611353f2-6759-4a63-a0d0-4a8a5cd29098)
  b. `execution_provider` accept ep value but not device value
  c. the pass of `GenAIModelExporter` is not EP agnostic. For cuda int4, the input shape is changed to fp16, but for cpu int4, it is still fp32.

2. Add phi2 example.
 - CUDA: v100
![image](https://github.com/microsoft/Olive/assets/13343117/1f102f01-62bf-4b88-9692-38ebf7a331ba)
- CPU:  Intel(R) Xeon(R) CPU E5-2698
![image](https://github.com/microsoft/Olive/assets/13343117/aa654681-7f1c-4199-8fba-4c42f8a95b5c)

4. Update genai generation example in README of llama2/phi2.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
