### PR TITLE
onnxruntime-genai based metadata and packaging

### DIFF
--- a/docs/source/features/packaging_output_models.md
+++ b/docs/source/features/packaging_output_models.md
@@ -138,6 +138,10 @@ If not specified, Olive will not package artifacts.
           The version for this data asset. This is `1` by default.
         * `description [str]`
           The description for this data asset. This is `None` by default.
+    * `include_sample_code [bool]`:
+      Whether or not to include sample code in zip file. Defaults to True
+    * `include_runtime_packages [bool]`:
+      Whether or not to include runtime packages (like onnxruntime) in zip file. Defaults to True
 
 You can add `PackagingConfig` to Engine configurations. e.g.:
 

--- a/examples/llama2/README.md
+++ b/examples/llama2/README.md
@@ -114,8 +114,10 @@ For using ONNX runtime GenAI to optimize, follow build and installation instruct
 
 Run the following command to execute the workflow:
 ```bash
-python -m olive.workflows.run --config lamma2_genai.json
+python llama2_genai.py [--model_name <>] [--metadata_only]
 ```
+
+To generate metadata only for pre-exported onnx model, use the `--metadata_only` option.
 
 Snippet below shows an example run of generated llama2 model.
 ```python

--- a/examples/llama2/llama2_genai.py
+++ b/examples/llama2/llama2_genai.py
@@ -1,0 +1,60 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import argparse
+import json
+
+from olive.common.utils import set_tempdir
+from olive.workflows import run as olive_run
+
+
+def get_args(raw_args):
+    parser = argparse.ArgumentParser(description="Llama2 optimization using Generative AI")
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="meta-llama/Llama-2-7b-hf",
+        help="Model name, currently only supports llama2 7B/13B",
+    )
+    parser.add_argument(
+        "--metadata-only", action="store_true", required=False, help="Whether to use gpu for optimization."
+    )
+    parser.add_argument("--tempdir", type=str, help="Root directory for tempfile directories and files", required=False)
+
+    return parser.parse_args(raw_args)
+
+
+def main(raw_args=None):
+    args = get_args(raw_args)
+    model_name = args.model_name
+
+    # set tempdir
+    set_tempdir(args.tempdir)
+
+    input_template = "llama2_genai_template.json"
+    with open(input_template) as f:
+        template_json_str = f.read()
+
+    # update model name
+    template_json_str = template_json_str.replace("<model_name_placeholder>", model_name)
+    template_json = json.loads(template_json_str)
+
+    # add pass flows
+    if args.metadata_only:
+        template_json["pass_flows"] = [["conversion", "metadata"]]
+    else:
+        template_json["pass_flows"] = [["exporter", "perf_tuning"]]
+    template_json["engine"]["output_dir"] = f"models/{model_name}"
+
+    # dump config
+    output_template = "llama2_genai.json"
+    with open(output_template, "w") as f:
+        json.dump(template_json, f, indent=4)
+
+    olive_run(template_json)  # pylint: disable=not-callable
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llama2/llama2_genai_template.json
+++ b/examples/llama2/llama2_genai_template.json
@@ -1,9 +1,9 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
-                "model_name": "meta-llama/Llama-2-7b-hf",
+                "model_name": "<model_name_placeholder>",
                 "model_class": "LlamaForCausalLM",
                 "task": "text-generation"
             }
@@ -25,10 +25,34 @@
         }
     },
     "passes": {
+        "conversion": {
+            "type": "OnnxConversion",
+            "config": {
+                "target_opset": 16,
+                "save_as_external_data": true,
+                "all_tensors_to_one_file": true,
+                "save_metadata_for_token_generation": true
+            }
+        },
         "exporter": {
             "type": "GenAIModelExporter",
             "config": {
-                "precision": "int4"
+                "precision": "int4",
+                "search": {
+                    "max_length": 2048,
+                    "min_length": 0
+                }
+            }
+        },
+        "metadata": {
+            "type": "GenAIModelExporter",
+            "config": {
+                "precision": "int4",
+                "metadata_only": true,
+                "search": {
+                    "max_length": 2048,
+                    "min_length": 0
+                }
             }
         },
         "perf_tuning": {
@@ -37,7 +61,7 @@
                 "user_script": "user_script.py",
                 "dataloader_func": "dataloader_func_for_merged",
                 "dataloader_func_kwargs": {
-                    "model_id": "meta-llama/Llama-2-7b-hf",
+                    "model_id": "<model_name_placeholder>",
                     "past_seq_length": 0,
                     "seq_length": 8,
                     "max_seq_length": 2048
@@ -48,11 +72,18 @@
         }
     },
     "engine": {
+        "packaging_config": [
+            {
+                "type": "Zipfile",
+                "name": "OutputModel",
+                "include_runtime_packages": false,
+                "include_sample_code": false
+            }
+        ],
         "log_severity_level": 0,
-        "evaluate_input_model": false,
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir": "models/genai"
+        "output_dir": null
     }
 }

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -243,6 +243,20 @@ def save_model(
         # save resource to output directory
         model_json["config"][resource_name] = local_resource_path.save_to_dir(save_dir, save_name, overwrite)
 
+    # Copy "additional files" to the output folder
+    model_attributes = model_json["config"].get("model_attributes") or {}
+    additional_files = model_attributes.get("additional_files", [])
+
+    for i, src_filepath in enumerate(additional_files):
+        dst_filepath = Path(output_dir) / output_name / Path(src_filepath).name
+        additional_files[i] = str(dst_filepath)
+
+        if not dst_filepath.exists():
+            shutil.copy(str(src_filepath), str(dst_filepath))
+
+    if additional_files:
+        model_json["config"]["model_attributes"]["additional_files"] = additional_files
+
     # save model json
     with (output_dir / f"{output_name}.json").open("w") as f:
         json.dump(model_json, f, indent=4)

--- a/olive/engine/packaging/packaging_config.py
+++ b/olive/engine/packaging/packaging_config.py
@@ -48,6 +48,8 @@ class PackagingConfig(ConfigBase):
     type: PackagingType = PackagingType.Zipfile
     name: str = "OutputModels"
     config: CommonPackagingConfig = None
+    include_runtime_packages: bool = True
+    include_sample_code: bool = True
 
     @validator("config", pre=True, always=True)
     def _validate_config(cls, v, values):

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -67,13 +67,14 @@ def _package_candidate_models(
     logger.info("Packaging output models to %s", packaging_type)
 
     with tempfile.TemporaryDirectory() as temp_dir:
-
         tempdir = Path(temp_dir)
 
         if packaging_type == PackagingType.Zipfile:
-            cur_path = Path(__file__).parent
-            _package_sample_code(cur_path, tempdir)
-            _package_onnxruntime_packages(tempdir, next(iter(pf_footprints.values())))
+            if packaging_config.include_sample_code:
+                _package_sample_code(Path(__file__).parent, tempdir)
+
+            if packaging_config.include_runtime_packages:
+                _package_onnxruntime_packages(tempdir, next(iter(pf_footprints.values())))
 
         for accelerator_spec, pf_footprint in pf_footprints.items():
             footprint = footprints[accelerator_spec]
@@ -113,7 +114,7 @@ def _package_candidate_models(
                     elif packaging_type == PackagingType.AzureMLData:
                         _upload_to_azureml_data(azureml_client_config, model_dir, model_name, config)
 
-                model_rank += 1
+                    model_rank += 1
 
         if packaging_type == PackagingType.Zipfile:
             _copy_models_rank(tempdir, model_info_list)

--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -50,15 +50,7 @@ class HfConfigMixin:
 
         return get_hf_model_config(self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained())
 
-    def save_hf_model_config(self, output_dir: str, **kwargs):
-        if self.hf_config is None:
-            raise ValueError("HF model_config is not available.")
-        if not Path(output_dir).is_dir():
-            raise ValueError("Expecting a directory as input.")
-
-        save_hf_model_config(self.get_hf_model_config(), output_dir, **kwargs)
-
-    def get_hf_model_generation_config(self):
+    def _get_hf_model_generation_config(self):
         if self.hf_config is None:
             raise ValueError("HF model_config is not available")
 
@@ -66,29 +58,13 @@ class HfConfigMixin:
             self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained()
         )
 
-    def save_hf_model_generation_config(self, output_dir: str, **kwargs):
-        if self.hf_config is None:
-            raise ValueError("HF model_config is not available.")
-        if not Path(output_dir).is_dir():
-            raise ValueError("Expecting a directory as input.")
-
-        save_hf_model_generation_config(self.get_hf_model_generation_config(), output_dir, **kwargs)
-
-    def get_hf_model_tokenizer(self):
+    def _get_hf_model_tokenizer(self):
         if self.hf_config is None:
             raise ValueError("HF model_config is not available")
 
         return get_hf_model_tokenizer(
             self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained()
         )
-
-    def save_hf_model_tokenizer(self, output_dir: str, **kwargs):
-        if self.hf_config is None:
-            raise ValueError("HF model_config is not available.")
-        if not Path(output_dir).is_dir():
-            raise ValueError("Expecting a directory as input.")
-
-        save_hf_model_tokenizer(self.get_hf_model_tokenizer(), output_dir, **kwargs)
 
     def save_metadata_for_token_generation(self, output_dir: str, **kwargs):
         if self.hf_config is None:
@@ -97,14 +73,14 @@ class HfConfigMixin:
             raise ValueError("Expecting a directory as input.")
 
         save_hf_model_config(self.get_hf_model_config(), output_dir, **kwargs)
-        save_hf_model_generation_config(self.get_hf_model_generation_config(), output_dir, **kwargs)
-        tokenizer_filepaths = save_hf_model_tokenizer(self.get_hf_model_tokenizer(), output_dir, **kwargs)
+        save_hf_model_generation_config(self._get_hf_model_generation_config(), output_dir, **kwargs)
+        tokenizer_filepaths = save_hf_model_tokenizer(self._get_hf_model_tokenizer(), output_dir, **kwargs)
 
         output_dir = Path(output_dir)
         return [
             str(output_dir / "config.json"),
             str(output_dir / "generation_config.json"),
-            *tokenizer_filepaths,
+            *[fp for fp in tokenizer_filepaths if Path(fp).exists()],
         ]
 
     def get_hf_io_config(self):

--- a/test/unit_test/passes/test_pass.py
+++ b/test/unit_test/passes/test_pass.py
@@ -1,0 +1,122 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from olive.model.handler.onnx import ONNXModelHandler
+from olive.passes.olive_pass import Pass
+
+
+@patch("shutil.copy")
+def test_pass_model_attributes_additional_files(self, tmpdir):
+    tmpdir = Path(tmpdir)
+
+    model_1_path = tmpdir / "model_1"
+    model_1_path.mkdir()
+
+    model_2_path = tmpdir / "model_2"
+    model_2_path.mkdir()
+    model_2_filepath_1 = model_2_path / "model_2_file_1.txt"
+    with open(model_2_filepath_1, "w") as strm:
+        pass
+    model_2_filepath_2 = model_2_path / "model_2_file_2.txt"
+    with open(model_2_filepath_2, "w") as strm:
+        strm.write("model_2_filepath_2")
+
+    model_3_path = tmpdir / "model_3"
+    model_3_path.mkdir()
+    model_3_filepath_1 = model_3_path / "model_3_file_1.txt"
+    with open(model_3_filepath_1, "w") as strm:
+        pass
+    model_3_filepath_2 = model_3_path / "model_3_file_2.txt"
+    with open(model_3_filepath_2, "w") as strm:
+        pass
+    model_3_filepath_3 = model_3_path / "model_2_file_2.txt"
+    with open(model_3_filepath_3, "w") as strm:
+        strm.write("model_3_filepath_3")
+
+    model_4_path = tmpdir / "model_4" / "model.onnx"
+    model_4_path.parent.mkdir()
+    with open(model_4_path, "w") as strm:
+        pass
+
+    def model_1_side_effect(arg):
+        return str(model_1_path) if arg == "model_path" else None
+
+    model_1 = MagicMock()
+    model_1.get_resource = MagicMock(side_effect=model_1_side_effect)
+    model_1.model_attributes = {}
+
+    def model_2_side_effect(arg):
+        return str(model_2_path) if arg == "model_path" else None
+
+    model_2 = MagicMock()
+    model_2.get_resource = MagicMock(side_effect=model_2_side_effect)
+    model_2.model_attributes = {"additional_files": [str(model_2_filepath_1), str(model_2_filepath_2)]}
+
+    # Input model with no additional files, and output model with additional files
+    Pass._carry_forward_additional_files(model_1, model_2)  # pylint: disable=W0212
+
+    assert "additional_files" in model_2.model_attributes
+    assert len(model_2.model_attributes["additional_files"]) == 2
+    assert str(model_2_filepath_1) in model_2.model_attributes["additional_files"]
+    assert str(model_2_filepath_2) in model_2.model_attributes["additional_files"]
+
+    def model_3_side_effect(arg):
+        return str(model_3_path) if arg == "model_path" else None
+
+    model_3 = MagicMock()
+    model_3.get_resource = MagicMock(side_effect=model_3_side_effect)
+    model_3.model_attributes = {
+        "additional_files": [str(model_3_filepath_1), str(model_3_filepath_2), str(model_3_filepath_3)]
+    }
+
+    # Both input & output models with additional files
+    Pass._carry_forward_additional_files(model_2, model_3)  # pylint: disable=W0212
+
+    # Input model should be unchanged
+    assert "additional_files" in model_2.model_attributes
+    assert len(model_2.model_attributes["additional_files"]) == 2
+    assert str(model_2_filepath_1) in model_2.model_attributes["additional_files"]
+    assert str(model_2_filepath_2) in model_2.model_attributes["additional_files"]
+
+    # Output model includes accumulated list of additional files
+    assert "additional_files" in model_3.model_attributes
+    assert len(model_3.model_attributes["additional_files"]) == 4
+    assert str(model_3_path / "model_2_file_1.txt") in model_3.model_attributes["additional_files"]
+    assert str(model_3_path / "model_2_file_2.txt") in model_3.model_attributes["additional_files"]
+    assert str(model_3_filepath_1) in model_3.model_attributes["additional_files"]
+    assert str(model_3_filepath_2) in model_3.model_attributes["additional_files"]
+
+    # Pass 3 generated file shouldn't be overwritten by Pass 2 even though the file names are the same
+    with open(str(model_3_filepath_3)) as strm:
+        content = strm.read()
+    assert content == "model_3_filepath_3"
+
+    def model_4_side_effect(arg):
+        return str(model_4_path) if arg == "model_path" else None
+
+    model_4 = MagicMock(spec=ONNXModelHandler)
+    model_4.get_resource = MagicMock(side_effect=model_4_side_effect)
+    model_4.model_attributes = {}
+
+    # Output model's output path is a file rather than directory
+    Pass._carry_forward_additional_files(model_3, model_4)  # pylint: disable=W0212
+
+    # Input model should be unchanged
+    assert "additional_files" in model_3.model_attributes
+    assert len(model_3.model_attributes["additional_files"]) == 4
+    assert str(model_3_path / "model_2_file_1.txt") in model_3.model_attributes["additional_files"]
+    assert str(model_3_path / "model_2_file_2.txt") in model_3.model_attributes["additional_files"]
+    assert str(model_3_filepath_1) in model_3.model_attributes["additional_files"]
+    assert str(model_3_filepath_2) in model_3.model_attributes["additional_files"]
+
+    # All files from input should be carried forward to output models parent directory
+    assert "additional_files" in model_4.model_attributes
+    assert len(model_4.model_attributes["additional_files"]) == 4
+    assert str(model_4_path.parent / "model_2_file_1.txt") in model_4.model_attributes["additional_files"]
+    assert str(model_4_path.parent / "model_2_file_2.txt") in model_4.model_attributes["additional_files"]
+    assert str(model_4_path.parent / "model_3_file_1.txt") in model_4.model_attributes["additional_files"]
+    assert str(model_4_path.parent / "model_3_file_2.txt") in model_4.model_attributes["additional_files"]


### PR DESCRIPTION
## onnxruntime-genai based metadata and packaging

* Added support for packaging models (and additional files) generated by the GenAIModelExporter. Also, updated the pass configuration to include search parameters that are forwarded to the generated genai_config file.
* Added support for carrying "additional files" from one pass to next. These files will end up in the generated models output folder and will be packaged.
* Two new packaging configuration options -
  * include_sample_code
  * inlcude_runtime_packages

### Release Note:
Packaging config include two new options -
* include_sample_code - whether or not to include sample code in zip archive. Defaults to true.
* include_runtime_packages - whether or not to include runtime packages (like onnxruntime) in zip archive. Defaults to true.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
