### PR TITLE
UT: Pin `peft` to `0.10.0`

### DIFF
--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -22,7 +22,9 @@ onnxruntime-extensions
 openvino==2023.2.0
 optimum>=1.17.0
 pandas
-peft
+# TODO(anyone): Unpin peft once the issue is resolved
+# occasional import error on Windows with peft 0.11.1
+peft==0.10.0
 plotly
 protobuf==3.20.3
 psutil

--- a/test/unit_test/passes/onnx/test_extract_adapters.py
+++ b/test/unit_test/passes/onnx/test_extract_adapters.py
@@ -2,13 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import platform
 from pathlib import Path
 
 import numpy as np
 import onnx
 import pytest
 from onnxruntime.quantization.calibrate import CalibrationDataReader
+from peft import LoraConfig, get_peft_model
+from peft.tuners.lora import LoraLayer
 from transformers import AutoModelForCausalLM
 
 from olive.common.utils import find_submodules
@@ -43,9 +44,6 @@ def get_calib_data_loader(dummy_input):
 
 @pytest.fixture(name="input_model_info", scope="module")
 def input_model_info_fixture(tmp_path_factory):
-    from peft import LoraConfig, get_peft_model
-    from peft.tuners.lora import LoraLayer
-
     # this tmp_path exists for the duration of the test session
     # module is scope is used to ensure that the fixture is only created once
     tmp_path = tmp_path_factory.mktemp("extract-adapters-test")
@@ -129,10 +127,6 @@ def input_model_info_fixture(tmp_path_factory):
     }
 
 
-# TODO(jambayk): re-enable this test once import issue is resolved
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Peft import sometimes fails on Windows after version 0.11.0"
-)
 @pytest.mark.parametrize("model_type", ["float", "qdq", "int4"])
 def test_extract_adapters_as_initializers(tmp_path, input_model_info, model_type):
     # setup
@@ -159,9 +153,6 @@ def test_extract_adapters_as_initializers(tmp_path, input_model_info, model_type
     assert seen_weights == expected_weights
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Peft import sometimes fails on Windows after version 0.11.0"
-)
 @pytest.mark.parametrize("model_type", ["float", "qdq", "int4"])
 @pytest.mark.parametrize("pack_inputs", [True, False])
 def test_extract_adapters_as_inputs(tmp_path, input_model_info, pack_inputs, model_type):
@@ -186,9 +177,6 @@ def test_extract_adapters_as_inputs(tmp_path, input_model_info, pack_inputs, mod
     assert all(i in io_config["input_names"] for i in expected_weights)
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Peft import sometimes fails on Windows after version 0.11.0"
-)
 @pytest.mark.parametrize("quantize_int4", [1, 0])
 @pytest.mark.parametrize("pack_weights", [True, False])
 def test_export_adapters_command(tmp_path, input_model_info, quantize_int4, pack_weights):


### PR DESCRIPTION
## Describe your changes
- The CI test on Windows fails occasionally during import of peft. At https://github.com/huggingface/peft/blob/e7b75070c72a88f0f7926cc6872858a2c5f0090d/src/peft/tuners/boft/layer.py#L30, the error is `OSError: [WinError 122] The data area passed to a system call is too small`. This code was added in https://github.com/huggingface/peft/commit/811169939ff466199cdd48767a10ca48497e03f7 which is part of peft version 0.11.0+.
- Revert #1180 since more tests are affected by the same issue. Will just pin peft version to the previous stable version 0.10.0 until the issue is fully investigated and resolved.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
