### PR TITLE
Update OrtPerfTuning pass to accept data only using data_config

### DIFF
--- a/docs/source/features/passes/onnx.md
+++ b/docs/source/features/passes/onnx.md
@@ -372,8 +372,7 @@ improve performance.
 {
     "type": "OrtPerfTuning",
     "config": {
-        "user_script": "user_script.py",
-        "dataloader_func": "create_dataloader",
+        "data_config": "perf_tuning_data_config",
         "batch_size": 1,
         "providers_list" : [
             [

--- a/examples/bert/bert_qat_customized_train_loop_cpu.json
+++ b/examples/bert/bert_qat_customized_train_loop_cpu.json
@@ -12,6 +12,19 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "perf_tuning_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "create_bert_dataset"
+            },
+            "dataloader_config": {
+                "type": "create_bert_dataloader"
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics":[
@@ -66,9 +79,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 1
+                "data_config": "perf_tuning_data_config"
             }
         }
     },

--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -24,6 +24,7 @@ from transformers import (
 )
 
 from olive.constants import Framework
+from olive.data.registry import Registry
 from olive.model import OliveModelHandler
 
 datasets_logging.disable_progress_bar()
@@ -146,11 +147,20 @@ def post_process(output):
 # -------------------------------------------------------------------------
 
 
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    bert_dataset = BertDataset("Intel/bert-base-uncased-mrpc")
+@Registry.register_dataset()
+def create_bert_dataset(data_dir, *args, **kwargs):
+    return BertDataset("Intel/bert-base-uncased-mrpc")
+
+
+@Registry.register_dataloader()
+def create_bert_dataloader(dataset, batch_size, *args, **kwargs):
     return torch.utils.data.DataLoader(
-        BertDatasetWrapper(bert_dataset.get_eval_dataset()), batch_size=batch_size, drop_last=True
+        BertDatasetWrapper(dataset.get_eval_dataset()), batch_size=batch_size, drop_last=True
     )
+
+
+def create_dataloader(data_dir, batch_size, *args, **kwargs):
+    return create_bert_dataloader(create_bert_dataset(data_dir), batch_size, *args, **kwargs)
 
 
 # -------------------------------------------------------------------------

--- a/examples/directml/squeezenet/squeezenet_config.json
+++ b/examples/directml/squeezenet/squeezenet_config.json
@@ -56,10 +56,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
                 "device": "gpu",
-                "batch_size": 1,
                 "execution_mode_list": [ "ORT_SEQUENTIAL" ],
                 "providers_list": [ "DmlExecutionProvider" ]
             }

--- a/examples/llama2/llama2_qlora.json
+++ b/examples/llama2/llama2_qlora.json
@@ -76,7 +76,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/llama2/notebook/llama2/config.json
+++ b/examples/llama2/notebook/llama2/config.json
@@ -112,7 +112,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/llama2/notebook/llama2/notebook.ipynb
+++ b/examples/llama2/notebook/llama2/notebook.ipynb
@@ -112,7 +112,7 @@
     "        \"user_script\": \"user_script.py\",\n",
     "        \"components\": {\n",
     "            \"load_dataset\": {\n",
-    "                \"type\": \"load_tiny_code_dataset\",\n",
+    "                \"type\": \"tiny_code_dataset\",\n",
     "                \"params\": {\n",
     "                    \"data_name\": \"nampdn-ai/tiny-codes\",\n",
     "                    \"split\": \"train\",\n",

--- a/examples/llama2/notebook/llama2/user_script.py
+++ b/examples/llama2/notebook/llama2/user_script.py
@@ -215,7 +215,7 @@ def dataloader_func_for_merged_gqa(data_dir, batch_size, **kwargs):
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
 ):
     dataset = load_dataset(data_name, split=split, token=token)

--- a/examples/llama2/notebook/llama2_multiep/user_script.py
+++ b/examples/llama2/notebook/llama2_multiep/user_script.py
@@ -215,7 +215,7 @@ def dataloader_func_for_merged_gqa(data_dir, batch_size, **kwargs):
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
 ):
     dataset = load_dataset(data_name, split=split, token=token)

--- a/examples/llama2/user_script.py
+++ b/examples/llama2/user_script.py
@@ -235,7 +235,7 @@ def dataloader_func_for_generative(data_dir, batch_size, **kwargs):
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
 ):
     dataset = load_dataset(data_name, split=split, token=token, trust_remote_code=trust_remote_code)

--- a/examples/open_llama/lora_user_script.py
+++ b/examples/open_llama/lora_user_script.py
@@ -11,7 +11,7 @@ from olive.data.registry import Registry
 
 # TODO(jambayk): remove custom dataset component once default dataset component supports filter, tokens and split
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
 ):
     dataset = load_dataset(data_name, split=split, token=token)

--- a/examples/open_llama/open_llama_loftq_tinycodes.json
+++ b/examples/open_llama/open_llama_loftq_tinycodes.json
@@ -26,7 +26,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/open_llama/open_llama_lora_tinycodes.json
+++ b/examples/open_llama/open_llama_lora_tinycodes.json
@@ -26,7 +26,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/open_llama/open_llama_qlora_ort_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_ort_tinycodes.json
@@ -26,7 +26,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/open_llama/open_llama_qlora_tinycodes.json
+++ b/examples/open_llama/open_llama_qlora_tinycodes.json
@@ -26,7 +26,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "lora_user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/phi/phi_qlora_tinycodes.json
+++ b/examples/phi/phi_qlora_tinycodes.json
@@ -29,7 +29,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",

--- a/examples/phi/user_script.py
+++ b/examples/phi/user_script.py
@@ -11,7 +11,7 @@ from olive.data.registry import Registry
 
 # TODO(jambayk): remove custom dataset component once default dataset component supports filter, tokens and split
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=None
 ):
     dataset = load_dataset(data_name, split=split, token=token)

--- a/examples/phi2/phi2_optimize_template.json
+++ b/examples/phi2/phi2_optimize_template.json
@@ -89,7 +89,7 @@
                     ],
                     "user_config": {
                         "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
+                        "dataloader_func": "phi2_dataloader",
                         "batch_size": 2,
                         "inference_settings": {
                             "onnx": {
@@ -200,9 +200,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 2,
+                "data_config": "perf_tuning_data_config",
                 "enable_profiling": false
             }
         }
@@ -213,7 +211,7 @@
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": {
-                "type": "load_tiny_code_dataset",
+                "type": "tiny_code_dataset",
                 "params": {
                     "data_name": "nampdn-ai/tiny-codes",
                     "split": "train",
@@ -258,6 +256,20 @@
             "pre_process_data_config": {
                 "params": {
                     "source_max_len": 2048
+                }
+            }
+        },
+        {
+            "name": "perf_tuning_data_config",
+            "type": "DummyDataContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "local_dataset"
+            },
+            "dataloader_config": {
+                "type": "phi2_dataloader",
+                "params": {
+                    "batch_size": 2
                 }
             }
         }

--- a/examples/phi2/user_script.py
+++ b/examples/phi2/user_script.py
@@ -23,14 +23,15 @@ config: "PhiConfig" = AutoConfig.from_pretrained(model_id, trust_remote_code=Tru
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=True
 ):
     dataset = load_dataset(data_name, split=split, token=token, trust_remote_code=trust_remote_code)
     return dataset.filter(lambda x: x["programming_language"] == language)
 
 
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def phi2_dataloader(dataset, batch_size, *args, **kwargs):
     sequence_length, past_sequence_length = 8, config.num_hidden_layers
     max_sequence_length = 512
     model_framework = kwargs.get("model_framework", Framework.PYTORCH)

--- a/examples/phi3/pass_configs/data_configs.json
+++ b/examples/phi3/pass_configs/data_configs.json
@@ -4,7 +4,7 @@
         "type": "HuggingfaceContainer",
         "user_script": "user_script.py",
         "load_dataset_config": {
-            "type": "load_tiny_code_dataset",
+            "type": "tiny_code_dataset",
             "params": {
                 "data_name": "nampdn-ai/tiny-codes",
                 "split": "train",

--- a/examples/phi3/user_script.py
+++ b/examples/phi3/user_script.py
@@ -11,7 +11,7 @@ from olive.data.registry import Registry
 
 
 @Registry.register_dataset()
-def load_tiny_code_dataset(
+def tiny_code_dataset(
     data_name: str, split: str, language: str, token: Union[bool, str] = True, trust_remote_code=True
 ):
     dataset = load_dataset(data_name, split=split, token=token, trust_remote_code=trust_remote_code)

--- a/examples/resnet/resnet_dynamic_ptq_cpu.json
+++ b/examples/resnet/resnet_dynamic_ptq_cpu.json
@@ -28,6 +28,28 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": "data"
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 16,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator":{
             "metrics":[
@@ -84,10 +106,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 16,
-                "data_dir": "data"
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/resnet_multiple_ep.json
+++ b/examples/resnet/resnet_multiple_ep.json
@@ -22,6 +22,28 @@
             "model_path": "models/resnet_trained_for_cifar10.onnx"
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": "data"
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 1,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator":{
             "metrics":[
@@ -66,10 +88,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 16,
-                "data_dir": "data"
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/resnet_ptq_cpu.json
+++ b/examples/resnet/resnet_ptq_cpu.json
@@ -28,6 +28,28 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": "data"
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 16,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator":{
             "metrics":[
@@ -89,10 +111,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 16,
-                "data_dir": "data"
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/resnet_ptq_cpu_aml_dataset.json
+++ b/examples/resnet/resnet_ptq_cpu_aml_dataset.json
@@ -19,6 +19,34 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": {
+                        "type": "azureml_datastore",
+                        "config": {
+                            "datastore_name": "workspaceblobstore",
+                            "relative_path": "LocalUpload/cifar-10"
+                        }
+                    }
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 16,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator":{
             "metrics":[
@@ -98,16 +126,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 16,
-                "data_dir": {
-                    "type": "azureml_datastore",
-                    "config": {
-                        "datastore_name": "workspaceblobstore",
-                        "relative_path": "LocalUpload/cifar-10"
-                    }
-                }
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/resnet_qat_default_train_loop_cpu.json
+++ b/examples/resnet/resnet_qat_default_train_loop_cpu.json
@@ -14,6 +14,28 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": "data"
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 1,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics":[
@@ -66,10 +88,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 1,
-                "data_dir": "data"
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/resnet_qat_lightning_module_cpu.json
+++ b/examples/resnet/resnet_qat_lightning_module_cpu.json
@@ -14,6 +14,28 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": "data"
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 1,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics":[
@@ -67,10 +89,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 1,
-                "data_dir": "data"
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/resnet_static_ptq_cpu.json
+++ b/examples/resnet/resnet_static_ptq_cpu.json
@@ -28,6 +28,28 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "cifar10_dataset",
+                "params": {
+                    "data_dir": "data"
+                }
+            },
+            "pre_process_data_config": {
+                "type": "skip_pre_process"
+            },
+            "dataloader_config": {
+                "params": {
+                    "batch_size": 1,
+                    "drop_last": true
+                }
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator":{
             "metrics":[
@@ -86,10 +108,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
-                "dataloader_func": "create_dataloader",
-                "batch_size": 16,
-                "data_dir": "data"
+                "data_config": "cifar10_data_config"
             }
         }
     },

--- a/examples/resnet/user_script.py
+++ b/examples/resnet/user_script.py
@@ -12,6 +12,7 @@ from torchvision import transforms
 from torchvision.datasets import CIFAR10
 
 from olive.constants import Framework
+from olive.data.registry import Registry
 from olive.model import OliveModelHandler
 
 # -------------------------------------------------------------------------
@@ -84,9 +85,14 @@ def post_process(output):
 # -------------------------------------------------------------------------
 
 
+@Registry.register_dataset()
+def cifar10_dataset(data_dir):
+    return PytorchResNetDataset(CIFAR10DataSet(data_dir).val_dataset)
+
+
+# TODO(shaahji): Remove this once metrics transitions to using DataConfig only!
 def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    cifar10_dataset = CIFAR10DataSet(data_dir)
-    return DataLoader(PytorchResNetDataset(cifar10_dataset.val_dataset), batch_size=batch_size, drop_last=True)
+    return DataLoader(cifar10_dataset(data_dir), batch_size=batch_size, drop_last=True)
 
 
 # -------------------------------------------------------------------------
@@ -177,8 +183,8 @@ def create_qat_config():
 
 
 def create_train_dataloader(data_dir, batch_size, *args, **kwargs):
-    cifar10_dataset = CIFAR10DataSet(data_dir)
-    return DataLoader(PytorchResNetDataset(cifar10_dataset.train_dataset), batch_size=batch_size, drop_last=True)
+    dataset = CIFAR10DataSet(data_dir)
+    return DataLoader(PytorchResNetDataset(dataset.train_dataset), batch_size=batch_size, drop_last=True)
 
 
 # -------------------------------------------------------------------------

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -31,6 +31,22 @@ def pre_process(dataset, **kwargs):
     return dataset
 
 
+@Registry.register_pre_process()
+def skip_pre_process(dataset, *args, **kwargs):
+    """Pre-process data.
+
+    Args:
+        dataset (object): Data to be pre-processed, reserved for internal dataset assignment.
+        *args: Additional unnamed arguments.
+        **kwargs: Additional named arguments.
+
+    Returns:
+        object: Pre-processed data.
+
+    """
+    return dataset
+
+
 def _huggingface_pre_process_helper(dataset, model_name, input_cols, label_cols, map_func, **kwargs):
     """Pre-process data.
 

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -58,12 +58,6 @@ def get_user_config_class(metric_type: str):
     return create_config_class(f"{metric_type.title()}UserConfig", default_config, ConfigBase, validators)
 
 
-def get_user_config_properties_from_metric_type(metric_type):
-    user_config_class = get_user_config_class(metric_type)
-    # avoid to use schema() to get the fields, because it will skip the ones with object type
-    return list(user_config_class.__fields__)
-
-
 # TODO(jambayk): automate latency metric config also we standardize accuracy metric config
 class LatencyMetricConfig(ConfigBase):
     warmup_num: int = WARMUP_NUM

--- a/test/unit_test/passes/common/test_user_script.py
+++ b/test/unit_test/passes/common/test_user_script.py
@@ -2,11 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import tempfile
-
-import pytest
-
-from olive.common.pydantic_v1 import ValidationError
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.passes.onnx.perf_tuning import OrtPerfTuning
 
@@ -16,22 +11,3 @@ class TestUserScriptConfig:
         config = {}
         config = OrtPerfTuning.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, True)
         assert config
-
-    def test_string_config(self):
-        config = {"dataloader_func": "dataloader_func"}
-        with pytest.raises(ValidationError):
-            OrtPerfTuning.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, True)
-
-    def test_object_config(self):
-        def dataloader_func():
-            return
-
-        config = {"dataloader_func": dataloader_func}
-        config = OrtPerfTuning.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, True)
-        assert config
-
-    def test_with_user_script(self):
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".py") as user_script_file:
-            config = {"dataloader_func": "dataloader_func", "user_script": user_script_file.name}
-            config = OrtPerfTuning.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, True)
-            assert config

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -226,7 +226,7 @@ class TestDockerSystem:
         docker_system = DockerSystem(docker_config, is_dev=True)
         data_root = "data_root"
 
-        p = create_pass_from_dict(OrtPerfTuning, {"data_dir": "data_dir"}, disable_search=True)
+        p = create_pass_from_dict(OrtPerfTuning, {}, disable_search=True)
         output_folder = str(tmp_path / "onnx")
 
         def validate_file_or_folder(v, values, **kwargs):
@@ -245,12 +245,10 @@ class TestDockerSystem:
 
         runner_local_path = Path(__file__).resolve().parents[4] / "olive" / "systems" / "docker" / "runner.py"
         model_path = onnx_model.config["model_path"]
-        data_dir = str(p.config["data_dir"])
         volumes_list = [
             f"{runner_local_path}:{container_root_path / 'runner.py'}",  # runner script
             f"{tmp_path / 'olive'}:{container_root_path / 'olive'}",  # olive dev
             f"{Path(model_path).resolve()}:{container_root_path / Path(model_path).name}",  # model
-            f"{Path(data_root) / data_dir}:{container_root_path / data_dir}",
             f"{tmp_path / 'config.json'}:{container_root_path / 'config.json'}",  # config
             f"{tmp_path / runner_output_path}:{container_root_path / runner_output_path}",  # output
         ]
@@ -277,7 +275,7 @@ class TestDockerSystem:
         from olive.systems.docker import utils as docker_utils
         from olive.systems.docker.runner import runner_entry as docker_runner_entry
 
-        p = create_pass_from_dict(OrtPerfTuning, {"data_dir": "data_dir"}, disable_search=True)
+        p = create_pass_from_dict(OrtPerfTuning, {}, disable_search=True)
         pass_config = p.to_json(check_object=True)
         config = p.config_at_search_point({})
         pass_config["config"].update(p.serialize_config(config, check_object=True))
@@ -289,7 +287,7 @@ class TestDockerSystem:
             onnx_model,
             pass_config,
             {"model_path": onnx_model.config["model_path"]},
-            {"data_dir": str(container_root_path / "data_dir")},
+            {},
         )
         docker_utils.create_config_file(tmp_path, data, container_root_path)
         with patch.object(OrtPerfTuning, "run", return_value=onnx_model):

--- a/test/unit_test/test_data_root.py
+++ b/test/unit_test/test_data_root.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from test.unit_test.utils import create_dummy_dataloader, get_pytorch_model_dummy_input, pytorch_model_loader
+from test.unit_test.utils import get_pytorch_model_dummy_input, get_pytorch_model_io_config, pytorch_model_loader
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,7 +29,7 @@ def get_dataloader_config():
             "config": {
                 "model_loader": pytorch_model_loader,
                 "dummy_inputs_func": get_pytorch_model_dummy_input,
-                "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+                "io_config": get_pytorch_model_io_config(),
             },
         },
         "data_configs": [
@@ -68,9 +68,7 @@ def get_dataloader_config():
             "perf_tuning": {
                 "type": "OrtPerfTuning",
                 "config": {
-                    "dataloader_func": create_dummy_dataloader,
-                    "batch_size": 16,
-                    "data_dir": "data",
+                    "data_config": "test_data_config",
                 },
             },
         },
@@ -91,7 +89,7 @@ def get_data_config():
             "config": {
                 "model_loader": pytorch_model_loader,
                 "dummy_inputs_func": get_pytorch_model_dummy_input,
-                "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+                "io_config": get_pytorch_model_io_config(),
             },
         },
         "data_configs": [

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -42,12 +42,16 @@ def pytorch_model_loader(model_path):
     return DummyModel().eval()
 
 
+def get_pytorch_model_io_config(batch_size=1):
+    return {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(batch_size, 1)]}
+
+
 def get_pytorch_model_config(batch_size=1):
     config = {
         "type": "PyTorchModel",
         "config": {
             "model_loader": pytorch_model_loader,
-            "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(batch_size, 1)]},
+            "io_config": get_pytorch_model_io_config(batch_size),
         },
     }
     return ModelConfig.parse_obj(config)
@@ -57,7 +61,7 @@ def get_pytorch_model(batch_size=1):
     return PyTorchModelHandler(
         model_loader=pytorch_model_loader,
         model_path=None,
-        io_config={"input_names": ["input"], "output_names": ["output"], "input_shapes": [(batch_size, 1)]},
+        io_config=get_pytorch_model_io_config(batch_size),
     )
 
 
@@ -87,21 +91,28 @@ def get_pytorch_model_dummy_input(model=None, batch_size=1):
 def create_onnx_model_file():
     pytorch_model = pytorch_model_loader(model_path=None)
     dummy_input = get_pytorch_model_dummy_input(pytorch_model)
+    io_config = get_pytorch_model_io_config()
     torch.onnx.export(
-        pytorch_model, dummy_input, ONNX_MODEL_PATH, opset_version=10, input_names=["input"], output_names=["output"]
+        pytorch_model,
+        dummy_input,
+        ONNX_MODEL_PATH,
+        opset_version=10,
+        input_names=io_config["input_names"],
+        output_names=io_config["output_names"],
     )
 
 
 def create_onnx_model_with_dynamic_axis(onnx_model_path, batch_size=1):
     pytorch_model = pytorch_model_loader(model_path=None)
     dummy_input = get_pytorch_model_dummy_input(pytorch_model, batch_size)
+    io_config = get_pytorch_model_io_config()
     torch.onnx.export(
         pytorch_model,
         dummy_input,
         onnx_model_path,
         opset_version=10,
-        input_names=["input"],
-        output_names=["output"],
+        input_names=io_config["input_names"],
+        output_names=io_config["output_names"],
         dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},
     )
 

--- a/test/unit_test/workflows/mock_data/default_engine.json
+++ b/test/unit_test/workflows/mock_data/default_engine.json
@@ -77,10 +77,37 @@
                         "label"
                     ]
                 }
-            },
-            "dataloader_config": {
+            }
+        },
+        {
+            "name": "perf_tuning_data_config",
+            "type": "DummyDataContainer",
+            "load_dataset_config": {
                 "params": {
-                    "batch_size": 1
+                    "input_names": [
+                        "input_ids",
+                        "attention_mask",
+                        "token_type_ids"
+                    ],
+                    "input_shapes": [
+                        [
+                            1,
+                            128
+                        ],
+                        [
+                            1,
+                            128
+                        ],
+                        [
+                            1,
+                            128
+                        ]
+                    ],
+                    "input_types": [
+                        "int64",
+                        "int64",
+                        "int64"
+                    ]
                 }
             }
         }
@@ -108,30 +135,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "input_names": [
-                    "input_ids",
-                    "attention_mask",
-                    "token_type_ids"
-                ],
-                "input_shapes": [
-                    [
-                        1,
-                        128
-                    ],
-                    [
-                        1,
-                        128
-                    ],
-                    [
-                        1,
-                        128
-                    ]
-                ],
-                "input_types": [
-                    "int64",
-                    "int64",
-                    "int64"
-                ]
+                "data_config": "perf_tuning_data_config"
             }
         }
     }

--- a/test/unit_test/workflows/test_workflow_run.py
+++ b/test/unit_test/workflows/test_workflow_run.py
@@ -2,6 +2,7 @@ from test.unit_test.utils import (
     create_dummy_dataloader,
     get_pytorch_model,
     get_pytorch_model_config,
+    get_pytorch_model_io_config,
     pytorch_model_loader,
 )
 from unittest.mock import patch
@@ -15,7 +16,7 @@ INPUT_MODEL_CONFIG = {
     "type": "PyTorchModel",
     "config": {
         "model_loader": pytorch_model_loader,
-        "io_config": {"input_names": ["input"], "output_names": ["output"], "input_shapes": [(1, 1)]},
+        "io_config": get_pytorch_model_io_config(),
     },
 }
 


### PR DESCRIPTION
## Update OrtPerfTuning pass to accept data only using data_config

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
