### PR TITLE
Allow local conda installer for QC sdk configure

### DIFF
--- a/examples/test/test_qnn_tooklit.py
+++ b/examples/test/test_qnn_tooklit.py
@@ -20,11 +20,20 @@ class TestQnnToolkit:
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):
         """Download the qnn sdk."""
-        blob, download_path = "", ""
         if platform.system() == OS.WINDOWS:
             blob, download_path = "qnn_sdk_windows.zip", "qnn_sdk_windows.zip"
+            conda_installer_blob, conda_installer_path = (
+                "conda-installers/Miniconda3-latest-Windows-x86_64.exe",
+                tmp_path / "conda_installer.exe",
+            )
         elif platform.system() == OS.LINUX:
             blob, download_path = "qnn_sdk_linux.zip", "qnn_sdk_linux.zip"
+            conda_installer_blob, conda_installer_path = (
+                "conda-installers/Miniconda3-latest-Linux-x86_64.sh",
+                tmp_path / "conda_installer.sh",
+            )
+        else:
+            raise NotImplementedError(f"Unsupported platform: {platform.system()}")
 
         download_azure_blob(
             container="olivetest",
@@ -40,6 +49,13 @@ class TestQnnToolkit:
             run_subprocess(cmd=f"unzip {download_path} -d {str(target_path)}", check=True)
 
         os.environ["QNN_SDK_ROOT"] = str(target_path / "opt" / "qcom" / "aistack")
+
+        download_azure_blob(
+            container="olivetest",
+            blob=conda_installer_blob,
+            download_path=conda_installer_path,
+        )
+        os.environ["CONDA_INSTALLER"] = str(conda_installer_path)
 
     def _setup_resource(self, use_olive_env):
         """Setups any state specific to the execution of the given module."""

--- a/examples/test/test_snpe_toolkit.py
+++ b/examples/test/test_snpe_toolkit.py
@@ -7,7 +7,7 @@ import platform
 from pathlib import Path
 
 import pytest
-from utils import check_output, download_azure_blob
+from utils import check_output, download_conda_installer, download_qc_toolkit
 
 from olive.common.constants import OS
 from olive.common.utils import retry_func, run_subprocess
@@ -19,26 +19,9 @@ set_verbosity_debug()
 class TestSnpeToolkit:
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):
-        """Download the snpe sdk."""
-        blob, download_path = "", ""
-        if platform.system() == OS.WINDOWS:
-            blob, download_path = "snpe_sdk_windows.zip", "snpe_sdk_windows.zip"
-        elif platform.system() == OS.LINUX:
-            blob, download_path = "snpe_sdk_linux.zip", "snpe_sdk_linux.zip"
-
-        download_azure_blob(
-            container="olivetest",
-            blob=blob,
-            download_path=download_path,
-        )
-        target_path = tmp_path / "snpe_sdk"
-        target_path.mkdir(parents=True, exist_ok=True)
-        if platform.system() == OS.WINDOWS:
-            cmd = f"powershell Expand-Archive -Path {download_path} -DestinationPath {str(target_path)}"
-            run_subprocess(cmd=cmd, check=True)
-        elif platform.system() == OS.LINUX:
-            run_subprocess(cmd=f"unzip {download_path} -d {str(target_path)}", check=True)
-        os.environ["SNPE_ROOT"] = str(target_path)
+        """Download the snpe sdk and conda installer."""
+        os.environ["SNPE_ROOT"] = download_qc_toolkit(tmp_path, "snpe")
+        os.environ["CONDA_INSTALLER"] = download_conda_installer(tmp_path)
 
     def _setup_resource(self, use_olive_env):
         """Setups any state specific to the execution of the given module."""

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -5,7 +5,11 @@
 import json
 import logging
 import os
+import platform
 import sys
+
+from olive.common.constants import OS
+from olive.common.utils import run_subprocess
 
 # pylint: disable=broad-exception-raised
 
@@ -153,6 +157,51 @@ def download_azure_blob(container, blob, download_path, storage_account="olivewh
     with open(download_path, "wb") as my_blob:
         blob_data = blob.download_blob()
         blob_data.readinto(my_blob)
+
+
+def download_conda_installer(parent_dir):
+    if platform.system() == OS.WINDOWS:
+        conda_installer_blob, conda_installer_path = (
+            "conda-installers/Miniconda3-latest-Windows-x86_64.exe",
+            parent_dir / "conda_installer.exe",
+        )
+    elif platform.system() == OS.LINUX:
+        conda_installer_blob, conda_installer_path = (
+            "conda-installers/Miniconda3-latest-Linux-x86_64.sh",
+            parent_dir / "conda_installer.sh",
+        )
+    else:
+        raise NotImplementedError(f"Unsupported platform: {platform.system()}")
+
+    download_azure_blob(
+        container="olivetest",
+        blob=conda_installer_blob,
+        download_path=conda_installer_path,
+    )
+
+    return str(conda_installer_path)
+
+
+def download_qc_toolkit(parent_dir, toolkit):
+    blob, download_path = (
+        f"{toolkit}_sdk_{platform.system().lower()}.zip",
+        f"{toolkit}_sdk_{platform.system().lower()}.zip",
+    )
+
+    download_azure_blob(
+        container="olivetest",
+        blob=blob,
+        download_path=download_path,
+    )
+    target_path = parent_dir / f"{toolkit}_sdk"
+    target_path.mkdir(parents=True, exist_ok=True)
+    if platform.system() == OS.WINDOWS:
+        cmd = f"powershell Expand-Archive -Path {download_path} -DestinationPath {str(target_path)}"
+        run_subprocess(cmd=cmd, check=True)
+    elif platform.system() == OS.LINUX:
+        run_subprocess(cmd=f"unzip {download_path} -d {str(target_path)}", check=True)
+
+    return str(target_path)
 
 
 def set_azure_identity_logging():

--- a/olive/platform_sdk/qualcomm/create_python_env.ps1
+++ b/olive/platform_sdk/qualcomm/create_python_env.ps1
@@ -34,9 +34,12 @@ New-Item -Path $FILES_DIR -ItemType Directory | Out-Null
 
 # Install conda if not already installed
 if (!(Get-Command -Name "conda" -ErrorAction SilentlyContinue)) {
+    # check if CONDA_INSTALLER is set, if not download the latest miniconda installer
+    if (-not $env:CONDA_INSTALLER) {
+        $CONDA_INSTALLER = Join-Path $FILES_DIR "Miniconda3-latest-Windows-x86_64.exe"
+        Invoke-WebRequest -Uri "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe" -OutFile $CONDA_INSTALLER
+    }
     # Install conda
-    $CONDA_INSTALLER = Join-Path $FILES_DIR "Miniconda3-latest-Windows-x86_64.exe"
-    Invoke-WebRequest -Uri "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe" -OutFile $CONDA_INSTALLER
     Start-Process -FilePath $CONDA_INSTALLER -ArgumentList "/S /D=$FILES_DIR\miniconda" -Wait
     $CONDA = Join-Path $FILES_DIR "miniconda\Scripts\conda.exe"
 }

--- a/olive/platform_sdk/qualcomm/create_python_env.ps1
+++ b/olive/platform_sdk/qualcomm/create_python_env.ps1
@@ -39,6 +39,9 @@ if (!(Get-Command -Name "conda" -ErrorAction SilentlyContinue)) {
         $CONDA_INSTALLER = Join-Path $FILES_DIR "Miniconda3-latest-Windows-x86_64.exe"
         Invoke-WebRequest -Uri "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe" -OutFile $CONDA_INSTALLER
     }
+    else {
+        $CONDA_INSTALLER = $env:CONDA_INSTALLER
+    }
     # Install conda
     Start-Process -FilePath $CONDA_INSTALLER -ArgumentList "/S /D=$FILES_DIR\miniconda" -Wait
     $CONDA = Join-Path $FILES_DIR "miniconda\Scripts\conda.exe"

--- a/olive/platform_sdk/qualcomm/create_python_env.sh
+++ b/olive/platform_sdk/qualcomm/create_python_env.sh
@@ -46,9 +46,13 @@ mkdir "$FILES_DIR"
 
 # Install conda if not already installed
 if ! command -v conda; then
+    # check if CONDA_INSTALLER is set, if not download the latest miniconda installer
+    if [ -z ${CONDA_INSTALLER+x} ]; then
+        CONDA_INSTALLER="$FILES_DIR"/install_conda.sh
+        curl -fsSL -o $CONDA_INSTALLER https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    fi
     # Install conda
-    curl -fsSL -o "$FILES_DIR"/install_conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    sh "$FILES_DIR"/install_conda.sh -b -p "$FILES_DIR"/miniconda
+    sh $CONDA_INSTALLER -b -p "$FILES_DIR"/miniconda
     CONDA=$FILES_DIR/miniconda/bin/conda
 else
     CONDA=conda

--- a/olive/platform_sdk/qualcomm/create_python_env.sh
+++ b/olive/platform_sdk/qualcomm/create_python_env.sh
@@ -49,10 +49,10 @@ if ! command -v conda; then
     # check if CONDA_INSTALLER is set, if not download the latest miniconda installer
     if [ -z ${CONDA_INSTALLER+x} ]; then
         CONDA_INSTALLER="$FILES_DIR"/install_conda.sh
-        curl -fsSL -o $CONDA_INSTALLER https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+        curl -fsSL -o "$CONDA_INSTALLER" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     fi
     # Install conda
-    sh $CONDA_INSTALLER -b -p "$FILES_DIR"/miniconda
+    sh "$CONDA_INSTALLER" -b -p "$FILES_DIR"/miniconda
     CONDA=$FILES_DIR/miniconda/bin/conda
 else
     CONDA=conda


### PR DESCRIPTION
## Describe your changes
The environment setup scripts currently download the conda installer each time. We are seeing rate limits for the downloads recently.
Now, the user can set `CONDA_INSTALLER` environment variables to use a local copy of the installer.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
