### PR TITLE
Report duplicate DataComponentType registration as fatal

### DIFF
--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -196,12 +196,12 @@ class DockerSystem(OliveSystem):
                         continue
 
                     logger.debug("Resource %s path: %s", resource_name, resource_str)
-                    original_resouce_path = mount_model_to_local.get(resource_str)
-                    if original_resouce_path:
+                    original_resource_path = mount_model_to_local.get(resource_str)
+                    if original_resource_path:
                         # If the output model path is something like /olive-ws/model.onnx
                         # we need replace with the original model path
-                        output_model.config[resource_name] = original_resouce_path
-                        logger.info("Original resource path for %s is: %s", resource_str, original_resouce_path)
+                        output_model.config[resource_name] = original_resource_path
+                        logger.info("Original resource path for %s is: %s", resource_str, original_resource_path)
                         continue
 
                     # output_local_path should be something like: /tmp/tmpd1sjw9xa/runner_output

--- a/test/unit_test/passes/onnx/test_transformer_optimization.py
+++ b/test/unit_test/passes/onnx/test_transformer_optimization.py
@@ -122,7 +122,7 @@ def test_invalid_ep_config(use_gpu, fp16, accelerator_spec, mock_inferece_sessio
                     # the use_gpu will be ignored by optimize_model, please refef to the following links for more info.
                     # https://github.com/microsoft/onnxruntime/blob/v1.15.1/onnxruntime/python/tools/transformers/optimizer.py#L280
                     if version.parse(ort.__version__) >= version.parse("1.16.0"):
-                        # for TensorRT EP, the graph optmization will be skipped but the fusion will be applied.
+                        # for TensorRT EP, the graph optimization will be skipped but the fusion will be applied.
                         assert "There is no gpu for onnxruntime to do optimization." in caplog.text
                         if mock_inferece_session:
                             assert inference_session_mock_call_count == 0

--- a/test/unit_test/test_data_root.py
+++ b/test/unit_test/test_data_root.py
@@ -18,7 +18,7 @@ from olive.workflows import run as olive_run
 
 
 @Registry.register_post_process()
-def post_processing_func(output):
+def post_processing_func_for_test(output):
     return output.argmax(axis=1)
 
 
@@ -57,7 +57,7 @@ def get_dataloader_config():
                         ],
                         "data_config": "test_data_config",
                         "user_config": {
-                            "post_processing_func": post_processing_func,
+                            "post_processing_func": post_processing_func_for_test,
                         },
                     }
                 ]
@@ -102,7 +102,7 @@ def get_data_config():
                     "type": "dummy_dataset",
                     "params": {"data_dir": "data", "input_shapes": [(1, 1)], "max_samples": 1},
                 },
-                "post_process_data_config": {"type": "post_processing_func"},
+                "post_process_data_config": {"type": "post_processing_func_for_test"},
             }
         ],
         "evaluators": {
@@ -138,7 +138,7 @@ def get_data_config():
                             type="dummy_dataset",
                             params={"data_dir": "perfdata", "input_shapes": [(1, 1)], "max_samples": 1},
                         ),
-                        post_process_data_config=DataComponentConfig(type="post_processing_func"),
+                        post_process_data_config=DataComponentConfig(type="post_processing_func_for_test"),
                     )
                 },
             },
@@ -209,9 +209,14 @@ def data_config(tmpdir, request):
     return config_obj
 
 
+@patch("olive.data.registry.inspect")
 @patch("olive.cache.get_local_path")
-def test_data_root_for_dataset(mock_get_local_path, data_config):
+def test_data_root_for_dataset(mock_get_local_path, mock_inspect, data_config):
     mock_get_local_path.side_effect = lambda x, cache_dir: x.get_path()
+
+    # Mock inspect.getfile and inspect.getsourcelines to return dummy values
+    mock_inspect.getfile = MagicMock(return_value="dummy")
+    mock_inspect.getsourcelines = MagicMock(return_value=("dummy", 1))
 
     config_obj = data_config
     data_root = config_obj.get("data_root")


### PR DESCRIPTION
## Report duplicate DataComponentType registration as fatal

Duplicate registration causes undesirable results and hard to debug errors.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
