### PR TITLE
🗡️ Use resolve_torch_dtype instead of maintain a mapping to torch dtype instance

### DIFF
--- a/docs/source/features/packaging_output_models.md
+++ b/docs/source/features/packaging_output_models.md
@@ -111,7 +111,7 @@ Olive will also upload model configuration file, inference config file, metrics 
 AzureMLDeployment packaging will [package](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-package-models?view=azureml-api-2&tabs=sdk) ranked No. 1 model across all output models to Azure ML workspace, and create an endpoint for it if the endpoint doesn't exist, then deploy the output model to this endpoint.
 
 ## How to package Olive artifacts
-Olive packaging configuration is configured in `PackagingConfig` in Engine configuration. `PackagingConfig` can be a single packging configuration. Alternatively, if you want to apply multiple packaging types, you can also define a list of packaging configurations.
+Olive packaging configuration is configured in `PackagingConfig` in Engine configuration. `PackagingConfig` can be a single packaging configuration. Alternatively, if you want to apply multiple packaging types, you can also define a list of packaging configurations.
 
 If not specified, Olive will not package artifacts.
 

--- a/docs/source/features/passes/onnx.md
+++ b/docs/source/features/passes/onnx.md
@@ -124,7 +124,7 @@ You can refer to [here](https://github.com/microsoft/onnxruntime-extensions/blob
 * The `tool_command_args` will be used to describe the input parameters to create the `PrePostProcessor` instance. It is list of `PrePostProcessorInput`.
   The `name` is the tensor name. The `data_type` and `shape` will be used to create the tensor type. The `shape` can be a list of integers or a list of string.
 
-Users that write their own pre/post processing steps need to have the knowledge about whether the step includes the operators that is built-in support or supported in onnxextension.
+Users that write their own pre/post processing steps need to have the knowledge about whether the step includes the operators that is built-in support or supported in onnxruntime-extensions.
 For example, for some ops like `ConvertImageToBGR` which requires other extensions may be incompatible with ort-web, user need to exclude this kind of ops to generate proper models.
 
 Here are some examples to describe the pre/post processing which is exactly same with [superresolution](https://github.com/microsoft/onnxruntime-extensions/blob/main/onnxruntime_extensions/tools/add_pre_post_processing_to_model.py#L89)

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -44,11 +44,11 @@ This pass only supports Hugging Face transformers PyTorch models. Please refer t
     "config": {
         "compute_dtype": "bfloat16",
         "quant_type": "nf4",
-        "train_data_config": // ...,
         "training_args": {
             "learning_rate": 0.0002,
             // ...
-        }
+        },
+        "train_data_config": // ...,
     }
 }
 ```
@@ -68,11 +68,11 @@ This pass only supports Hugging Face transformers PyTorch models. Please refer t
     "type": "LoftQ",
     "config": {
         "compute_dtype": "bfloat16",
-        "train_data_config": // ...,
         "training_args": {
             "learning_rate": 0.0002,
             // ...
-        }
+        },
+        "train_data_config": // ...,
     }
 }
 ```
@@ -160,7 +160,7 @@ for an example implementation of `"wikitext2_train"`.
 
 ## SparseGPT
 `SparseGPT` prunes GPT like models using a pruning method called [SparseGPT](https://arxiv.org/abs/2301.00774). This one-shot pruning method can perform unstructured
-sparsity upto 60% on large models like OPT-175B and BLOOM-176B efficiently with negligible perplexity increase. It also supports semi-structured sparsity patterns such
+sparsity up to 60% on large models like OPT-175B and BLOOM-176B efficiently with negligible perplexity increase. It also supports semi-structured sparsity patterns such
 as 2:4 and 4:8 patterns.
 
 Please refer to the original paper linked above for more details on the algorithm and performance results for different models, sparsities and datasets.

--- a/docs/source/features/passes/qnn.md
+++ b/docs/source/features/passes/qnn.md
@@ -1,6 +1,6 @@
 # QNN
 
-Qualcomm AI Engine Direct is a Qualcomm Technologies Inc. software architure for AI/ML use cases on Qualcomm chipsets and AI acceleration cores.
+Qualcomm AI Engine Direct is a Qualcomm Technologies Inc. software architecture for AI/ML use cases on Qualcomm chipsets and AI acceleration cores.
 
 Olive provides tools to convert models from different frameworks such as ONNX, TensorFlow, and PyTorch to QNN model formats and quantize them to 8 bit fixed point for running on NPU cores.
 Olive uses the development tools available in the [Qualcomm AI Engine Direct SDK](https://developer.qualcomm.com/software/qualcomm-ai-engine-direct-sdk) (QNN SDK).

--- a/olive/data/component/dataset.py
+++ b/olive/data/component/dataset.py
@@ -11,6 +11,8 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset as TorchDataset
 
+from olive.common.utils import resolve_torch_dtype
+
 
 class BaseDataset(TorchDataset):
     """Define the Olive dataset which should return the data with following format.
@@ -113,15 +115,7 @@ class DummyDataset(BaseDataset):
         if index < 0 or index >= len(self):
             raise IndexError("Index out of range")
 
-        str_to_type = {
-            "float32": torch.float32,
-            "float16": torch.float16,
-            "int32": torch.int32,
-            "int64": torch.int64,
-            "int8": torch.int8,
-            "bool": torch.bool,
-        }
-        input_types = [str_to_type[type_] for type_ in self.input_types]
+        input_types = [resolve_torch_dtype(dtype_str) for dtype_str in self.input_types]
 
         if not self.input_names:
             dummy_inputs = []

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -24,7 +24,7 @@ from transformers import AutoTokenizer
 
 from olive.common.config_utils import ConfigBase, ConfigWithExtraArgs
 from olive.common.pydantic_v1 import Field, validator
-from olive.common.utils import find_submodules
+from olive.common.utils import find_submodules, resolve_torch_dtype
 from olive.data.config import DataConfig
 from olive.data.constants import IGNORE_INDEX
 from olive.hardware.accelerator import AcceleratorSpec
@@ -740,15 +740,9 @@ class LoRABase(Pass):
     @staticmethod
     def get_torch_dtype(torch_dtype: str) -> torch.dtype:
         """Get the torch dtype from the string."""
-        supported_dtypes = {
-            "bfloat16": torch.bfloat16,
-            "float16": torch.float16,
-            "float32": torch.float32,
-        }
-        assert (
-            torch_dtype in supported_dtypes
-        ), f"torch_dtype must be one of {list(supported_dtypes.keys())} but got {torch_dtype}"
-        return supported_dtypes[torch_dtype]
+        supported_dtypes = ("bfloat16", "float16", "float32")
+        assert torch_dtype in supported_dtypes, f"torch_dtype must be one of {supported_dtypes} but got {torch_dtype}"
+        return resolve_torch_dtype(torch_dtype)
 
     @classmethod
     def input_model_check(cls, model: PyTorchModelHandler) -> PyTorchModelHandler:


### PR DESCRIPTION
## Describe your changes
1. Use resolve_torch_dtype instead of maintain a mapping to torch dtype instance
2. Fix a few typos in docs.


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
