### PR TITLE
fix typos in configure_systems.rst

### DIFF
--- a/docs/source/tutorials/configure_systems.rst
+++ b/docs/source/tutorials/configure_systems.rst
@@ -42,7 +42,7 @@ The local system represents the local machine where the Pass is run or the Model
         .. code-block:: json
 
             {
-                "system": {
+                "systems": {
                     "local_system" : {
                         "type": "LocalSystem",
                         "config": {
@@ -115,7 +115,7 @@ Here are the examples of configuring the general Python Environment System.
         .. code-block:: json
 
             {
-                "system"  : {
+                "systems"  : {
                     "python_system" : {
                         "type": "PythonEnvironment",
                         "config": {


### PR DESCRIPTION
## Describe your changes

There were a couple of typos in the "how to configure systems" doc where `system` was used in the JSON rather than `systems`.
