### PR TITLE
Remove name ambiguity in dataset configuration

### DIFF
--- a/docs/source/features/huggingface_model_optimization.md
+++ b/docs/source/features/huggingface_model_optimization.md
@@ -194,24 +194,22 @@ Pass config:
 
 Example: datasets in `data_configs`:
 ```json
-"data_configs": {
-    "oasst1_train": {
-        "name": "oasst1",
-        "type": "HuggingfaceContainer",
-        "params_config": {
-            "data_name": "timdettmers/openassistant-guanaco",
-            "split": "train",
-            "component_kwargs": {
-                "pre_process_data": {
-                    "text_cols": ["text"],
-                    "corpus_strategy": "line-by-line",
-                    "source_max_len": 512,
-                    "pad_to_max_len": false
-                }
+"data_configs": [{
+    "name": "oasst1_train",
+    "type": "HuggingfaceContainer",
+    "params_config": {
+        "data_name": "timdettmers/openassistant-guanaco",
+        "split": "train",
+        "component_kwargs": {
+            "pre_process_data": {
+                "text_cols": ["text"],
+                "corpus_strategy": "line-by-line",
+                "source_max_len": 512,
+                "pad_to_max_len": false
             }
         }
     }
-}
+}]
 ```
 
 Pass config:

--- a/docs/source/tutorials/configure_data.rst
+++ b/docs/source/tutorials/configure_data.rst
@@ -9,10 +9,10 @@ The configuration of Olive data config is positioned under Olive run config with
 
 .. code-block::
 
-    "data_configs": {
-        "dataset_1": {...},
-        "dataset_2": {...},
-    }
+    "data_configs": [
+        { "name": "dataset_1", ...},
+        { "name": "dataset_2", ...},
+    ]
 
 Note: `name` for each dataset should be unique, and must be composed letters, numbers, and underscores.
 

--- a/examples/bert/npu/bert_snpe.json
+++ b/examples/bert/npu/bert_snpe.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -18,21 +18,30 @@
                     "data_config": "snpe_dataset",
                     "user_config": {
                         "inference_settings": {
-                            "snpe":{
+                            "snpe": {
                                 "return_numpy_results": true
                             }
                         }
                     },
                     "sub_types": [
-                        {"name": "accuracy", "priority": 1, "goal": {"type": "max-degradation", "value": 0.05}},
-                        {"name": "f1"}
+                        {
+                            "name": "accuracy",
+                            "priority": 1,
+                            "goal": {
+                                "type": "max-degradation",
+                                "value": 0.05
+                            }
+                        },
+                        {
+                            "name": "f1"
+                        }
                     ]
                 }
             ]
         }
     },
-    "data_configs": {
-        "snpe_dataset": {
+    "data_configs": [
+        {
             "name": "snpe_dataset",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
@@ -46,8 +55,13 @@
                 "task": "text-classification",
                 "batch_size": 2,
                 "data_name": "glue",
-                "input_cols": ["sentence1", "sentence2"],
-                "label_cols": ["label"],
+                "input_cols": [
+                    "sentence1",
+                    "sentence2"
+                ],
+                "label_cols": [
+                    "label"
+                ],
                 "split": "validation",
                 "subset": "mrpc",
                 "component_kwargs": {
@@ -58,7 +72,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "conversion": {
             "type": "OnnxConversion",
@@ -69,16 +83,41 @@
         "dynamic_shape_to_fixed": {
             "type": "DynamicToFixedShape",
             "config": {
-                "dim_param": ["batch", "sequence"],
-                "dim_value": [2, 128]
+                "dim_param": [
+                    "batch",
+                    "sequence"
+                ],
+                "dim_value": [
+                    2,
+                    128
+                ]
             }
         },
         "to_snpe_dlc": {
             "type": "SNPEConversion",
             "config": {
-                "input_names": ["input_ids", "attention_mask", "token_type_ids"],
-                "input_shapes": [[2, 128], [2, 128], [2, 128]],
-                "output_names": ["logits"]
+                "input_names": [
+                    "input_ids",
+                    "attention_mask",
+                    "token_type_ids"
+                ],
+                "input_shapes": [
+                    [
+                        2,
+                        128
+                    ],
+                    [
+                        2,
+                        128
+                    ],
+                    [
+                        2,
+                        128
+                    ]
+                ],
+                "output_names": [
+                    "logits"
+                ]
             }
         }
     },
@@ -87,6 +126,6 @@
         "clean_cache": true,
         "evaluator": "snpe_evaluator",
         "evaluate_input_model": false,
-        "output_dir" : "models/bert_snpe"
+        "output_dir": "models/bert_snpe"
     }
 }

--- a/examples/inception/inception_config.json
+++ b/examples/inception/inception_config.json
@@ -5,8 +5,8 @@
             "model_path": "models/inception_v3.pb"
         }
     },
-    "data_configs": {
-        "raw_data": {
+    "data_configs": [
+        {
             "name": "raw_data",
             "type": "RawDataContainer",
             "user_script": "user_script.py",
@@ -33,7 +33,7 @@
                 "batch_size": 7
             }
         }
-    },
+    ],
     "systems": {
         "local_system": {
             "type": "LocalSystem",

--- a/examples/llama2/llama2_qlora.json
+++ b/examples/llama2/llama2_qlora.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "model_script": "user_script.py",
@@ -29,8 +29,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
@@ -55,7 +55,7 @@
                 }
             }
         }
-    },
+    ],
     "evaluators": {
         "merged_evaluator": {
             "metrics": [
@@ -140,6 +140,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/qlora"
+        "output_dir": "models/qlora"
     }
 }

--- a/examples/llama2/llama2_template.json
+++ b/examples/llama2/llama2_template.json
@@ -15,8 +15,8 @@
             }
         }
     },
-    "data_configs": {
-        "wikitext2_train": {
+    "data_configs": [
+        {
             "name": "wikitext2_train",
             "type": "HuggingfaceContainer",
             "params_config": {
@@ -37,7 +37,7 @@
                 }
             }
         }
-    },
+    ],
     "systems": {
         "local_system": {
             "type": "LocalSystem",

--- a/examples/llama2/notebook/llama2/config.json
+++ b/examples/llama2/notebook/llama2/config.json
@@ -5,7 +5,7 @@
         "workspace_name": "<workspace_name>",
         "keyvault_name": "<my_keyvault_name>"
     },
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "model_script": "user_script.py",
@@ -18,9 +18,9 @@
                     "registry_name": "azureml-meta",
                     "version": "13"
                 }
-             },
-             "model_file_format": "PyTorch.MLflow",
-             "hf_config": {
+            },
+            "model_file_format": "PyTorch.MLflow",
+            "hf_config": {
                 "model_name": "meta-llama/Llama-2-7b-hf",
                 "task": "text-generation"
             }
@@ -65,8 +65,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
@@ -91,14 +91,22 @@
                 }
             }
         }
-    },
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [{"name": "avg", "goal": {"type": "percent-min-improvement", "value": 10}}],
+                    "sub_types": [
+                        {
+                            "name": "avg",
+                            "goal": {
+                                "type": "percent-min-improvement",
+                                "value": 10
+                            }
+                        }
+                    ],
                     "user_config": {
                         "user_script": "user_script.py",
                         "dataloader_func": "dataloader_func_for_merged",
@@ -170,6 +178,6 @@
         "host": "aml",
         "target": "aml",
         "cache_dir": "cache",
-        "output_dir" : "models/llama2"
+        "output_dir": "models/llama2"
     }
 }

--- a/examples/open_llama/llama_qlora.json
+++ b/examples/open_llama/llama_qlora.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -20,8 +20,8 @@
             }
         }
     },
-    "data_configs": {
-        "oasst1_train": {
+    "data_configs": [
+        {
             "name": "oasst1",
             "type": "HuggingfaceContainer",
             "params_config": {
@@ -29,7 +29,9 @@
                 "split": "train",
                 "component_kwargs": {
                     "pre_process_data": {
-                        "text_cols": ["text"],
+                        "text_cols": [
+                            "text"
+                        ],
                         "corpus_strategy": "line-by-line",
                         "source_max_len": 512,
                         "pad_to_max_len": false
@@ -37,7 +39,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "qlora": {
             "type": "QLoRA",
@@ -76,6 +78,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/huggyllama_qlora"
+        "output_dir": "models/huggyllama_qlora"
     }
 }

--- a/examples/open_llama/open_llama_loftq_tinycodes.json
+++ b/examples/open_llama/open_llama_loftq_tinycodes.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -20,8 +20,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
@@ -46,7 +46,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "loftq": {
             "type": "LoftQ",
@@ -76,6 +76,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/open_llama_loftq_tinycodes"
+        "output_dir": "models/open_llama_loftq_tinycodes"
     }
 }

--- a/examples/open_llama/open_llama_lora_tinycodes.json
+++ b/examples/open_llama/open_llama_lora_tinycodes.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -20,8 +20,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
@@ -46,7 +46,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "lora": {
             "type": "LoRA",
@@ -76,6 +76,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/open_llama_lora_tinycodes"
+        "output_dir": "models/open_llama_lora_tinycodes"
     }
 }

--- a/examples/open_llama/open_llama_qlora_ort_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_ort_tinycodes.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -20,8 +20,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
@@ -46,7 +46,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "qlora": {
             "type": "QLoRA",
@@ -78,6 +78,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/open_llama_qlora_ort_tinycodes"
+        "output_dir": "models/open_llama_qlora_ort_tinycodes"
     }
 }

--- a/examples/open_llama/open_llama_qlora_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_tinycodes.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -20,8 +20,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
@@ -46,7 +46,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "qlora": {
             "type": "QLoRA",
@@ -76,6 +76,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/open_llama_qlora_tinycodes"
+        "output_dir": "models/open_llama_qlora_tinycodes"
     }
 }

--- a/examples/open_llama/open_llama_sparsegpt_gpu.json
+++ b/examples/open_llama/open_llama_sparsegpt_gpu.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -23,18 +23,22 @@
             }
         }
     },
-    "data_configs": {
-        "c4_train": {
+    "data_configs": [
+        {
             "name": "c4_train",
             "type": "HuggingfaceContainer",
             "params_config": {
                 "data_name": "allenai/c4",
                 "subset": "allenai--c4",
                 "split": "train",
-                "data_files": {"train": "en/c4-train.00000-of-01024.json.gz"},
+                "data_files": {
+                    "train": "en/c4-train.00000-of-01024.json.gz"
+                },
                 "component_kwargs": {
                     "pre_process_data": {
-                        "text_cols": ["text"],
+                        "text_cols": [
+                            "text"
+                        ],
                         "corpus_strategy": "join-random",
                         "add_special_tokens": false,
                         "source_max_len": 2048,
@@ -44,7 +48,7 @@
                 }
             }
         },
-        "wikitext2_test": {
+        {
             "name": "wikitext2_test",
             "type": "HuggingfaceContainer",
             "params_config": {
@@ -53,7 +57,9 @@
                 "split": "test",
                 "component_kwargs": {
                     "pre_process_data": {
-                        "text_cols": ["text"],
+                        "text_cols": [
+                            "text"
+                        ],
                         "corpus_strategy": "join",
                         "add_special_tokens": false,
                         "source_max_len": 2048
@@ -61,15 +67,17 @@
                 }
             }
         }
-    },
+    ],
     "evaluators": {
         "common_evaluator": {
-            "metrics":[
+            "metrics": [
                 {
                     "name": "perplexity",
                     "type": "accuracy",
                     "sub_types": [
-                        {"name": "perplexity"}
+                        {
+                            "name": "perplexity"
+                        }
                     ],
                     "data_config": "wikitext2_test"
                 }
@@ -80,7 +88,10 @@
         "sparsegpt": {
             "type": "SparseGPT",
             "config": {
-                "sparsity": [2,4],
+                "sparsity": [
+                    2,
+                    4
+                ],
                 "data_config": "c4_train"
             }
         },
@@ -98,6 +109,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/open_llama_sparsegpt"
+        "output_dir": "models/open_llama_sparsegpt"
     }
 }

--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -1,5 +1,5 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "hf_config": {
@@ -23,8 +23,8 @@
             }
         }
     },
-    "data_configs": {
-        "tiny_codes_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
@@ -49,7 +49,7 @@
                 }
             }
         }
-    },
+    ],
     "passes": {
         "qlora": {
             "type": "QLoRA",
@@ -79,6 +79,6 @@
         "host": "local_system",
         "target": "local_system",
         "cache_dir": "cache",
-        "output_dir" : "models/phi_qlora_tinycodes"
+        "output_dir": "models/phi_qlora_tinycodes"
     }
 }

--- a/examples/phi2/phi2_optimize_template.json
+++ b/examples/phi2/phi2_optimize_template.json
@@ -84,7 +84,7 @@
                     "gradient_accumulation_steps": 4,
                     "gradient_checkpointing": false,
                     "learning_rate": 0.0001,
-                    "num_train_epochs":3,
+                    "num_train_epochs": 3,
                     "max_steps": 10,
                     "logging_steps": 10,
                     "evaluation_strategy": "steps",
@@ -161,8 +161,8 @@
             }
         }
     },
-    "data_configs": {
-        "dataset_default_train": {
+    "data_configs": [
+        {
             "name": "tiny_codes_train",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
@@ -187,7 +187,7 @@
                 }
             }
         },
-        "wikitext2": {
+        {
             "name": "wikitext2",
             "type": "HuggingfaceContainer",
             "params_config": {
@@ -196,13 +196,15 @@
                 "split": "train",
                 "component_kwargs": {
                     "pre_process_data": {
-                        "text_cols": ["text"],
+                        "text_cols": [
+                            "text"
+                        ],
                         "source_max_len": 2048
                     }
                 }
             }
         }
-    },
+    ],
     "engine": {
         "evaluate_input_model": true,
         "evaluator": "common_evaluator",

--- a/examples/vgg/vgg_config.json
+++ b/examples/vgg/vgg_config.json
@@ -1,31 +1,53 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "ONNXModel",
         "config": {
             "model_path": "models/vgg.onnx"
         }
     },
-    "data_configs": {
-        "raw_data": {
+    "data_configs": [
+        {
             "name": "raw_data",
             "type": "RawDataContainer",
             "params_config": {
                 "data_dir": "data",
-                "input_names": ["data"],
-                "input_shapes": [[1, 3, 224, 224]],
-                "input_dirs": ["."],
+                "input_names": [
+                    "data"
+                ],
+                "input_shapes": [
+                    [
+                        1,
+                        3,
+                        224,
+                        224
+                    ]
+                ],
+                "input_dirs": [
+                    "."
+                ],
                 "input_suffix": ".raw",
                 "input_order_file": "input_order.txt"
             }
         }
-    },
+    ],
     "passes": {
         "snpe_conversion": {
             "type": "SNPEConversion",
             "config": {
-                "input_names": ["data"],
-                "input_shapes": [[1, 3, 224, 224]],
-                "output_names": ["vgg0_dense2_fwd"]
+                "input_names": [
+                    "data"
+                ],
+                "input_shapes": [
+                    [
+                        1,
+                        3,
+                        224,
+                        224
+                    ]
+                ],
+                "output_names": [
+                    "vgg0_dense2_fwd"
+                ]
             },
             "output_name": "vgg_snpe"
         },
@@ -42,6 +64,6 @@
         "log_severity_level": 0,
         "clean_cache": true,
         "cache_dir": "cache",
-        "output_dir" : "outputs"
+        "output_dir": "outputs"
     }
 }

--- a/olive/auto_optimizer/__init__.py
+++ b/olive/auto_optimizer/__init__.py
@@ -6,7 +6,7 @@
 import logging
 from copy import deepcopy
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from olive.auto_optimizer.regulate_mixins import RegulatePassConfigMixin
 from olive.common.config_utils import ConfigBase
@@ -58,13 +58,13 @@ class AutoOptimizer(RegulatePassConfigMixin):
         evaluator_config: OliveEvaluatorConfig,
         accelerator_spec: AcceleratorSpec,
         auto_optimizer_config: Optional[AutoOptimizerConfig] = None,
-        data_configs: Optional[Dict[str, DataConfig]] = None,
+        data_configs: Optional[List[DataConfig]] = None,
     ):
         self.input_model_config = input_model_config
         self.evaluator_config = evaluator_config
         self.accelerator_spec = accelerator_spec
         self.auto_optimizer_config = auto_optimizer_config or AutoOptimizerConfig()
-        self.data_configs = data_configs or {}
+        self.data_configs = data_configs or []
         self._initialize()
 
     def _initialize(self):

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -35,7 +35,7 @@ DefaultDataComponentCombos = {
 
 
 class DataConfig(ConfigBase):
-    name: str = DefaultDataContainer.DATA_CONTAINER.value
+    name: str
     type: str = DefaultDataContainer.DATA_CONTAINER.value
 
     # used to store the params for each component

--- a/test/unit_test/data_container/test_config.py
+++ b/test/unit_test/data_container/test_config.py
@@ -19,7 +19,7 @@ class TestDataConfig:
         self.dc_config = get_data_config()
 
     def test_default_property(self):
-        dc_config = DataConfig()
+        dc_config = DataConfig(name="test_dc_config")
         for k in dc_config.default_components:
             assert k in dc_config.components
         assert dc_config.dataloader

--- a/test/unit_test/data_container/test_data_container.py
+++ b/test/unit_test/data_container/test_data_container.py
@@ -26,7 +26,7 @@ class TestDataConfig:
         self.dc = DataContainer(config=self.dc_config)
 
     def test_constructor(self):
-        dc_config = DataConfig()
+        dc_config = DataConfig(name="test_dc_config")
         dc = DataContainer(config=dc_config)
         assert dc.config
         assert dc
@@ -37,7 +37,7 @@ class TestDataConfig:
         assert "label_from_params_config" in dc_config.components["load_dataset"].params["label_cols"]
 
     def test_huggingface_constructor(self):
-        dc_config = DataConfig(type="HuggingfaceContainer")
+        dc_config = DataConfig(name="test_dc_config", type="HuggingfaceContainer")
         dc = dc_config.to_data_container()
         assert dc.config.load_dataset.__name__.startswith("huggingface")
 
@@ -50,7 +50,7 @@ class TestDataConfig:
         dc.create_calibration_dataloader(data_root_path=None)
 
     def test_raw_data_constructor(self):
-        dc_config = DataConfig(type="RawDataContainer")
+        dc_config = DataConfig(name="test_dc_config", type="RawDataContainer")
         dc = dc_config.to_data_container()
         assert dc.config.load_dataset.__name__.startswith("raw_dataset")
 
@@ -61,6 +61,7 @@ class TestDataConfig:
         data = create_raw_data(tmpdir, input_names, input_shapes, input_types)
 
         dc_config = DataConfig(
+            name="test_raw_dc_config",
             type="RawDataContainer",
             params_config={
                 "data_dir": str(tmpdir),

--- a/test/unit_test/passes/inc/test_inc_quantization.py
+++ b/test/unit_test/passes/inc/test_inc_quantization.py
@@ -103,7 +103,7 @@ def test_inc_quantization_with_data_config(mock_model_saver, tmp_path):
     ov_model = get_onnx_model(tmp_path)
     data_dir = tmp_path / "data"
     data_dir.mkdir(exist_ok=True)
-    config = {"approach": "static", "data_dir": data_dir, "data_config": DataConfig()}
+    config = {"approach": "static", "data_dir": data_dir, "data_config": DataConfig(name="test_dc_config")}
     output_folder = str(tmp_path / "quantized")
 
     mock_model_saver.return_value = ov_model

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -35,13 +35,14 @@ def test_openvino_quantization(data_source, tmp_path):
         config.update(
             {
                 "data_config": DataConfig(
+                    name="test_dc_config",
                     components={
                         "load_dataset": {
                             "name": "cifar10_dataset",
                             "type": "cifar10_dataset",
                             "params": {"data_dir": data_dir},
                         }
-                    }
+                    },
                 )
             }
         )
@@ -84,13 +85,14 @@ def test_openvino_quantization_with_accuracy(data_source, tmp_path):
         config.update(
             {
                 "data_config": DataConfig(
+                    name="test_dc_config",
                     components={
                         "load_dataset": {
                             "name": "cifar10_dataset",
                             "type": "cifar10_dataset",
                             "params": {"data_dir": data_dir},
                         }
-                    }
+                    },
                 )
             }
         )

--- a/test/unit_test/test_data_root.py
+++ b/test/unit_test/test_data_root.py
@@ -107,8 +107,9 @@ def get_data_config():
                 "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
             },
         },
-        "data_configs": {
-            "test_data_config": DataConfig(
+        "data_configs": [
+            DataConfig(
+                name="test_data_config",
                 components={
                     "load_dataset": {
                         "name": "dummy_dataset_dataroot",
@@ -118,9 +119,9 @@ def get_data_config():
                     "post_process_data": {
                         "type": "post_processing_func",
                     },
-                }
+                },
             ),
-        },
+        ],
         "evaluators": {
             "common_evaluator": {
                 "metrics": [
@@ -148,6 +149,7 @@ def get_data_config():
                     # "data_config": "test_data_config"
                     # This is just demo purpose to show how to use data_config in passes
                     "data_config": DataConfig(
+                        name="test_data_config",
                         components={
                             "load_dataset": {
                                 "name": "dummy_dataset_dataroot",
@@ -157,7 +159,7 @@ def get_data_config():
                             "post_process_data": {
                                 "type": "post_processing_func",
                             },
-                        }
+                        },
                     )
                 },
             },

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -286,6 +286,7 @@ def get_data_config():
     def _post_process(output, test_value): ...
 
     return DataConfig(
+        name="test_data_config",
         components={
             "load_dataset": {
                 "name": "test_dataset",
@@ -297,12 +298,13 @@ def get_data_config():
                 "type": "_test_dataloader",  # This is the key to get dataloader
                 "params": {"test_value": "test_value"},
             },
-        }
+        },
     )
 
 
 def get_glue_huggingface_data_config():
     return DataConfig(
+        name="glue_huggingface_data_config",
         type="HuggingfaceContainer",
         params_config={
             "task": "text-classification",
@@ -319,6 +321,7 @@ def get_glue_huggingface_data_config():
 
 def get_dc_params_config():
     return DataConfig(
+        name="dc_params_config",
         params_config={
             "data_dir": "./params_config",
             "batch_size": 1,


### PR DESCRIPTION
## Remove name ambiguity in dataset configuration
Dataset configuration i.e. data_configs are represeneted as objects in config and so have two name entries -
  - the key of the object itself
  - DataConfig::name field

Use cases around the code use either/or and expect both these names to be identifical with no enforcement during validation. Removing the duplication by making the data_configs a list of objects so the key isn't required anymore. Updated the code to use DataConfig::name for all look-ups.

Note: Pending document update.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
