### PR TITLE
Skip `test_extract_adapters` on windows temporarily

### DIFF
--- a/test/unit_test/passes/onnx/test_extract_adapters.py
+++ b/test/unit_test/passes/onnx/test_extract_adapters.py
@@ -2,14 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import platform
 from pathlib import Path
 
 import numpy as np
 import onnx
 import pytest
 from onnxruntime.quantization.calibrate import CalibrationDataReader
-from peft import LoraConfig, get_peft_model
-from peft.tuners.lora import LoraLayer
 from transformers import AutoModelForCausalLM
 
 from olive.common.utils import find_submodules
@@ -44,6 +43,9 @@ def get_calib_data_loader(dummy_input):
 
 @pytest.fixture(name="input_model_info", scope="module")
 def input_model_info_fixture(tmp_path_factory):
+    from peft import LoraConfig, get_peft_model
+    from peft.tuners.lora import LoraLayer
+
     # this tmp_path exists for the duration of the test session
     # module is scope is used to ensure that the fixture is only created once
     tmp_path = tmp_path_factory.mktemp("extract-adapters-test")
@@ -127,6 +129,10 @@ def input_model_info_fixture(tmp_path_factory):
     }
 
 
+# TODO(jambayk): re-enable this test once import issue is resolved
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Peft import sometimes fails on Windows after version 0.11.0"
+)
 @pytest.mark.parametrize("model_type", ["float", "qdq", "int4"])
 def test_extract_adapters_as_initializers(tmp_path, input_model_info, model_type):
     # setup
@@ -153,6 +159,9 @@ def test_extract_adapters_as_initializers(tmp_path, input_model_info, model_type
     assert seen_weights == expected_weights
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Peft import sometimes fails on Windows after version 0.11.0"
+)
 @pytest.mark.parametrize("model_type", ["float", "qdq", "int4"])
 @pytest.mark.parametrize("pack_inputs", [True, False])
 def test_extract_adapters_as_inputs(tmp_path, input_model_info, pack_inputs, model_type):
@@ -177,6 +186,9 @@ def test_extract_adapters_as_inputs(tmp_path, input_model_info, pack_inputs, mod
     assert all(i in io_config["input_names"] for i in expected_weights)
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Peft import sometimes fails on Windows after version 0.11.0"
+)
 @pytest.mark.parametrize("quantize_int4", [1, 0])
 @pytest.mark.parametrize("pack_weights", [True, False])
 def test_export_adapters_command(tmp_path, input_model_info, quantize_int4, pack_weights):


### PR DESCRIPTION
## Describe your changes
The CI test on Windows fails occasionally during import of `peft`. The test is disabled temporarily to unblock other PRs while I find a solution for it.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
