### PR TITLE
Make the accelerator EP optional for non-onnx pass

### DIFF
--- a/examples/open_llama/llama_qlora.json
+++ b/examples/open_llama/llama_qlora.json
@@ -14,10 +14,7 @@
             "config": {
                 "accelerators": [
                     {
-                        "device": "gpu",
-                        "execution_providers": [
-                            "CPUExecutionProvider"
-                        ]
+                        "device": "gpu"
                     }
                 ]
             }

--- a/examples/open_llama/open_llama_loftq_tinycodes.json
+++ b/examples/open_llama/open_llama_loftq_tinycodes.json
@@ -14,10 +14,7 @@
             "config": {
                 "accelerators": [
                     {
-                        "device": "gpu",
-                        "execution_providers": [
-                            "CPUExecutionProvider"
-                        ]
+                        "device": "gpu"
                     }
                 ]
             }

--- a/examples/open_llama/open_llama_lora_tinycodes.json
+++ b/examples/open_llama/open_llama_lora_tinycodes.json
@@ -14,10 +14,7 @@
             "config": {
                 "accelerators": [
                     {
-                        "device": "gpu",
-                        "execution_providers": [
-                            "CPUExecutionProvider"
-                        ]
+                        "device": "gpu"
                     }
                 ]
             }

--- a/examples/open_llama/open_llama_qlora_ort_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_ort_tinycodes.json
@@ -14,10 +14,7 @@
             "config": {
                 "accelerators": [
                     {
-                        "device": "gpu",
-                        "execution_providers": [
-                            "CPUExecutionProvider"
-                        ]
+                        "device": "gpu"
                     }
                 ]
             }

--- a/examples/open_llama/open_llama_qlora_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_tinycodes.json
@@ -14,10 +14,7 @@
             "config": {
                 "accelerators": [
                     {
-                        "device": "gpu",
-                        "execution_providers": [
-                            "CPUExecutionProvider"
-                        ]
+                        "device": "gpu"
                     }
                 ]
             }

--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -17,10 +17,7 @@
             "config": {
                 "accelerators": [
                     {
-                        "device": "gpu",
-                        "execution_providers": [
-                            "CPUExecutionProvider"
-                        ]
+                        "device": "gpu"
                     }
                 ]
             }

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -171,199 +171,192 @@ class AcceleratorLookup:
         return inferred_devices[0]
 
 
-def fill_device(system_config: "SystemConfig"):
-    """Fill only the device in the system config accelerators and leave the execution providers None."""
-    if not system_config.config.accelerators:
-        system_config.config.accelerators = [{"device": "cpu"}]
-    else:
-        for accelerator in system_config.config.accelerators:
-            if not accelerator.device:
-                accelerator.device = "cpu"
-                accelerator.execution_providers = None
-    return system_config
+class AcceleratorNormalizer:
+    """Fill the device, execution providers and check the compatibility between the device and execution providers."""
 
+    def __init__(
+        self, system_config: "SystemConfig", skip_supported_eps_check: bool = True, is_ep_required: bool = True
+    ) -> None:
+        self.system_config = system_config
+        self.skip_supported_eps_check = skip_supported_eps_check
+        self.is_ep_required = is_ep_required
+        self.system_supported_eps = None
 
-def fill_accelerators(system_config: "SystemConfig", system_supported_eps: List[str]):
-    """Fill the accelerators including device and execution providers in the system config.
+    def normalize(self) -> "SystemConfig":
+        from olive.systems.common import SystemType
 
-    * If the accelerators are not specified, fill the device and execution providers based on the installed ORT for
-      local/python system.
-    * If the device is specified but the execution providers are not, fill the execution providers based on the
-      installed ORT for local/python system.
-    * If the execution providers are specified but the device is not, fill the device based on the installed ORT.
-    """
-    if not system_config.config.accelerators:
-        # User does not specify the accelerators.
-        inferred_device = AcceleratorLookup.infer_single_device_from_execution_providers(system_supported_eps)
-        # here the pydantic validate_assignment will initialize the accelerator instances
-        system_config.config.accelerators = [{"device": inferred_device, "execution_providers": system_supported_eps}]
-        logger.info(
-            "There is no any accelerator specified. Inferred accelerators: %s",
-            system_config.config.accelerators,
-        )
-    else:
-        for accelerator in system_config.config.accelerators:
-            if not accelerator.device:
-                # User does not specify the device but providing the execution providers
-                assert accelerator.execution_providers, "The execution providers are not specified."
-                inferred_device = AcceleratorLookup.infer_single_device_from_execution_providers(
-                    accelerator.execution_providers
-                )
-                logger.info("the accelerator device is not specified. Inferred device: %s.", inferred_device)
-                accelerator.device = inferred_device
-            elif not accelerator.execution_providers:
-                # User specify the device but missing the execution providers
-                execution_providers = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(
-                    accelerator.device.lower(), system_supported_eps
-                )
-                accelerator.execution_providers = execution_providers
-                filtered_eps = [ep for ep in system_supported_eps if ep not in execution_providers]
-                if filtered_eps:
-                    logger.warning(
-                        "The following execution providers are filtered: %s. "
-                        "Please raise issue in Olive site since it might be a bug. ",
-                        ",".join(filtered_eps),
-                    )
+        if self.system_config.olive_managed_env:
+            if not self.system_config.config.accelerators:
+                raise ValueError("Managed environment requires accelerators to be specified.")
 
-                logger.info(
-                    "The accelerator execution providers is not specified for %s. Use the inferred ones. %s",
-                    accelerator.device,
-                    accelerator.execution_providers,
-                )
-            else:
-                logger.debug("The accelerator device and execution providers are specified, skipping deduce.")
-
-    return system_config
-
-
-def check_execution_providers(
-    system_config: "SystemConfig", system_supported_eps: List[str], skip_supported_eps_check: bool = True
-):
-    """Check the execution providers are supported by the device and remove the unsupported ones.
-
-    If the skip_supported_eps_check is True, the check will be skipped and the accelerators will be filtered against
-    the device.
-    """
-    from olive.systems.common import SystemType
-
-    # check the execution providers are supported
-    # TODO(myguo): should we cleanup the EPs if ep is not used?
-    ep_not_supported = []
-    for accelerator in system_config.config.accelerators:
-        device = Device(accelerator.device.lower())
-        eps_per_device = AcceleratorLookup.get_managed_supported_execution_providers(device)
-
-        if system_config.olive_managed_env:
-            available_eps = eps_per_device
-        elif (
-            system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT)
-            and not skip_supported_eps_check
-        ):
-            # skip_supported_eps_check is False here
-            # target is used so we need to check that the system supported eps are compatible with the accelerators
-            available_eps = system_supported_eps
-        else:
-            # AzureML and Docker system: These are required to be specified by the user.
-            # Local, PythonEnvironment, IsolatedORT: skip_supported_eps_check is True
-            # the target is not used so no need to check the compatibility between the system supported eps and
-            # the accelerators (available_eps == accelerator.execution_providers, the check will always pass)
-            # Example scenario: to run optimization workflow for qnn-ep on x86 machine, the pass (onnxquantization)
-            # needs to know qnn-ep is the target ep, but ort-qnn is not available on x86 machine.
-            # we can still run the workflow using cpu ORT package as the target is not used for evaluation or
-            # pass runs (= no inference sesion is created). The ort tools don't need the ep to be available.
-            eps = AcceleratorLookup.filter_execution_providers(accelerator.execution_providers, eps_per_device)
-            available_eps = eps or ["CPUExecutionProvider"]
-
-        supported_eps = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(
-            device, available_eps
-        )
-        logger.debug("Supported execution providers for device %s: %s", device, supported_eps)
-
-        eps = []
-        for ep in accelerator.execution_providers:
-            if ep not in supported_eps:
-                ep_not_supported.append(ep)
-            else:
-                eps.append(ep)
-
-        # remove the unsupported execution providers
-        accelerator.execution_providers = eps or ["CPUExecutionProvider"]
-
-    if ep_not_supported:
-        logger.warning(
-            "The following execution providers are not supported: '%s' by the device: '%s' and will be ignored. "
-            "Please consider installing an onnxruntime build that contains the relevant execution providers. ",
-            ",".join(ep_not_supported),
-            ",".join([accelerator.device for accelerator in system_config.config.accelerators]),
-        )
-
-
-def normalize_accelerators(
-    system_config: "SystemConfig", skip_supported_eps_check: bool = True, is_ep_required=True
-) -> "SystemConfig":
-    """Normalize the accelerators in the system config.
-
-    * the accelerators is not specified, infer the device/ep based on the installed ORT in case of local/python system.
-    * only device is specified, infer the execution providers based on the installed ORT in case of local/python system.
-    * only EP is specified, infer the device based on the installed ORT in case of local/python system.
-    * For AzureML and Docker system, the accelerators and execution providers must be specified.
-
-    :param system_config: The system config to be normalized.
-    :param skip_supported_eps_check: Whether to skip the check that the system supported eps are compatible with the
-        accelerators in the system config. This is True when target system is not used for evaluation or pass runs.
-    """
-    from olive.systems.common import SystemType
-
-    if system_config.olive_managed_env:
-        if not system_config.config.accelerators:
-            raise ValueError("Managed environment requires accelerators to be specified.")
-
-        for accelerator in system_config.config.accelerators:
-            if not accelerator.execution_providers:
-                raise ValueError(
-                    f"Managed environment requires execution providers to be specified for {accelerator.device}"
-                )
-    else:
-        system_supported_eps = None
-        if system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT):
-            if is_ep_required:
-                target = system_config.create_system()
-                # TODO(myguo): Handle the ORT not installed scenario. In this case, the call will raise ImportError.
-                # and the system_supported_eps will be None.
-                system_supported_eps = target.get_supported_execution_providers()
-                # Remove the AzureMLExecutionProvider
-                if "AzureExecutionProvider" in system_supported_eps:
-                    system_supported_eps.remove("AzureExecutionProvider")
-
-                assert system_supported_eps, "No supported execution providers found for the target system."
-
-                system_config = fill_accelerators(system_config, system_supported_eps)
-            else:
-                system_config = fill_device(system_config)
-        else:
-            # for AzureML and Docker System
-            if not system_config.config.accelerators:
-                raise ValueError("AzureML and Docker system requires accelerators to be specified.")
-            for accelerator in system_config.config.accelerators:
-                if not accelerator.device or (not accelerator.execution_providers and is_ep_required):
+            for accelerator in self.system_config.config.accelerators:
+                if not accelerator.execution_providers:
                     raise ValueError(
-                        "AzureML and Docker system requires device and execution providers to be specified explicitly."
+                        f"Managed environment requires execution providers to be specified for {accelerator.device}"
                     )
+        else:
+            if self.system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT):
+                if self.is_ep_required:
+                    target = self.system_config.create_system()
+                    # TODO(myguo): Handle the ORT not installed scenario. In this case, the call will raise ImportError.
+                    # and the system_supported_eps will be None.
+                    self.system_supported_eps = target.get_supported_execution_providers()
+                    # Remove the AzureMLExecutionProvider
+                    if "AzureExecutionProvider" in self.system_supported_eps:
+                        self.system_supported_eps.remove("AzureExecutionProvider")
 
-        if is_ep_required:
-            check_execution_providers(system_config, system_supported_eps, skip_supported_eps_check)
+                    assert self.system_supported_eps, "No supported execution providers found for the target system."
 
-    return system_config
+                    self._fill_accelerators()
+                else:
+                    self._fill_device()
+            else:
+                # for AzureML and Docker System
+                if not self.system_config.config.accelerators:
+                    raise ValueError("AzureML and Docker system requires accelerators to be specified.")
+                for accelerator in self.system_config.config.accelerators:
+                    if not accelerator.device or (not accelerator.execution_providers and self.is_ep_required):
+                        raise ValueError(
+                            "AzureML and Docker system requires device and execution providers to be specified "
+                            "explicitly."
+                        )
+
+            if self.is_ep_required:
+                self._check_execution_providers()
+
+        return self.system_config
+
+    def _fill_device(self):
+        """Fill only the device in the system config accelerators and leave the execution providers None."""
+        if not self.system_config.config.accelerators:
+            self.system_config.config.accelerators = [{"device": "cpu"}]
+        else:
+            for accelerator in self.system_config.config.accelerators:
+                if not accelerator.device:
+                    accelerator.device = "cpu"
+                    accelerator.execution_providers = None
+
+    def _fill_accelerators(self):
+        """Fill the accelerators including device and execution providers in the system config.
+
+        * If the accelerators are not specified, fill the device and execution providers based on the installed ORT for
+        local/python system.
+        * If the device is specified but the execution providers are not, fill the execution providers based on the
+        installed ORT for local/python system.
+        * If the execution providers are specified but the device is not, fill the device based on the installed ORT.
+        """
+        if not self.system_config.config.accelerators:
+            # User does not specify the accelerators.
+            inferred_device = AcceleratorLookup.infer_single_device_from_execution_providers(self.system_supported_eps)
+            # here the pydantic validate_assignment will initialize the accelerator instances
+            self.system_config.config.accelerators = [
+                {"device": inferred_device, "execution_providers": self.system_supported_eps}
+            ]
+            logger.info(
+                "There is no any accelerator specified. Inferred accelerators: %s",
+                self.system_config.config.accelerators,
+            )
+        else:
+            for accelerator in self.system_config.config.accelerators:
+                if not accelerator.device:
+                    # User does not specify the device but providing the execution providers
+                    assert accelerator.execution_providers, "The execution providers are not specified."
+                    inferred_device = AcceleratorLookup.infer_single_device_from_execution_providers(
+                        accelerator.execution_providers
+                    )
+                    logger.info("the accelerator device is not specified. Inferred device: %s.", inferred_device)
+                    accelerator.device = inferred_device
+                elif not accelerator.execution_providers:
+                    # User specify the device but missing the execution providers
+                    execution_providers = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(
+                        accelerator.device.lower(), self.system_supported_eps
+                    )
+                    accelerator.execution_providers = execution_providers
+                    filtered_eps = [ep for ep in self.system_supported_eps if ep not in execution_providers]
+                    if filtered_eps:
+                        logger.warning(
+                            "The following execution providers are filtered: %s. "
+                            "Please raise issue in Olive site since it might be a bug. ",
+                            ",".join(filtered_eps),
+                        )
+
+                    logger.info(
+                        "The accelerator execution providers is not specified for %s. Use the inferred ones. %s",
+                        accelerator.device,
+                        accelerator.execution_providers,
+                    )
+                else:
+                    logger.debug("The accelerator device and execution providers are specified, skipping deduce.")
+
+    def _check_execution_providers(self):
+        """Check the execution providers are supported by the device and remove the unsupported ones.
+
+        If the skip_supported_eps_check is True, the check will be skipped and the accelerators will be filtered against
+        the device.
+        """
+        from olive.systems.common import SystemType
+
+        # check the execution providers are supported
+        # TODO(myguo): should we cleanup the EPs if ep is not used?
+        ep_not_supported = []
+        for accelerator in self.system_config.config.accelerators:
+            device = Device(accelerator.device.lower())
+            eps_per_device = AcceleratorLookup.get_managed_supported_execution_providers(device)
+
+            if self.system_config.olive_managed_env:
+                available_eps = eps_per_device
+            elif (
+                self.system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT)
+                and not self.skip_supported_eps_check
+            ):
+                # skip_supported_eps_check is False here
+                # target is used so we need to check that the system supported eps are compatible with the accelerators
+                available_eps = self.system_supported_eps
+            else:
+                # AzureML and Docker system: These are required to be specified by the user.
+                # Local, PythonEnvironment, IsolatedORT: skip_supported_eps_check is True
+                # the target is not used so no need to check the compatibility between the system supported eps and
+                # the accelerators (available_eps == accelerator.execution_providers, the check will always pass)
+                # Example scenario: to run optimization workflow for qnn-ep on x86 machine, the pass (onnxquantization)
+                # needs to know qnn-ep is the target ep, but ort-qnn is not available on x86 machine.
+                # we can still run the workflow using cpu ORT package as the target is not used for evaluation or
+                # pass runs (= no inference sesion is created). The ort tools don't need the ep to be available.
+                eps = AcceleratorLookup.filter_execution_providers(accelerator.execution_providers, eps_per_device)
+                available_eps = eps or ["CPUExecutionProvider"]
+
+            supported_eps = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(
+                device, available_eps
+            )
+            logger.debug("Supported execution providers for device %s: %s", device, supported_eps)
+
+            eps = []
+            for ep in accelerator.execution_providers:
+                if ep not in supported_eps:
+                    ep_not_supported.append(ep)
+                else:
+                    eps.append(ep)
+
+            # remove the unsupported execution providers
+            accelerator.execution_providers = eps or ["CPUExecutionProvider"]
+
+        if ep_not_supported:
+            logger.warning(
+                "The following execution providers are not supported: '%s' by the device: '%s' and will be ignored. "
+                "Please consider installing an onnxruntime build that contains the relevant execution providers. ",
+                ",".join(ep_not_supported),
+                ",".join([accelerator.device for accelerator in self.system_config.config.accelerators]),
+            )
 
 
 def create_accelerators(
     system_config: "SystemConfig", skip_supported_eps_check: bool = True, is_ep_required=True
 ) -> List[AcceleratorSpec]:
-    system_config = normalize_accelerators(system_config, skip_supported_eps_check, is_ep_required)
+    normalizer = AcceleratorNormalizer(system_config, skip_supported_eps_check, is_ep_required)
+    system_config = normalizer.normalize()
 
-    device_to_eps = {}
-    for accelerator in system_config.config.accelerators:
-        device_to_eps[accelerator.device] = accelerator.execution_providers
+    device_to_eps = {
+        accelerator.device: accelerator.execution_providers for accelerator in system_config.config.accelerators
+    }
     logger.debug("Initial accelerators and execution providers: %s", device_to_eps)
 
     # Flatten the accelerators to list of AcceleratorSpec

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -292,10 +292,18 @@ def normalize_accelerators(
                 system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT)
                 and not skip_supported_eps_check
             ):
-                # don't need to check the supported execution providers if there is no evaluation
-                # target is only used for evaluation
+                # skip_supported_eps_check is False here
+                # target is used so we need to check that the system supported eps are compatible with the accelerators
                 available_eps = system_supported_eps
             else:
+                # AzureML and Docker system: These are required to be specified by the user.
+                # Local, PythonEnvironment, IsolatedORT: skip_supported_eps_check is True
+                # the target is not used so no need to check the compatibility between the system supported eps and
+                # the accelerators (available_eps == accelerator.execution_providers, the check will always pass)
+                # Example scenario: to run optimization workflow for qnn-ep on x86 machine, the pass (onnxquantization)
+                # needs to know qnn-ep is the target ep, but ort-qnn is not available on x86 machine.
+                # we can still run the workflow using cpu ORT package as the target is not used for evaluation or
+                # pass runs (= no inference sesion is created). The ort tools don't need the ep to be available.
                 eps = AcceleratorLookup.filter_execution_providers(accelerator.execution_providers, eps_per_device)
                 available_eps = eps or ["CPUExecutionProvider"]
 

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -52,8 +52,10 @@ def create_evaluate_command(
         f"--output_path {output_path}",
         f"--output_name {output_name}",
         f"--accelerator_type {accelerator.accelerator_type}",
-        f"--execution_provider {accelerator.execution_provider}",
     ]
+    if accelerator.execution_provider:
+        parameters.append(f"--execution_provider {accelerator.execution_provider}")
+
     return f"python {eval_script_path} {' '.join(parameters)}"
 
 

--- a/olive/systems/utils/misc.py
+++ b/olive/systems/utils/misc.py
@@ -39,9 +39,9 @@ def create_managed_system(system_config: "SystemConfig", accelerator: "Accelerat
 
     # for host system, use the first available accelerator
     if accelerator:
-        accelerator_cfg = [
-            {"device": accelerator.accelerator_type, "execution_providers": [accelerator.execution_provider]}
-        ]
+        accelerator_cfg = [{"device": accelerator.accelerator_type}]
+        if accelerator.execution_provider:
+            accelerator_cfg[0]["execution_providers"] = [accelerator.execution_provider]
     else:
         accelerator_cfg = None
         accelerator = DEFAULT_CPU_ACCELERATOR
@@ -83,6 +83,7 @@ def create_managed_system(system_config: "SystemConfig", accelerator: "Accelerat
     elif system_config.type == SystemType.Docker:
         from olive.systems.docker import DockerSystem
 
+        assert accelerator.execution_provider, "Execution provider must be specified for Docker system"
         dockerfile = PROVIDER_DOCKERFILE_MAPPING.get(accelerator.execution_provider, "Dockerfile.cpu")
         # TODO(myguo): create a temp dir for the build context
         new_system = DockerSystem(
@@ -102,6 +103,7 @@ def create_managed_system(system_config: "SystemConfig", accelerator: "Accelerat
     elif system_config.type == SystemType.AzureML:
         from olive.systems.azureml import AzureMLSystem
 
+        assert accelerator.execution_provider, "Execution provider must be specified for Docker system"
         dockerfile = PROVIDER_DOCKERFILE_MAPPING.get(accelerator.execution_provider, "Dockerfile.cpu")
         temp_dir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         build_context_path = Path(temp_dir.name)

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Generator, Generator, List, Union
+from typing import Generator, List, Union
 
 from olive.auto_optimizer import AutoOptimizer
 from olive.hardware.accelerator import create_accelerators
@@ -352,18 +352,6 @@ def get_local_ort_packages() -> List[str]:
 
 
 def get_used_passes(run_config: RunConfig) -> Generator["RunPassConfig", None, None]:
-    if run_config.pass_flows:
-        passes = set()
-        for pass_flow in run_config.pass_flows:
-            for pass_name in pass_flow:
-                if run_config.passes[pass_name].type not in passes:
-                    passes.add(run_config.passes[pass_name].type)
-                    yield run_config.passes[pass_name]
-    elif run_config.passes:
-        yield from run_config.passes.values()
-
-
-def get_used_passes(run_config: RunConfig) -> Generator[RunPassConfig, None, None]:
     if run_config.pass_flows:
         passes = set()
         for pass_flow in run_config.pass_flows:

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from olive.common.config_utils import validate_config
-from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec, create_accelerators, normalize_accelerators
+from olive.hardware.accelerator import AcceleratorLookup, AcceleratorNormalizer, AcceleratorSpec, create_accelerators
 from olive.systems.common import AcceleratorConfig, SystemType
 from olive.systems.python_environment.python_environment_system import PythonEnvironmentSystem
 from olive.systems.system_config import SystemConfig
@@ -302,7 +302,7 @@ def test_normalize_accelerators(
         )
         python_mock.start()
 
-    normalized_accs = normalize_accelerators(system_config, skip_supported_eps_check=False)
+    normalized_accs = AcceleratorNormalizer(system_config, skip_supported_eps_check=False).normalize()
     assert len(normalized_accs.config.accelerators) == len(expected_accs)
     for i, acc in enumerate(expected_accs):
         assert normalized_accs.config.accelerators[i].device == acc["device"]
@@ -337,7 +337,7 @@ def test_normalize_accelerators(
 )
 def test_normalize_accelerators_skip_ep_check(system_config, expected_acc):
     system_config = validate_config(system_config, SystemConfig)
-    normalized_accs = normalize_accelerators(system_config, skip_supported_eps_check=True)
+    normalized_accs = AcceleratorNormalizer(system_config, skip_supported_eps_check=True).normalize()
     assert normalized_accs.config.accelerators[0].device == expected_acc[0]
     assert normalized_accs.config.accelerators[0].execution_providers == expected_acc[1]
 

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -248,7 +248,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
                     "execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
                 }
             ],
-            ["The following execution providers are not supported: ROCMExecutionProvider"],
+            ["The following execution providers are not supported: 'ROCMExecutionProvider'"],
             ["CUDAExecutionProvider", "CPUExecutionProvider"],
         ),
         (
@@ -273,7 +273,7 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
                     "execution_providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
                 }
             ],
-            ["The following execution providers are not supported: ROCMExecutionProvider"],
+            ["The following execution providers are not supported: 'ROCMExecutionProvider'"],
             ["CUDAExecutionProvider", "CPUExecutionProvider"],
         ),
     ],
@@ -314,6 +314,32 @@ def test_normalize_accelerators(
 
     if python_mock:
         python_mock.stop()
+
+
+@pytest.mark.parametrize(
+    ("system_config", "expected_acc"),
+    [
+        (
+            {
+                "type": "LocalSystem",
+                "config": {"accelerators": [{"device": "cpu", "execution_providers": ["CUDAExecutionProvider"]}]},
+            },
+            ("cpu", ["CPUExecutionProvider"]),
+        ),
+        (
+            {
+                "type": "LocalSystem",
+                "config": {"accelerators": [{"execution_providers": ["QNNExecutionProvider"]}]},
+            },
+            ("npu", ["QNNExecutionProvider"]),
+        ),
+    ],
+)
+def test_normalize_accelerators_skip_ep_check(system_config, expected_acc):
+    system_config = validate_config(system_config, SystemConfig)
+    normalized_accs = normalize_accelerators(system_config, skip_supported_eps_check=True)
+    assert normalized_accs.config.accelerators[0].device == expected_acc[0]
+    assert normalized_accs.config.accelerators[0].execution_providers == expected_acc[1]
 
 
 @pytest.mark.parametrize(

--- a/test/unit_test/workflows/test_workfow_run.py
+++ b/test/unit_test/workflows/test_workfow_run.py
@@ -1,0 +1,67 @@
+from test.unit_test.utils import create_dataloader, get_pytorch_model, get_pytorch_model_config, pytorch_model_loader
+from unittest.mock import patch
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.workflows import run as olive_run
+
+
+@patch("olive.passes.pytorch.quantization_aware_training.QuantizationAwareTraining._run_for_config")
+@patch("olive.systems.local.ModelConfig.from_json")
+@patch("olive.engine.engine.ModelConfig.to_json")
+def test_run_without_ep(mock_model_to_json, mock_model_from_json, mock_run, tmp_path):
+    user_script = tmp_path / "user_script.py"
+    with user_script.open("w"):
+        pass
+
+    config = {
+        "input_model": {
+            "type": "PyTorchModel",
+            "config": {
+                "model_loader": pytorch_model_loader,
+                "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+            },
+        },
+        "evaluators": {
+            "common_evaluator": {
+                "metrics": [
+                    {
+                        "name": "latency",
+                        "type": "latency",
+                        "sub_types": [
+                            {
+                                "name": "avg",
+                            },
+                        ],
+                        "user_config": {"dataloader_func": create_dataloader},
+                    }
+                ]
+            }
+        },
+        "passes": {
+            "qat": {
+                "type": "QuantizationAwareTraining",
+                "config": {
+                    "user_script": str(user_script),
+                    "train_data_dir": "data",
+                    "val_data_dir": "data",
+                    "num_epochs": 1,
+                    "train_dataloader_func": "create_train_dataloader",
+                    "train_batch_size": 100,
+                    "modules_to_fuse": [["conv1", "bn1"], ["conv2", "bn2"], ["conv3", "bn3"]],
+                    "qconfig_func": "create_qat_config",
+                },
+                "evaluator": "common_evaluator",
+            },
+        },
+        "engine": {
+            "cache_dir": str(tmp_path / "cache"),
+            "output_dir": str(tmp_path / "output"),
+        },
+    }
+
+    mock_run.return_value = get_pytorch_model()
+    mock_model_from_json.return_value = get_pytorch_model_config()
+    mock_model_to_json.return_value = {"type": "PyTorchModel", "config": {}}
+    ret = olive_run(config)
+    assert len(ret) == 1
+    assert next(iter(ret)) == AcceleratorSpec("cpu")


### PR DESCRIPTION
## Describe your changes
* Originally, the execution_providers in accelerator spec is required regardless whether it is used or not. Even if user doesn't specify them, the local system will infer and get the available EPs to autofill the EPs. This is painful for passes that doesn't use the EP. 
* In this PR, if there is no pass that belongs to onnx techniques, we will not infer the EP based on the device. 
* On the other hand, if the device is not specified, we will choose cpu by default.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
