### PR TITLE
disable Vitis in ORT 1.18

### DIFF
--- a/olive/passes/onnx/vitis_ai/quant_utils.py
+++ b/olive/passes/onnx/vitis_ai/quant_utils.py
@@ -452,9 +452,9 @@ def is_ort_version_below_1_17():
 
 def is_ort_version_below_1_18():
     """
-    This function checks whether the current version of ONNX Runtime (ORT) is below 1.17.0.
+    This function checks whether the current version of ONNX Runtime (ORT) is below 1.18.0.
 
     Returns:
-        True if the current ORT version is less than 1.17.0, False otherwise.
+        True if the current ORT version is less than 1.18.0, False otherwise.
     """
     return version.parse(OrtVersion) < version.parse("1.18.0")

--- a/olive/passes/onnx/vitis_ai/quant_utils.py
+++ b/olive/passes/onnx/vitis_ai/quant_utils.py
@@ -448,3 +448,13 @@ def is_ort_version_below_1_17():
         True if the current ORT version is less than 1.17.0, False otherwise.
     """
     return version.parse(OrtVersion) < version.parse("1.17.0")
+
+
+def is_ort_version_below_1_18():
+    """
+    This function checks whether the current version of ONNX Runtime (ORT) is below 1.17.0.
+
+    Returns:
+        True if the current ORT version is less than 1.17.0, False otherwise.
+    """
+    return version.parse(OrtVersion) < version.parse("1.18.0")

--- a/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
+++ b/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
@@ -10,6 +10,7 @@ import pytest
 from onnxruntime.quantization.calibrate import CalibrationDataReader
 
 from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.vitis_ai.quant_utils import is_ort_version_below_1_18
 from olive.passes.onnx.vitis_ai_quantization import VitisAIQuantization
 
 
@@ -34,6 +35,7 @@ def dummy_calibration_reader(data_dir, batch_size, *args, **kwargs):
     return RandomDataReader()
 
 
+@pytest.mark.skipif(not is_ort_version_below_1_18(), reason="Vitis API only compatible with onnxruntime<=1.17")
 @pytest.mark.parametrize("calibrate_method", ["MinMSE", "NonOverflow"])
 def test_vitis_ai_quantization_pass(calibrate_method, tmp_path):
     # setup


### PR DESCRIPTION
## Describe your changes
* Disable Vitis technique for ORT 1.18 and above since of the API signature is changed. Please re-enable the CI when Amd fix the issue

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
