### PR TITLE
trust_remote_code now required in both preprocess & load_dataset parameters

### DIFF
--- a/examples/bert/docker/Dockerfile
+++ b/examples/bert/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN pip install pandas \
             datasets \
             transformers \
             onnxruntime-openvino \
+            "numpy<2.0" \
             evaluate \
             scikit-learn \
             git+https://github.com/microsoft/Olive.git \

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -219,7 +219,8 @@
         ],
         "openvino": [
             "openvino==2023.2.0",
-            "nncf==2.7.0"
+            "nncf==2.7.0",
+            "numpy<2.0"
         ],
         "tf": [
             "tensorflow==1.15.0"
@@ -249,7 +250,8 @@
             "onnxruntime",
             "onnxruntime-directml",
             "onnxruntime-gpu",
-            "onnxruntime-openvino"
+            "onnxruntime-openvino",
+            "numpy<2.0"
         ],
         "nvmo": [
             "nvidia-modelopt~=0.11.0",

--- a/olive/systems/docker/Dockerfile.openvino
+++ b/olive/systems/docker/Dockerfile.openvino
@@ -14,7 +14,7 @@ RUN apt-get -y update && ACCEPT_EULA=Y apt-get -y upgrade
 RUN apt-get install -y --no-install-recommends wget gnupg
 
 RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime-openvino olive-ai
+RUN pip install --no-cache-dir pandas plotly psutil datasets transformers onnxruntime-openvino "numpy<2.0" olive-ai
 
 ENV INTEL_OPENVINO_DIR /opt/intel/openvino_${OPENVINO_VERSION}
 ENV LD_LIBRARY_PATH $INTEL_OPENVINO_DIR/runtime/lib/intel64:$INTEL_OPENVINO_DIR/runtime/3rdparty/tbb/lib:/usr/local/openblas/lib:$LD_LIBRARY_PATH

--- a/olive/systems/python_environment/common_requirements.txt
+++ b/olive/systems/python_environment/common_requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2.0
 protobuf<4.0.0
 psutil
 pydantic

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -204,12 +204,13 @@ class RunConfig(ConfigBase):
             # auto insert trust_remote_code from input model hf config
             # won't override if value was set to False explicitly
             if hf_config.get("from_pretrained_args", {}).get("trust_remote_code"):
-                v["pre_process_data_config"] = component_config = v.get("pre_process_data_config") or {}
-                component_config["params"] = component_config_params = component_config.get("params") or {}
-                if component_config_params.get("trust_remote_code") is None:
-                    component_config_params["trust_remote_code"] = hf_config["from_pretrained_args"][
-                        "trust_remote_code"
-                    ]
+                for config_name in ["pre_process_data_config", "load_dataset_config"]:
+                    v[config_name] = component_config = v.get(config_name) or {}
+                    component_config["params"] = component_config_params = component_config.get("params") or {}
+                    if component_config_params.get("trust_remote_code") is None:
+                        component_config_params["trust_remote_code"] = hf_config["from_pretrained_args"][
+                            "trust_remote_code"
+                        ]
 
         return validate_config(v, DataConfig)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2.0
 onnx
 optuna
 pandas

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -23,7 +23,14 @@ from olive.passes.pytorch.lora import LoftQ, LoRA, QLoRA
 
 def get_pass_config(model_name, task, **kwargs):
     dataset = {
-        "load_dataset_config": {"params": {"data_name": "ptb_text_only", "subset": "penn_treebank", "split": "train"}},
+        "load_dataset_config": {
+            "params": {
+                "data_name": "ptb_text_only",
+                "subset": "penn_treebank",
+                "split": "train",
+                "trust_remote_code": True,
+            }
+        },
         "pre_process_data_config": {
             "params": {
                 "text_cols": ["sentence"],
@@ -58,7 +65,7 @@ def run_finetuning(pass_class, tmp_path, **pass_config_kwargs):
     # setup
     model_name = "hf-internal-testing/tiny-random-OPTForCausalLM"
     task = "text-generation"
-    input_model = PyTorchModelHandler(hf_config={"model_name": model_name, "task": task})
+    input_model = PyTorchModelHandler(hf_config={"model_name": model_name, "task": task, "trust_remote_code": True})
     # convert to json to ensure the pass can handle serialized data config
     config = get_pass_config(model_name, task, **pass_config_kwargs)
     p = create_pass_from_dict(pass_class, config, disable_search=True)

--- a/test/unit_test/passes/pytorch/test_slicegpt.py
+++ b/test/unit_test/passes/pytorch/test_slicegpt.py
@@ -20,7 +20,14 @@ def test_slicegpt(tmp_path):
     task = "text-generation"
     input_model = PyTorchModelHandler(hf_config={"model_name": model_name, "task": task})
     dataset = {
-        "load_dataset_config": {"params": {"data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train"}},
+        "load_dataset_config": {
+            "params": {
+                "data_name": "wikitext",
+                "subset": "wikitext-2-raw-v1",
+                "split": "train",
+                "trust_remote_code": True,
+            }
+        },
         "pre_process_data_config": {
             "params": {
                 "text_cols": ["text"],
@@ -29,6 +36,7 @@ def test_slicegpt(tmp_path):
                 "source_max_len": 2048,
                 "max_samples": 128,
                 "joiner": "\n\n",
+                "trust_remote_code": True,
             }
         },
     }

--- a/test/unit_test/passes/pytorch/test_sparsegpt.py
+++ b/test/unit_test/passes/pytorch/test_sparsegpt.py
@@ -14,7 +14,14 @@ def test_sparsegpt(tmp_path):
     task = "text-generation"
     input_model = PyTorchModelHandler(hf_config={"model_name": model_name, "task": task})
     component_configs = {
-        "load_dataset_config": {"params": {"data_name": "ptb_text_only", "subset": "penn_treebank", "split": "train"}},
+        "load_dataset_config": {
+            "params": {
+                "data_name": "ptb_text_only",
+                "subset": "penn_treebank",
+                "split": "train",
+                "trust_remote_code": True,
+            }
+        },
         "pre_process_data_config": {
             "params": {
                 "text_cols": ["sentence"],
@@ -22,6 +29,7 @@ def test_sparsegpt(tmp_path):
                 "source_max_len": 1024,
                 "max_samples": 1,
                 "random_seed": 42,
+                "trust_remote_code": True,
             }
         },
     }

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -55,7 +55,14 @@ def test_torch_trt_conversion_success(tmp_path):
     )
 
     dataset = {
-        "load_dataset_config": {"params": {"data_name": "ptb_text_only", "subset": "penn_treebank", "split": "train"}},
+        "load_dataset_config": {
+            "params": {
+                "data_name": "ptb_text_only",
+                "subset": "penn_treebank",
+                "split": "train",
+                "trust_remote_code": True,
+            }
+        },
         "pre_process_data_config": {
             "params": {
                 "text_cols": ["sentence"],
@@ -63,6 +70,7 @@ def test_torch_trt_conversion_success(tmp_path):
                 "source_max_len": 100,
                 "max_samples": 1,
                 "random_seed": 42,
+                "trust_remote_code": True,
             }
         },
     }

--- a/test/unit_test/workflows/mock_data/text_generation_dataset.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset.json
@@ -4,7 +4,10 @@
         "config": {
             "hf_config": {
                 "model_name": "gpt2",
-                "task": "text-generation"
+                "task": "text-generation",
+                "from_pretrained_args": {
+                    "trust_remote_code": true
+                }
             }
         }
     },

--- a/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
+++ b/test/unit_test/workflows/mock_data/text_generation_dataset_random.json
@@ -4,7 +4,10 @@
         "config": {
             "hf_config": {
                 "model_name": "gpt2",
-                "task": "text-generation"
+                "task": "text-generation",
+                "from_pretrained_args": {
+                    "trust_remote_code": true
+                }
             }
         }
     },

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -324,12 +324,14 @@ class TestDataConfigValidation:
                     "name": "dummy_data_config2",
                     "type": HuggingfaceContainer.__name__,
                     "pre_process_data_config": {"params": {"trust_remote_code": data_config_trust_remote_code}},
+                    "load_dataset_config": {"params": {"trust_remote_code": data_config_trust_remote_code}},
                 }
             ]
 
         run_config = RunConfig.parse_obj(config_dict)
 
         assert run_config.data_configs[0].name == "dummy_data_config2"
+        assert run_config.data_configs[0].load_dataset_params.get("trust_remote_code") == expected_trust_remote_code
         assert run_config.data_configs[0].pre_process_params.get("trust_remote_code") == expected_trust_remote_code
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## trust_remote_code now required in both preprocess & load_dataset parameters

* Add rquired "trust_remote_code" field to both preprocess_config & load_dataset_config
* Propogate the field from input_model to both configs

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
