### PR TITLE
Few renames to prevent user errors

### DIFF
--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -146,10 +146,10 @@ def post_process(output):
 # -------------------------------------------------------------------------
 
 
-def create_dataloader(data_dir, batchsize, *args, **kwargs):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     bert_dataset = BertDataset("Intel/bert-base-uncased-mrpc")
     return torch.utils.data.DataLoader(
-        BertDatasetWrapper(bert_dataset.get_eval_dataset()), batch_size=batchsize, drop_last=True
+        BertDatasetWrapper(bert_dataset.get_eval_dataset()), batch_size=batch_size, drop_last=True
     )
 
 

--- a/examples/directml/squeezenet/user_script.py
+++ b/examples/directml/squeezenet/user_script.py
@@ -10,14 +10,14 @@ def load_pytorch_origin_model(torch_hub_model_path):
 
 
 class DataLoader:
-    def __init__(self, batchsize):
-        self.batchsize = batchsize
+    def __init__(self, batch_size):
+        self.batch_size = batch_size
 
     def __getitem__(self, idx):
-        input_data = torch.rand((self.batchsize, 3, 224, 224), dtype=torch.float16)
+        input_data = torch.rand((self.batch_size, 3, 224, 224), dtype=torch.float16)
         label = None
         return input_data, label
 
 
-def create_dataloader(data_dir, batchsize, *args, **kwargs):
-    return DataLoader(batchsize)
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
+    return DataLoader(batch_size)

--- a/examples/directml/stable_diffusion_xl/user_script.py
+++ b/examples/directml/stable_diffusion_xl/user_script.py
@@ -10,14 +10,14 @@ from transformers.models.clip.modeling_clip import CLIPTextModel, CLIPTextModelW
 
 # Helper latency-only dataloader that creates random tensors with no label
 class RandomDataLoader:
-    def __init__(self, create_inputs_func, batchsize, torch_dtype):
+    def __init__(self, create_inputs_func, batch_size, torch_dtype):
         self.create_input_func = create_inputs_func
-        self.batchsize = batchsize
+        self.batch_size = batch_size
         self.torch_dtype = torch_dtype
 
     def __getitem__(self, idx):
         label = None
-        return self.create_input_func(self.batchsize, self.torch_dtype), label
+        return self.create_input_func(self.batch_size, self.torch_dtype), label
 
 
 # -----------------------------------------------------------------------------
@@ -25,9 +25,9 @@ class RandomDataLoader:
 # -----------------------------------------------------------------------------
 
 
-def text_encoder_inputs(batchsize, torch_dtype):
+def text_encoder_inputs(batch_size, torch_dtype):
     return {
-        "input_ids": torch.zeros((batchsize, 77), dtype=torch_dtype),
+        "input_ids": torch.zeros((batch_size, 77), dtype=torch_dtype),
         "output_hidden_states": True,
     }
 
@@ -40,8 +40,8 @@ def text_encoder_conversion_inputs(model):
     return text_encoder_inputs(1, torch.int32)
 
 
-def text_encoder_data_loader(data_dir, batchsize, *args, **kwargs):
-    return RandomDataLoader(text_encoder_inputs, batchsize, torch.int32)
+def text_encoder_data_loader(data_dir, batch_size, *args, **kwargs):
+    return RandomDataLoader(text_encoder_inputs, batch_size, torch.int32)
 
 
 # -----------------------------------------------------------------------------
@@ -49,9 +49,9 @@ def text_encoder_data_loader(data_dir, batchsize, *args, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-def text_encoder_2_inputs(batchsize, torch_dtype):
+def text_encoder_2_inputs(batch_size, torch_dtype):
     return {
-        "input_ids": torch.zeros((batchsize, 77), dtype=torch_dtype),
+        "input_ids": torch.zeros((batch_size, 77), dtype=torch_dtype),
         "output_hidden_states": True,
     }
 
@@ -64,8 +64,8 @@ def text_encoder_2_conversion_inputs(model):
     return text_encoder_2_inputs(1, torch.int64)
 
 
-def text_encoder_2_data_loader(data_dir, batchsize, *args, **kwargs):
-    return RandomDataLoader(text_encoder_2_inputs, batchsize, torch.int64)
+def text_encoder_2_data_loader(data_dir, batch_size, *args, **kwargs):
+    return RandomDataLoader(text_encoder_2_inputs, batch_size, torch.int64)
 
 
 # -----------------------------------------------------------------------------
@@ -73,23 +73,23 @@ def text_encoder_2_data_loader(data_dir, batchsize, *args, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-def unet_inputs(batchsize, torch_dtype, is_conversion_inputs=False):
+def unet_inputs(batch_size, torch_dtype, is_conversion_inputs=False):
     inputs = {
-        "sample": torch.rand((2 * batchsize, 4, config.unet_sample_size, config.unet_sample_size), dtype=torch_dtype),
+        "sample": torch.rand((2 * batch_size, 4, config.unet_sample_size, config.unet_sample_size), dtype=torch_dtype),
         "timestep": torch.rand((1,), dtype=torch_dtype),
-        "encoder_hidden_states": torch.rand((2 * batchsize, 77, config.cross_attention_dim), dtype=torch_dtype),
+        "encoder_hidden_states": torch.rand((2 * batch_size, 77, config.cross_attention_dim), dtype=torch_dtype),
     }
 
     if is_conversion_inputs:
         inputs["additional_inputs"] = {
             "added_cond_kwargs": {
-                "text_embeds": torch.rand((2 * batchsize, 1280), dtype=torch_dtype),
-                "time_ids": torch.rand((2 * batchsize, config.time_ids_size), dtype=torch_dtype),
+                "text_embeds": torch.rand((2 * batch_size, 1280), dtype=torch_dtype),
+                "time_ids": torch.rand((2 * batch_size, config.time_ids_size), dtype=torch_dtype),
             }
         }
     else:
-        inputs["text_embeds"] = torch.rand((2 * batchsize, 1280), dtype=torch_dtype)
-        inputs["time_ids"] = torch.rand((2 * batchsize, config.time_ids_size), dtype=torch_dtype)
+        inputs["text_embeds"] = torch.rand((2 * batch_size, 1280), dtype=torch_dtype)
+        inputs["time_ids"] = torch.rand((2 * batch_size, config.time_ids_size), dtype=torch_dtype)
 
     return inputs
 
@@ -102,8 +102,8 @@ def unet_conversion_inputs(model):
     return tuple(unet_inputs(1, torch.float32, True).values())
 
 
-def unet_data_loader(data_dir, batchsize, *args, **kwargs):
-    return RandomDataLoader(unet_inputs, batchsize, torch.float16)
+def unet_data_loader(data_dir, batch_size, *args, **kwargs):
+    return RandomDataLoader(unet_inputs, batch_size, torch.float16)
 
 
 # -----------------------------------------------------------------------------
@@ -111,9 +111,9 @@ def unet_data_loader(data_dir, batchsize, *args, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-def vae_encoder_inputs(batchsize, torch_dtype):
+def vae_encoder_inputs(batch_size, torch_dtype):
     return {
-        "sample": torch.rand((batchsize, 3, config.vae_sample_size, config.vae_sample_size), dtype=torch_dtype),
+        "sample": torch.rand((batch_size, 3, config.vae_sample_size, config.vae_sample_size), dtype=torch_dtype),
         "return_dict": False,
     }
 
@@ -129,8 +129,8 @@ def vae_encoder_conversion_inputs(model):
     return tuple(vae_encoder_inputs(1, torch.float32).values())
 
 
-def vae_encoder_data_loader(data_dir, batchsize, *args, **kwargs):
-    return RandomDataLoader(vae_encoder_inputs, batchsize, torch.float16)
+def vae_encoder_data_loader(data_dir, batch_size, *args, **kwargs):
+    return RandomDataLoader(vae_encoder_inputs, batch_size, torch.float16)
 
 
 # -----------------------------------------------------------------------------
@@ -138,10 +138,10 @@ def vae_encoder_data_loader(data_dir, batchsize, *args, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-def vae_decoder_inputs(batchsize, torch_dtype):
+def vae_decoder_inputs(batch_size, torch_dtype):
     return {
         "latent_sample": torch.rand(
-            (batchsize, 4, config.unet_sample_size, config.unet_sample_size), dtype=torch_dtype
+            (batch_size, 4, config.unet_sample_size, config.unet_sample_size), dtype=torch_dtype
         ),
         "return_dict": False,
     }
@@ -158,5 +158,5 @@ def vae_decoder_conversion_inputs(model):
     return tuple(vae_decoder_inputs(1, torch.float32).values())
 
 
-def vae_decoder_data_loader(data_dir, batchsize, *args, **kwargs):
-    return RandomDataLoader(vae_decoder_inputs, batchsize, torch.float16)
+def vae_decoder_data_loader(data_dir, batch_size, *args, **kwargs):
+    return RandomDataLoader(vae_decoder_inputs, batch_size, torch.float16)

--- a/examples/mistral/user_script.py
+++ b/examples/mistral/user_script.py
@@ -21,8 +21,8 @@ def calib_dataloader(data_dir, batch_size, *args, **kwargs):
     return PileDataloader(model_path, batch_size=batch_size)
 
 
-def create_dataloader(data_dir, batchsize, *args, **kwargs):
-    dataloader = PileDataloader(model_id, batch_size=batchsize, seq_len=32, past_seq_len=32, sub_folder="train")
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
+    dataloader = PileDataloader(model_id, batch_size=batch_size, seq_len=32, past_seq_len=32, sub_folder="train")
     for data, label in dataloader:
         d = {name: to_numpy(inp_data) for name, inp_data in data.items()}
         yield d, label

--- a/examples/resnet/user_script.py
+++ b/examples/resnet/user_script.py
@@ -179,9 +179,9 @@ def create_qat_config():
 # -------------------------------------------------------------------------
 
 
-def create_train_dataloader(data_dir, batchsize, *args, **kwargs):
+def create_train_dataloader(data_dir, batch_size, *args, **kwargs):
     cifar10_dataset = CIFAR10DataSet(data_dir)
-    return DataLoader(PytorchResNetDataset(cifar10_dataset.train_dataset), batch_size=batchsize, drop_last=True)
+    return DataLoader(PytorchResNetDataset(cifar10_dataset.train_dataset), batch_size=batch_size, drop_last=True)
 
 
 # -------------------------------------------------------------------------

--- a/test/unit_test/passes/inc/test_inc_quantization.py
+++ b/test/unit_test/passes/inc/test_inc_quantization.py
@@ -136,7 +136,7 @@ def get_onnx_model(tmp_path):
     return p.run(pytorch_model, None, output_folder)
 
 
-def create_dataloader(data_dir, batchsize, *args, **kwargs):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     # import neural_compressor here to avoid hanging on Windows
     from neural_compressor.data import DefaultDataLoader
 
@@ -144,7 +144,7 @@ def create_dataloader(data_dir, batchsize, *args, **kwargs):
         [transforms.ToTensor(), transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))]
     )
     dataset = CifarDataset(CIFAR10(root=data_dir, train=False, transform=transform, download=True))
-    return DefaultDataLoader(dataset=dataset, batch_size=batchsize)
+    return DefaultDataLoader(dataset=dataset, batch_size=batch_size)
 
 
 class CifarDataset:

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -143,10 +143,10 @@ def cifar10_dataset(data_dir):
     return CIFAR10(root=data_dir, train=False, transform=ToTensor(), download=True)
 
 
-def create_dataloader(data_dir, batchsize, *args, **kwargs):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     from torch.utils.data.dataloader import DataLoader
     from torchvision.datasets import CIFAR10
     from torchvision.transforms import ToTensor
 
     dataset = CIFAR10(root=data_dir, train=False, transform=ToTensor(), download=True)
-    return DataLoader(dataset, batchsize, shuffle=True)
+    return DataLoader(dataset, batch_size, shuffle=True)

--- a/test/unit_test/test_data_root.py
+++ b/test/unit_test/test_data_root.py
@@ -39,7 +39,7 @@ def post_processing_func(output):
     return output.argmax(axis=1)
 
 
-def create_dataloader(datadir, batchsize, *args, **kwargs):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     return DataLoader(DummyDataset(1))
 
 

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -162,11 +162,11 @@ def get_mock_openvino_model():
     return olive_model
 
 
-def create_dataloader(datadir, batchsize, *args, **kwargs):
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
     return DataLoader(DummyDataset(1))
 
 
-def create_fixed_dataloader(datadir, batchsize, *args, **kwargs):
+def create_fixed_dataloader(data_dir, batch_size, *args, **kwargs):
     return DataLoader(FixedDummyDataset(1))
 
 


### PR DESCRIPTION
## Few renames to prevent user errors

Renamed batchsize to batch_size
Renamed datadir to data_dir

With transition to use more of DataConfig and keyword args, parameter naming consistency becomes important.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
