### PR TITLE
[azureml model catalog]MLflow-transformer model path 

### DIFF
--- a/olive/model/handler/mixin/__init__.py
+++ b/olive/model/handler/mixin/__init__.py
@@ -8,6 +8,7 @@ from olive.model.handler.mixin.hf_config import HfConfigMixin
 from olive.model.handler.mixin.io_config import IoConfigMixin
 from olive.model.handler.mixin.json import JsonMixin
 from olive.model.handler.mixin.kv_cache import PytorchKvCacheMixin
+from olive.model.handler.mixin.mlflow import MLFlowMixin
 from olive.model.handler.mixin.onnx_ep import OnnxEpValidateMixin
 from olive.model.handler.mixin.onnx_graph import OnnxGraphMixin
 from olive.model.handler.mixin.resource import ResourceMixin
@@ -18,6 +19,7 @@ __all__ = [
     "HfConfigMixin",
     "IoConfigMixin",
     "JsonMixin",
+    "MLFlowMixin",
     "OnnxEpValidateMixin",
     "OnnxGraphMixin",
     "PytorchKvCacheMixin",

--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -143,14 +143,6 @@ class HfConfigMixin:
 
     def get_model_path_or_name(self):
         if self.model_file_format == ModelFileFormat.PYTORCH_MLFLOW_MODEL:
-            # both config.json and model file will be saved under data/model
-            # TODO(trajep): investigate to use olive cache to restore mlflow format to huggingface format
-            mlflow_model_config_path = Path(self.model_path) / "data" / "model"
-            if not mlflow_model_config_path.exists():
-                logger.debug(
-                    "Model path %s does not exist. Use hf_config.model_name instead.", mlflow_model_config_path
-                )
-                return self.hf_config.model_name
-            return str(mlflow_model_config_path)
+            return self.get_mlflow_model_path_or_name(self.mlflow_transformer_model_cache_dir)
         else:
             return self.model_path or self.hf_config.model_name

--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -143,6 +143,6 @@ class HfConfigMixin:
 
     def get_model_path_or_name(self):
         if self.model_file_format == ModelFileFormat.PYTORCH_MLFLOW_MODEL:
-            return self.get_mlflow_model_path_or_name(self.mlflow_transformer_model_cache_dir)
+            return self.get_mlflow_model_path_or_name(self.get_mlflow_transformers_dir())
         else:
             return self.model_path or self.hf_config.model_name

--- a/olive/model/handler/mixin/hf_config.py
+++ b/olive/model/handler/mixin/hf_config.py
@@ -145,6 +145,12 @@ class HfConfigMixin:
         if self.model_file_format == ModelFileFormat.PYTORCH_MLFLOW_MODEL:
             # both config.json and model file will be saved under data/model
             # TODO(trajep): investigate to use olive cache to restore mlflow format to huggingface format
-            return str(Path(self.model_path) / "data" / "model")
+            mlflow_model_config_path = Path(self.model_path) / "data" / "model"
+            if not mlflow_model_config_path.exists():
+                logger.debug(
+                    "Model path %s does not exist. Use hf_config.model_name instead.", mlflow_model_config_path
+                )
+                return self.hf_config.model_name
+            return str(mlflow_model_config_path)
         else:
             return self.model_path or self.hf_config.model_name

--- a/olive/model/handler/mixin/mlflow.py
+++ b/olive/model/handler/mixin/mlflow.py
@@ -30,9 +30,11 @@ class MLFlowMixin:
             logger.debug("Use cached mlflow-transformers models from %s", target_path)
             return target_path
         if (Path(self.model_path) / "data" / "model").exists():
-            copy_dir(os.path.join(self.model_path, "data/model"), target_path, dirs_exist_ok=True)
-            copy_dir(os.path.join(self.model_path, "data/config"), target_path, dirs_exist_ok=True)
-            copy_dir(os.path.join(self.model_path, "data/tokenizer"), target_path, dirs_exist_ok=True)
+            copy_dir(Path(self.model_path) / "data" / "model", target_path, dirs_exist_ok=True, copy_function=os.link)
+            copy_dir(Path(self.model_path) / "data" / "config", target_path, dirs_exist_ok=True, copy_function=os.link)
+            copy_dir(
+                Path(self.model_path) / "data" / "tokenizer", target_path, dirs_exist_ok=True, copy_function=os.link
+            )
             return target_path
         return None
 

--- a/olive/model/handler/mixin/mlflow.py
+++ b/olive/model/handler/mixin/mlflow.py
@@ -1,0 +1,48 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import logging
+import os
+from pathlib import Path
+
+from olive.common.utils import copy_dir
+from olive.constants import ModelFileFormat
+
+logger = logging.getLogger(__name__)
+
+
+class MLFlowMixin:
+    def _get_mlflow_transformers_model_path(self, cache_dir):
+        # DO NOT use the model.to_json() to get hash_dict, since it will get hf_config from the model
+        # and the operation to get hf_config will use this function to get model_path, which will
+        # cause infinite loop
+        return str(Path(cache_dir) / "olive_tmp" / "transformers")
+
+    def to_mlflow_transformer_model(self, cache_dir):
+        if self.model_file_format != ModelFileFormat.PYTORCH_MLFLOW_MODEL:
+            raise ValueError(
+                "Model file format is not PyTorch MLFlow model, you cannot get MLFlow transformers model path."
+            )
+        target_path = self._get_mlflow_transformers_model_path(cache_dir)
+        if (Path(target_path) / "config.json").exists():
+            logger.debug("Use cached mlflow-transformers models from %s", target_path)
+            return target_path
+        if (Path(self.model_path) / "data" / "model").exists():
+            copy_dir(os.path.join(self.model_path, "data/model"), target_path, dirs_exist_ok=True)
+            copy_dir(os.path.join(self.model_path, "data/config"), target_path, dirs_exist_ok=True)
+            copy_dir(os.path.join(self.model_path, "data/tokenizer"), target_path, dirs_exist_ok=True)
+            return target_path
+        return None
+
+    def get_mlflow_model_path_or_name(self, cache_dir=None):
+        # both config.json and model file will be saved under data/model
+        cache_dir = cache_dir or self.model_path
+        mlflow_transformer_model_path = self.to_mlflow_transformer_model(cache_dir)
+        if not mlflow_transformer_model_path:
+            logger.debug(
+                "Model path %s does not exist. Use hf_config.model_name instead.", mlflow_transformer_model_path
+            )
+            return self.hf_config.model_name
+        return str(mlflow_transformer_model_path)

--- a/olive/model/handler/mixin/mlflow.py
+++ b/olive/model/handler/mixin/mlflow.py
@@ -36,9 +36,8 @@ class MLFlowMixin:
             return target_path
         return None
 
-    def get_mlflow_model_path_or_name(self, cache_dir=None):
+    def get_mlflow_model_path_or_name(self, cache_dir):
         # both config.json and model file will be saved under data/model
-        cache_dir = cache_dir or self.model_path
         mlflow_transformer_model_path = self.to_mlflow_transformer_model(cache_dir)
         if not mlflow_transformer_model_path:
             logger.debug(

--- a/olive/model/handler/mixin/mlflow.py
+++ b/olive/model/handler/mixin/mlflow.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------
 
 import logging
-import os
 from pathlib import Path
 
 from olive.common.utils import copy_dir
@@ -30,11 +29,9 @@ class MLFlowMixin:
             logger.debug("Use cached mlflow-transformers models from %s", target_path)
             return target_path
         if (Path(self.model_path) / "data" / "model").exists():
-            copy_dir(Path(self.model_path) / "data" / "model", target_path, dirs_exist_ok=True, copy_function=os.link)
-            copy_dir(Path(self.model_path) / "data" / "config", target_path, dirs_exist_ok=True, copy_function=os.link)
-            copy_dir(
-                Path(self.model_path) / "data" / "tokenizer", target_path, dirs_exist_ok=True, copy_function=os.link
-            )
+            copy_dir(Path(self.model_path) / "data" / "model", target_path, dirs_exist_ok=True)
+            copy_dir(Path(self.model_path) / "data" / "config", target_path, dirs_exist_ok=True)
+            copy_dir(Path(self.model_path) / "data" / "tokenizer", target_path, dirs_exist_ok=True)
             return target_path
         return None
 

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -75,7 +75,7 @@ class PyTorchModelHandler(
             raise ValueError(
                 "model_path is required since model_loader is not callable or model_script is not provided"
             )
-        self.mlflow_transformer_model_cache_dir = mlflow_transformer_model_cache_dir or model_path
+        self.mlflow_transformer_model_cache_dir = mlflow_transformer_model_cache_dir
         self.model_loader = model_loader
         self.model = None
         super().__init__(
@@ -121,6 +121,9 @@ class PyTorchModelHandler(
     @property
     def adapter_path(self) -> str:
         return self.get_resource("adapter_path")
+
+    def get_mlflow_transformers_dir(self):
+        return self.mlflow_transformer_model_cache_dir or self.model_path
 
     def load_model(self, rank: int = None) -> torch.nn.Module:
         if self.model is not None:
@@ -193,7 +196,7 @@ class PyTorchModelHandler(
 
     def _load_mlflow_model(self):
         logger.info("Loading MLFlow model from %s", self.model_path)
-        mlflow_transformers_path = self.to_mlflow_transformer_model(self.mlflow_transformer_model_cache_dir)
+        mlflow_transformers_path = self.to_mlflow_transformer_model(self.get_mlflow_transformers_dir())
         with open(os.path.join(self.model_path, "MLmodel")) as fp:
             mlflow_data = yaml.safe_load(fp)
             # default flavor is "hftransformersv2" from azureml.evaluate.mlflow>=0.0.8

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -75,7 +75,7 @@ class PyTorchModelHandler(
             raise ValueError(
                 "model_path is required since model_loader is not callable or model_script is not provided"
             )
-
+        self.mlflow_transformer_model_cache_dir = mlflow_transformer_model_cache_dir or model_path
         self.model_loader = model_loader
         self.model = None
         super().__init__(
@@ -86,7 +86,6 @@ class PyTorchModelHandler(
             io_config=io_config,
         )
         self.add_resources(locals())
-
         self.hf_config = None
         if hf_config:
             self.hf_config = validate_config(hf_config, HfConfig)
@@ -110,7 +109,6 @@ class PyTorchModelHandler(
 
         self.dummy_inputs_func = dummy_inputs_func
         self.dummy_inputs = None
-        self.mlflow_transformer_model_cache_dir = mlflow_transformer_model_cache_dir
 
     @property
     def script_dir(self) -> str:

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------
 import logging
 import os
-import tempfile
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
@@ -14,7 +13,6 @@ import yaml
 
 from olive.common.config_utils import serialize_to_json, validate_config
 from olive.common.user_module_loader import UserModuleLoader
-from olive.common.utils import copy_dir
 from olive.constants import Framework, ModelFileFormat
 from olive.hardware.accelerator import Device
 from olive.model.config import (
@@ -26,7 +24,7 @@ from olive.model.config import (
 )
 from olive.model.config.registry import model_handler_registry
 from olive.model.handler.base import OliveModelHandler
-from olive.model.handler.mixin import DummyInputsMixin, HfConfigMixin, PytorchKvCacheMixin
+from olive.model.handler.mixin import DummyInputsMixin, HfConfigMixin, MLFlowMixin, PytorchKvCacheMixin
 from olive.model.utils.hf_utils import load_hf_model_from_model_class
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS, ResourceType, create_resource_path
 
@@ -35,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 @model_handler_registry("PyTorchModel")
 class PyTorchModelHandler(
-    OliveModelHandler, HfConfigMixin, DummyInputsMixin, PytorchKvCacheMixin
+    OliveModelHandler, HfConfigMixin, DummyInputsMixin, PytorchKvCacheMixin, MLFlowMixin
 ):  # pylint: disable=too-many-ancestors
     """PyTorch model handler.
 
@@ -66,6 +64,7 @@ class PyTorchModelHandler(
         hf_config: Union[Dict[str, Any], HfConfig] = None,
         adapter_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         model_attributes: Optional[Dict[str, Any]] = None,
+        mlflow_transformer_model_cache_dir: Optional[str] = None,
     ):
         if not (
             isinstance(model_loader, Callable)
@@ -111,6 +110,7 @@ class PyTorchModelHandler(
 
         self.dummy_inputs_func = dummy_inputs_func
         self.dummy_inputs = None
+        self.mlflow_transformer_model_cache_dir = mlflow_transformer_model_cache_dir
 
     @property
     def script_dir(self) -> str:
@@ -195,38 +195,34 @@ class PyTorchModelHandler(
 
     def _load_mlflow_model(self):
         logger.info("Loading MLFlow model from %s", self.model_path)
-        with tempfile.TemporaryDirectory(prefix="mlflow_tmp") as tmp_dir:
-            copy_dir(os.path.join(self.model_path, "data/model"), tmp_dir, dirs_exist_ok=True)
-            copy_dir(os.path.join(self.model_path, "data/config"), tmp_dir, dirs_exist_ok=True)
-            copy_dir(os.path.join(self.model_path, "data/tokenizer"), tmp_dir, dirs_exist_ok=True)
+        mlflow_transformers_path = self.to_mlflow_transformer_model(self.mlflow_transformer_model_cache_dir)
+        with open(os.path.join(self.model_path, "MLmodel")) as fp:
+            mlflow_data = yaml.safe_load(fp)
+            # default flavor is "hftransformersv2" from azureml.evaluate.mlflow>=0.0.8
+            # "hftransformers" from azureml.evaluate.mlflow<0.0.8
+            # TODO(trajep): let user specify flavor name if needed
+            # to support other flavors in mlflow not only hftransformers
+            hf_pretrained_class = None
+            flavors = mlflow_data.get("flavors", {})
+            if not flavors:
+                raise ValueError(
+                    "Invalid MLFlow model format. Please make sure the input model"
+                    " format is same with the result of mlflow.transformers.save_model,"
+                    " or aml_mlflow.hftransformers.save_model from azureml.evaluate.mlflow"
+                )
 
-            with open(os.path.join(self.model_path, "MLmodel")) as fp:
-                mlflow_data = yaml.safe_load(fp)
-                # default flavor is "hftransformersv2" from azureml.evaluate.mlflow>=0.0.8
-                # "hftransformers" from azureml.evaluate.mlflow<0.0.8
-                # TODO(trajep): let user specify flavor name if needed
-                # to support other flavors in mlflow not only hftransformers
-                hf_pretrained_class = None
-                flavors = mlflow_data.get("flavors", {})
-                if not flavors:
-                    raise ValueError(
-                        "Invalid MLFlow model format. Please make sure the input model"
-                        " format is same with the result of mlflow.transformers.save_model,"
-                        " or aml_mlflow.hftransformers.save_model from azureml.evaluate.mlflow"
-                    )
-
-                if "hftransformersv2" in flavors:
-                    hf_pretrained_class = flavors["hftransformersv2"].get("hf_pretrained_class", "AutoModel")
-                elif "hftransformers" in flavors:
-                    hf_pretrained_class = flavors["hftransformers"].get("hf_pretrained_class", "AutoModel")
-                else:
-                    raise ValueError(
-                        "Unsupported MLFlow model flavor. Currently only support hftransformersv2/hftransformers."
-                    )
-            loading_args = self.hf_config.get_loading_args_from_pretrained() if self.hf_config else {}
-            loaded_model = load_hf_model_from_model_class(hf_pretrained_class, tmp_dir, **loading_args)
-            loaded_model.eval()
-            return loaded_model
+            if "hftransformersv2" in flavors:
+                hf_pretrained_class = flavors["hftransformersv2"].get("hf_pretrained_class", "AutoModel")
+            elif "hftransformers" in flavors:
+                hf_pretrained_class = flavors["hftransformers"].get("hf_pretrained_class", "AutoModel")
+            else:
+                raise ValueError(
+                    "Unsupported MLFlow model flavor. Currently only support hftransformersv2/hftransformers."
+                )
+        loading_args = self.hf_config.get_loading_args_from_pretrained() if self.hf_config else {}
+        loaded_model = load_hf_model_from_model_class(hf_pretrained_class, mlflow_transformers_path, **loading_args)
+        loaded_model.eval()
+        return loaded_model
 
     def _load_slicegpt_model(self):
         logger.info("Loading SliceGPT model from %s", self.model_path)

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -13,6 +13,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Union
 
+from olive.constants import ModelFileFormat
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import ONNXModelHandler, PyTorchModelHandler
 from olive.model.utils import resolve_onnx_path
@@ -131,10 +132,15 @@ class ModelBuilder(Pass):
         precision = config["precision"]
         metadata_only = config["metadata_only"]
 
-        if not metadata_only and not model.hf_config:
+        if (
+            not metadata_only
+            and not model.hf_config
+            and model.model_file_format != ModelFileFormat.PYTORCH_MLFLOW_MODEL
+        ):
             raise ValueError(
                 "ModelBuilder pass only supports exporting HF models i.e. PyTorchModelHandler "
-                "with hf_config and exporting the metadata only for pre-optimized onnx models."
+                "with hf_config, mlflow-transformer model and exporting the metadata only for "
+                "pre-optimized onnx models."
             )
 
         if metadata_only:
@@ -174,7 +180,7 @@ class ModelBuilder(Pass):
             model_path = None
             input_path = str(model.get_resource("model_path"))
         else:
-            model_path = str(model.hf_config.model_name)
+            model_path = str(model.get_model_path_or_name())
             input_path = ""
 
         if config.get("int4_block_size"):

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -384,7 +384,13 @@ class AzureMLRegistryModel(AzureMLResource):
             "azureml_client": ConfigParam(
                 type_=AzureMLClientConfig, required=False, description="AzureML client config."
             ),
-            "registry_name": ConfigParam(type_=str, required=True, description="Name of the registry."),
+            "registry_name": ConfigParam(
+                type_=str,
+                required=True,
+                description=(
+                    "Name of the registry. Basically, the value is parent directory name of given model in azureml"
+                ),
+            ),
             "name": ConfigParam(type_=str, required=True, description="Name of the model."),
             "version": ConfigParam(type_=Union[int, str], required=True, description="Version of the model."),
         }

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -80,8 +80,6 @@ class TestPyTorchMLflowModel(unittest.TestCase):
             model_path=self.model_path,
             model_file_format="PyTorch.MLflow",
             hf_config={
-                "task": self.task,
-                "model_name": self.architecture,
                 "from_pretrained_args": {"trust_remote_code": True},
             },
         ).load_model()

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -63,7 +63,6 @@ class TestPyTorchMLflowModel(unittest.TestCase):
             },
         )
         # load_hf_model only works for huggingface models and not for mlflow models
-        assert mlflow_olive_model.get_hf_model_config() == hf_model.get_hf_model_config()
         assert mlflow_olive_model.get_hf_io_config() == hf_model.get_hf_io_config()
         assert len(list(mlflow_olive_model.get_hf_components())) == len(list(hf_model.get_hf_components()))
         assert len(mlflow_olive_model.get_hf_dummy_inputs()) == len(hf_model.get_hf_dummy_inputs())


### PR DESCRIPTION
## Describe your changes

For transformers model like phi2/phi3 in aml model cataklog, it is hosted with mlflow model format. 
But Genai require the input model format is standard transformers structure.

This pr is used to fill this gap to let model builder can convert aml mlflow-transformers models.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
