### PR TITLE
Qualcomm SDK tests: retry configure sdk

### DIFF
--- a/examples/test/test_qnn_tooklit.py
+++ b/examples/test/test_qnn_tooklit.py
@@ -10,6 +10,9 @@ import pytest
 from utils import check_output, download_azure_blob
 
 from olive.common.utils import retry_func, run_subprocess
+from olive.logging import set_verbosity_debug
+
+set_verbosity_debug()
 
 
 class TestQnnToolkit:
@@ -45,9 +48,11 @@ class TestQnnToolkit:
 
         if use_olive_env:
             os.environ["USE_OLIVE_ENV"] = "1"
-            # prepare model and data
             # retry since it fails randomly
-            run_subprocess(cmd="olive configure-qualcomm-sdk --py_version 3.8 --sdk qnn", check=True)
+            retry_func(
+                run_subprocess,
+                kwargs={"cmd": "olive configure-qualcomm-sdk --py_version 3.8 --sdk qnn", "check": True},
+            )
             # install dependencies
             python_cmd = ""
             if platform.system() == "Windows":

--- a/examples/test/test_snpe_toolkit.py
+++ b/examples/test/test_snpe_toolkit.py
@@ -10,6 +10,9 @@ import pytest
 from utils import check_output, download_azure_blob
 
 from olive.common.utils import retry_func, run_subprocess
+from olive.logging import set_verbosity_debug
+
+set_verbosity_debug()
 
 
 class TestSnpeToolkit:
@@ -44,9 +47,11 @@ class TestSnpeToolkit:
         os.chdir(example_dir)
         if use_olive_env:
             os.environ["USE_OLIVE_ENV"] = "1"
-            # prepare model and data
             # retry since it fails randomly
-            run_subprocess(cmd="olive configure-qualcomm-sdk --py_version 3.8 --sdk snpe", check=True)
+            retry_func(
+                run_subprocess,
+                kwargs={"cmd": "olive configure-qualcomm-sdk --py_version 3.8 --sdk snpe", "check": True},
+            )
             # install dependencies
             python_cmd = ""
             if platform.system() == "Windows":


### PR DESCRIPTION
## Describe your changes
inception_snpe_toolkit started randomly failing due to mismatched sha between downloaded wheel and expected wheel. Looking at the failure logs, it appears to be due to incomplete download of the wheels. 
- retry the configure sdk command
- set log verbosity to debug so that we get logs for the test setup too

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
