### PR TITLE
Check last command status in Qualcomm SDK configure PowerShell script

### DIFF
--- a/olive/platform_sdk/qualcomm/create_python_env.ps1
+++ b/olive/platform_sdk/qualcomm/create_python_env.ps1
@@ -8,6 +8,14 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+# conda and python commands don't exit with non-zero status code on failure
+# helper to check if the last command was successful
+function ExitOnFailure {
+    if (!$?) {
+        exit $LASTEXITCODE
+    }
+}
+
 if ($SDK -eq "snpe") {
     $SDK_ROOT = $env:SNPE_ROOT
 }
@@ -38,6 +46,7 @@ else {
 
 # Create python environment
 & $CONDA create -y -p (Join-Path $FILES_DIR $PY_ENV_NAME) python=$PY_VERSION
+ExitOnFailure
 
 # Install snpe requirements
 # if PIP_EXTRA_ARGS is set, then use it else use ""
@@ -56,6 +65,7 @@ else {
     Write-Host "Unsupported python version: $PY_VERSION, only 3.6 and 3.8 are supported"
     exit 1
 }
+ExitOnFailure
 
 Remove-Item -Path "$SDK_ROOT\$PY_ENV_NAME" -Recurse -Force -ErrorAction SilentlyContinue
 Move-Item -Path (Join-Path $FILES_DIR $PY_ENV_NAME) -Destination (Join-Path $SDK_ROOT $PY_ENV_NAME) -Force


### PR DESCRIPTION
Conda and python commands in the `.ps1` do not exit when they fail even though `$ErrorActionPreference = "Stop"`. This leads the script to succeed even though there might have been issues during the conda environment creation or pip installs. 

Added a function to check the status of last command and exit if it failed. 

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
