### PR TITLE
🐛 Fix arguments error for trust_remote_code in customized data component

### DIFF
--- a/docs/source/tutorials/configure_data.rst
+++ b/docs/source/tutorials/configure_data.rst
@@ -348,7 +348,7 @@ The above case shows to rewrite all the components in data config. But sometime,
             from olive.data.registry import Registry
 
             @Registry.register_dataset()
-            def customized_huggingface_dataset(_output):
+            def customized_huggingface_dataset(_output, trust_remote_code=None, **kwargs):
                 ...
 
             from olive.data.config import DataConfig
@@ -368,18 +368,21 @@ The above case shows to rewrite all the components in data config. But sometime,
             )
 
 .. note::
-    User should provide the ``user_script`` and ``script_dir`` if they want to customize the component type. The ``user_script`` should be a python script which contains the customized component type. The ``script_dir`` should be the directory path which contains the ``user_script``. Here is an example for ``user_script``:
+    User should provide the ``user_script`` and ``script_dir`` if they want to customize the component type. The ``user_script`` should be a python script which contains the customized component type. The ``script_dir`` should be the directory path which contains the ``user_script``. Another thing you might need to notice is that when your customized dataset is from huggingface, you should at least allow the ``trust_remote_code`` in your function's arguments list to indicate whether you trust the remote code or not. ``kwargs`` is the additional keyword arguments provided in the config, it can cover the case of ``trust_remote_code`` as well.
+    Here is an example for ``user_script``:
 
     .. code-block:: python
 
         from olive.data.registry import Registry
 
         @Registry.register_dataset()
-        def customized_huggingface_dataset(data_dir):
+        def customized_huggingface_dataset(data_dir, **kwargs):
+            # kwargs can cover the case of trust_remote_code or user can add trust_remote_code in the function's
+            # arguments list, like, customized_huggingface_dataset(data_dir, trust_remote_code=None, **kwargs):
             ...
 
         @Registry.register_pre_process()
-        def customized_huggingface_pre_process(dataset):
+        def customized_huggingface_pre_process(dataset, **kwargs):
             ...
 
         @Registry.register_post_process()

--- a/examples/llama2/notebook/llama2/user_script.py
+++ b/examples/llama2/notebook/llama2/user_script.py
@@ -215,6 +215,8 @@ def dataloader_func_for_merged_gqa(data_dir, batch_size, **kwargs):
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
+):
     dataset = load_dataset(data_name, split=split, token=token)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/examples/llama2/notebook/llama2_multiep/user_script.py
+++ b/examples/llama2/notebook/llama2_multiep/user_script.py
@@ -215,6 +215,8 @@ def dataloader_func_for_merged_gqa(data_dir, batch_size, **kwargs):
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
+):
     dataset = load_dataset(data_name, split=split, token=token)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/examples/llama2/user_script.py
+++ b/examples/llama2/user_script.py
@@ -219,6 +219,8 @@ def dataloader_func_for_merged_gqa(data_dir, batch_size, **kwargs):
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
-    dataset = load_dataset(data_name, split=split, token=token)
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
+):
+    dataset = load_dataset(data_name, split=split, token=token, trust_remote_code=trust_remote_code)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/examples/open_llama/lora_user_script.py
+++ b/examples/open_llama/lora_user_script.py
@@ -11,6 +11,8 @@ from olive.data.registry import Registry
 
 # TODO(jambayk): remove custom dataset component once default dataset component supports filter, tokens and split
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
+):
     dataset = load_dataset(data_name, split=split, token=token)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/examples/phi/user_script.py
+++ b/examples/phi/user_script.py
@@ -11,6 +11,8 @@ from olive.data.registry import Registry
 
 # TODO(jambayk): remove custom dataset component once default dataset component supports filter, tokens and split
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
+):
     dataset = load_dataset(data_name, split=split, token=token)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/examples/phi2/user_script.py
+++ b/examples/phi2/user_script.py
@@ -23,8 +23,10 @@ config: "PhiConfig" = AutoConfig.from_pretrained(model_id, trust_remote_code=Tru
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
-    dataset = load_dataset(data_name, split=split, token=token)
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=True
+):
+    dataset = load_dataset(data_name, split=split, token=token, trust_remote_code=trust_remote_code)
     return dataset.filter(lambda x: x["programming_language"] == language)
 
 

--- a/examples/phi3/user_script.py
+++ b/examples/phi3/user_script.py
@@ -11,6 +11,8 @@ from olive.data.registry import Registry
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
-    dataset = load_dataset(data_name, split=split, token=token)
+def load_tiny_code_dataset(
+    data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=True
+):
+    dataset = load_dataset(data_name, split=split, token=token, trust_remote_code=trust_remote_code)
     return dataset.filter(lambda x: x["programming_language"] == language)

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -17,7 +17,7 @@ from olive.data.registry import Registry
 
 
 @Registry.register_default_pre_process()
-def pre_process(dataset):
+def pre_process(dataset, **kwargs):
     """Pre-process data.
 
     Args:

--- a/olive/data/container/huggingface_container.py
+++ b/olive/data/container/huggingface_container.py
@@ -19,7 +19,7 @@ class HuggingfaceContainer(DataContainer):
     # Extra arguments auto generation for data components
 
     task_type_components_map: ClassVar[dict] = {
-        # TODO(trajep): user enumerate update task type
+        # TODO(trajep): use enumerate update task type
         "text-classification": {
             DataComponentType.POST_PROCESS_DATA.value: "text_classification_post_process",
         },


### PR DESCRIPTION
## Describe your changes
#1199 enabled `trust_remote_code` for huggingface container in `load_dataset` and `pre_process` components. That will pass  `trust_remote_code` to the  function into `load_dataset_config` if `trust_remote_code` is in `hf_config.from_pretrained_args`.
But last PR did not update the customized user_script.py.
![image](https://github.com/microsoft/Olive/assets/13343117/9218da4e-abde-42b0-b276-52e74da98d18)

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
