### PR TITLE
`OnnxFloatToFloat16`: Use ort float16 converter

### DIFF
--- a/docs/source/features/passes/onnx.md
+++ b/docs/source/features/passes/onnx.md
@@ -402,7 +402,7 @@ for an example implementation of `"user_script.py"` and `"create_dataloader"`.
 
 ## Float16 Conversion
 
-Converting a model to use Float16 instead of Float32 can decrease the model size and improve performance on some GPUs. The `OnnxFloatToFloat16` pass wraps [onnxconverter_common.float16.convert_float_to_float16](https://github.com/microsoft/onnxconverter-common/blob/master/onnxconverter_common/float16.py#L111), which convert most nodes/operators to use Float16 instead of Float32.
+Converting a model to use Float16 instead of Float32 can decrease the model size and improve performance on some GPUs. The `OnnxFloatToFloat16` pass the [float16 converter from onnxruntime](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/float16.py) to convert the model to float16, which convert most nodes/operators to use Float16 instead of Float32.
 
 Conversion to Float16 is often exposed at multiple stages of optimization, including model conversion and transformer optimization. This stand-alone pass is best suited for models that are not transformer architectures, where fusions may rely on a specific data types in node patterns.
 

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -46,10 +46,7 @@
             "module_path": "olive.passes.onnx.quantization.OnnxDynamicQuantization"
         },
         "OnnxFloatToFloat16": {
-            "module_path": "olive.passes.onnx.float16_conversion.OnnxFloatToFloat16",
-            "module_dependencies": [
-                "onnxconverter-common"
-            ]
+            "module_path": "olive.passes.onnx.float16_conversion.OnnxFloatToFloat16"
         },
         "OnnxMatMul4Quantizer": {
             "module_path": "olive.passes.onnx.quantization.OnnxMatMul4Quantizer"

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -281,7 +281,8 @@ class OnnxConversion(Pass):
                 for key in unused_keys:
                     dummy_inputs[key] = None
 
-            pytorch_model(*dummy_inputs.values())
+            dummy_inputs = dummy_inputs.values() if isinstance(dummy_inputs, dict) else dummy_inputs
+            pytorch_model(*dummy_inputs)
 
             with tempfile.TemporaryDirectory(dir=tempdir, prefix="olive_tmp") as tmp_dir:
                 tmp_dir_path = Path(tmp_dir)
@@ -289,7 +290,7 @@ class OnnxConversion(Pass):
 
                 dynamo_export(
                     pytorch_model,
-                    *dummy_inputs.values(),
+                    *dummy_inputs,
                     export_options=torch.onnx.ExportOptions(dynamic_shapes=True),
                 ).save(tmp_model_path)
                 onnx.checker.check_model(tmp_model_path)

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -5,8 +5,6 @@
 from pathlib import Path
 from typing import Any, Dict, List
 
-import onnx
-
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
@@ -18,18 +16,17 @@ from olive.passes.pass_config import PassConfigParam
 class OnnxFloatToFloat16(Pass):
     """Converts a model to float16.
 
-    It is based on onnxconverter-common.convert_float_to_float16.
-    See https://onnxruntime.ai/docs/performance/model-optimizations/float16.html#float16-conversion
+    It uses the float16 converter from onnxruntime to convert the model to float16.
     """
 
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
         config = {
             "min_positive_val": PassConfigParam(
-                type_=float, default_value=1e-7, description="Constant values will be clipped against this value"
+                type_=float, default_value=5.96e-08, description="Constant values will be clipped against this value"
             ),
             "max_finite_val": PassConfigParam(
-                type_=float, default_value=1e4, description="Constant values will be clipped against this value"
+                type_=float, default_value=65504.0, description="Constant values will be clipped against this value"
             ),
             "keep_io_types": PassConfigParam(
                 type_=bool, default_value=False, description="Whether model inputs/outputs should be left as float32"
@@ -50,22 +47,14 @@ class OnnxFloatToFloat16(Pass):
     def _run_for_config(
         self, model: ONNXModelHandler, data_root: str, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModelHandler:
-        from onnxconverter_common import float16
+        from onnxruntime.transformers.onnx_model import OnnxModel
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
-        config = self._config_class(**config)
-
-        model_fp32 = onnx.load(str(model.model_path))
-        model_fp16 = float16.convert_float_to_float16(
-            model_fp32,
-            min_positive_val=config.min_positive_val,
-            max_finite_val=config.max_finite_val,
-            keep_io_types=config.keep_io_types,
-            disable_shape_infer=config.disable_shape_infer,
-            op_block_list=config.op_block_list,
-            node_block_list=config.node_block_list,
-        )
+        # using the float16 converter from onnxruntime since it is regularly updated
+        # and can handle large models (>2GB) as well as ort contrib ops
+        ort_onnx_model = OnnxModel(model.load_model())
+        ort_onnx_model.convert_float_to_float16(**config)
 
         # save the model to the output path and return the model
-        return model_proto_to_olive_model(model_fp16, output_model_path, config.dict())
+        return model_proto_to_olive_model(ort_onnx_model.model, output_model_path, config)

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -57,7 +57,7 @@ class OnnxFloatToFloat16(Pass):
         # and can handle large models (>2GB) as well as ort contrib ops
         ort_onnx_model = OnnxModel(model.load_model())
         ort_onnx_model.convert_float_to_float16(
-            {
+            **{
                 key: config[key]
                 for key in [
                     "min_positive_val",

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -302,19 +302,6 @@ class OrtTransformersOptimization(Pass):
                     "ExecutionProvider", ""
                 ).lower()
 
-        if run_config["model_type"] == "phi" and not run_config["only_onnxruntime"]:
-            # fusions for phi model type are implemented only for dynamo exported models
-            # will check model_proto.functions as a proxy to determine if the model was exported using dynamo_export
-            onnx_model = onnx.load(model.model_path, load_external_data=False)
-            if len(onnx_model.functions) == 0:
-                logger.warning(
-                    "model_type `phi` expects the model to have been exported using torch.onnx.dynamo_export. However,"
-                    " the model doesn't appear to have been exported using torch.onnx.dynamo_export. This may result in"
-                    " a failure. Please convert the model using torch.onnx.dynamo_export or provide a different"
-                    " model_type value."
-                )
-            del onnx_model
-
         optimizer = transformers_optimizer.optimize_model(input=model.model_path, **run_config)
 
         if config["float16"]:

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -302,6 +302,19 @@ class OrtTransformersOptimization(Pass):
                     "ExecutionProvider", ""
                 ).lower()
 
+        if run_config["model_type"] == "phi" and not run_config["only_onnxruntime"]:
+            # fusions for phi model type are implemented only for dynamo exported models
+            # will check model_proto.functions as a proxy to determine if the model was exported using dynamo_export
+            onnx_model = onnx.load(model.model_path, load_external_data=False)
+            if len(onnx_model.functions) == 0:
+                logger.warning(
+                    "model_type `phi` expects the model to have been exported using torch.onnx.dynamo_export. However,"
+                    " the model doesn't appear to have been exported using torch.onnx.dynamo_export. This may result in"
+                    " a failure. Please convert the model using torch.onnx.dynamo_export or provide a different"
+                    " model_type value."
+                )
+            del onnx_model
+
         optimizer = transformers_optimizer.optimize_model(input=model.model_path, **run_config)
 
         if config["float16"]:

--- a/test/unit_test/passes/onnx/test_float16_conversion.py
+++ b/test/unit_test/passes/onnx/test_float16_conversion.py
@@ -1,0 +1,33 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from test.unit_test.utils import get_onnx_model
+
+import onnx
+import pytest
+
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.float16_conversion import OnnxFloatToFloat16
+
+
+@pytest.mark.parametrize("keep_io_types", [True, False])
+def test_onnxfloattofloat16(keep_io_types, tmp_path):
+    # setup
+    # this is a simple model with a single Gemm node
+    input_model = get_onnx_model()
+    p = create_pass_from_dict(OnnxFloatToFloat16, {"keep_io_types": keep_io_types}, disable_search=True)
+    output_folder = str(tmp_path / "onnx")
+
+    # execute
+    output_model = p.run(input_model, None, output_folder)
+
+    # assert
+    # check that the input and output types are as expected
+    io_config = output_model.io_config
+    for io_type in [*io_config["input_types"], *io_config["output_types"]]:
+        assert io_type == "float32" if keep_io_types else "float16"
+
+    # check that the model initializer types are float16
+    for initializer in output_model.get_graph().initializer:
+        assert initializer.data_type == onnx.TensorProto.FLOAT16

--- a/test/unit_test/passes/onnx/test_float16_conversion.py
+++ b/test/unit_test/passes/onnx/test_float16_conversion.py
@@ -26,7 +26,7 @@ def test_onnxfloattofloat16(keep_io_types, tmp_path):
     # check that the input and output types are as expected
     io_config = output_model.io_config
     for io_type in [*io_config["input_types"], *io_config["output_types"]]:
-        assert io_type == "float32" if keep_io_types else "float16"
+        assert io_type == ("float32" if keep_io_types else "float16")
 
     # check that the model initializer types are float16
     for initializer in output_model.get_graph().initializer:


### PR DESCRIPTION
## Describe your changes
- `onnxconverter-common`'s float16 converter tool is not regularly maintained and it also cannot large models (>2GB). Use the float16 converted from onnxruntime which is a modified version of the previous tool and has more features.
- Added unit test for pass.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
