### PR TITLE
ModelBuilder: remove `enable_GQA_on_CPU` option

### DIFF
--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -94,12 +94,6 @@ class ModelBuilder(Pass):
                     "for the CUDA graph to be used correctly."
                 ),
             ),
-            "enable_GQA_on_CPU": PassConfigParam(
-                type_=bool,
-                default_value=None,  # Explicitly setting to None to differentiate between user intent and default.
-                required=False,
-                description="Enable G(Group)Query(Q)Attention(A) on CPU.",
-            ),
         }
 
     def validate_search_point(
@@ -197,7 +191,7 @@ class ModelBuilder(Pass):
                 extra_args[arg] = True
 
         # args that are checked for presence and value (if present)
-        for arg in ["enable_cuda_graph", "enable_GQA_on_CPU"]:
+        for arg in ["enable_cuda_graph"]:
             if config[arg] is not None:
                 extra_args[arg] = "1" if config[arg] else "0"
 


### PR DESCRIPTION
## Describe your changes
This option doesn't exist anymore. GQA is enabled by default for CPU.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
