### PR TITLE
Add support for generic data sets to SliceGPT pass

### DIFF
--- a/examples/phi2/phi2.py
+++ b/examples/phi2/phi2.py
@@ -129,7 +129,7 @@ def main(raw_args=None):
     if not args.model_type and not args.finetune_method and not args.slicegpt:
         raise ValueError("Please specify either model_type or finetune_method or args.slicegpt")
 
-    model_type = str(args.model_type) or ""
+    model_type = str(args.model_type) if args.model_type else ""
 
     if args.genai_optimization:
         json_file_template = "phi2_genai.json"
@@ -179,8 +179,6 @@ def main(raw_args=None):
         if args.slicegpt:
             pass_flows[0].extend(SUPPORTED_WORKFLOWS["slicegpt"][0])
             update_accelerator(template_json, "gpu")
-            del template_json["input_model"]["config"]["model_script"]
-            del template_json["input_model"]["config"]["dummy_inputs_func"]
             del template_json["input_model"]["config"]["io_config"]
 
         if model_type:
@@ -219,7 +217,7 @@ def main(raw_args=None):
                 }
             ]
 
-        new_json_file = f"phi2_{model_type}.json"
+        new_json_file = "phi2_slicegpt.json" if args.slicegpt else f"phi2_{model_type}.json"
         with open(new_json_file, "w") as f:
             json.dump(template_json, f, indent=4)
 

--- a/examples/phi2/phi2_optimize_template.json
+++ b/examples/phi2/phi2_optimize_template.json
@@ -71,7 +71,7 @@
             "type": "SliceGPT",
             "config": {
                 "sparsity": 0.4,
-                "calibration_data_config": "wikitext2"
+                "calibration_data_config": "wikitext2_train"
             }
         },
         "qlora": {
@@ -192,6 +192,28 @@
                         "corpus_strategy": "join",
                         "text_template": "### Question: {prompt} \n### Answer: {response}",
                         "source_max_len": 1024
+                    }
+                }
+            }
+        },
+        {
+            "name": "wikitext2_train",
+            "type": "HuggingfaceContainer",
+            "params_config": {
+                "data_name": "wikitext",
+                "subset": "wikitext-2-raw-v1",
+                "split": "train",
+                "component_kwargs": {
+                    "pre_process_data": {
+                        "text_cols": [
+                            "text"
+                        ],
+                        "corpus_strategy": "join",
+                        "add_special_tokens": false,
+                        "source_max_len": 2048,
+                        "max_samples": 128,
+                        "joiner": "\n\n",
+                        "batch_size": 1
                     }
                 }
             }

--- a/test/unit_test/passes/pytorch/test_slicegpt.py
+++ b/test/unit_test/passes/pytorch/test_slicegpt.py
@@ -26,12 +26,15 @@ def test_slicegpt(tmp_path):
         "component_kwargs": {
             "pre_process_data": {
                 "text_cols": ["text"],
+                "corpus_strategy": "join",
+                "add_special_tokens": False,
                 "source_max_len": 2048,
+                "max_samples": 128,
+                "joiner": "\n\n",
             }
         },
     }
     data_config = huggingface_data_config_template(model_name=model_name, task=task, **dataset)
-    data_config.name = "wikitext2"
     config = {
         "sparsity": 0.4,
         "calibration_data_config": data_config,


### PR DESCRIPTION
## Add support for generic data sets to SliceGPT pass

Implementation of SliceGPT supported only a handful of specific datasets. Widen the support for any generic dataset via the data_config configuration.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
