### PR TITLE
Fix unused bug in gptq_utils

### DIFF
--- a/olive/passes/pytorch/gptq_utils.py
+++ b/olive/passes/pytorch/gptq_utils.py
@@ -234,7 +234,7 @@ class QuantLinearORT(nn.Module):
         intzeros_pt = (intzeros_pt[:, 0::2]) | (intzeros_pt[:, 1::2] << 4)
         intzeros_pt = intzeros_pt.reshape(-1)
 
-        intweight_pt_t = intweight.T
+        intweight_pt_t = intweight_pt.T
         intweight_pt_t = (intweight_pt_t[:, 0::2]) | (intweight_pt_t[:, 1::2] << 4)
         intweight_pt_t = intweight_pt_t.reshape(cols, k_blocks, blob_size)
 


### PR DESCRIPTION
## Describe your changes
fix unused bug in gptq_utils, this bug only exists when GEMM weights need padding which is not common.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
