### PR TITLE
🍵 Use system's temp dir to set genai exporter cache folder

### DIFF
--- a/examples/phi2/phi2_genai.json
+++ b/examples/phi2/phi2_genai.json
@@ -33,7 +33,6 @@
         }
     },
     "engine": {
-        "log_severity_level": 0,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",

--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -95,7 +95,7 @@ class GenAIModelExporter(Pass):
             cache_dir = os.environ.get("TRANSFORMERS_CACHE", None)
         if not cache_dir:
             # please do not clean up the cache dir as it may contain model's data
-            os.environ["HF_HOME"] = str(Path(tempfile.gettempdir()) / "hf_cache")
+            cache_dir = str(Path(tempfile.gettempdir()) / "hf_cache")
 
         # currently we only support regular hf models so we can pass the name_or_path directly to model_name
         # could also check if it is a locally saved model and pass the path to input_path but it is not necessary

--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------
 import logging
 import os
+import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict
@@ -93,7 +94,8 @@ class GenAIModelExporter(Pass):
         if not cache_dir:
             cache_dir = os.environ.get("TRANSFORMERS_CACHE", None)
         if not cache_dir:
-            cache_dir = output_model_filepath.parent / "genai_cache_dir"
+            # please do not clean up the cache dir as it may contain model's data
+            os.environ["HF_HOME"] = str(Path(tempfile.gettempdir()) / "hf_cache")
 
         # currently we only support regular hf models so we can pass the name_or_path directly to model_name
         # could also check if it is a locally saved model and pass the path to input_path but it is not necessary

--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -105,7 +105,7 @@ class GenAIModelExporter(Pass):
             output_dir=str(output_model_filepath.parent),
             precision=precision,
             execution_provider=target_execution_provider,
-            cache_dir=str(cache_dir),
+            cache_dir=cache_dir,
             filename=str(output_model_filepath.name),
         )
 

--- a/olive/passes/onnx/genai_model_exporter.py
+++ b/olive/passes/onnx/genai_model_exporter.py
@@ -94,7 +94,8 @@ class GenAIModelExporter(Pass):
         if not cache_dir:
             cache_dir = os.environ.get("TRANSFORMERS_CACHE", None)
         if not cache_dir:
-            # please do not clean up the cache dir as it may contain model's data
+            # please do not clean up the cache dir as it contains huggingface model
+            # snapshots that can be reused for future runs
             cache_dir = str(Path(tempfile.gettempdir()) / "hf_cache")
 
         # currently we only support regular hf models so we can pass the name_or_path directly to model_name


### PR DESCRIPTION
## Describe your changes

Use system's temp dir to set genai exporter cache folder as in windows, the length of cache folder may exceed file path max_length limitation.
https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
