### PR TITLE
HFConfig: don't pass kwargs to get tokenizer

### DIFF
--- a/olive/model/config/hf_config.py
+++ b/olive/model/config/hf_config.py
@@ -251,17 +251,9 @@ class HfConfig(ConfigBase):
             raise ValueError("Either task or model_class must be specified")
         return v
 
-    def get_loading_args_from_pretrained(self, exclude_keys: List[str] = None) -> Dict[str, Any]:
-        """Return all args from from_pretrained_args in a dict with types expected by `from_pretrained`.
-
-        :param exclude_keys: List of keys to exclude from the returned dict.
-        :return: Dict of args with types expected by `from_pretrained`.
-        """
-        loading_args = self.from_pretrained_args.get_loading_args() if self.from_pretrained_args else {}
-        if exclude_keys:
-            for key in exclude_keys:
-                loading_args.pop(key, None)
-        return loading_args
+    def get_loading_args_from_pretrained(self) -> Dict[str, Any]:
+        """Return all args from from_pretrained_args in a dict with types expected by `from_pretrained`."""
+        return self.from_pretrained_args.get_loading_args() if self.from_pretrained_args else {}
 
 
 def get_model_type_from_hf_config(hf_config: HfConfig) -> str:

--- a/olive/model/config/hf_config.py
+++ b/olive/model/config/hf_config.py
@@ -251,9 +251,17 @@ class HfConfig(ConfigBase):
             raise ValueError("Either task or model_class must be specified")
         return v
 
-    def get_loading_args_from_pretrained(self) -> Dict[str, Any]:
-        """Return all args from from_pretrained_args in a dict with types expected by `from_pretrained`."""
-        return self.from_pretrained_args.get_loading_args() if self.from_pretrained_args else {}
+    def get_loading_args_from_pretrained(self, exclude_keys: List[str] = None) -> Dict[str, Any]:
+        """Return all args from from_pretrained_args in a dict with types expected by `from_pretrained`.
+
+        :param exclude_keys: List of keys to exclude from the returned dict.
+        :return: Dict of args with types expected by `from_pretrained`.
+        """
+        loading_args = self.from_pretrained_args.get_loading_args() if self.from_pretrained_args else {}
+        if exclude_keys:
+            for key in exclude_keys:
+                loading_args.pop(key, None)
+        return loading_args
 
 
 def get_model_type_from_hf_config(hf_config: HfConfig) -> str:

--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -62,9 +62,9 @@ class HfConfigMixin:
         if self.hf_config is None:
             raise ValueError("HF model_config is not available")
 
-        return get_hf_model_tokenizer(
-            self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained()
-        )
+        # don't provide loading args for tokenizer since it tries to serialize all kwargs
+        # TODO(anyone): only provide relevant kwargs, no use case for now to provide kwargs
+        return get_hf_model_tokenizer(self._get_model_path_or_name())
 
     def save_metadata_for_token_generation(self, output_dir: str, **kwargs):
         if self.hf_config is None:

--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -58,13 +58,13 @@ class HfConfigMixin:
             self._get_model_path_or_name(), **self.hf_config.get_loading_args_from_pretrained()
         )
 
-    def _get_hf_model_tokenizer(self):
+    def _get_hf_model_tokenizer(self, **kwargs):
         if self.hf_config is None:
             raise ValueError("HF model_config is not available")
 
-        # don't provide loading args for tokenizer since it tries to serialize all kwargs
+        # don't provide loading args for tokenizer directly since it tries to serialize all kwargs
         # TODO(anyone): only provide relevant kwargs, no use case for now to provide kwargs
-        return get_hf_model_tokenizer(self._get_model_path_or_name())
+        return get_hf_model_tokenizer(self._get_model_path_or_name(), **kwargs)
 
     def save_metadata_for_token_generation(self, output_dir: str, **kwargs):
         if self.hf_config is None:


### PR DESCRIPTION
## Describe your changes
When creating a tokenizer using `AutoTokenizer.from_pretrained`, it saves the kwargs and tries to serialize them during `save_pretrained`. The model loading args contains kwargs that are not related to tokenizer and cannot be serialized like torch.dtype and BitsAndBytesConfig. 
Don't pass any kwargs when getting tokenizer. If needed, we can filter the keys in the future.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
