### PR TITLE
Restrict SliceGPT pass to only supported datasets

### DIFF
--- a/examples/phi2/phi2.py
+++ b/examples/phi2/phi2.py
@@ -174,6 +174,7 @@ def main(raw_args=None):
             # torch fine tuning does not require execution provider, just set it to CUDAExecutionProvider
             update_accelerator(template_json, "gpu")
         if args.slicegpt:
+            model_type = "slicegpt"
             pass_flows[0].extend(SUPPORTED_WORKFLOWS["slicegpt"][0])
             update_accelerator(template_json, "gpu")
             del template_json["input_model"]["config"]["model_script"]

--- a/examples/phi2/phi2_optimize_template.json
+++ b/examples/phi2/phi2_optimize_template.json
@@ -62,7 +62,7 @@
             "type": "SliceGPT",
             "config": {
                 "sparsity": 0.4,
-                "calibration_data_config": "wikitext2"
+                "calibration_dataset": "wikitext2"
             }
         },
         "qlora": {

--- a/olive/passes/pytorch/slicegpt.py
+++ b/olive/passes/pytorch/slicegpt.py
@@ -6,12 +6,11 @@
 import json
 import logging
 import sys
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import torch
 
 from olive.constants import ModelFileFormat
-from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import PyTorchModelHandler
 from olive.model.utils.path_utils import normalize_path_suffix
@@ -32,10 +31,12 @@ class SliceGPT(Pass):
     @staticmethod
     def _default_config(accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
         return {
-            "calibration_data_config": PassConfigParam(
-                type_=Union[DataConfig, Dict],
+            "calibration_dataset": PassConfigParam(
+                type_=str,
                 required=True,
-                description=("Data config for Dataset to calibrate and calculate perplexity on."),
+                description=(
+                    "Dataset to calibrate and calculate perplexity on. Choose from wikitext2, ptb, c4, or alpaca"
+                ),
             ),
             "calibration_nsamples": PassConfigParam(
                 type_=int,
@@ -128,7 +129,7 @@ class SliceGPT(Pass):
             100 * (1 - new_embedding_dim / model_adapter.hidden_size),
         )
 
-        train_dataset = get_dataset(config.calibration_data_config.name)["train"]
+        train_dataset = get_dataset(config.calibration_dataset)["train"]
         train_loader = prepare_dataloader(
             dataset=train_dataset,
             tokenizer=tokenizer,

--- a/test/unit_test/passes/pytorch/test_slicegpt.py
+++ b/test/unit_test/passes/pytorch/test_slicegpt.py
@@ -6,7 +6,6 @@ import sys
 
 import pytest
 
-from olive.data.template import huggingface_data_config_template
 from olive.model import PyTorchModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 
@@ -19,22 +18,9 @@ def test_slicegpt(tmp_path):
     model_name = "facebook/opt-125m"
     task = "text-generation"
     input_model = PyTorchModelHandler(hf_config={"model_name": model_name, "task": task})
-    dataset = {
-        "data_name": "wikitext",
-        "subset": "wikitext-2-raw-v1",
-        "split": "train",
-        "component_kwargs": {
-            "pre_process_data": {
-                "text_cols": ["text"],
-                "source_max_len": 2048,
-            }
-        },
-    }
-    data_config = huggingface_data_config_template(model_name=model_name, task=task, **dataset)
-    data_config.name = "wikitext2"
     config = {
         "sparsity": 0.4,
-        "calibration_data_config": data_config,
+        "calibration_dataset": "wikitext2",
     }
 
     p = create_pass_from_dict(SliceGPT, config, disable_search=True)


### PR DESCRIPTION
## Restrict SliceGPT pass to only supported datasets

SliceGPT supports only a limited number of datasets for calibration purposes. However, the Olive/SliceGPT pass' use of DataConfig to accept that user parameter gave the impression that any/all datasets are legal.

Removed use of DataConfig and instead accept a dataset name (from among the list of supported datasets) to resolve the ambiguity.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
