### PR TITLE
Fix exception handling in `load_hf_model_from_task`

### DIFF
--- a/olive/model/utils/hf_utils.py
+++ b/olive/model/utils/hf_utils.py
@@ -51,7 +51,7 @@ def load_hf_model_from_task(task: str, name: str, **kwargs) -> "PreTrainedModel"
             # the ValueError need to be caught since there will be multiple model_class for single task.
             # if the model_class is not the one for the task, it will raise ValueError and
             # next model_class will be tried.
-            logger.debug(
+            logger.info(
                 "Failed to load model %s with name_or_path %s.\n kwargs: %s.\n Exception raised: %s",
                 model_class,
                 name,
@@ -59,12 +59,8 @@ def load_hf_model_from_task(task: str, name: str, **kwargs) -> "PreTrainedModel"
                 e,
             )
 
-    if model is None:
-        # don't expect for this condition to be true since class_tuple is never empty
-        # either model load worked or error raised
-        # just to be safe from_pretrained returned a model and to satisfy linter
-        raise ValueError(f"Failed to load model with name_or_path {name}. Class tuples were {class_tuple}.")
-
+    # this won't be None since class_tuple is never empty and we only reach here if model loaded successfully
+    # satisfies linter too
     return model
 
 

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -41,7 +41,7 @@ def test_load_hf_model_from_task():
         ([None, ValueError("value error")], None, None),
         ([ValueError("value error"), None], None, None),
         ([ValueError("value error"), ImportError("import error")], ImportError, "import error"),
-        ([ValueError("value error 1"), ValueError("value error 2")], ValueError, "Failed to load model with task *"),
+        ([ValueError("value error 1"), ValueError("value error 2")], ValueError, "value error 2"),
     ],
 )
 def test_load_hf_model_from_task_exception_handling(exceptions, expected_exception, expected_message):

--- a/test/unit_test/model/test_hf_utils.py
+++ b/test/unit_test/model/test_hf_utils.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
 import transformers
@@ -21,6 +23,46 @@ def test_load_hf_model_from_task():
 
     model = load_hf_model_from_task(task, model_name)
     assert isinstance(model, torch.nn.Module)
+
+
+@pytest.mark.parametrize(
+    ("exceptions", "expected_exception", "expected_message"),
+    [
+        ([None], None, None),
+        ([FileNotFoundError("file not found error")], FileNotFoundError, "file not found error"),
+        ([ValueError("value error")], ValueError, "value error"),
+        ([ImportError("import error")], ImportError, "import error"),
+        (
+            [ImportError("import error"), ValueError("value error")],
+            ImportError,
+            "import error",
+        ),
+        ([None, ImportError("import error")], None, None),
+        ([None, ValueError("value error")], None, None),
+        ([ValueError("value error"), None], None, None),
+        ([ValueError("value error"), ImportError("import error")], ImportError, "import error"),
+        ([ValueError("value error 1"), ValueError("value error 2")], ValueError, "Failed to load model with task *"),
+    ],
+)
+def test_load_hf_model_from_task_exception_handling(exceptions, expected_exception, expected_message):
+    with patch("transformers.pipelines.check_task") as mock_check_task:
+        mocked_model_classes = []
+        for exception in exceptions:
+            mock_class = MagicMock()
+            if exception is None:
+                mock_class.from_pretrained = MagicMock(return_value=MagicMock(spec=torch.nn.Module))
+            else:
+                mock_class.from_pretrained = MagicMock(side_effect=exception)
+            mocked_model_classes.append(mock_class)
+
+        mock_check_task.return_value = ("text-classification", {"pt": tuple(mocked_model_classes)}, None)
+
+        if expected_exception is None:
+            model = load_hf_model_from_task("text-classification", "dummy-model-name")
+            assert isinstance(model, torch.nn.Module)
+        else:
+            with pytest.raises(expected_exception, match=expected_message):
+                _ = load_hf_model_from_task("text-classification", "dummy-model-name")
 
 
 def test_load_hf_model_from_model_class():


### PR DESCRIPTION
## Describe your changes
`load_hf_model_from_task` catches `OSError,ValueError` to allow iterating over potentially multiple candidate classes. However, for most cases, there is only one model class to try and there are valid errors like device OOM, unsupported kwargs, that need to be rethrown. 
Currently, the model loading silently fails and the caller gets `None` as the model. This is unexpected behavior and makes it hard to debug without error logs or failure with traceback.
 
## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
