### PR TITLE
🎃 Support ORT 1.18 QNN Preprocess

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -227,6 +227,63 @@ _static_optional_config = {
             Should be set to True if model is targeted for QNN EP.
         """,
     ),
+    "init_overrides": PassConfigParam(
+        type_=dict,
+        default_value=None,
+        description="""
+            Initial tensor-level quantization overrides. Defaults to None. This function updates of a copy
+            of these overrides with any necessary adjustments and includes them in the returned
+            configuration object (i.e., config.extra_options['TensorQuantOverrides']).
+
+            The key is a tensor name and the value is a list of dictionaries. For per-tensor quantization, the list
+            contains a single dictionary. For per-channel quantization, the list contains either a dictionary for
+            each channel in the tensor or a single dictionary that is assumed to apply to all channels. An 'axis'
+            key must be present in the first dictionary for per-channel quantization.
+
+            Each dictionary contains optional overrides with the following keys and values.
+                'quant_type' = QuantType : The tensor's quantization data type.
+                'axis' = Int             : The per-channel axis. Must be present for per-channel weights.
+                'scale' =  Float         : The scale value to use. Must also specify `zero_point` if set.
+                'zero_point' = Int       : The zero-point value to use. Must also specify `scale` is set.
+                'symmetric' = Bool       : If the tensor should use symmetric quantization. Invalid if also
+                                            set `scale` or `zero_point`.
+                'reduce_range' = Bool    : If the quantization range should be reduced. Invalid if also
+                                            set `scale` or `zero_point`. Only valid for initializers.
+                'rmax' = Float           : Override the maximum real tensor value in calibration data.
+                                            Invalid if also set `scale` or `zero_point`.
+                'rmin' = Float           : Override the minimum real tensor value in calibration data.
+                                            Invalid if also set `scale` or `zero_point`.
+                'convert' = Dict         : A nested dictionary with the same keys for an activation
+                                           tensor that should be converted to another quantization type.
+                'convert["recv_nodes"] = Set : Set of node names that consume the converted activation,
+                                               other nodes get the original type. If not specified,
+                                               assume all consumer nodes get the converted type.
+        """,
+    ),
+    "add_qtype_converts": PassConfigParam(
+        type_=bool,
+        default_value=True,
+        description="""
+            True if this function should automatically add "convert" entries to the provided
+            `init_overrides` to ensure that operators use valid input/output types (activations only).
+            Ex: if you override the output of an Add to 16-bit, this option ensures that the activation inputs
+            of the Add are also up-converted to 16-bit and that data types for surrounding ops are converted
+            appropriately. Refer to the documentation in mixed_precision_overrides_utils.py for additional details.
+        """,
+    ),
+    "activation_symmetric": PassConfigParam(
+        type_=bool,
+        default_value=False,
+        description="Symmetrize calibration data for activations.",
+    ),
+    "weight_symmetric": PassConfigParam(
+        type_=bool,
+        default_value=None,
+        description="""
+            True if weights should be quantized symmetrically (i.e., rmax == -rmin) by default.
+            Defaults to None. If set to None, weight_symmetric is assumed true if the weight_type is a signed int.
+        """,
+    ),
 }
 
 

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -496,7 +496,7 @@ class OnnxQuantization(Pass):
                 from onnxruntime.quantization.execution_providers.qnn import get_qnn_qdq_config
 
                 qnn_extra_options = (
-                    {} if version.parse(OrtVersion) < version.parse("1.18.0") else config["qnn_extra_options"]
+                    {} if version.parse(OrtVersion) < version.parse("1.18.0") else config["qnn_extra_options"] or {}
                 )
                 qnn_config = get_qnn_qdq_config(
                     model_input=model.model_path,

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -227,61 +227,50 @@ _static_optional_config = {
             Should be set to True if model is targeted for QNN EP.
         """,
     ),
-    "init_overrides": PassConfigParam(
+    "qnn_extra_options": PassConfigParam(
         type_=dict,
         default_value=None,
         description="""
-            Initial tensor-level quantization overrides. Defaults to None. This function updates of a copy
-            of these overrides with any necessary adjustments and includes them in the returned
-            configuration object (i.e., config.extra_options['TensorQuantOverrides']).
+            Extra options for QNN quantization. Please refer to
+            onnxruntime.quantization.execution_providers.qnn.get_qnn_qdq_config.
+            By default, the options are set to None. Options are only used if
+            prepare_qnn_config is set to True. Available options are:
+            - `init_overrides:dict = None`: Initial tensor-level quantization overrides. Defaults to None. This function
+                updates of a copy of these overrides with any necessary adjustments and includes them in the returned
+                configuration object (i.e., config.extra_options['TensorQuantOverrides']).
 
-            The key is a tensor name and the value is a list of dictionaries. For per-tensor quantization, the list
-            contains a single dictionary. For per-channel quantization, the list contains either a dictionary for
-            each channel in the tensor or a single dictionary that is assumed to apply to all channels. An 'axis'
-            key must be present in the first dictionary for per-channel quantization.
+                The key is a tensor name and the value is a list of dictionaries. For per-tensor quantization, the list
+                contains a single dictionary. For per-channel quantization, the list contains either a dictionary for
+                each channel in the tensor or a single dictionary that is assumed to apply to all channels. An 'axis'
+                key must be present in the first dictionary for per-channel quantization.
 
-            Each dictionary contains optional overrides with the following keys and values.
-                'quant_type' = QuantType : The tensor's quantization data type.
-                'axis' = Int             : The per-channel axis. Must be present for per-channel weights.
-                'scale' =  Float         : The scale value to use. Must also specify `zero_point` if set.
-                'zero_point' = Int       : The zero-point value to use. Must also specify `scale` is set.
-                'symmetric' = Bool       : If the tensor should use symmetric quantization. Invalid if also
-                                            set `scale` or `zero_point`.
-                'reduce_range' = Bool    : If the quantization range should be reduced. Invalid if also
-                                            set `scale` or `zero_point`. Only valid for initializers.
-                'rmax' = Float           : Override the maximum real tensor value in calibration data.
-                                            Invalid if also set `scale` or `zero_point`.
-                'rmin' = Float           : Override the minimum real tensor value in calibration data.
-                                            Invalid if also set `scale` or `zero_point`.
-                'convert' = Dict         : A nested dictionary with the same keys for an activation
-                                           tensor that should be converted to another quantization type.
-                'convert["recv_nodes"] = Set : Set of node names that consume the converted activation,
-                                               other nodes get the original type. If not specified,
-                                               assume all consumer nodes get the converted type.
-        """,
-    ),
-    "add_qtype_converts": PassConfigParam(
-        type_=bool,
-        default_value=True,
-        description="""
-            True if this function should automatically add "convert" entries to the provided
-            `init_overrides` to ensure that operators use valid input/output types (activations only).
-            Ex: if you override the output of an Add to 16-bit, this option ensures that the activation inputs
-            of the Add are also up-converted to 16-bit and that data types for surrounding ops are converted
-            appropriately. Refer to the documentation in mixed_precision_overrides_utils.py for additional details.
-        """,
-    ),
-    "activation_symmetric": PassConfigParam(
-        type_=bool,
-        default_value=False,
-        description="Symmetrize calibration data for activations.",
-    ),
-    "weight_symmetric": PassConfigParam(
-        type_=bool,
-        default_value=None,
-        description="""
-            True if weights should be quantized symmetrically (i.e., rmax == -rmin) by default.
-            Defaults to None. If set to None, weight_symmetric is assumed true if the weight_type is a signed int.
+                Each dictionary contains optional overrides with the following keys and values.
+                    'quant_type' = QuantType : The tensor's quantization data type.
+                    'axis' = Int             : The per-channel axis. Must be present for per-channel weights.
+                    'scale' =  Float         : The scale value to use. Must also specify `zero_point` if set.
+                    'zero_point' = Int       : The zero-point value to use. Must also specify `scale` is set.
+                    'symmetric' = Bool       : If the tensor should use symmetric quantization. Invalid if also
+                                                set `scale` or `zero_point`.
+                    'reduce_range' = Bool    : If the quantization range should be reduced. Invalid if also
+                                                set `scale` or `zero_point`. Only valid for initializers.
+                    'rmax' = Float           : Override the maximum real tensor value in calibration data.
+                                                Invalid if also set `scale` or `zero_point`.
+                    'rmin' = Float           : Override the minimum real tensor value in calibration data.
+                                                Invalid if also set `scale` or `zero_point`.
+                    'convert' = Dict         : A nested dictionary with the same keys for an activation
+                                            tensor that should be converted to another quantization type.
+                    'convert["recv_nodes"] = Set : Set of node names that consume the converted activation,
+                                                other nodes get the original type. If not specified,
+                                                assume all consumer nodes get the converted type.
+            - `add_qtype_converts: bool = True`: True if this function should automatically add "convert" entries to
+                the provided `init_overrides` to ensure that operators use valid input/output types (activations only).
+                Ex: if you override the output of an Add to 16-bit, this option ensures that the activation inputs
+                of the Add are also up-converted to 16-bit and that data types for surrounding ops are converted
+                appropriately. Refer to the documentation in mixed_precision_overrides_utils.py for additional details.
+            - `activation_symmetric: bool = False`: Symmetrize calibration data for activations.
+            - `weight_symmetric: bool = None`: True if weights should be quantized symmetrically (i.e., rmax == -rmin)
+                Defaults to None. If set to None, weight_symmetric is assumed true if the weight_type is a signed int.
+            To be noted that the options might be updated in the further version of onnxruntime.
         """,
     ),
 }
@@ -506,6 +495,9 @@ class OnnxQuantization(Pass):
 
                 from onnxruntime.quantization.execution_providers.qnn import get_qnn_qdq_config
 
+                qnn_extra_options = (
+                    {} if version.parse(OrtVersion) < version.parse("1.18.0") else config["qnn_extra_options"]
+                )
                 qnn_config = get_qnn_qdq_config(
                     model_input=model.model_path,
                     calibration_data_reader=dataloader,
@@ -513,23 +505,16 @@ class OnnxQuantization(Pass):
                     activation_type=run_config["activation_type"],
                     weight_type=run_config["weight_type"],
                     per_channel=run_config["per_channel"],
-                    init_overrides=run_config["init_overrides"],
-                    add_qtype_converts=run_config["add_qtype_converts"],
-                    activation_symmetric=run_config["activation_symmetric"],
-                    weight_symmetric=run_config["weight_symmetric"],
+                    **qnn_extra_options,
                 )
                 # override the run_config with qnn_config
                 # get all attributes of qnn_config
                 run_config = {k: v for k, v in inspect.getmembers(qnn_config) if not k.startswith("_")}
                 # remove the calibration_data_reader from run_config
-                run_config.pop("calibration_data_reader", None)
 
             run_config = exclude_keys(
                 run_config,
-                (
-                    "calibration_data_reader",
-                    "use_external_data_format",
-                ),
+                ("calibration_data_reader", "use_external_data_format", "qnn_extra_options"),
             )
             try:
                 quantize_static(

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -513,6 +513,10 @@ class OnnxQuantization(Pass):
                     activation_type=run_config["activation_type"],
                     weight_type=run_config["weight_type"],
                     per_channel=run_config["per_channel"],
+                    init_overrides=run_config["init_overrides"],
+                    add_qtype_converts=run_config["add_qtype_converts"],
+                    activation_symmetric=run_config["activation_symmetric"],
+                    weight_symmetric=run_config["weight_symmetric"],
                 )
                 # override the run_config with qnn_config
                 # get all attributes of qnn_config
@@ -520,7 +524,13 @@ class OnnxQuantization(Pass):
                 # remove the calibration_data_reader from run_config
                 run_config.pop("calibration_data_reader", None)
 
-            run_config = exclude_keys(run_config, ("calibration_data_reader", "use_external_data_format"))
+            run_config = exclude_keys(
+                run_config,
+                (
+                    "calibration_data_reader",
+                    "use_external_data_format",
+                ),
+            )
             try:
                 quantize_static(
                     model_input=model.model_path,

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -79,10 +79,12 @@ def test_qnn_quantization(tmp_path):
         "dataloader_func": dummpy_dataloader_func,
         "weight_type": "QUInt8",
         "activation_type": "QUInt16",
-        "init_overrides": None,
-        "add_qtype_converts": True,
-        "activation_symmetric": True,
-        "weight_symmetric": None,
+        "qnn_extra_options": {
+            "init_overrides": None,
+            "add_qtype_converts": True,
+            "activation_symmetric": True,
+            "weight_symmetric": None,
+        },
     }
     accelerator_spec = AcceleratorSpec(
         accelerator_type="NPU",

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -79,6 +79,10 @@ def test_qnn_quantization(tmp_path):
         "dataloader_func": dummpy_dataloader_func,
         "weight_type": "QUInt8",
         "activation_type": "QUInt16",
+        "init_overrides": None,
+        "add_qtype_converts": True,
+        "activation_symmetric": True,
+        "weight_symmetric": None,
     }
     accelerator_spec = AcceleratorSpec(
         accelerator_type="NPU",

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -79,11 +79,11 @@ def test_qnn_quantization(tmp_path):
         "dataloader_func": dummpy_dataloader_func,
         "weight_type": "QUInt8",
         "activation_type": "QUInt16",
+        "WeightSymmetric": None,
+        "ActivationSymmetric": True,
         "qnn_extra_options": {
             "init_overrides": None,
             "add_qtype_converts": True,
-            "activation_symmetric": True,
-            "weight_symmetric": None,
         },
     }
     accelerator_spec = AcceleratorSpec(


### PR DESCRIPTION
## Describe your changes

Support ORT 1.18 QNN Preprocess by adding configs:
- init_overrides
- add_qtype_converts
- activation_symmetric
- weight_symmetric

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
