### PR TITLE
Deprecate unused field DataComponentConfig::name

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,12 +286,10 @@ Then the design for `DataContainer` interface will be like:
     DataConfig(
         components={
             "load_dataset": {
-                "name": "test_dataset",
                 "type": "test_dataset",
                 "params": {"test_value": "test_value"},
             },
             "dataloader": {
-                "name": "test_dataloader",
                 "type": "_test_dataloader",  # This is the key to get dataloader
                 "params": {"test_value": "test_value"},
             },

--- a/docs/source/tutorials/configure_data.rst
+++ b/docs/source/tutorials/configure_data.rst
@@ -213,7 +213,6 @@ Then the complete config would be like:
                 "type": "DataContainer",
                 "components": {
                     "load_dataset": {
-                        "name": "_huggingface_dataset",
                         "type": "huggingface_dataset",
                         "params": {
                             "data_dir": null,
@@ -224,7 +223,6 @@ Then the complete config would be like:
                         }
                     },
                     "pre_process_data": {
-                        "name": "_huggingface_pre_process",
                         "type": "huggingface_pre_process",
                         "params": {
                             "model_name": "Intel/bert-base-uncased-mrpc",
@@ -239,12 +237,10 @@ Then the complete config would be like:
                         }
                     },
                     "post_process_data": {
-                        "name": "_text_classification_post_process",
                         "type": "text_classification_post_process",
                         "params": {}
                     },
                     "dataloader": {
-                        "name": "_default_dataloader",
                         "type": "default_dataloader",
                         "params": {
                             "batch_size": 1
@@ -263,7 +259,6 @@ Then the complete config would be like:
                 type="DataContainer",
                 components={
                     "load_dataset": {
-                        "name": "_huggingface_dataset",
                         "type": "huggingface_dataset",
                         "params": {
                             "data_dir": null,
@@ -274,7 +269,6 @@ Then the complete config would be like:
                         }
                     },
                     "pre_process_data": {
-                        "name": "_huggingface_pre_process",
                         "type": "huggingface_pre_process",
                         "params": {
                             "model_name": "Intel/bert-base-uncased-mrpc",
@@ -289,12 +283,10 @@ Then the complete config would be like:
                         }
                     },
                     "post_process_data": {
-                        "name": "_text_classification_post_process",
                         "type": "text_classification_post_process",
                         "params": {}
                     },
                     "dataloader": {
-                        "name": "_default_dataloader",
                         "type": "default_dataloader",
                         "params": {
                             "batch_size": 1
@@ -322,7 +314,6 @@ The above case shows to rewrite all the components in data config. But sometime,
                 "script_dir": "user_dir",
                 "components": {
                     "load_dataset": {
-                        "name": "_huggingface_dataset",
                         "type": "customized_huggingface_dataset",
                         "params": {
                             "data_dir": null,
@@ -351,7 +342,6 @@ The above case shows to rewrite all the components in data config. But sometime,
                 script_dir="user_dir",
                 components={
                     "load_dataset": {
-                        "name": "_huggingface_dataset",
                         "type": "customized_huggingface_dataset",
                         "params": {
                             "data_dir": null,

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
 
 class DataComponentConfig(ConfigBase):
-    name: str = None
     type: str = None
     params: Dict = None
 
@@ -95,7 +94,6 @@ class DataConfig(ConfigBase):
             else:
                 # both are strings, so we don't need to deepcopy
                 self.components[k].type = self.components[k].type or v.type
-                self.components[k].name = self.components[k].name or v.name
                 # v.params is a dict, so we deepcopy it
                 self.components[k].params = self.components[k].params or deepcopy(v.params)
 
@@ -115,7 +113,7 @@ class DataConfig(ConfigBase):
     def _update_default_component(self):
         """Resolve the default component type."""
         for k, v in self.default_components_type.items():
-            self.default_components[k] = DataComponentConfig(type=v, name=v, params={})
+            self.default_components[k] = DataComponentConfig(type=v, params={})
 
     def fill_in_params(self):
         """Fill in the default parameters for each component.

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -38,7 +38,6 @@ def test_openvino_quantization(data_source, tmp_path):
                     name="test_dc_config",
                     components={
                         "load_dataset": {
-                            "name": "cifar10_dataset",
                             "type": "cifar10_dataset",
                             "params": {"data_dir": data_dir},
                         }
@@ -88,7 +87,6 @@ def test_openvino_quantization_with_accuracy(data_source, tmp_path):
                     name="test_dc_config",
                     components={
                         "load_dataset": {
-                            "name": "cifar10_dataset",
                             "type": "cifar10_dataset",
                             "params": {"data_dir": data_dir},
                         }

--- a/test/unit_test/test_data_root.py
+++ b/test/unit_test/test_data_root.py
@@ -112,7 +112,6 @@ def get_data_config():
                 name="test_data_config",
                 components={
                     "load_dataset": {
-                        "name": "dummy_dataset_dataroot",
                         "type": "dummy_dataset_dataroot",
                         "params": {"data_dir": "data"},
                     },
@@ -152,7 +151,6 @@ def get_data_config():
                         name="test_data_config",
                         components={
                             "load_dataset": {
-                                "name": "dummy_dataset_dataroot",
                                 "type": "dummy_dataset_dataroot",
                                 "params": {"data_dir": "perfdata"},
                             },

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -289,12 +289,10 @@ def get_data_config():
         name="test_data_config",
         components={
             "load_dataset": {
-                "name": "test_dataset",
                 "type": "test_dataset",  # renamed by Registry.register_dataset
                 "params": {"test_value": "test_value"},
             },
             "dataloader": {
-                "name": "test_dataloader",
                 "type": "_test_dataloader",  # This is the key to get dataloader
                 "params": {"test_value": "test_value"},
             },


### PR DESCRIPTION
## Deprecate unused field DataComponentConfig::name

Removed the unused field and related references across the codebase. Also, updated the relevant documentation.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
