### PR TITLE
Fix handling of extra_args for ModelBuilder pass

### DIFF
--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -186,9 +186,14 @@ class ModelBuilder(Pass):
         if config.get("int4_accuracy_level"):
             extra_args["int4_accuracy_level"] = config["int4_accuracy_level"].value
 
-        extra_args["exclude_embeds"] = config["exclude_embeds"]
-        extra_args["exclude_lm_head"] = config["exclude_lm_head"]
-        extra_args["enable_cuda_graph"] = "1" if config["enable_cuda_graph"] else "0"
+        if config["exclude_embeds"]:
+            extra_args["exclude_embeds"] = config["exclude_embeds"]
+
+        if config["exclude_lm_head"]:
+            extra_args["exclude_lm_head"] = config["exclude_lm_head"]
+
+        if config["enable_cuda_graph"] is not None:
+            extra_args["enable_cuda_graph"] = "1" if config["enable_cuda_graph"] else "0"
 
         create_model(
             model_name=model_path,


### PR DESCRIPTION
## Fix handling of extra_args for ModelBuilder pass

GenAI model builder's extra_args works based on existence of a key rather then the value of the key itself. So, Olive cannot pass a key with a value of true/false. The key has to explicitly be added/removed based on the value of the key itself in the user config.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
