### PR TITLE
Fix doc for calling cli as module.

### DIFF
--- a/docs/source/features/cli.rst
+++ b/docs/source/features/cli.rst
@@ -5,7 +5,7 @@ Command Line Tools
 
 Olive provides command line tools that can be invoked using the ``olive`` command. The command line tools are used to perform various tasks such as running an Olive workflow, managing AzureML compute, and more.
 
-If ``olive`` is not in your PATH, you can run the command line tools by replacing ``olive`` with ``python -m olive.cli``.
+If ``olive`` is not in your PATH, you can run the command line tools by replacing ``olive`` with ``python -m olive``.
 
 .. argparse::
     :module: olive.cli.launcher


### PR DESCRIPTION
## Describe your changes
Accidentally added it as `python -m olive.cli` instead of `python -m olive`.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
