### PR TITLE
change node name to lowercase to avoid warning

### DIFF
--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -349,8 +349,10 @@ class AzureMLSystem(OliveSystem):
         env_vars = copy.deepcopy(self.env_vars) if self.env_vars else {}
         env_vars["OLIVE_LOG_LEVEL"] = logging.getLevelName(logger.getEffectiveLevel())
 
+        # the name need to be lowercase
+        # https://github.com/Azure/azure-sdk-for-python/blob/8b5217499caedba762b47fa6a118e51209f6f604/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py#L217
         return command(
-            name=name,
+            name=name.lower(),  # convert to lowercase to avoid AzureML name restrictions
             display_name=display_name,
             description=description,
             command=cmd_line,


### PR DESCRIPTION
## Describe your changes
When create aml job, the node name need to be lowercase. Otherwise, the following waring will be emitted.
* Changing node name OnnxQuantization to lower case: onnxquantization since upper case is not allowed node name.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
