### PR TITLE
LoRA/QLoRA: Workaround accelerate bug for multi-gpu bnb model

### DIFF
--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -650,13 +650,14 @@ class LoRABase(Pass):
 
             # there is a bug in accelerate where it assumes 4bit models on multiple gpus cannot be trained but it is
             # not the case. refer to https://github.com/huggingface/accelerate/pull/2714 for more details
-            # we will force the accelerator to use the first device using the ACCELERATE_TORCH_DEVICE environment variable
-            # only catches the bug on aml compute with multiple gpus where the model has no weights on device 0 for some reason
+            # we will force the accelerator to use the first device using the ACCELERATE_TORCH_DEVICE env variable
+            # only catches the bug on aml compute with multiple gpus where the model has no weights on device 0 for
+            # some reason
             # TODO(jambayk): add a version check when the fix is released
             accelerate_torch_device = os.environ.get("ACCELERATE_TORCH_DEVICE", None)
             try:
                 # using a try finally block in case the environment variable is used elsewhere
-                first_device = list(set(model.hf_device_map.values()))[0]
+                first_device = next(iter(set(model.hf_device_map.values())))
                 first_device_index = first_device.index if isinstance(first_device, torch.device) else first_device
                 os.environ["ACCELERATE_TORCH_DEVICE"] = f"cuda:{first_device_index}"
                 logger.debug("ACCELERATE_TORCH_DEVICE set to: %s", os.environ["ACCELERATE_TORCH_DEVICE"])


### PR DESCRIPTION
## Describe your changes
There is a bug in accelerate where it assumes that bnb (loaded_in_4bit) models on multiple gpus cannot be trained but this is not the case. On AML computes with multiple GPUs, the model doesn't have any weights on device 0 which is the default device for accelerator and catches the bug https://github.com/huggingface/accelerate/blob/e82de1215ae701b6bf567eb705615c656e7f55c7/src/accelerate/accelerator.py#L1374. This has been fixed on main by https://github.com/huggingface/accelerate/pull/2714 but is not in a release yet. 

We workaround this bug for current stable releases of accelerate by setting `ACCELERATE_TORCH_DEVICE` to the same device as the first device the model is on. 
`
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
