### PR TITLE
Llama2: Multi-lora generate using genai, Update default kv cache io names

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -119,13 +119,13 @@ find more details in [Olive Models](https://microsoft.github.io/Olive/api/models
           - If it is `False`, Olive will not use key value cache.
           - If it is `True`, Olive will infer the cache configuration from the input_names/input_shapes and input model based on default `kv_cache`.
           - If it is a dictionary, it should contains the key value cache configuration. Here is an default configuration example:
-            - `ort_past_key_name`: "past_key_<id>"
+            - `ort_past_key_name`: "past_key_values.<id>.key"
                 Template for the past key name. The `<id>` will be replaced by the id of the past key.
-            - `ort_past_value_name`: "past_value_<id>"
+            - `ort_past_value_name`: "past_key_values.<id>.value"
                 Template for the past value name. The `<id>` will be replaced by the id of the past value.
-            - `ort_present_key_name`: "present_key_<id>"
+            - `ort_present_key_name`: "present.<id>.key"
                 Template for the present key name. The `<id>` will be replaced by the id of the present key.
-            - `ort_present_value_name`: "present_value_<id>"
+            - `ort_present_value_name`: "present.<id>.value"
                 Template for the present value name. The `<id>` will be replaced by the id of the present value.
             - `world_size`: 1
                 It is only used for distributed models.

--- a/examples/llama2/llama2_multilora.ipynb
+++ b/examples/llama2/llama2_multilora.ipynb
@@ -29,7 +29,9 @@
    "outputs": [],
    "source": [
     "!pip install -r requirements-qlora.txt\n",
-    "!pip install ipywidgets tabulate"
+    "!pip install ipywidgets tabulate\n",
+    "!pip install --pre onnxruntime-genai-cuda --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/\n",
+    "# !pip install --pre onnxruntime-genai"
    ]
   },
   {
@@ -79,17 +81,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2024-04-25 12:53:57,682] [INFO] [run.py:279:run] test/lib/python3.8/site-packages/olive/olive_config.json\n",
-      "[2024-04-25 12:53:57,683] [INFO] [run.py:285:run] Loading run configuration from: llama2_qlora.json\n",
-      "[2024-04-25 12:53:58,125] [INFO] [run.py:91:dependency_setup] The following packages are required in the local environment: ['onnxruntime-gpu']\n",
-      "[2024-04-25 12:53:58,164] [INFO] [run.py:321:check_local_ort_installation] onnxruntime-gpu is already installed.\n"
+      "[2024-06-15 04:21:32,243] [INFO] [run.py:91:dependency_setup] The following packages are required in the local environment: ['onnxruntime-gpu']\n",
+      "[2024-06-15 04:21:32,300] [INFO] [run.py:317:check_local_ort_installation] onnxruntime-gpu is already installed.\n"
      ]
     }
    ],
@@ -101,76 +101,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2024-04-25 12:59:55,351] [INFO] [run.py:279:run] Loading Olive module configuration from: test/lib/python3.8/site-packages/olive/olive_config.json\n",
-      "[2024-04-25 12:59:55,351] [INFO] [run.py:285:run] Loading run configuration from: llama2_qlora.json\n",
-      "[2024-04-25 12:59:56,812] [INFO] [accelerator_creator.py:224:create_accelerators] Running workflow on accelerator specs: gpu-cuda\n",
-      "[2024-04-25 12:59:56,812] [INFO] [engine.py:107:initialize] Using cache directory: cache\n",
-      "[2024-04-25 12:59:56,813] [INFO] [engine.py:263:run] Running Olive on accelerator: gpu-cuda\n",
-      "[2024-04-25 12:59:56,813] [INFO] [engine.py:1075:_create_system] Creating target system ...\n",
-      "[2024-04-25 12:59:56,813] [INFO] [engine.py:1078:_create_system] Target system created in 0.000093 seconds\n",
-      "[2024-04-25 12:59:56,813] [INFO] [engine.py:1087:_create_system] Creating host system ...\n",
-      "[2024-04-25 12:59:56,813] [INFO] [engine.py:1090:_create_system] Host system created in 0.000076 seconds\n",
-      "[2024-04-25 12:59:56,862] [INFO] [engine.py:325:run_accelerator] Input model evaluation results: {\n",
-      "  \"onnx_merged_latency-avg\": 37.44323\n",
-      "}\n",
-      "[2024-04-25 12:59:56,863] [INFO] [engine.py:330:run_accelerator] Saved evaluation results of input model to models/tiny-codes-qlora/gpu-cuda_input_model_metrics.json\n",
-      "[2024-04-25 12:59:56,863] [INFO] [engine.py:865:_run_pass] Running pass qlora:QLoRA\n",
-      "[2024-04-25 12:59:57,523] [INFO] [hf_config.py:107:load_hf_model] Loading Huggingface model from meta-llama/Llama-2-7b-hf\n",
-      "Loading checkpoint shards: 100%|██████████████████| 2/2 [00:07<00:00,  3.60s/it]\n",
-      "[2024-04-25 13:00:12,820] [INFO] [lora.py:709:smart_tokenizer_and_embedding_resize] Added 1 new tokens to tokenizer and resized model embedding layer.\n",
-      "Generating train split: 100%|█| 1632309/1632309 [00:14<00:00, 112795.00 examples\n",
-      "Filter: 100%|███████████████| 1632309/1632309 [00:21<00:00, 76882.92 examples/s]\n",
-      "Map: 100%|█████████████████████| 129063/129063 [00:25<00:00, 4994.97 examples/s]\n",
-      "[2024-04-25 13:01:55,902] [INFO] [lora.py:664:train_and_save_new_model] Running fine-tuning\n",
-      "{'loss': 1.3355, 'grad_norm': 0.1982421875, 'learning_rate': 0.0002, 'epoch': 0.0}\n",
-      " 67%|████████████████████████████▋              | 10/15 [01:01<00:30,  6.12s/it]\n",
-      " 98%|██████████████████████████████████████████▎| 63/64 [01:56<00:01,  1.88s/it]\u001b[A\n",
-      "                                                                                \u001b[A\n",
-      "\u001b[A{'eval_loss': 1.085297703742981, 'eval_runtime': 120.0963, 'eval_samples_per_second': 8.526, 'eval_steps_per_second': 0.533, 'epoch': 0.0}\n",
-      " 67%|████████████████████████████▋              | 10/15 [03:02<00:30,  6.12s/it]\n",
-      "100%|███████████████████████████████████████████| 64/64 [01:58<00:00,  1.88s/it]\u001b[A\n",
-      "{'train_runtime': 216.3513, 'train_samples_per_second': 1.109, 'train_steps_per_second': 0.069, 'train_loss': 1.2367729822794595, 'epoch': 0.0}\n",
-      "100%|███████████████████████████████████████████| 15/15 [03:36<00:00, 14.42s/it]\n",
-      "[2024-04-25 13:05:48,511] [INFO] [engine.py:952:_run_pass] Pass qlora:QLoRA finished in 351.644019 seconds\n",
-      "[2024-04-25 13:05:48,517] [INFO] [engine.py:865:_run_pass] Running pass conversion:OnnxConversion\n",
-      "[2024-04-25 13:05:48,589] [WARNING] [conversion.py:399:_load_pytorch_model] Bitsandbytes 4bit quantization is not supported for conversion. The quantization config is removed from the model loading args. Use OnnxBnb4Quantization pass after conversion to quantize the model.\n",
-      "[2024-04-25 13:05:48,658] [INFO] [hf_config.py:107:load_hf_model] Loading Huggingface model from meta-llama/Llama-2-7b-hf\n",
-      "Loading checkpoint shards: 100%|██████████████████| 2/2 [00:06<00:00,  3.48s/it]\n",
-      "[2024-04-25 13:28:10,754] [INFO] [engine.py:952:_run_pass] Pass conversion:OnnxConversion finished in 1342.234356 seconds\n",
-      "[2024-04-25 13:28:10,757] [INFO] [engine.py:865:_run_pass] Running pass transformers_optimization:OrtTransformersOptimization\n",
-      "Unable to determine if past_sequence_length + sequence_length <= total_sequence_length, treat as equal\n",
-      "[2024-04-25 13:34:26,000] [INFO] [engine.py:952:_run_pass] Pass transformers_optimization:OrtTransformersOptimization finished in 375.239734 seconds\n",
-      "[2024-04-25 13:34:26,002] [INFO] [engine.py:865:_run_pass] Running pass extract:ExtractAdapters\n",
-      "[2024-04-25 13:35:06,168] [INFO] [engine.py:952:_run_pass] Pass extract:ExtractAdapters finished in 24.839953 seconds\n",
-      "[2024-04-25 13:35:06,174] [INFO] [engine.py:843:_run_passes] Run model evaluation for the final model...\n",
-      "[2024-04-25 13:35:37,035] [INFO] [engine.py:362:run_accelerator] Save footprint to models/tiny-codes-qlora/gpu-cuda_footprints.json.\n",
-      "[2024-04-25 13:35:37,039] [INFO] [engine.py:280:run] Run history for gpu-cuda:\n",
-      "+---------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+----------------+---------------------------------------+\n",
-      "| model_id                                                                  | parent_model_id                                                           | from_pass                   |   duration_sec | metrics                               |\n",
-      "+===========================================================================+===========================================================================+=============================+================+=======================================+\n",
-      "| cc026a1e9eb8ef3842cd61d229cbe524                                          |                                                                           |                             |                | {                                     |\n",
-      "|                                                                           |                                                                           |                             |                |   \"onnx_merged_latency-avg\": 37.44323 |\n",
-      "|                                                                           |                                                                           |                             |                | }                                     |\n",
-      "+---------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+----------------+---------------------------------------+\n",
-      "| 1_QLoRA-cc026a1e9eb8ef3842cd61d229cbe524-fbada217619dd1cb52eaeb9812410205 | cc026a1e9eb8ef3842cd61d229cbe524                                          | QLoRA                       |        351.644 |                                       |\n",
-      "+---------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+----------------+---------------------------------------+\n",
-      "| 2_OnnxConversion-1-a05534eac4724f42a8f509b5df07c775                       | 1_QLoRA-cc026a1e9eb8ef3842cd61d229cbe524-fbada217619dd1cb52eaeb9812410205 | OnnxConversion              |       1342.23  |                                       |\n",
-      "+---------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+----------------+---------------------------------------+\n",
-      "| 3_OrtTransformersOptimization-2-b146ae945480fd90646289242722efbf-gpu-cuda | 2_OnnxConversion-1-a05534eac4724f42a8f509b5df07c775                       | OrtTransformersOptimization |        375.24  |                                       |\n",
-      "+---------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+----------------+---------------------------------------+\n",
-      "| 4_ExtractAdapters-3-1480088e998491a7ff11e7d3e07986c7                      | 3_OrtTransformersOptimization-2-b146ae945480fd90646289242722efbf-gpu-cuda | ExtractAdapters             |         24.84  | {                                     |\n",
-      "|                                                                           |                                                                           |                             |                |   \"onnx_merged_latency-avg\": 20.6524  |\n",
-      "|                                                                           |                                                                           |                             |                | }                                     |\n",
-      "+---------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+----------------+---------------------------------------+\n",
-      "[2024-04-25 13:35:37,040] [INFO] [engine.py:295:run] No packaging config provided, skip packaging artifacts\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!CUDA_VISIBLE_DEVICES=0 olive run --config llama2_qlora.json"
    ]
@@ -220,7 +151,35 @@
    "source": [
     "## Deploy Model with Multiple Adapters\n",
     "\n",
-    "We can now deploy the same base model with multiple adapters for different tasks by loading the adapter weights independently of the model and providing the relevant weights as input at inference time.\n",
+    "We can now deploy the same model with multiple adapters for different tasks by loading the adapter weights independently of the model and providing the relevant weights as input at inference time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_model_name = \"meta-llama/llama-2-7b-hf\"\n",
+    "model_path = \"models/tiny-codes-qlora/qlora-conversion-transformers_optimization-extract-metadata/gpu-cuda_model/model.onnx\"\n",
+    "adapters = {\n",
+    "    \"guanaco\": {\n",
+    "        \"weights\": \"models/exported/guanaco_qlora.npz\",\n",
+    "        \"template\": \"### Human: {prompt} ### Assistant:\"\n",
+    "    },\n",
+    "    \"tiny-codes\": {\n",
+    "        \"weights\": \"models/tiny-codes-qlora/qlora-conversion-transformers_optimization-extract-metadata/gpu-cuda_model/adapter_weights.npz\",\n",
+    "        \"template\": \"### Question: {prompt} \\n### Answer:\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom Generate Loop\n",
+    "\n",
     "\n",
     "We implemented an example class `ORTGenerator` in [generator.py](../utils/generator.py) that loads the model and adapters, and generates code given a prompt. If your execution provider supports IO Binding, it is recommended to use it for better performance since the adapter weights will be preallocated in the device memory."
    ]
@@ -240,19 +199,6 @@
     "from generator import ORTGenerator\n",
     "from transformers import AutoTokenizer\n",
     "\n",
-    "base_model_name = \"meta-llama/llama-2-7b-hf\"\n",
-    "model_path = \"models/tiny-codes-qlora/qlora-conversion-transformers_optimization-extract/gpu-cuda_model/model.onnx\"\n",
-    "adapters = {\n",
-    "    \"guanaco\": {\n",
-    "        \"weights\": \"models/exported/guanaco_qlora.npz\",\n",
-    "        \"template\": \"### Human: {prompt} ### Assistant:\"\n",
-    "    },\n",
-    "    \"tiny-codes\": {\n",
-    "        \"weights\": \"models/tiny-codes-qlora/qlora-conversion-transformers_optimization-extract/gpu-cuda_model/adapter_weights.npz\",\n",
-    "        \"template\": \"### Question: {prompt} \\n### Answer:\"\n",
-    "    }\n",
-    "}\n",
-    "\n",
     "# load the tokenizer\n",
     "tokenizer = AutoTokenizer.from_pretrained(base_model_name)\n",
     "\n",
@@ -264,12 +210,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate using Guanaco Adapters"
+    "#### Generate using Guanaco Adapters"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -298,44 +244,172 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate with Tiny Codes Adapters"
+    "#### Generate with Tiny Codes Adapters"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "### Question: Calculate the sum of a list of integers. \n",
-      "### Answer: Here is some python code that implements this functionality: \n",
+      "### Question: Calculate the sum of all even numbers in a list. \n",
+      "### Answer: Here's some python code which implements this functionality:\n",
       "\n",
-      "def sum_list(lst):\n",
+      "```python \n",
+      "def sum_even_numbers(lst):\n",
       "    \"\"\"\n",
-      "    Calculates the sum of a list of integers.\n",
-      "    \n",
+      "    Returns the sum of all even numbers in a list.\n",
+      "\n",
       "    Args:\n",
-      "        lst (list): List of integers to sum.\n",
-      "    \n",
+      "        lst (list): List of numbers to sum.\n",
+      "\n",
       "    Returns:\n",
-      "        int: Sum of the list elements.\n",
-      "    \"\"\"  \n",
-      "    \n",
-      "    return sum(lst)\n",
-      "    \n",
-      "    \n",
-      "if __name__ == \"__main__\":\n",
-      "   \n"
+      "        int: The sum of all even numbers in the input list.\n",
+      "    \"\"\"\n",
+      "    even_nums = []\n",
+      "    for num in lst:\n",
+      "        if num % 2 == 0:\n",
+      "            even_nums.append(num)\n",
+      "\n",
+      "    return sum(even_nums)\n",
+      "``` \n"
      ]
     }
    ],
    "source": [
-    "prompt = \"Calculate the sum of a list of integers.\"\n",
+    "prompt = \"Calculate the sum of all even numbers in a list.\"\n",
     "\n",
-    "response = generator.generate(prompt, adapter=\"tiny-codes\", max_gen_len=100, use_io_binding=True)\n",
+    "response = generator.generate(prompt, adapter=\"tiny-codes\", max_gen_len=200, use_io_binding=True)\n",
+    "\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ONNX Runtime generate() API\n",
+    "\n",
+    "The [ONNX Runtime generate() API](https://github.com/microsoft/onnxruntime-genai) also supports loading multiple adapters for inference. During generation, the adapter weights can be provided as inputs to the model using `GeneratorParam`'s `set_model_input` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "# import torch\n",
+    "import onnxruntime_genai as og\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def generate(model, tokenizer, adapter_weights, prompt, template, max_gen_len=100):\n",
+    "    params = og.GeneratorParams(model)\n",
+    "    # model doesn't have GQA nodes so we can't use the share buffer option\n",
+    "    params.set_search_options(max_length=max_gen_len, past_present_share_buffer=False)\n",
+    "    params.input_ids = tokenizer.encode(template.format(prompt=prompt))\n",
+    "\n",
+    "    for k, v in adapter_weights.items():\n",
+    "        params.set_model_input(k, v)\n",
+    "\n",
+    "    # generate the response\n",
+    "    output_tokens = model.generate(params)\n",
+    "    return tokenizer.decode(output_tokens)\n",
+    "\n",
+    "model = og.Model(str(Path(model_path).parent))\n",
+    "tokenizer = og.Tokenizer(model)\n",
+    "\n",
+    "# load the adapter weights\n",
+    "adapters_weights = {\n",
+    "    key: dict(np.load(value[\"weights\"])) for key, value in adapters.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Generate with Guanaco Adapters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### Human: What time is it? ### Assistant: I'm sorry, but as an AI language model, I do not have access to real-time information.\n",
+      "\n",
+      "However, I can try to estimate the current time based on the context of your question and my knowledge of the current time zone.\n",
+      "\n",
+      "In general, the current time can vary depending on your location and the time zone you are in.\n",
+      "\n",
+      "If you would like to know the current time for a\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = \"What time is it?\"\n",
+    "\n",
+    "response = generate(model, tokenizer, adapters_weights[\"guanaco\"], prompt, adapters[\"guanaco\"][\"template\"], max_gen_len=100)\n",
+    "\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Generate with Tiny Codes Adapters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### Question: Calculate the sum of all even numbers in a list. \n",
+      "### Answer: Here's some python code which implements this functionality:\n",
+      "\n",
+      "```python \n",
+      "def sum_even_numbers(lst):\n",
+      "    \"\"\"\n",
+      "    Returns the sum of all even numbers in a list.\n",
+      "\n",
+      "    Args:\n",
+      "        lst (list): List of numbers to sum.\n",
+      "\n",
+      "    Returns:\n",
+      "        int: The sum of all even numbers in the input list.\n",
+      "    \"\"\"\n",
+      "    even_nums = []\n",
+      "    for num in lst:\n",
+      "        if num % 2 == 0:\n",
+      "            even_nums.append(num)\n",
+      "\n",
+      "    return sum(even_nums)\n",
+      "``` \n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = \"Calculate the sum of all even numbers in a list.\"\n",
+    "\n",
+    "response = generate(model, tokenizer, adapters_weights[\"tiny-codes\"], prompt, adapters[\"tiny-codes\"][\"template\"], max_gen_len=200)\n",
     "\n",
     "print(response)"
    ]
@@ -357,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/examples/llama2/llama2_multilora.ipynb
+++ b/examples/llama2/llama2_multilora.ipynb
@@ -81,18 +81,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2024-06-15 04:21:32,243] [INFO] [run.py:91:dependency_setup] The following packages are required in the local environment: ['onnxruntime-gpu']\n",
-      "[2024-06-15 04:21:32,300] [INFO] [run.py:317:check_local_ort_installation] onnxruntime-gpu is already installed.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!olive run --config llama2_qlora.json --setup"
    ]

--- a/examples/llama2/llama2_qlora.json
+++ b/examples/llama2/llama2_qlora.json
@@ -26,9 +26,9 @@
                     ]
                 ],
                 "input_types": [
-                    "int32",
-                    "int32",
-                    "int32"
+                    "int64",
+                    "int64",
+                    "int64"
                 ],
                 "dynamic_axes": {
                     "input_ids": {
@@ -134,9 +134,9 @@
                     "per_device_train_batch_size": 16,
                     "per_device_eval_batch_size": 16,
                     "gradient_accumulation_steps": 1,
-                    "max_steps": 1500,
-                    "logging_steps": 100,
-                    "save_steps": 100,
+                    "max_steps": 150,
+                    "logging_steps": 50,
+                    "save_steps": 50,
                     "evaluation_strategy": "steps",
                     "adam_beta2": 0.999,
                     "max_grad_norm": 0.3,
@@ -151,7 +151,8 @@
                 "target_opset": 17,
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true,
-                "torch_dtype": "float32"
+                "torch_dtype": "float32",
+                "save_metadata_for_token_generation": true
             }
         },
         "transformers_optimization": {
@@ -172,6 +173,13 @@
                 "save_as_external_data": true,
                 "all_tensors_to_one_file": true,
                 "make_inputs": true
+            }
+        },
+        "metadata": {
+            "type": "ModelBuilder",
+            "config": {
+                "precision": "fp16",
+                "metadata_only": true
             }
         }
     },

--- a/examples/llama2/user_script.py
+++ b/examples/llama2/user_script.py
@@ -66,6 +66,7 @@ def get_merged_sample_with_past_kv_inputs(
     input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seq_len), dtype=torch.int64)
     attention_mask = torch.ones(batch_size, past_seq_len + seq_len, dtype=torch.int64)
     position_ids = get_position_ids(attention_mask, past_seq_len=past_seq_len)
+    position_ids = position_ids.to(torch.int64)
     past_kv = get_past_kv_inputs(config, batch_size, past_seq_len, use_fp16=use_fp16, world_size=world_size)
 
     return (input_ids, attention_mask, position_ids, past_kv)
@@ -104,8 +105,8 @@ def flatten_past_kv_inputs(past_key_values: List[Tuple[torch.Tensor, torch.Tenso
     past_kv = {}
     # Convert list of past_kv to dict of past_key and past_value
     for i, (past_k, past_v) in enumerate(past_key_values):
-        past_kv[f"past_key_{i}"] = past_k
-        past_kv[f"past_value_{i}"] = past_v
+        past_kv[f"past_key_values.{i}.key"] = past_k
+        past_kv[f"past_key_values.{i}.value"] = past_v
     return past_kv
 
 

--- a/examples/phi2/phi2_optimize_template.json
+++ b/examples/phi2/phi2_optimize_template.json
@@ -44,7 +44,12 @@
                         "1": "sequence_length"
                     }
                 },
-                "kv_cache": true
+                "kv_cache": {
+                    "ort_past_key_name" : "past_key_<id>",
+                    "ort_past_value_name" : "past_value_<id>",
+                    "ort_present_key_name" : "present_key_<id>",
+                    "ort_present_value_name" : "present_value_<id>"
+                }
             },
             "hf_config": {
                 "model_name": "microsoft/phi-2",

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -194,6 +194,8 @@ def text_generation_huggingface_pre_process(
     from transformers import AutoTokenizer
 
     all_kwargs = deepcopy(kwargs)
+    # task is not used in the pre-process function. Will pop it so that the config validation doesn't warn about unused kwargs
+    all_kwargs.pop("task", None)
     all_kwargs.update({"max_samples": max_samples, "source_max_len": source_max_len})
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=trust_remote_code)

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -194,7 +194,8 @@ def text_generation_huggingface_pre_process(
     from transformers import AutoTokenizer
 
     all_kwargs = deepcopy(kwargs)
-    # task is not used in the pre-process function. Will pop it so that the config validation doesn't warn about unused kwargs
+    # task is not used in the pre-process function. Will pop it so that the config validation doesn't warn about
+    # unused kwargs
     all_kwargs.pop("task", None)
     all_kwargs.update({"max_samples": max_samples, "source_max_len": source_max_len})
 

--- a/olive/model/config/kv_cache_config.py
+++ b/olive/model/config/kv_cache_config.py
@@ -13,10 +13,10 @@ class KVCacheConfig(ConfigBase):
     num_attention_heads: int
     hidden_size: int
 
-    ort_past_key_name: str = "past_key_<id>"
-    ort_past_value_name: str = "past_value_<id>"
-    ort_present_key_name: str = "present_key_<id>"
-    ort_present_value_name: str = "present_value_<id>"
+    ort_past_key_name: str = "past_key_values.<id>.key"
+    ort_past_value_name: str = "past_key_values.<id>.value"
+    ort_present_key_name: str = "present.<id>.key"
+    ort_present_value_name: str = "present.<id>.value"
 
     # world_size is used for distributed model. If world_size > 1,
     # the number of heads should be divisible by world_size

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -338,9 +338,10 @@ def get_local_ort_packages() -> List[str]:
     local_ort_packages = []
     for package in all_packages:
         package_name = package.metadata["Name"]
-        if package_name == "onnxruntime-extensions":
+        if package_name == "onnxruntime-extensions" or package_name.startswith("onnxruntime-genai"):
             # onnxruntime-packages is under onnxruntime_extensions namespace
-            # not an actual onnxruntime package
+            # onnxruntime-genai is under onnxruntime_genai namespace
+            # not onnxruntime packages
             continue
         if package_name.startswith(("onnxruntime", "ort-nightly")):
             local_ort_packages.append(package_name)

--- a/test/unit_test/model/test_kv_cache_config.py
+++ b/test/unit_test/model/test_kv_cache_config.py
@@ -28,8 +28,14 @@ def test_kv_cache_dynamic_axes(num_hidden_layers, shared_kv, sequence_length_idx
 
     past_sequence_length_name = "past_sequence_length" if not shared_kv else "max_sequence_length"
     present_sequence_length_name = "past_sequence_length + sequence_length" if not shared_kv else "max_sequence_length"
-    assert dynamic_axes["past_key_values.0.key"] == {"0": "batch_size", str(sequence_length_idx): past_sequence_length_name}
-    assert dynamic_axes["past_key_values.0.value"] == {"0": "batch_size", str(sequence_length_idx): past_sequence_length_name}
+    assert dynamic_axes["past_key_values.0.key"] == {
+        "0": "batch_size",
+        str(sequence_length_idx): past_sequence_length_name,
+    }
+    assert dynamic_axes["past_key_values.0.value"] == {
+        "0": "batch_size",
+        str(sequence_length_idx): past_sequence_length_name,
+    }
     assert dynamic_axes["present.0.key"] == {"0": "batch_size", str(sequence_length_idx): present_sequence_length_name}
     assert dynamic_axes["present.0.value"] == {
         "0": "batch_size",

--- a/test/unit_test/model/test_kv_cache_config.py
+++ b/test/unit_test/model/test_kv_cache_config.py
@@ -28,10 +28,10 @@ def test_kv_cache_dynamic_axes(num_hidden_layers, shared_kv, sequence_length_idx
 
     past_sequence_length_name = "past_sequence_length" if not shared_kv else "max_sequence_length"
     present_sequence_length_name = "past_sequence_length + sequence_length" if not shared_kv else "max_sequence_length"
-    assert dynamic_axes["past_key_0"] == {"0": "batch_size", str(sequence_length_idx): past_sequence_length_name}
-    assert dynamic_axes["past_value_0"] == {"0": "batch_size", str(sequence_length_idx): past_sequence_length_name}
-    assert dynamic_axes["present_key_0"] == {"0": "batch_size", str(sequence_length_idx): present_sequence_length_name}
-    assert dynamic_axes["present_value_0"] == {
+    assert dynamic_axes["past_key_values.0.key"] == {"0": "batch_size", str(sequence_length_idx): past_sequence_length_name}
+    assert dynamic_axes["past_key_values.0.value"] == {"0": "batch_size", str(sequence_length_idx): past_sequence_length_name}
+    assert dynamic_axes["present.0.key"] == {"0": "batch_size", str(sequence_length_idx): present_sequence_length_name}
+    assert dynamic_axes["present.0.value"] == {
         "0": "batch_size",
         str(sequence_length_idx): present_sequence_length_name,
     }
@@ -52,8 +52,8 @@ def test_kv_cache_output_names(num_hidden_layers):
     )
     output_names = config.get_output_names()
     for i in range(num_hidden_layers):
-        assert output_names[i] == f"present_key_{i}"
-        assert output_names[i + num_hidden_layers] == f"present_value_{i}"
+        assert output_names[i] == f"present.{i}.key"
+        assert output_names[i + num_hidden_layers] == f"present.{i}.value"
 
 
 @pytest.mark.parametrize("num_hidden_layers", [16, 32])
@@ -73,8 +73,8 @@ def test_kv_cache_input_names_shape_types(num_hidden_layers, num_attention_heads
     )
     input_names, input_shape, input_types = config.get_input_names_shapes_types()
     for i in range(num_hidden_layers):
-        assert input_names[i] == f"past_key_{i}"
-        assert input_names[i + num_hidden_layers] == f"past_value_{i}"
+        assert input_names[i] == f"past_key_values.{i}.key"
+        assert input_names[i + num_hidden_layers] == f"past_key_values.{i}.value"
         assert input_shape[i] == [2, num_attention_heads // 1, 128, hidden_size // num_attention_heads]
         assert input_shape[i + num_hidden_layers] == [
             2,

--- a/test/unit_test/model/test_pytorch_model.py
+++ b/test/unit_test/model/test_pytorch_model.py
@@ -175,7 +175,7 @@ class TestPytorchDummyInput:
         dummy_inputs = olive_model.get_dummy_inputs()
         # len(["input_ids", "attention_mask", "token_type_ids"]) + 2 * num_hidden_layers
         assert len(dummy_inputs) == 3 + 12 * 2
-        assert list(dummy_inputs["past_key_0"].shape) == [1, 12, 0, 64]
+        assert list(dummy_inputs["past_key_values.0.key"].shape) == [1, 12, 0, 64]
 
     def test_dummy_input_with_kv_cache_dict(self):
         io_config = self.io_config
@@ -186,7 +186,7 @@ class TestPytorchDummyInput:
         dummy_inputs = olive_model.get_dummy_inputs()
         # len(["input_ids", "attention_mask", "token_type_ids"]) + 2 * num_hidden_layers
         assert len(dummy_inputs) == 3 + 12 * 2
-        assert list(dummy_inputs["past_key_0"].shape) == [1, 12, 0, 64]
+        assert list(dummy_inputs["past_key_values.0.key"].shape) == [1, 12, 0, 64]
 
     def test_dict_io_config(self):
         olive_model = PyTorchModelHandler(


### PR DESCRIPTION
## Describe your changes
- The default input-output names are changed to `past_key_values.<id>.key/value` and `present.<id>.key/value` since this is the most commonly used template (by both genai and optimum)
- Ignore `onnxruntime-genai` package when checking for `onnxruntime` dependency
- `llama2_multilora` notebook now has example generation for different lora adapters using genai.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
