### PR TITLE
Write configs as part of conversion pass

### DIFF
--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -3,15 +3,21 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Generator, Optional, Tuple
 
 from olive.constants import ModelFileFormat
 from olive.model.utils.hf_utils import (
     get_hf_model_config,
     get_hf_model_dummy_input,
+    get_hf_model_generation_config,
     get_hf_model_io_config,
+    get_hf_model_tokenizer,
     load_hf_model_from_model_class,
     load_hf_model_from_task,
+    save_hf_model_config,
+    save_hf_model_generation_config,
+    save_hf_model_tokenizer,
 )
 
 if TYPE_CHECKING:
@@ -43,6 +49,63 @@ class HfConfigMixin:
             raise ValueError("HF model_config is not available")
 
         return get_hf_model_config(self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained())
+
+    def save_hf_model_config(self, output_dir: str, **kwargs):
+        if self.hf_config is None:
+            raise ValueError("HF model_config is not available.")
+        if not Path(output_dir).is_dir():
+            raise ValueError("Expecting a directory as input.")
+
+        save_hf_model_config(self.get_hf_model_config(), output_dir, **kwargs)
+
+    def get_hf_model_generation_config(self):
+        if self.hf_config is None:
+            raise ValueError("HF model_config is not available")
+
+        return get_hf_model_generation_config(
+            self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained()
+        )
+
+    def save_hf_model_generation_config(self, output_dir: str, **kwargs):
+        if self.hf_config is None:
+            raise ValueError("HF model_config is not available.")
+        if not Path(output_dir).is_dir():
+            raise ValueError("Expecting a directory as input.")
+
+        save_hf_model_generation_config(self.get_hf_model_generation_config(), output_dir, **kwargs)
+
+    def get_hf_model_tokenizer(self):
+        if self.hf_config is None:
+            raise ValueError("HF model_config is not available")
+
+        return get_hf_model_tokenizer(
+            self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained()
+        )
+
+    def save_hf_model_tokenizer(self, output_dir: str, **kwargs):
+        if self.hf_config is None:
+            raise ValueError("HF model_config is not available.")
+        if not Path(output_dir).is_dir():
+            raise ValueError("Expecting a directory as input.")
+
+        save_hf_model_tokenizer(self.get_hf_model_tokenizer(), output_dir, **kwargs)
+
+    def save_metadata_for_token_generation(self, output_dir: str, **kwargs):
+        if self.hf_config is None:
+            raise ValueError("HF model_config is not available.")
+        if not Path(output_dir).is_dir():
+            raise ValueError("Expecting a directory as input.")
+
+        save_hf_model_config(self.get_hf_model_config(), output_dir, **kwargs)
+        save_hf_model_generation_config(self.get_hf_model_generation_config(), output_dir, **kwargs)
+        tokenizer_filepaths = save_hf_model_tokenizer(self.get_hf_model_tokenizer(), output_dir, **kwargs)
+
+        output_dir = Path(output_dir)
+        return [
+            str(output_dir / "config.json"),
+            str(output_dir / "generation_config.json"),
+            *tokenizer_filepaths,
+        ]
 
     def get_hf_io_config(self):
         """Get Io config for the model."""

--- a/olive/model/utils/hf_utils.py
+++ b/olive/model/utils/hf_utils.py
@@ -5,10 +5,18 @@
 import logging
 from functools import partial
 from itertools import chain
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import transformers
-from transformers import AutoConfig, AutoModel, AutoTokenizer
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoTokenizer,
+    GenerationConfig,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+    PreTrainedTokenizerFast,
+)
 
 from olive.model.utils.hf_mappings import FEATURE_TO_PEFT_TASK_TYPE, MODELS_TO_MAX_LENGTH_MAPPING, TASK_TO_FEATURE
 
@@ -61,9 +69,36 @@ def huggingface_model_loader(model_loader):
     return model_loader.from_pretrained
 
 
-def get_hf_model_config(model_name: str, **kwargs):
+def get_hf_model_config(model_name: str, **kwargs) -> PretrainedConfig:
     """Get HF Config for the given model name."""
     return AutoConfig.from_pretrained(model_name, **kwargs)
+
+
+def save_hf_model_config(config: PretrainedConfig, output_dir: str, **kwargs):
+    """Save input HF Config to output directory."""
+    config.save_pretrained(output_dir, **kwargs)
+
+
+def get_hf_model_generation_config(model_name: str, **kwargs) -> GenerationConfig:
+    """Get HF model's generation config for the given model name."""
+    return GenerationConfig.from_pretrained(model_name, **kwargs)
+
+
+def save_hf_model_generation_config(config: GenerationConfig, output_dir: str, **kwargs):
+    """Save input HF generation Config to output directory."""
+    config.save_pretrained(output_dir, **kwargs)
+
+
+def get_hf_model_tokenizer(model_name: str, **kwargs) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
+    """Get HF model's tokenizer."""
+    return AutoTokenizer.from_pretrained(model_name, **kwargs)
+
+
+def save_hf_model_tokenizer(
+    tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], output_dir: str, **kwargs
+) -> Tuple[str]:
+    """Save input tokenizer to output directory."""
+    return tokenizer.save_pretrained(output_dir, **kwargs)
 
 
 def load_hf_model_from_model_class(model_class: str, name: str, **kwargs):

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -107,11 +107,53 @@ class OnnxConversion(Pass):
                     "models with adapter weights"
                 ),
             ),
+            "save_metadata_for_token_generation": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description=(
+                    "Whether to save metadata for token generation or not. "
+                    "Includes config.json, generation_config.json, and  tokenizer related files."
+                ),
+            ),
         }
         config.update(get_external_data_config())
         return config
 
     def _run_for_config(
+        self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
+    ) -> Union[CompositeModelHandler, DistributedOnnxModelHandler, ONNXModelHandler]:
+        output_model = self._run_for_config_internal(model, data_root, config, output_model_path)
+
+        if model.hf_config and config["save_metadata_for_token_generation"]:
+            if isinstance(output_model, CompositeModelHandler):
+                for _, component_model in output_model.get_model_components():
+                    output_dir = Path(component_model.get_resource("model_path"))
+                    if not output_dir.is_dir():
+                        output_dir = str(output_dir.parent)
+                        component_model.set_resource("model_path", output_dir)
+
+                    component_model.model_attributes = model_attributes = component_model.model_attributes or {}
+                    model_attributes["additional_files"] = additional_files = model_attributes.get(
+                        "additional_files", []
+                    )
+                    additional_files.extend(model.save_metadata_for_token_generation(str(output_dir)))
+
+            elif isinstance(output_model, (DistributedOnnxModelHandler, ONNXModelHandler)):
+                output_dir = Path(output_model.get_resource("model_path"))
+                if not output_dir.is_dir():
+                    output_dir = str(output_dir.parent)
+                    output_model.set_resource("model_path", output_dir)
+
+                output_model.model_attributes = model_attributes = output_model.model_attributes or {}
+                model_attributes["additional_files"] = additional_files = model_attributes.get("additional_files", [])
+                additional_files.extend(model.save_metadata_for_token_generation(str(output_dir)))
+
+            else:
+                raise RuntimeError("Encountered an unknown model type during conversion.")
+
+        return output_model
+
+    def _run_for_config_internal(
         self, model: PyTorchModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> Union[CompositeModelHandler, DistributedOnnxModelHandler, ONNXModelHandler]:
         # get the device to use for conversion


### PR DESCRIPTION
## Write configs as part of conversion pass

For generative models using GenAI model builder, when using ONNX model as input configs (config.json, generation_config.json & tokenizer) are required inputs. So, write out these files as outputs from the conversion pass.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
