### PR TITLE
Bug fix: Don't fail `get_hf_model_io_config`, Optional Accelerator execution_provider

### DIFF
--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -44,10 +44,11 @@ class AcceleratorSpec:
             return str(self.accelerator_type).lower()
 
     def to_json(self):
-        return {
-            "accelerator_type": str(self.accelerator_type),
-            "execution_provider": self.execution_provider,
-        }
+        json_data = {"accelerator_type": str(self.accelerator_type)}
+        if self.execution_provider:
+            json_data["execution_provider"] = self.execution_provider
+
+        return json_data
 
 
 DEFAULT_CPU_ACCELERATOR = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider="CPUExecutionProvider")

--- a/olive/model/handler/mixin/dummy_inputs.py
+++ b/olive/model/handler/mixin/dummy_inputs.py
@@ -55,8 +55,10 @@ class DummyInputsMixin:
                     .get_first_batch(data_root_path=None)
                 )
             elif not self.hf_config.components:
-                logger.debug("Using hf onnx_config to get dummy inputs")
+                logger.debug("Trying hf onnx_config to get dummy inputs")
                 dummy_inputs = self.get_hf_dummy_inputs()
+                if dummy_inputs is not None:
+                    logger.debug("Got dummy inputs from hf onnx_config")
 
         if dummy_inputs is None:
             raise ValueError(

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -42,7 +42,6 @@ class PyTorchModelHandler(OliveModelHandler, HfConfigMixin, DummyInputsMixin):  
     json_config_keys: Tuple[str, ...] = (
         "model_file_format",
         "model_loader",
-        "io_config",
         "dummy_inputs_func",
         "hf_config",
     )
@@ -230,6 +229,8 @@ class PyTorchModelHandler(OliveModelHandler, HfConfigMixin, DummyInputsMixin):  
 
     def to_json(self, check_object: bool = False):
         config = super().to_json(check_object)
+        # add _io_config to config to keep what was provided at init
+        config["config"]["io_config"] = self._io_config
         # only keep model_attributes that are not in hf_config
         if self.model_attributes and self.hf_config:
             model_attributes = {}
@@ -274,10 +275,12 @@ class PyTorchModelHandler(OliveModelHandler, HfConfigMixin, DummyInputsMixin):  
             io_config = self.get_user_io_config(self._io_config)
         elif self.hf_config and self.hf_config.task and not self.hf_config.components:
             # hf_config is provided
-            logger.debug("Using hf onnx_config to get io_config")
+            logger.debug("Trying hf onnx_config to get io_config")
             # For MLFlow model, get io config from model_name instead of model_path
             # TODO(xiaoyu): more investigation on the integration between MLFlow and HF
             io_config = self.get_hf_io_config()
+            if io_config:
+                logger.debug("Got io_config from hf_config")
 
         return io_config
 

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -29,10 +29,6 @@ def parse_pass_config_arg(raw_args):
 
     # parse config arg
     parser.add_argument("--pass_config", type=str, help="pass config", required=True)
-    parser.add_argument("--pass_accelerator_type", type=str, help="pass accelerator type", default="cpu")
-    parser.add_argument(
-        "--pass_execution_provider", type=str, help="pass execution provider", default="CPUExecutionProvider"
-    )
 
     return parser.parse_known_args(raw_args)
 
@@ -135,7 +131,7 @@ def main(raw_args=None):
             input_model_config["config"]["model_path"] = str(new_path)
 
     # pass specific args
-    accelerator_spec = AcceleratorSpec(pass_config_arg.pass_accelerator_type, pass_config_arg.pass_execution_provider)
+    accelerator_spec = AcceleratorSpec(**pass_config["accelerator"])
     pass_args, extra_args = parse_pass_args(pass_type, accelerator_spec, extra_args)
 
     # load input_model

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -391,17 +391,12 @@ class AzureMLSystem(OliveSystem):
 
         self.copy_code(code_files, code_root)
 
-        accelerator_info = {
-            "pass_accelerator_type": pass_config["accelerator"]["accelerator_type"],
-            "pass_execution_provider": pass_config["accelerator"]["execution_provider"],
-        }
         # prepare inputs
         model_resource_paths = model_config.get_resource_paths()
         inputs = {
             **self._create_model_inputs(model_resource_paths),
             **self._create_pass_inputs(pass_path_params),
             **data_params.data_inputs,
-            **accelerator_info,
         }
         # prepare outputs
         outputs = {"pipeline_output": Output(type=AssetTypes.URI_FOLDER)}
@@ -432,7 +427,6 @@ class AzureMLSystem(OliveSystem):
             **self._create_model_args(model_json, model_resource_paths, tmp_dir),
             **self._create_pass_args(pass_config, pass_path_params, data_root, tmp_dir),
             **data_params.data_args,
-            **accelerator_info,
         }
 
         @pipeline()

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -535,10 +535,6 @@ class TestAzureMLSystem:
             str(tmp_path / "pass_config.json"),
             "--pipeline_output",
             str(output_dir),
-            "--pass_accelerator_type",
-            f"{DEFAULT_CPU_ACCELERATOR.accelerator_type}",
-            "--pass_execution_provider",
-            f"{DEFAULT_CPU_ACCELERATOR.execution_provider}",
         ]
         aml_pass_runner_main(args)
 


### PR DESCRIPTION
## Describe your changes
This fixes some bugs introduced by some recent PRs:
- #1091
   - made `model.io_config` a property which calls `get_hf_model_io_config` if the conditions meet. 
   - However, this function fails if the model is not supported. Now it doesn't fail and logs when unsupported.
   - `PytorchModelHandler.to_json` uses `_io_config` for `"io_config"` so that the serialized model is the same as the one that was initialized. 
- #1072
   - execution_provider is optional for non-onnx pass but `to_json` still has the key. Which doesn't match the signature for https://github.com/microsoft/Olive/blob/91c4c20e324fbc47dcbbea20bf89035ec94fa4a6/olive/passes/olive_pass.py#L459
   - Only add when not None
   - Also removed `pass_accelerator_type` and `pass_execution_provider` from the aml_pass_runner command line inputs. These values are already present in `pass_config.json`
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
