### PR TITLE
Add workflow schema to doc website

### DIFF
--- a/.azure_pipelines/job_templates/olive-build-doc-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-doc-template.yaml
@@ -35,6 +35,7 @@ jobs:
         python -m pip install -r requirements.txt
         make html
         make linkcheck
+        make schema
       displayName: Make Docs
 
     - task:  PublishPipelineArtifact@1

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,12 +7,16 @@ SPHINXOPTS    ?= -a -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+SCHEMABUILD   = python $(SOURCEDIR)/dump_schema.py
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+schema:
+	$(SCHEMABUILD) --output $(BUILDDIR)/html/schema.json
+
+.PHONY: help Makefile schema
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=source
 set BUILDDIR=build
+set SCHEMABUILD="python %SOURCEDIR%/dump_schema.py"
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -25,11 +26,17 @@ if errorlevel 9009 (
 
 if "%1" == "" goto help
 
+if "%1" == "schema" goto schema
+
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% -W %O%
 goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:schema
+%SCHEMABUILD% --output %SOURCEDIR%/html/schema.json
 
 :end
 popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,4 +97,6 @@ linkcheck_ignore = [
     r"https://docs.qualcomm.com/*",
     # TODO(jambayk): remove this when the issue is fixed
     r"https://www.intel.com/*",
+    # TODO(jambayk): remove this once schema PR is merged
+    "https://microsoft.github.io/Olive/schema.json",
 ]

--- a/docs/source/dump_schema.py
+++ b/docs/source/dump_schema.py
@@ -1,0 +1,17 @@
+import argparse
+from pathlib import Path
+
+from olive.workflows.run.config import RunConfig
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Dump workflow schema")
+
+    parser.add_argument("--output", type=str, default="schema.json", help="Output file")
+
+    args = parser.parse_args()
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w") as f:
+        f.write(RunConfig.schema_json(indent=2))

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -4,6 +4,11 @@ Olive enables users to easily compose and customize their own model optimization
 used to compose a pipeline. Olive receives input model, target hardware, performance requirements, and list of optimizations techniques
 to apply from user in the form of a json dictionary. In this document, we document the options user can set in this dictionary.
 
+**Note**: The json schema for the config file can be found [here](https://microsoft.github.io/Olive/schema.json). It can be used in IDEs like VSCode to provide intellisense by adding the following line at the top of the config file:
+```json
+"$schema": "https://microsoft.github.io/Olive/schema.json"
+```
+
 The options are organized into following sections:
 
 - [Workflow id](#workflow-id) `workflow_id`

--- a/olive/azureml/azureml_client.py
+++ b/olive/azureml/azureml_client.py
@@ -14,6 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 class AzureMLClientConfig(ConfigBase):
+    """Configuration for AzureMLClient.
+
+    This class is used to create an MLClient instance for AzureML operations.
+    Some fields like `read_timeout`, `max_operation_retries`, `operation_retry_interval` are used to control the
+    behavior of azureml operations like resource creation or download.
+    """
+
     subscription_id: str = Field(
         None, description="Azure subscription id. Required if aml_config_path is not provided."
     )
@@ -50,7 +57,7 @@ class AzureMLClientConfig(ConfigBase):
     )
     keyvault_name: Optional[str] = Field(
         None,
-        description=("Name of the keyvault to use. If provided, the keyvault will be used to retrieve secrets."),
+        description="Name of the keyvault to use. If provided, the keyvault will be used to retrieve secrets.",
     )
 
     @validator("aml_config_path", always=True)

--- a/olive/model/config/model_config.py
+++ b/olive/model/config/model_config.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from olive.common.config_utils import ConfigBase
-from olive.common.pydantic_v1 import validator
+from olive.common.pydantic_v1 import Field, validator
 from olive.model.config.registry import get_model_handler, is_valid_model_type
 from olive.resource_path import create_resource_path
 
@@ -12,82 +12,61 @@ class ModelConfig(ConfigBase):
     """Input model config which will be used to create the model handler.
 
     For example, the config looks like for llama2:
+
     .. code-block:: json
 
         {
             "input_model": {
                 "type": "CompositePyTorchModel",
                 "config": {
-
                     "model_path": "llama_v2",
                     "model_components": [
-
                         {
                             "name": "decoder_model",
                             "type": "PyTorchModel",
                             "config": {
-
                                 "model_script": "user_script.py",
                                 "io_config": {
-
-                                    "input_names": ["tokens", "position_ids", "attn_mask", ...],
-                                    "output_names": ["logits", "attn_mask_out", ...],
+                                    "input_names": ["tokens", "position_ids", "attn_mask", //...],
+                                    "output_names": ["logits", "attn_mask_out", //...],
                                     "dynamic_axes": {
-
                                         "tokens": { "0": "batch_size", "1": "seq_len" },
                                         "position_ids": { "0": "batch_size", "1": "seq_len" },
                                         "attn_mask": { "0": "batch_size", "1": "max_seq_len" },
-                                        ...
-
+                                        //...
                                     }
-
                                 },
                                 "model_loader": "load_decoder_model",
                                 "dummy_inputs_func": "decoder_inputs"
-
                             }
-
                         },
                         {
-
                             "name": "decoder_with_past_model",
                             "type": "PyTorchModel",
                             "config": {
-
                                 "model_script": "user_script.py",
                                 "io_config": {
-
-                                    "input_names": ["tokens_increment", "position_ids_increment", "attn_mask", ...],
-                                    "output_names": ["logits", "attn_mask_out", ...],
+                                    "input_names": ["tokens_increment", "position_ids_increment", "attn_mask", //...],
+                                    "output_names": ["logits", "attn_mask_out", //...],
                                     "dynamic_axes": {
-
                                         "tokens_increment": { "0": "batch_size", "1": "seq_len_increment" },
                                         "position_ids_increment": { "0": "batch_size", "1": "seq_len_increment" },
                                         "attn_mask": { "0": "batch_size", "1": "max_seq_len" },
-                                        ...
-
+                                        //...
                                     }
-
                                 },
                                 "model_loader": "load_decoder_with_past_model",
                                 "dummy_inputs_func": "decoder_with_past_inputs"
-
                             }
-
                         }
-
                     ]
-
                 }
-
             }
-
         }
-
     """
 
-    type: str
-    config: dict
+    type: str = Field(description="The type of the model handler.")
+    config: dict = Field(description="The config for the model handler. Used to initialize the model handler.")
 
     @validator("type")
     def validate_type(cls, v):

--- a/olive/passes/__init__.py
+++ b/olive/passes/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.passes.olive_pass import CommonPassConfig, FullPassConfig, Pass
+from olive.passes.olive_pass import AbstractPassConfig, FullPassConfig, Pass
 from olive.passes.pass_config import PassModuleConfig, PassParamDefault
 
 REGISTRY = Pass.registry
@@ -11,7 +11,7 @@ __all__ = [
     "Pass",
     "PassParamDefault",
     "PassModuleConfig",
-    "CommonPassConfig",
+    "AbstractPassConfig",
     "FullPassConfig",
     "REGISTRY",
 ]

--- a/olive/passes/__init__.py
+++ b/olive/passes/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.passes.olive_pass import FullPassConfig, Pass
+from olive.passes.olive_pass import CommonPassConfig, FullPassConfig, Pass
 from olive.passes.pass_config import PassModuleConfig, PassParamDefault
 
 REGISTRY = Pass.registry
@@ -11,6 +11,7 @@ __all__ = [
     "Pass",
     "PassParamDefault",
     "PassModuleConfig",
+    "CommonPassConfig",
     "FullPassConfig",
     "REGISTRY",
 ]

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -473,7 +473,7 @@ class CommonPassConfig(ConfigBase):
         None,
         description=(
             "The configuration of the pass. Values for required parameters must be provided. For optional parameters,"
-            " default values or searchable values (if avalable and search is not disabled) will be used if not"
+            " default values or searchable values (if available and search is not disabled) will be used if not"
             " provided."
         ),
     )

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, Optional, Tuple, Type, Union, get_args
 
 from olive.common.config_utils import ConfigBase, ParamCategory, validate_config
+from olive.common.pydantic_v1 import Field
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.config import DataConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
@@ -463,12 +464,30 @@ class Pass(ABC):
 
 
 # TODO(jambayk): rename. We are using FullPassConfig since PassConfigBase already refers to inner config
-class FullPassConfig(ConfigBase):
-    type: str
-    disable_search: bool = False
+class CommonPassConfig(ConfigBase):
+    """Base class for pass configuration."""
+
+    type: str = Field(description="The type of the pass.")
+    disable_search: bool = Field(default=False, description="Whether to disable search.")
+    config: Dict[str, Any] = Field(
+        None,
+        description=(
+            "The configuration of the pass. Values for required parameters must be provided. For optional parameters,"
+            " default values or searchable values (if avalable and search is not disabled) will be used if not"
+            " provided."
+        ),
+    )
+
+
+class FullPassConfig(CommonPassConfig):
+    """Configuration for a pass serialization.
+
+    This class can be used to serialize a pass configuration to a JSON file and
+    reconstruct the pass from the JSON file.
+    """
+
     accelerator: Dict[str, str] = None
     host_device: Optional[str] = None
-    config: Dict[str, Any] = None
 
     def create_pass(self):
         if not isinstance(self.accelerator, dict):

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -463,8 +463,7 @@ class Pass(ABC):
         raise NotImplementedError
 
 
-# TODO(jambayk): rename. We are using FullPassConfig since PassConfigBase already refers to inner config
-class CommonPassConfig(ConfigBase):
+class AbstractPassConfig(ConfigBase):
     """Base class for pass configuration."""
 
     type: str = Field(description="The type of the pass.")
@@ -479,7 +478,8 @@ class CommonPassConfig(ConfigBase):
     )
 
 
-class FullPassConfig(CommonPassConfig):
+# TODO(jambayk): rename. We are using FullPassConfig since PassConfigBase already refers to inner config
+class FullPassConfig(AbstractPassConfig):
     """Configuration for a pass serialization.
 
     This class can be used to serialize a pass configuration to a JSON file and

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -17,7 +17,7 @@ from olive.engine import Engine, EngineConfig
 from olive.engine.packaging.packaging_config import PackagingConfig
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.model import ModelConfig
-from olive.passes import CommonPassConfig
+from olive.passes import AbstractPassConfig
 from olive.passes.pass_config import PassParamDefault
 from olive.resource_path import AZUREML_RESOURCE_TYPES
 from olive.systems.system_config import SystemConfig
@@ -25,7 +25,7 @@ from olive.systems.system_config import SystemConfig
 logger = logging.getLogger(__name__)
 
 
-class RunPassConfig(CommonPassConfig):
+class RunPassConfig(AbstractPassConfig):
     """Pass configuration for Olive workflow.
 
     This is the configuration for a single pass in Olive workflow. It includes configurations for pass type, config,

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -10,14 +10,14 @@ from olive.auto_optimizer import AutoOptimizerConfig
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.common.config_utils import ConfigBase, validate_config
 from olive.common.constants import DEFAULT_WORKFLOW_ID
-from olive.common.pydantic_v1 import validator
+from olive.common.pydantic_v1 import Field, validator
 from olive.data.config import DataConfig
 from olive.data.container.huggingface_container import HuggingfaceContainer
 from olive.engine import Engine, EngineConfig
 from olive.engine.packaging.packaging_config import PackagingConfig
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.model import ModelConfig
-from olive.passes import FullPassConfig
+from olive.passes import CommonPassConfig
 from olive.passes.pass_config import PassParamDefault
 from olive.resource_path import AZUREML_RESOURCE_TYPES
 from olive.systems.system_config import SystemConfig
@@ -25,11 +25,53 @@ from olive.systems.system_config import SystemConfig
 logger = logging.getLogger(__name__)
 
 
-class RunPassConfig(FullPassConfig):
-    host: SystemConfig = None
-    evaluator: OliveEvaluatorConfig = None
-    clean_run_cache: bool = False
-    output_name: str = None
+class RunPassConfig(CommonPassConfig):
+    """Pass configuration for Olive workflow.
+
+    This is the configuration for a single pass in Olive workflow. It includes configurations for pass type, config,
+    etc.
+
+    Example:
+    .. code-block:: json
+
+        {
+            "type": "OlivePass",
+            "config": {
+                "param1": "value1",
+                "param2": "value2"
+            }
+        }
+
+    """
+
+    host: Union[SystemConfig, str] = Field(
+        None,
+        description=(
+            "Host system for the pass. If it is a string, must refer to a system config under `systems` section. If not"
+            " provided, use the engine's host system."
+        ),
+    )
+    evaluator: Union[OliveEvaluatorConfig, str] = Field(
+        None,
+        description=(
+            "Evaluator for the pass. If it is a string, must refer to an evaluator config under `evaluators` section."
+            " If not provided, use the engine's evaluator."
+        ),
+    )
+    clean_run_cache: bool = Field(
+        False,
+        description=(
+            "Whether to clean the run cache before running the pass. If set to True, the cache related to all runs"
+            " related to this pass type will be cleaned."
+        ),
+    )
+    output_name: str = Field(
+        None,
+        description=(
+            "Prefix of the name of the output of this pass in the output directory. Only used when the workflow is run"
+            " in no-search mode. If not provided, only the output of the last pass will be saved."
+        ),
+    )
 
 
 class RunEngineConfig(EngineConfig):
@@ -48,17 +90,68 @@ class RunEngineConfig(EngineConfig):
 
 
 class RunConfig(ConfigBase):
-    workflow_id: str = DEFAULT_WORKFLOW_ID
-    azureml_client: AzureMLClientConfig = None
-    input_model: ModelConfig
-    systems: Dict[str, SystemConfig] = None
-    data_root: str = None
-    data_configs: List[DataConfig] = []  # noqa: RUF012
-    evaluators: Dict[str, OliveEvaluatorConfig] = None
-    engine: RunEngineConfig = None
-    pass_flows: List[List[str]] = None
-    passes: Dict[str, RunPassConfig] = None
-    auto_optimizer_config: AutoOptimizerConfig = None
+    """Run configuration for Olive workflow.
+
+    This is the top-level configuration. It includes configurations for input model, systems, data,
+    evaluators, engine, passes, and auto optimizer.
+    """
+
+    workflow_id: str = Field(
+        DEFAULT_WORKFLOW_ID, description="Workflow ID. If not provided, use the default ID 'default_workflow'."
+    )
+    azureml_client: AzureMLClientConfig = Field(
+        None,
+        description=(
+            "AzureML client configuration. This client configuration will be used for all AzureML related resources in"
+            " the workflow."
+        ),
+    )
+    input_model: ModelConfig = Field(description="Input model configuration.")
+    systems: Dict[str, SystemConfig] = Field(
+        None,
+        description="System configurations. Other fields such as engine and passes can refer to these systems by name.",
+    )
+    data_root: str = Field(
+        None,
+        description=(
+            "Root directory for data. If provided, all relative data paths in other configs will be resolved based on"
+            " this root."
+        ),
+    )
+    data_configs: List[DataConfig] = Field(
+        default_factory=list,
+        description=(
+            "Data configurations. Each data config must have a unique name. Other fields such as engine, passes and"
+            " evaluators can refer to these data configs by name. In auto-optimizer mode, only one data config is"
+            " allowed."
+        ),
+    )
+    evaluators: Dict[str, OliveEvaluatorConfig] = Field(
+        None,
+        description=(
+            "Evaluator configurations. Other fields such as engine and passes can refer to these evaluators by name."
+        ),
+    )
+    engine: RunEngineConfig = Field(
+        default_factory=RunEngineConfig,
+        description=(
+            "Engine configuration. If not provided, the workflow uses the default engine configuration which runs in"
+            " no-search or auto-optimizer mode based on whether passes field is provided."
+        ),
+    )
+    passes: Dict[str, RunPassConfig] = Field(None, description="Pass configurations.")
+    pass_flows: List[List[str]] = Field(
+        None,
+        description=(
+            "Pass flows. Each member must be a list of pass names from `passes` field. If provided,"
+            " each flow will be run sequentially. If not provided, all passes will be run as a single flow in the order"
+            " of `passes` field."
+        ),
+    )
+    auto_optimizer_config: AutoOptimizerConfig = Field(
+        default_factory=AutoOptimizerConfig,
+        description="Auto optimizer configuration. Only valid when passes field is empty or not provided.",
+    )
 
     @validator("input_model", pre=True)
     def insert_aml_client(cls, v, values):
@@ -72,12 +165,6 @@ class RunConfig(ConfigBase):
 
         if _have_aml_client(input_model_path, values):
             v["config"]["model_path"]["config"]["azureml_client"] = values["azureml_client"]
-        return v
-
-    @validator("engine", pre=True, always=True)
-    def default_engine_config(cls, v):
-        if v is None:
-            v = {}
         return v
 
     @validator("data_configs", pre=True)
@@ -191,12 +278,6 @@ class RunConfig(ConfigBase):
                 f" set {searchable_configs} to SEARCHABLE_VALUES at the same time."
                 " Please remove SEARCHABLE_VALUES or enable search(needs search strategy configs)."
             )
-        return v
-
-    @validator("auto_optimizer_config", always=True)
-    def validate_auto_optimizer_config(cls, v, values):
-        if not v:
-            v = AutoOptimizerConfig()
         return v
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ classmethod-decorators = ["classmethod", "olive.common.pydantic_v1.validator", "
 ".azure_pipelines/**" = ["INP001"]
 "examples/**" = ["INP001"]
 "olive/engine/packaging/sample_code/ONNXModel/python/**" = ["INP001"]
+"docs/**" = ["INP001"]
 "test/**" = ["INP001"]
 "scripts/**" = ["INP001"]
 "examples/directml/llm/chat_app/**" = ["TID252", "UP006", "T201"]


### PR DESCRIPTION
## Describe your changes
- Add olive workflow schema to doc website. This schema file can be used in IDEs when writing workflow configs.
- Config objects related to workflow are updated to use `Field` with descriptions. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
Schema for olive workflow config json can be found at https://microsoft.github.io/Olive/schema.json.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
