### PR TITLE
AzureMLSystem: catch `JobException` and retry job creation

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -172,12 +172,12 @@ def retry_func(func, args=None, kwargs=None, max_tries=3, delay=5, backoff=2, ex
             out = func(*args, **kwargs)
             logger.debug("Succeeded.")
             return out
-        except exceptions:
+        except exceptions as e:
             num_tries += 1
             if num_tries == max_tries:
                 logger.exception("The operation failed after the maximum number of retries.")
                 raise
-            logger.debug("Failed. Retrying in %d seconds...", sleep_time)
+            logger.debug("Failed with %s. Retrying in %d seconds...", e, sleep_time)
             time.sleep(sleep_time)
             sleep_time *= backoff
     return None

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -14,6 +14,7 @@ from azure.ai.ml import Input, Output, command
 from azure.ai.ml.constants import AssetTypes
 from azure.ai.ml.dsl import pipeline
 from azure.ai.ml.entities import BuildContext, Environment, Model, UserIdentityConfiguration
+from azure.ai.ml.exceptions import JobException
 from azure.core.exceptions import HttpResponseError, ServiceResponseError
 
 from olive.azureml.azureml_client import AzureMLClientConfig
@@ -490,7 +491,7 @@ class AzureMLSystem(OliveSystem):
             {"experiment_name": experiment_name, "tags": tags},
             max_tries=self.azureml_client_config.max_operation_retries,
             delay=self.azureml_client_config.operation_retry_interval,
-            exceptions=HttpResponseError,
+            exceptions=(HttpResponseError, JobException),
         )
         logger.info("Pipeline submitted. Job name: %s. Job link: %s", job.name, job.studio_url)
         ml_client.jobs.stream(job.name)


### PR DESCRIPTION
## Describe your changes
Recently we started getting aml test failures due to `JobException` with `message: Service invocation timed out.`. This failure appears to be random so just catch it in the `retry_func`.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
