### PR TITLE
Update `skip_supported_eps_check`, Fix Mobilenet QNN EP example

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -112,6 +112,9 @@ jobs:
       inception_snpe_toolkit:
         exampleFolder: inception
         exampleName: snpe_toolkit
+      mobilenet_qnn_ep:
+        exampleFolder: mobilenet
+        exampleName: mobilenet_qnn_ep
 
 # # Windows examples test
 - template: job_templates/olive-example-template.yaml
@@ -141,6 +144,9 @@ jobs:
       inception_snpe_toolkit:
         exampleFolder: inception
         exampleName: snpe_toolkit
+      mobilenet_qnn_ep:
+        exampleFolder: mobilenet
+        exampleName: mobilenet_qnn_ep
 
 # Linux GPU examples testing.
 - template: job_templates/olive-example-template.yaml

--- a/.azure_pipelines/olive-ort-last.yaml
+++ b/.azure_pipelines/olive-ort-last.yaml
@@ -69,6 +69,7 @@ jobs:
       whisper:
         exampleFolder: whisper
         exampleName: whisper
+      # TODO(anyone): add mobilenet_qnn_ep when last version is 1.17.x
 
 # # Windows examples test
 - template: job_templates/olive-example-template.yaml
@@ -89,6 +90,7 @@ jobs:
       whisper:
         exampleFolder: whisper
         exampleName: whisper
+      # TODO(anyone): add mobilenet_qnn_ep when last version is 1.17.x
 
 # Linux GPU examples testing.
 - template: job_templates/olive-example-template.yaml

--- a/.azure_pipelines/olive-ort-nightly.yaml
+++ b/.azure_pipelines/olive-ort-nightly.yaml
@@ -66,6 +66,9 @@ jobs:
       whisper:
         exampleFolder: whisper
         exampleName: whisper
+      mobilenet_qnn_ep:
+        exampleFolder: mobilenet
+        exampleName: mobilenet_qnn_ep
 
 # # Windows examples test
 - template: job_templates/olive-example-template.yaml
@@ -86,6 +89,9 @@ jobs:
       whisper:
         exampleFolder: whisper
         exampleName: whisper
+      mobilenet_qnn_ep:
+        exampleFolder: mobilenet
+        exampleName: mobilenet_qnn_ep
 
 # Linux GPU examples testing.
 - template: job_templates/olive-example-template.yaml

--- a/examples/mobilenet/mobilenet_qnn_ep.py
+++ b/examples/mobilenet/mobilenet_qnn_ep.py
@@ -61,7 +61,7 @@ def main(raw_args=None):
         del config["systems"]["local_system"]
     else:
         # set target to local_system
-        # it is QNN EP as the target EP even though local environment has
+        # QNN EP is the target EP even though local environment has
         # cpu package installed
         # this is okay since there is no evaluation done in this case
         config["engine"]["target"] = "local_system"

--- a/examples/mobilenet/mobilenet_qnn_ep.py
+++ b/examples/mobilenet/mobilenet_qnn_ep.py
@@ -51,18 +51,24 @@ def main(raw_args=None):
                 "<evaluator>": "common_evaluator",
             }
         )
-        # Set the environment variables
+        # replace template variables with actual values
         config_str = json.dumps(config)
         for name, value in template_args.items():
             config_str = config_str.replace(name, value)
         config = json.loads(config_str)
         config_name += "_eval"
+        # delete unnecessary fields
+        del config["systems"]["local_system"]
     else:
+        # set target to local_system
+        # it is QNN EP as the target EP even though local environment has
+        # cpu package installed
+        # this is okay since there is no evaluation done in this case
+        config["engine"]["target"] = "local_system"
         # delete unnecessary fields
         del (
-            config["systems"],
+            config["systems"]["qnn_ep_env"],
             config["evaluators"],
-            config["engine"]["target"],
             config["engine"]["evaluator"],
             config["engine"]["evaluate_input_model"],
         )
@@ -72,10 +78,11 @@ def main(raw_args=None):
         with open(f"{config_name}.json", "w") as f:
             json.dump(config, f, indent=4)
         print(f"Config file {config_name}.json is generated")  # noqa: T201
+        return config
     else:
         if not args.skip_data_download:
             download_files()
-        olive_run(config)  # pylint: disable=not-callable
+        return olive_run(config)  # pylint: disable=not-callable
 
 
 if __name__ == "__main__":

--- a/examples/mobilenet/mobilenet_qnn_ep_template.json
+++ b/examples/mobilenet/mobilenet_qnn_ep_template.json
@@ -6,13 +6,24 @@
         }
     },
     "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "config": {
+                "accelerators": [
+                    {
+                        "execution_providers": [
+                            "QNNExecutionProvider"
+                        ]
+                    }
+                ]
+            }
+        },
         "qnn_ep_env": {
             "type": "IsolatedORT",
             "config": {
                 "python_environment_path": "<qnn_env_path>",
                 "accelerators": [
                     {
-                        "device": "npu",
                         "execution_providers": [
                             "QNNExecutionProvider"
                         ]
@@ -67,7 +78,7 @@
     },
     "passes": {
         "qnn_preprocess": {
-            "type": "QnnPreprocess"
+            "type": "QNNPreprocess"
         },
         "quantization": {
             "type": "OnnxStaticQuantization",
@@ -85,6 +96,6 @@
         "evaluator": "<evaluator>",
         "evaluate_input_model": false,
         "cache_dir": "cache",
-        "output_dir": "models"
+        "output_dir": "models/mobilenet_qnn_ep"
     }
 }

--- a/examples/test/test_mobilenet_qnn_ep.py
+++ b/examples/test/test_mobilenet_qnn_ep.py
@@ -27,7 +27,8 @@ def setup():
 def test_mobilenet_qnn_ep():
     from mobilenet_qnn_ep import main as mobilenet_qnn_ep_main
 
-    result = mobilenet_qnn_ep_main(["--skip_data_download"])
+    # need to pass [] since the parser reads from sys.argv
+    result = mobilenet_qnn_ep_main([])
 
     expected_accelerator_spec = AcceleratorSpec(accelerator_type="npu", execution_provider="QNNExecutionProvider")
     # make sure it only ran for npu-qnn

--- a/examples/test/test_mobilenet_qnn_ep.py
+++ b/examples/test/test_mobilenet_qnn_ep.py
@@ -1,0 +1,35 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from olive.hardware import AcceleratorSpec
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    """Setups any state specific to the execution of the given module."""
+    cur_dir = Path(__file__).resolve().parent.parent
+    example_dir = str(cur_dir / "mobilenet")
+    os.chdir(example_dir)
+    sys.path.insert(0, example_dir)
+
+    yield
+    os.chdir(cur_dir)
+    sys.path.remove(example_dir)
+
+
+def test_mobilenet_qnn_ep():
+    from mobilenet_qnn_ep import main as mobilenet_qnn_ep_main
+
+    result = mobilenet_qnn_ep_main(["--skip_data_download"])
+
+    expected_accelerator_spec = AcceleratorSpec(accelerator_type="npu", execution_provider="QNNExecutionProvider")
+    # make sure it only ran for npu-qnn
+    assert len(result) == 1
+    assert expected_accelerator_spec in result

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -175,6 +175,10 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
     * only device is specified, infer the execution providers based on the installed ORT in case of local/python system.
     * only EP is specified, infer the device based on the installed ORT in case of local/python system.
     * For AzureML and Docker system, the accelerators and execution providers must be specified.
+
+    :param system_config: The system config to be normalized.
+    :param skip_supported_eps_check: Whether to skip the check that the system supported eps are compatible with the
+        accelerators in the system config. This is True when target is not used for evaluation or pass runs.
     """
     from olive.systems.common import SystemType
 
@@ -263,10 +267,15 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
             system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT)
             and not skip_supported_eps_check
         ):
-            # don't need to check the supported execution providers if there is no evaluation
-            # target is only used for evaluation
+            # skip_supported_eps_check is True here
+            # target is used so we need to check that the system supported eps are compatible with the accelerators
             available_eps = system_supported_eps
         else:
+            # AzureML and Docker system: These are required to be specified by the user.
+            # Local, PythonEnvironment, IsolatedORT: skip_supported_eps_check is True
+            # the target is not used so no need to check the compatibility between the system supported eps and
+            # the accelerators
+            # since availiable_eps == accelerator.execution_providers, the check will always pass
             available_eps = accelerator.execution_providers
 
         supported_eps = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -178,7 +178,7 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
 
     :param system_config: The system config to be normalized.
     :param skip_supported_eps_check: Whether to skip the check that the system supported eps are compatible with the
-        accelerators in the system config. This is True when target is not used for evaluation or pass runs.
+        accelerators in the system config. This is True when target system is not used for evaluation or pass runs.
     """
     from olive.systems.common import SystemType
 
@@ -267,15 +267,18 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
             system_config.type in (SystemType.Local, SystemType.PythonEnvironment, SystemType.IsolatedORT)
             and not skip_supported_eps_check
         ):
-            # skip_supported_eps_check is True here
+            # skip_supported_eps_check is False here
             # target is used so we need to check that the system supported eps are compatible with the accelerators
             available_eps = system_supported_eps
         else:
             # AzureML and Docker system: These are required to be specified by the user.
             # Local, PythonEnvironment, IsolatedORT: skip_supported_eps_check is True
             # the target is not used so no need to check the compatibility between the system supported eps and
-            # the accelerators
-            # since available_eps == accelerator.execution_providers, the check will always pass
+            # the accelerators (available_eps == accelerator.execution_providers, the check will always pass)
+            # Example scenario: to run optimization workflow for qnn-ep on x86 machine, the pass (like onnxquantization)
+            # needs to know qnn-ep is the target ep, but ort-qnn is not available on x86 machine.
+            # we can still run the workflow using cpu ORT package as the target is not used for evaluation or
+            # pass runs (= no inference sesion is created). The ort tools don't need the ep to be available.
             available_eps = accelerator.execution_providers
 
         supported_eps = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(

--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -275,7 +275,7 @@ def normalize_accelerators(system_config: "SystemConfig", skip_supported_eps_che
             # Local, PythonEnvironment, IsolatedORT: skip_supported_eps_check is True
             # the target is not used so no need to check the compatibility between the system supported eps and
             # the accelerators
-            # since availiable_eps == accelerator.execution_providers, the check will always pass
+            # since available_eps == accelerator.execution_providers, the check will always pass
             available_eps = accelerator.execution_providers
 
         supported_eps = AcceleratorLookup.get_execution_providers_for_device_by_available_providers(

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -148,7 +148,8 @@ def run_engine(package_config: OlivePackageConfig, run_config: RunConfig, data_r
         AzureMLSystem.olive_config = run_config.to_json()
 
     # Register passes since we need to know whether they need to run on target
-    for pass_config in get_used_passes(run_config):
+    used_passes = list(get_used_passes(run_config))
+    for pass_config in used_passes:
         logger.debug("Registering pass %s", pass_config.type)
         package_config.import_pass_module(pass_config.type)
 
@@ -159,11 +160,10 @@ def run_engine(package_config: OlivePackageConfig, run_config: RunConfig, data_r
         # not using auto optimizer
         and run_config.passes
         # no pass specific evaluator
-        and all(pass_config.evaluator is None for pass_config in get_used_passes(run_config))
         # no pass needs to run on target
         and all(
-            Pass.registry[pass_config.type.lower()].run_on_target is False
-            for pass_config in get_used_passes(run_config)
+            pass_config.evaluator is None and Pass.registry[pass_config.type.lower()].run_on_target is False
+            for pass_config in used_passes
         )
     )
     accelerator_specs = create_accelerators(engine.target_config, skip_supported_eps_check=target_not_used)
@@ -341,5 +341,5 @@ def get_used_passes(run_config: RunConfig) -> Generator[RunPassConfig, None, Non
                 if run_config.passes[pass_name].type not in passes:
                     passes.add(run_config.passes[pass_name].type)
                     yield run_config.passes[pass_name]
-    else:
+    elif run_config.passes:
         yield from run_config.passes.values()

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -158,7 +158,7 @@ def run_engine(package_config: OlivePackageConfig, run_config: RunConfig, data_r
         # no evaluator given (also implies no search)
         engine.evaluator_config is None
         # not using auto optimizer
-        and run_config.passes
+        and used_passes
         # no pass specific evaluator
         # no pass needs to run on target
         and all(


### PR DESCRIPTION
## Describe your changes
- Added doc and comment for `skip_supported_eps_check`.
- The value provided to `skip_supported_eps_check` is updated so that we also check that there are no passes that need to run on target.
- Mobilenet QNN EP example is fixed so that it only runs for qnn ep. #998 had made the example incorrect when running with no evaluation. Since no target was provided, it would run for all installed eps but it is only supposed to run for qnn ep.
- Added test for the example with no evaluation. Evaluation requires ARM64 Windows which we don't have in our agent pools.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
