### PR TITLE
Use DataConfig based metric configuration

### DIFF
--- a/examples/bert/bert_inc_dynamic_ptq_cpu.json
+++ b/examples/bert/bert_inc_dynamic_ptq_cpu.json
@@ -12,29 +12,43 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "glue_mrpc",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "params": {
+                    "data_name": "glue",
+                    "split": "validation",
+                    "subset": "mrpc"
+                }
+            },
+            "pre_process_data_config": {
+                "params": {
+                    "input_cols": [ "sentence1", "sentence2" ],
+                    "label_cols": [ "label" ],
+                    "max_samples": 100
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "glue_mrpc",
                     "sub_types": [ { "name": "accuracy_score", "priority": 1 } ],
-                    "user_config": {
-                        "post_processing_func": "post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "user_config": { "post_processing_func": "post_process", "user_script": "user_script.py" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg", "priority": 2 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "data_config": "glue_mrpc",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
                 }
             ]
         }

--- a/examples/bert/bert_inc_ptq_cpu.json
+++ b/examples/bert/bert_inc_ptq_cpu.json
@@ -12,12 +12,35 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "glue_mrpc",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "params": {
+                    "data_name": "glue",
+                    "split": "validation",
+                    "subset": "mrpc"
+                }
+            },
+            "pre_process_data_config": {
+                "params": {
+                    "input_cols": [ "sentence1", "sentence2" ],
+                    "label_cols": [ "label" ],
+                    "max_samples": 100
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "glue_mrpc",
                     "sub_types": [
                         {
                             "name": "accuracy_score",
@@ -25,24 +48,15 @@
                             "goal": { "type": "percent-max-degradation", "value": 2 }
                         }
                     ],
-                    "user_config": {
-                        "post_processing_func": "post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "user_config": { "post_processing_func": "post_process", "user_script": "user_script.py" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "glue_mrpc",
                     "sub_types": [
                         { "name": "avg", "priority": 2, "goal": { "type": "percent-min-improvement", "value": 20 } }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/bert/bert_inc_smoothquant_ptq_cpu.json
+++ b/examples/bert/bert_inc_smoothquant_ptq_cpu.json
@@ -12,12 +12,35 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "glue_mrpc",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "params": {
+                    "data_name": "glue",
+                    "split": "validation",
+                    "subset": "mrpc"
+                }
+            },
+            "pre_process_data_config": {
+                "params": {
+                    "input_cols": [ "sentence1", "sentence2" ],
+                    "label_cols": [ "label" ],
+                    "max_samples": 100
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "glue_mrpc",
                     "sub_types": [
                         {
                             "name": "accuracy_score",
@@ -25,24 +48,15 @@
                             "goal": { "type": "percent-max-degradation", "value": 2 }
                         }
                     ],
-                    "user_config": {
-                        "post_processing_func": "post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "user_config": { "post_processing_func": "post_process", "user_script": "user_script.py" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "glue_mrpc",
                     "sub_types": [
                         { "name": "avg", "priority": 2, "goal": { "type": "percent-min-improvement", "value": 20 } }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/bert/bert_inc_static_ptq_cpu.json
+++ b/examples/bert/bert_inc_static_ptq_cpu.json
@@ -12,12 +12,35 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "glue_mrpc",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "params": {
+                    "data_name": "glue",
+                    "split": "validation",
+                    "subset": "mrpc"
+                }
+            },
+            "pre_process_data_config": {
+                "params": {
+                    "input_cols": [ "sentence1", "sentence2" ],
+                    "label_cols": [ "label" ],
+                    "max_samples": 100
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "glue_mrpc",
                     "sub_types": [
                         {
                             "name": "accuracy_custom",
@@ -26,23 +49,15 @@
                             "goal": { "type": "percent-max-degradation", "value": 2 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 1
-                    }
+                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "glue_mrpc",
                     "sub_types": [
                         { "name": "avg", "priority": 2, "goal": { "type": "percent-min-improvement", "value": 20 } }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/bert/bert_nvmo_ptq.json
+++ b/examples/bert/bert_nvmo_ptq.json
@@ -3,7 +3,7 @@
         "type": "PyTorchModel",
         "config": {
             "model_loader": "load_pytorch_origin_model",
-            "model_script": "user_script.py",
+            "model_script": "nv_user_script.py",
             "io_config": {
                 "input_names": [ "input_ids", "attention_mask", "token_type_ids" ],
                 "input_shapes": [ [ 1, 128 ], [ 1, 128 ], [ 1, 128 ] ],
@@ -12,6 +12,16 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "rotten_tomatoes",
+            "type": "HuggingfaceContainer",
+            "user_script": "nv_user_script.py",
+            "load_dataset_config": { "params": { "data_name": "rotten_tomatoes", "split": "validation[:10%]" } },
+            "dataloader_config": { "type": "nvmo_calibration_dataloader" },
+            "pre_process_data_config": { "type": "skip_pre_process" }
+        }
+    ],
     "passes": {
         "conversion": { "type": "OnnxConversion", "config": { "target_opset": 17 } },
         "transformers_optimization": {
@@ -22,10 +32,9 @@
         "quantization": {
             "type": "NVModelOptQuantization",
             "config": {
-                "user_script": "nv_user_script.py",
-                "dataloader_func": "create_calibration_dataloader",
                 "precision": "int4",
-                "algorithm": "AWQ"
+                "algorithm": "AWQ",
+                "data_config": "rotten_tomatoes"
             }
         }
     }

--- a/examples/bert/bert_qat_customized_train_loop_cpu.json
+++ b/examples/bert/bert_qat_customized_train_loop_cpu.json
@@ -2,8 +2,10 @@
     "input_model": {
         "type": "PyTorchModel",
         "config": {
-            "model_loader": "load_pytorch_origin_model",
-            "model_script": "user_script.py",
+            "hf_config": {
+                "model_name": "Intel/bert-base-uncased-mrpc",
+                "task": "text-classification"
+            },
             "io_config": {
                 "input_names": [ "input_ids", "attention_mask", "token_type_ids" ],
                 "input_shapes": [ [ 1, 128 ], [ 1, 128 ], [ 1, 128 ] ],
@@ -14,11 +16,24 @@
     },
     "data_configs": [
         {
-            "name": "perf_tuning_data_config",
+            "name": "glue_mrpc",
             "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "create_bert_dataset" },
-            "dataloader_config": { "type": "create_bert_dataloader" }
+            "load_dataset_config": {
+                "params": {
+                    "data_name": "glue",
+                    "split": "validation",
+                    "subset": "mrpc"
+                }
+            },
+            "pre_process_data_config": {
+                "params": {
+                    "input_cols": [ "sentence1", "sentence2" ],
+                    "label_cols": [ "label" ],
+                    "max_samples": 100
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 1 } }
         }
     ],
     "evaluators": {
@@ -27,23 +42,15 @@
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "glue_mrpc",
                     "sub_types": [ { "name": "accuracy_score", "priority": 1 } ],
-                    "user_config": {
-                        "post_processing_func": "qat_post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "user_config": { "post_processing_func": "qat_post_process", "user_script": "user_script.py" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg", "priority": 2 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "data_config": "glue_mrpc",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
                 }
             ]
         }
@@ -56,7 +63,7 @@
         "conversion": { "type": "OnnxConversion", "config": { "target_opset": 17 } },
         "model_optimizer": { "type": "ONNXModelOptimizer" },
         "transformers_optimization": { "type": "OrtTransformersOptimization" },
-        "perf_tuning": { "type": "OrtPerfTuning", "config": { "data_config": "perf_tuning_data_config" } }
+        "perf_tuning": { "type": "OrtPerfTuning" }
     },
     "engine": {
         "evaluator": "common_evaluator",

--- a/examples/bert/bert_trt_gpu.json
+++ b/examples/bert/bert_trt_gpu.json
@@ -6,7 +6,9 @@
     "systems": {
         "local_system": {
             "type": "LocalSystem",
-            "config": { "accelerators": [ { "device": "gpu", "execution_providers": [ "TensorrtExecutionProvider" ] } ] }
+            "config": {
+                "accelerators": [ { "device": "gpu", "execution_providers": [ "TensorrtExecutionProvider" ] } ]
+            }
         }
     },
     "data_configs": [

--- a/examples/bert/nv_user_script.py
+++ b/examples/bert/nv_user_script.py
@@ -3,27 +3,28 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import torch
-from datasets import load_dataset  # type: ignore[import]
 from datasets.utils import logging as datasets_logging  # type: ignore[import]
 from transformers import AutoTokenizer, BertModel  # type: ignore[import]
+
+from olive.data.registry import Registry
 
 datasets_logging.disable_progress_bar()
 datasets_logging.set_verbosity_error()
 
 
-def load_pytorch_origin_model():
+def load_pytorch_origin_model(model_path):
     model = BertModel.from_pretrained("bert-base-uncased")
     model.eval()
     return model
 
 
-def create_calibration_dataloader(batch_size, calib_size, *args, **kwargs):
+@Registry.register_dataloader("nvmo_calibration_dataloader")
+def create_calibration_dataloader(dataset, batch_size, calib_size=64, **kwargs):
     tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
 
     def tokenization(example):
         return tokenizer(example["text"], padding="max_length", max_length=128, truncation=True)
 
-    dataset = load_dataset("rotten_tomatoes", split="validation[:10%]")
     dataset = dataset.map(tokenization, batched=True)
     dataset.set_format(type="torch", columns=["input_ids", "token_type_ids", "attention_mask"])
 

--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import copy
+from typing import Union
 
 import numpy as np
 import torch
@@ -147,20 +148,14 @@ def post_process(output):
 # -------------------------------------------------------------------------
 
 
-@Registry.register_dataset()
-def create_bert_dataset(data_dir, *args, **kwargs):
-    return BertDataset("Intel/bert-base-uncased-mrpc")
+@Registry.register_dataset("bert_dataset")
+def create_dataset(data_name: str, split: str, language: str, token: Union[bool, str] = True):
+    return BertDataset(data_name).get_eval_dataset()
 
 
-@Registry.register_dataloader()
-def create_bert_dataloader(dataset, batch_size, *args, **kwargs):
-    return torch.utils.data.DataLoader(
-        BertDatasetWrapper(dataset.get_eval_dataset()), batch_size=batch_size, drop_last=True
-    )
-
-
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    return create_bert_dataloader(create_bert_dataset(data_dir), batch_size, *args, **kwargs)
+@Registry.register_dataloader("bert_dataloader")
+def create_dataloader(dataset, batch_size, *args, **kwargs):
+    return torch.utils.data.DataLoader(BertDatasetWrapper(dataset), batch_size=batch_size, drop_last=True)
 
 
 # -------------------------------------------------------------------------

--- a/examples/mobilenet/raw_qnn_sdk_template.json
+++ b/examples/mobilenet/raw_qnn_sdk_template.json
@@ -1,6 +1,26 @@
 {
     "input_model": { "type": "OnnxModel", "config": { "model_path": "models/mobilenetv2-12.onnx" } },
     "systems": { "local_system": { "type": "LocalSystem", "config": { "accelerators": [ { "device": "cpu" } ] } } },
+    "data_configs": [
+        {
+            "name": "accuracy_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "dataloader_config": { "type": "qnn_dataloader", "params": { "data_dir": "data", "batch_size": 1 } },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "qnn_sdk_post_process" }
+        },
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "dataloader_config": { "type": "qnn_dataloader", "params": { "data_dir": "data", "batch_size": 1 } },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -14,26 +34,15 @@
                             "metric_config": { "task": "multiclass", "num_classes": 1000 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "batch_size": 1,
-                        "dataloader_func": "qnn_data_loader",
-                        "post_processing_func": "qnn_sdk_post_process",
-                        "inference_settings": { "qnn": { "backend": "libQnnCpu" } }
-                    }
+                    "data_config": "accuracy_data_config",
+                    "user_config": { "inference_settings": { "qnn": { "backend": "libQnnCpu" } } }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg", "priority": 2 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "batch_size": 1,
-                        "dataloader_func": "qnn_data_loader",
-                        "inference_settings": { "qnn": { "backend": "libQnnCpu" } }
-                    }
+                    "data_config": "latency_data_config",
+                    "user_config": { "inference_settings": { "qnn": { "backend": "libQnnCpu" } } }
                 }
             ]
         }

--- a/examples/resnet/resnet_dynamic_ptq_cpu.json
+++ b/examples/resnet/resnet_dynamic_ptq_cpu.json
@@ -7,10 +7,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -27,7 +24,8 @@
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 16, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 16, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
         }
     ],
     "evaluators": {
@@ -36,36 +34,28 @@
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_custom",
-                            "priority": 1, "higher_is_better": true,
+                            "priority": 1,
+                            "higher_is_better": true,
                             "goal": { "type": "max-degradation", "value": 0.01 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 16
-                    }
+                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "avg",
                             "priority": 2,
                             "goal": { "type": "percent-min-improvement", "value": 20 }
                         }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 16
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/resnet/resnet_multiple_ep.json
+++ b/examples/resnet/resnet_multiple_ep.json
@@ -1,4 +1,6 @@
-{ "systems": {
+{
+    "input_model": { "type": "ONNXModel", "config": { "model_path": "models/resnet_trained_for_cifar10.onnx" } },
+    "systems": {
         "python_system": {
             "type": "PythonEnvironment",
             "config": {
@@ -13,7 +15,6 @@
             }
         }
     },
-    "input_model": { "type": "ONNXModel", "config": { "model_path": "models/resnet_trained_for_cifar10.onnx" } },
     "data_configs": [
         {
             "name": "cifar10_data_config",
@@ -21,7 +22,17 @@
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
+        },
+        {
+            "name": "cifar10_accuracy_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "post_process_data_config": { "type": "cifar10_post_process" }
         }
     ],
     "evaluators": {
@@ -30,30 +41,19 @@
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "cifar10_accuracy_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_score",
                             "priority": 1, "metric_config": { "task": "multiclass", "num_classes": 1000 }
                         }
-                    ],
-                    "user_config": {
-                        "post_processing_func": "post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1,
-                        "data_dir": "data"
-                    }
+                    ]
                 },
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg", "priority": 2 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1,
-                        "data_dir": "data"
-                    }
+                    "data_config": "cifar10_data_config",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
                 }
             ]
         }

--- a/examples/resnet/resnet_ptq_cpu.json
+++ b/examples/resnet/resnet_ptq_cpu.json
@@ -7,10 +7,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -27,7 +24,8 @@
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 16, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 16, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
         }
     ],
     "evaluators": {
@@ -36,36 +34,28 @@
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_custom",
-                            "priority": 1, "higher_is_better": true,
+                            "priority": 1,
+                            "higher_is_better": true,
                             "goal": { "type": "max-degradation", "value": 0.05 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 16
-                    }
+                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "avg",
                             "priority": 2,
                             "goal": { "type": "percent-min-improvement", "value": 10 }
                         }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 16
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/resnet/resnet_ptq_cpu_aml_dataset.json
+++ b/examples/resnet/resnet_ptq_cpu_aml_dataset.json
@@ -12,10 +12,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -34,7 +31,8 @@
                 }
             },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 16, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 16, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
         }
     ],
     "evaluators": {
@@ -43,48 +41,28 @@
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_custom",
-                            "priority": 1, "higher_is_better": true,
+                            "priority": 1,
+                            "higher_is_better": true,
                             "goal": { "type": "max-degradation", "value": 0.05 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": {
-                            "type": "azureml_datastore",
-                            "config": {
-                                "datastore_name": "workspaceblobstore",
-                                "relative_path": "LocalUpload/cifar-10"
-                            }
-                        },
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 16
-                    }
+                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "avg",
                             "priority": 2,
                             "goal": { "type": "percent-min-improvement", "value": 10 }
                         }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": {
-                            "type": "azureml_datastore",
-                            "config": {
-                                "datastore_name": "workspaceblobstore",
-                                "relative_path": "LocalUpload/cifar-10"
-                            }
-                        },
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 16
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/resnet/resnet_qat_default_train_loop_cpu.json
+++ b/examples/resnet/resnet_qat_default_train_loop_cpu.json
@@ -7,10 +7,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -21,7 +18,17 @@
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
+        },
+        {
+            "name": "cifar10_accuracy_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "cifar10_post_process" }
         }
     ],
     "evaluators": {
@@ -30,31 +37,20 @@
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "cifar10_accuracy_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_score",
                             "priority": 1,
                             "metric_config": { "task": "multiclass", "num_classes": 1000 }
                         }
-                    ],
-                    "user_config": {
-                        "post_processing_func": "post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1,
-                        "data_dir": "data"
-                    }
+                    ]
                 },
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg", "priority": 2 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1,
-                        "data_dir": "data"
-                    }
+                    "data_config": "cifar10_data_config",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
                 }
             ]
         }

--- a/examples/resnet/resnet_qat_lightning_module_cpu.json
+++ b/examples/resnet/resnet_qat_lightning_module_cpu.json
@@ -7,10 +7,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -21,7 +18,17 @@
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
+        },
+        {
+            "name": "cifar10_accuracy_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "cifar10_post_process" }
         }
     ],
     "evaluators": {
@@ -30,31 +37,20 @@
                 {
                     "name": "accuracy",
                     "type": "accuracy",
+                    "data_config": "cifar10_accuracy_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_score",
                             "priority": 1,
                             "metric_config": { "task": "multiclass", "num_classes": 1000 }
                         }
-                    ],
-                    "user_config": {
-                        "post_processing_func": "post_process",
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1,
-                        "data_dir": "data"
-                    }
+                    ]
                 },
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg", "priority": 2 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1,
-                        "data_dir": "data"
-                    }
+                    "data_config": "cifar10_data_config",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
                 }
             ]
         }

--- a/examples/resnet/resnet_static_ptq_cpu.json
+++ b/examples/resnet/resnet_static_ptq_cpu.json
@@ -7,10 +7,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -27,7 +24,8 @@
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
             "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } }
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
         }
     ],
     "evaluators": {
@@ -36,36 +34,28 @@
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_custom",
-                            "priority": 1, "higher_is_better": true,
+                            "priority": 1,
+                            "higher_is_better": true,
                             "goal": { "type": "max-degradation", "value": 0.01 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 16
-                    }
+                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "avg",
                             "priority": 2,
                             "goal": { "type": "percent-min-improvement", "value": 20 }
                         }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 16
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/resnet/resnet_vitis_ai_ptq_cpu.json
+++ b/examples/resnet/resnet_vitis_ai_ptq_cpu.json
@@ -7,10 +7,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -20,42 +17,45 @@
             "config": { "accelerators": [ { "execution_providers": [ "CPUExecutionProvider" ] } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "cifar10_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_dataset", "params": { "data_dir": "data" } },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "dataloader_config": { "params": { "batch_size": 1, "drop_last": true } },
+            "post_process_data_config": { "type": "skip_post_process" }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_custom",
-                            "priority": 1, "higher_is_better": true,
+                            "priority": 1,
+                            "higher_is_better": true,
                             "goal": { "type": "max-degradation", "value": 0.1 }
                         }
                     ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 16
-                    }
+                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "cifar10_data_config",
                     "sub_types": [
                         {
                             "name": "avg",
                             "priority": 2,
                             "goal": { "type": "percent-min-improvement", "value": 10 }
                         }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "data",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 16
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/stable_diffusion/config_safety_checker.json
+++ b/examples/stable_diffusion/config_safety_checker.json
@@ -22,18 +22,25 @@
             "config": { "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" },
+            "dataloader_config": { "type": "safety_checker_data_loader", "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "safety_checker_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config",
+                    "sub_types": [ { "name": "avg" } ]
                 }
             ]
         }

--- a/examples/stable_diffusion/config_text_encoder.json
+++ b/examples/stable_diffusion/config_text_encoder.json
@@ -19,18 +19,25 @@
             "config": { "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" },
+            "dataloader_config": { "type": "text_encoder_data_loader", "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "text_encoder_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config",
+                    "sub_types": [ { "name": "avg" } ]
                 }
             ]
         }

--- a/examples/stable_diffusion/config_unet.json
+++ b/examples/stable_diffusion/config_unet.json
@@ -28,18 +28,25 @@
             "config": { "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" },
+            "dataloader_config": { "type": "unet_data_loader", "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "unet_data_loader",
-                        "batch_size": 2
-                    }
+                    "data_config": "latency_data_config",
+                    "sub_types": [ { "name": "avg" } ]
                 }
             ]
         }

--- a/examples/stable_diffusion/config_vae_decoder.json
+++ b/examples/stable_diffusion/config_vae_decoder.json
@@ -19,18 +19,25 @@
             "config": { "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" },
+            "dataloader_config": { "type": "vae_decoder_data_loader", "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "vae_decoder_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config",
+                    "sub_types": [ { "name": "avg" } ]
                 }
             ]
         }

--- a/examples/stable_diffusion/config_vae_encoder.json
+++ b/examples/stable_diffusion/config_vae_encoder.json
@@ -19,18 +19,25 @@
             "config": { "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "local_dataset" },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" },
+            "dataloader_config": { "type": "vae_encoder_data_loader", "params": { "batch_size": 1 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "vae_encoder_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config",
+                    "sub_types": [ { "name": "avg" } ]
                 }
             ]
         }

--- a/examples/stable_diffusion/user_script.py
+++ b/examples/stable_diffusion/user_script.py
@@ -9,6 +9,8 @@ from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionS
 from huggingface_hub import model_info
 from transformers.models.clip.modeling_clip import CLIPTextModel
 
+from olive.data.registry import Registry
+
 
 # Helper latency-only dataloader that creates random tensors with no label
 class RandomDataLoader:
@@ -135,7 +137,8 @@ def text_encoder_conversion_inputs(model=None):
     return text_encoder_inputs(1, torch.int32)
 
 
-def text_encoder_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def text_encoder_data_loader(dataset, batch_size, *args, **kwargs):
     return RandomDataLoader(text_encoder_inputs, batch_size, torch.int32)
 
 
@@ -194,7 +197,8 @@ def unet_conversion_inputs(model=None):
     return tuple(unet_inputs(1, torch.float32, True).values())
 
 
-def unet_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def unet_data_loader(dataset, batch_size, *args, **kwargs):
     return RandomDataLoader(unet_inputs, batch_size, torch.float16)
 
 
@@ -218,7 +222,8 @@ def vae_encoder_conversion_inputs(model=None):
     return tuple(vae_encoder_inputs(1, torch.float32).values())
 
 
-def vae_encoder_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def vae_encoder_data_loader(dataset, batch_size, *args, **kwargs):
     return RandomDataLoader(vae_encoder_inputs, batch_size, torch.float16)
 
 
@@ -246,7 +251,8 @@ def vae_decoder_conversion_inputs(model=None):
     return tuple(vae_decoder_inputs(1, torch.float32).values())
 
 
-def vae_decoder_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def vae_decoder_data_loader(dataset, batch_size, *args, **kwargs):
     return RandomDataLoader(vae_decoder_inputs, batch_size, torch.float16)
 
 
@@ -273,5 +279,6 @@ def safety_checker_conversion_inputs(model=None):
     return tuple(safety_checker_inputs(1, torch.float32).values())
 
 
-def safety_checker_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def safety_checker_data_loader(dataset, batch_size, *args, **kwargs):
     return RandomDataLoader(safety_checker_inputs, batch_size, torch.float16)

--- a/examples/whisper/code/user_script.py
+++ b/examples/whisper/code/user_script.py
@@ -7,6 +7,7 @@ from whisper_dataset import WhisperDataset
 from whisper_decoder import WhisperDecoder, WhisperDecoderInputs
 from whisper_encoder_decoder_init import WhisperEncoderDecoderInit, WhisperEncoderDecoderInitInputs
 
+from olive.data.registry import Registry
 from olive.model import PyTorchModelHandler
 
 
@@ -166,7 +167,8 @@ def decoder_dummy_inputs(olive_model: PyTorchModelHandler):
     return tuple(inputs.to_list())
 
 
-def whisper_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataset()
+def whisper_dataset(data_dir, **kwargs):
     model_name = kwargs["model_name"]
     use_audio_decoder = kwargs["use_audio_decoder"]
     predict_timestamps = kwargs.get("predict_timestamps", False)

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -119,14 +119,12 @@ def main(raw_args=None):
     if transformers_version_4_36:
         template_json["input_model"]["config"]["hf_config"]["from_pretrained_args"] = {"attn_implementation": "eager"}
 
+    load_dataset_params = template_json["data_configs"][0]["load_dataset_config"]["params"]
+    load_dataset_params["model_name"] = model_name
+    load_dataset_params["use_audio_decoder"] = not args.no_audio_decoder
+
     # set dataloader
-    if not args.skip_evaluation:
-        metric_dataloader_kwargs = template_json["evaluators"]["common_evaluator"]["metrics"][0]["user_config"][
-            "func_kwargs"
-        ]["dataloader_func"]
-        metric_dataloader_kwargs["model_name"] = model_name
-        metric_dataloader_kwargs["use_audio_decoder"] = not args.no_audio_decoder
-    else:
+    if args.skip_evaluation:
         del template_json["evaluators"]
         template_json["engine"]["evaluator"] = None
 

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -1,13 +1,13 @@
 {
-    "input_model":{
+    "input_model": {
         "type": "PyTorchModel",
         "config": {
             "model_script": "code/user_script.py",
             "script_dir": "code",
             "hf_config": {
-                "model_class" : "WhisperForConditionalGeneration",
-                "model_name" : "<place_holder>",
-                "components" : [
+                "model_class": "WhisperForConditionalGeneration",
+                "model_name": "<place_holder>",
+                "components": [
                     {
                         "name": "encoder_decoder_init",
                         "io_config": "get_encdec_io_config",
@@ -27,88 +27,66 @@
     "systems": {
         "local_system": {
             "type": "LocalSystem",
-            "config": {
-                "accelerators": [
-                    {
-                        "device": "<place_holder>",
-                        "execution_providers": "<place_holder>"
-                    }
-                ]
-            }
+            "config": { "accelerators": [ { "device": "<place_holder>", "execution_providers": "<place_holder>" } ] }
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "code/user_script.py",
+            "script_dir": "code",
+            "load_dataset_config": {
+                "type": "whisper_dataset",
+                "params": {
+                    "data_dir": "data",
+                    "model_name": "<place_holder>",
+                    "use_audio_decoder": "<place_holder>"
+                }
+            },
+            "pre_process_data_config": { "type": "skip_pre_process" },
+            "post_process_data_config": { "type": "skip_post_process" },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [
-                        {"name": "avg", "priority": 1}
-                    ],
-                    "user_config": {
-                        "user_script": "code/user_script.py",
-                        "script_dir": "code",
-                        "data_dir": "data",
-                        "dataloader_func": "whisper_dataloader",
-                        "func_kwargs": {
-                            "dataloader_func": {
-                                "model_name" : "<place_holder>",
-                                "use_audio_decoder" : "<place_holder>"
-                            }
-                        }
-                    }
+                    "sub_types": [ { "name": "avg", "priority": 1 } ],
+                    "data_config": "latency_data_config"
                 }
             ]
         }
     },
     "passes": {
-        "conversion": {
-            "type": "OnnxConversion",
-            "config": {
-                "target_opset": 17
-            }
-        },
+        "conversion": { "type": "OnnxConversion", "config": { "target_opset": 17 } },
         "transformers_optimization": {
             "type": "OrtTransformersOptimization",
-            "config": {
-                "optimization_options": {"use_multi_head_attention": true},
-                "use_gpu": "<place_holder>"
-            }
+            "config": { "optimization_options": { "use_multi_head_attention": true }, "use_gpu": "<place_holder>" }
         },
-        "mixed_precision": {
-            "type": "OrtMixedPrecision",
-            "config": {
-                "atol": 1e-6
-            }
-        },
+        "mixed_precision": { "type": "OrtMixedPrecision", "config": { "atol": 1e-6 } },
         "onnx_dynamic_quantization": {
             "type": "OnnxDynamicQuantization",
             "config": {
                 "per_channel": false,
                 "reduce_range": false,
-                "op_types_to_quantize": ["MatMul", "Gemm", "Gather"],
+                "op_types_to_quantize": [ "MatMul", "Gemm", "Gather" ],
                 "MatMulConstBOnly": false
             }
         },
-        "inc_dynamic_quantization": {
-            "type": "IncDynamicQuantization"
-        },
-        "insert_beam_search" : {
-            "type" : "InsertBeamSearch",
-            "config": {
-                "use_forced_decoder_ids": "<place_holder>",
-                "use_logits_processor": "<place_holder>"
-            }
+        "inc_dynamic_quantization": { "type": "IncDynamicQuantization" },
+        "insert_beam_search": {
+            "type": "InsertBeamSearch",
+            "config": { "use_forced_decoder_ids": "<place_holder>", "use_logits_processor": "<place_holder>" }
         },
         "prepost": {
             "type": "AppendPrePostProcessingOps",
             "config": {
                 "tool_command": "whisper",
-                "tool_command_args": {
-                    "model_name" : "<place_holder>",
-                    "use_audio_decoder" : "<place_holder>"
-                },
+                "tool_command_args": { "model_name": "<place_holder>", "use_audio_decoder": "<place_holder>" },
                 "target_opset": 17
             }
         }

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader, default_collate
 from olive.data.registry import Registry
 
 
+@Registry.register_dataloader()
 @Registry.register_default_dataloader()
 def default_dataloader(dataset, batch_size=1, **kwargs):
     return DataLoader(dataset, batch_size=batch_size, **kwargs)

--- a/olive/data/component/dataset.py
+++ b/olive/data/component/dataset.py
@@ -101,6 +101,7 @@ class DummyDataset(BaseDataset):
         input_names: Optional[List] = None,
         input_types: Optional[List] = None,
         max_samples: Optional[int] = 32,
+        **kwargs,
     ):
         """Initialize the dataset with dummy data.
 

--- a/olive/data/component/load_dataset.py
+++ b/olive/data/component/load_dataset.py
@@ -7,19 +7,13 @@ from olive.data.component.dataset import DummyDataset, RawDataset, TransformersD
 from olive.data.registry import Registry
 
 
-@Registry.register_default_dataset()
-def local_dataset(data_dir, label_cols=None, **kwargs):
-    pass
-
-
 @Registry.register_dataset()
-def simple_dataset(data_dir, input_data, label_cols=None, **kwargs):
-    """Create a simple dataset from input data.
-
-    The input data can be:
-    1. a text
-    2. a tensor
-    """
+@Registry.register_default_dataset()
+@Registry.register_dataset("simple_dataset")
+def local_dataset(**kwargs):
+    """Create a simple local dataset from input data."""
+    # TODO(olivedevs): Implement this feature if and when needed.
+    return
 
 
 @Registry.register_dataset()
@@ -36,8 +30,8 @@ def huggingface_dataset(data_dir, data_name=None, subset=None, split="validation
 
 
 @Registry.register_dataset()
-def dummy_dataset(data_dir, input_shapes, input_names=None, input_types=None, max_samples=32):
-    return DummyDataset(input_shapes, input_names, input_types, max_samples)
+def dummy_dataset(input_shapes, input_names=None, input_types=None, max_samples=32, **kwargs):
+    return DummyDataset(input_shapes, input_names, input_types, max_samples, **kwargs)
 
 
 @Registry.register_dataset()

--- a/olive/data/component/post_process_data.py
+++ b/olive/data/component/post_process_data.py
@@ -8,8 +8,20 @@ import transformers
 from olive.data.registry import Registry
 
 
+@Registry.register_post_process()
 @Registry.register_default_post_process()
+@Registry.register_post_process("skip_post_process")
 def post_process(output_data, **kwargs):
+    """Post-process data.
+
+    Args:
+        output_data (object): Model output to be post-processed.
+        **kwargs: Additional named arguments.
+
+    Returns:
+        object: Post-processed data.
+
+    """
     return output_data
 
 

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -16,29 +16,15 @@ from olive.data.component.text_generation import (
 from olive.data.registry import Registry
 
 
+@Registry.register_pre_process()
 @Registry.register_default_pre_process()
+@Registry.register_pre_process("skip_pre_process")
 def pre_process(dataset, **kwargs):
     """Pre-process data.
 
     Args:
         dataset (object): Data to be pre-processed, reserved for internal dataset assignment.
         **kwargs: Additional arguments.
-
-    Returns:
-        object: Pre-processed data.
-
-    """
-    return dataset
-
-
-@Registry.register_pre_process()
-def skip_pre_process(dataset, *args, **kwargs):
-    """Pre-process data.
-
-    Args:
-        dataset (object): Data to be pre-processed, reserved for internal dataset assignment.
-        *args: Additional unnamed arguments.
-        **kwargs: Additional named arguments.
 
     Returns:
         object: Pre-processed data.

--- a/olive/evaluator/metric_config.py
+++ b/olive/evaluator/metric_config.py
@@ -4,11 +4,10 @@
 # --------------------------------------------------------------------------
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, Union
 
 from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, create_config_class
 from olive.common.pydantic_v1 import validator
-from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS, validate_resource_path
 
 logger = logging.getLogger(__name__)
 
@@ -20,30 +19,19 @@ _common_user_config = {
     "script_dir": ConfigParam(type_=Union[Path, str]),
     "user_script": ConfigParam(type_=Union[Path, str]),
     "inference_settings": ConfigParam(type_=dict),
-    "data_dir": ConfigParam(type_=OLIVE_RESOURCE_ANNOTATIONS, category=ParamCategory.DATA),
-    "dataloader_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
-    "func_kwargs": ConfigParam(type_=Dict[str, Dict[str, Any]]),
-    "batch_size": ConfigParam(type_=int, default_value=1),
-    "input_names": ConfigParam(type_=List),
-    "input_shapes": ConfigParam(type_=List),
-    "input_types": ConfigParam(type_=List),
     "shared_kv_buffer": ConfigParam(type_=bool, default_value=False),
     "io_bind": ConfigParam(type_=bool, default_value=False),
     "run_kwargs": ConfigParam(type_=dict),
 }
 
-_common_user_config_validators = {
-    "validate_data_dir_resource_path": validator("data_dir", allow_reuse=True)(validate_resource_path)
-}
+_common_user_config_validators = {}
 
 _type_to_user_config = {
-    "accuracy": {
-        "post_processing_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
-    },
     "custom": {
-        "post_processing_func": ConfigParam(type_=Union[Callable, str], category=ParamCategory.OBJECT),
         "evaluate_func": ConfigParam(type_=Union[Callable, str], required=False, category=ParamCategory.OBJECT),
+        "evaluate_func_kwargs": ConfigParam(type_=Dict[str, Any]),
         "metric_func": ConfigParam(type_=Union[Callable, str], required=False, category=ParamCategory.OBJECT),
+        "metric_func_kwargs": ConfigParam(type_=Dict[str, Any]),
     },
 }
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -14,14 +14,15 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, NamedTuple, Tuple, 
 import numpy as np
 import torch
 
-import olive.data.template as data_config_template
-from olive.common.config_utils import ConfigBase
+from olive.common.config_utils import ConfigBase, validate_config
 from olive.common.ort_inference import OrtInferenceSession, prepare_io_bindings
 from olive.common.pydantic_v1 import validator
 from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import tensor_data_to_device
 from olive.constants import Framework
+from olive.data.config import DataConfig
 from olive.data.container.dummy_data_container import TRANSFORMER_DUMMY_DATA_CONTAINER
+from olive.data.template import dummy_data_config_template
 from olive.evaluator.metric import LatencySubType, Metric, MetricType, ThroughputSubType, get_latency_config_from_metric
 from olive.evaluator.metric_backend import MetricBackend
 from olive.evaluator.metric_result import MetricResult, SubMetricResult, flatten_metric_result, joint_metric_key
@@ -141,10 +142,12 @@ class OliveEvaluator(ABC):
     ) -> MetricResult:
         raw_res = None
         if metric.user_config.evaluate_func:
+            data_dir = metric.data_config.load_dataset_params.get("data_dir") if metric.data_config else None
+            batch_size = metric.data_config.dataloader_params.get("batch_size", 1) if metric.data_config else 1
             raw_res = eval_func(
                 model,
-                metric.user_config.data_dir,
-                metric.user_config.batch_size,
+                data_dir,
+                batch_size,
                 device,
                 execution_providers,
             )
@@ -180,8 +183,6 @@ class OliveEvaluator(ABC):
         metrics_res = {}
         for original_metric in metrics:
             # use model io_config if user does not specify input_names and input_shapes
-            # only do this if data_config or dataloader is not provided
-            # priority: dataloader_func > data_config > user_config.input_names/input_shapes > model io_config
             metric = OliveEvaluator.generate_metric_user_config_with_model_io(original_metric, model)
             dataloader, eval_func, post_func = OliveEvaluator.get_user_config(model.framework, metric)
             if metric.type == MetricType.ACCURACY:
@@ -206,11 +207,14 @@ class OliveEvaluator(ABC):
 
     @staticmethod
     def generate_metric_user_config_with_model_io(metric: Metric, model: "OliveModelHandler"):
-        # if the io_config is not specified in the metrics, use the one in the model
+        # if the io_config is not specified in the data config, use the one in the model
         # should not change the original metric object which is created from config jsons
         # otherwise, if affects hashing + caching of the olive restoring.
         metric = deepcopy(metric)
         if metric.data_config:
+            return metric
+
+        if metric.type != MetricType.LATENCY:
             return metric
 
         io_config = model.io_config
@@ -226,87 +230,46 @@ class OliveEvaluator(ABC):
                 "Model input shapes are not static. Cannot use inferred input shapes for creating dummy data. This will"
                 " cause an error when creating dummy data for tuning."
             )
-        if io_config and not metric.user_config.input_names and not metric.user_config.input_shapes:
-            metric.user_config.input_names = io_config["input_names"]
-            # input_shapes is optional for hf models
-            metric.user_config.input_shapes = io_config.get("input_shapes")
-            # input_types is optional which can be None. If None, it will be replaced with float32 in DummyDataset
-            metric.user_config.input_types = io_config.get("input_types")
-        return metric
 
-    @staticmethod
-    def _get_func_kwargs(metric: Metric, func_name: str):
-        """Get the function kwargs from the metric config."""
-        if metric.user_config.func_kwargs:
-            return metric.user_config.func_kwargs.get(func_name, {})
-        return {}
+        metric.data_config = dummy_data_config_template(
+            io_config.get("input_shapes"), io_config.get("input_names"), io_config.get("input_types")
+        )
+        metric.data_config = validate_config(metric.data_config, DataConfig)
+        return metric
 
     @classmethod
     def get_user_config(cls, framework: Framework, metric: Metric):
         assert metric.user_config, "user_config is not specified in the metric config"
-        user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
 
-        # load the post processing function
-        post_processing_func = getattr(metric.user_config, "post_processing_func", None)
-        post_func = user_module.load_object(post_processing_func)
-        post_func_kwargs = cls._get_func_kwargs(metric, "post_processing_func")
-        if post_func_kwargs:
-            # apply the kwargs to the post processing function
-            post_func = partial(post_func, **post_func_kwargs)
-
-        # load the dataloader function and create the dataloader
-        dataloader_func = getattr(metric.user_config, "dataloader_func", None)
-        if dataloader_func:
-            dataloader = user_module.call_object(
-                dataloader_func,
-                metric.user_config.data_dir,
-                batch_size=metric.user_config.batch_size,
-                model_framework=framework,
-                **cls._get_func_kwargs(metric, "dataloader_func"),
-            )
-        else:
-            dataloader = None
+        dataloader = None
+        eval_func = None
+        post_func = None
 
         # load the evaluate function
         # priority: evaluate_func > metric_func
-        eval_func = None
         if metric.type == MetricType.CUSTOM:
             evaluate_func = getattr(metric.user_config, "evaluate_func", None)
-            kwargs = cls._get_func_kwargs(metric, "evaluate_func")
+            kwargs = getattr(metric.user_config, "evaluate_func_kwargs", None) or {}
             if not evaluate_func:
                 evaluate_func = getattr(metric.user_config, "metric_func", None)
-                kwargs = cls._get_func_kwargs(metric, "metric_func")
+                kwargs = getattr(metric.user_config, "metric_func_kwargs", None) or {}
 
             if not evaluate_func:
                 raise ValueError("evaluate_func or metric_func is not specified in the metric config")
 
+            user_module = UserModuleLoader(metric.user_config.user_script, metric.user_config.script_dir)
             eval_func = user_module.load_object(evaluate_func)
             if kwargs:
                 eval_func = partial(eval_func, **kwargs)
 
         # get dataloader and/or post processing function from data_config if not specified in the metric config
-        if (not dataloader or not post_func) and metric.data_config:
+        if metric.data_config:
             if metric.data_config.type in TRANSFORMER_DUMMY_DATA_CONTAINER:
                 metric.data_config.load_dataset_config.params["model_framework"] = framework
+
             dc = metric.data_config.to_data_container()
-
-            # TODO(trajep): remove user_scripts dataloader: we should respect user scripts
-            # dataloder to meet back compatibility for time being.
-            dataloader = dataloader or dc.create_dataloader()
-            post_func = post_func or dc.config.post_process
-
-        # get dataloader and/or post processing function from model io_config if not specified in the metric config
-        # or data config
-        if metric.user_config.input_names and metric.user_config.input_shapes and not dataloader and not eval_func:
-            dataloader = (
-                data_config_template.dummy_data_config_template(
-                    input_names=metric.user_config.input_names,
-                    input_shapes=metric.user_config.input_shapes,
-                    input_types=metric.user_config.input_types,
-                )
-                .to_data_container()
-                .create_dataloader()
-            )
+            dataloader = dc.create_dataloader()
+            post_func = dc.config.post_process
 
         return dataloader, eval_func, post_func
 
@@ -348,7 +311,7 @@ class OliveEvaluator(ABC):
         """Compute throughput metrics."""
         latency_metrics = OliveEvaluator.latency_helper(latencies)
         metric_res = {}
-        batch_size = metric.user_config.batch_size
+        batch_size = metric.data_config.dataloader_params.get("batch_size", 1) if metric.data_config else 1
         for sub_type in metric.sub_types:
             if sub_type.name == ThroughputSubType.MIN:
                 latency_sub_type_name = LatencySubType.MAX

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -296,7 +296,7 @@ class DockerSystem(OliveSystem):
         for k, v in model_mounts.items():
             model_json["config"][k] = v
 
-        return {"metrics": [k.dict() for k in metrics], "model": model_json}
+        return {"metrics": [k.to_json(check_object=True) for k in metrics], "model": model_json}
 
     @staticmethod
     def _create_runner_config(

--- a/olive/systems/docker/utils.py
+++ b/olive/systems/docker/utils.py
@@ -87,9 +87,27 @@ def create_metric_volumes_list(metrics: List["Metric"], container_root_path: Pat
             volume_list.append(f"{script_dir_path}:{script_dir_mount_path}")
             metric.user_config.script_dir = script_dir_mount_path
 
-        if metric.user_config.data_dir:
-            volume_list.append(f"{metric.user_config.data_dir}:{str(metric_path / 'data_dir')}")
-            metric.user_config.data_dir = str(metric_path / "data_dir")
+        if metric.data_config:
+            if metric.data_config.load_dataset_params.get("data_dir"):
+                data_dir_path = str(Path(metric.data_config.load_dataset_params.get("data_dir")).resolve())
+                volume_list.append(f"{data_dir_path}:{str(metric_path / 'data_dir')}")
+                metric.data_config.load_dataset_params["data_dir"] = str(metric_path / "data_dir")
+
+            if metric.data_config.user_script:
+                user_script_path = str(Path(metric.data_config.user_script).resolve())
+                user_script_name = Path(metric.data_config.user_script).name
+                user_script_mount_path = str(metric_path / user_script_name)
+
+                volume_list.append(f"{user_script_path}:{user_script_mount_path}")
+                metric.data_config.user_script = user_script_mount_path
+
+            if metric.data_config.script_dir:
+                script_dir_path = str(Path(metric.data_config.script_dir).resolve())
+                script_dir_name = Path(metric.data_config.script_dir).name
+                script_dir_mount_path = str(metric_path / script_dir_name)
+
+                volume_list.append(f"{script_dir_path}:{script_dir_mount_path}")
+                metric.data_config.script_dir = script_dir_mount_path
 
     return volume_list
 

--- a/test/integ_test/evaluator/azureml_eval/user_script.py
+++ b/test/integ_test/evaluator/azureml_eval/user_script.py
@@ -2,15 +2,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import torch
 from torchvision import datasets
 from torchvision.transforms import ToTensor
 
+from olive.data.registry import Registry
 
-def post_process(res):
+
+@Registry.register_post_process()
+def mnist_post_process_for_azureml_eval(res):
     return res.argmax(1)
 
 
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    dataset = datasets.MNIST(data_dir, download=True, transform=ToTensor())
-    return torch.utils.data.DataLoader(dataset, batch_size)
+@Registry.register_dataset()
+def mnist_dataset_for_azureml_eval(data_dir):
+    return datasets.MNIST(data_dir, download=True, transform=ToTensor())

--- a/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
+++ b/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
@@ -37,18 +37,28 @@ class TestDockerEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE: ClassVar[List] = [
-        ("PyTorchModel", get_pytorch_model, partial(get_accuracy_metric, "post_process"), 0.99),
+        ("PyTorchModel", get_pytorch_model, partial(get_accuracy_metric, "mnist_post_process_for_docker_eval"), 0.99),
         ("PyTorchModel", get_pytorch_model, get_latency_metric, 0.001),
         (
             "PyTorchModel",
             get_huggingface_model,
-            partial(get_accuracy_metric, "hf_post_process", "create_hf_dataloader"),
+            partial(get_accuracy_metric, "mnist_post_process_hf_for_docker_eval", "prajjwal1_dataset_for_docker_eval"),
             0.1,
         ),
-        ("PyTorchModel", get_huggingface_model, partial(get_latency_metric, "create_hf_dataloader"), 0.001),
-        ("ONNXModel", get_onnx_model, partial(get_accuracy_metric, "post_process"), 0.99),
+        (
+            "PyTorchModel",
+            get_huggingface_model,
+            partial(get_latency_metric, "prajjwal1_dataset_for_docker_eval"),
+            0.001,
+        ),
+        ("ONNXModel", get_onnx_model, partial(get_accuracy_metric, "mnist_post_process_for_docker_eval"), 0.99),
         ("ONNXModel", get_onnx_model, get_latency_metric, 0.001),
-        ("OpenVINOModel", get_openvino_model, partial(get_accuracy_metric, "openvino_post_process"), 0.99),
+        (
+            "OpenVINOModel",
+            get_openvino_model,
+            partial(get_accuracy_metric, "mnist_post_process_openvino_for_docker_eval"),
+            0.99,
+        ),
         ("OpenVINOModel", get_openvino_model, get_latency_metric, 0.001),
     ]
 

--- a/test/integ_test/evaluator/docker_eval/utils.py
+++ b/test/integ_test/evaluator/docker_eval/utils.py
@@ -10,6 +10,8 @@ from zipfile import ZipFile
 from torchvision import datasets
 from torchvision.transforms import ToTensor
 
+from olive.common.config_utils import validate_config
+from olive.data.config import DataComponentConfig, DataConfig
 from olive.evaluator.metric import AccuracySubType, LatencySubType, Metric, MetricType
 from olive.systems.docker import DockerSystem, LocalDockerConfig
 
@@ -25,40 +27,46 @@ def get_directories():
     data_dir = current_dir / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    return current_dir, models_dir, data_dir
+    user_script = current_dir / "user_script.py"
+
+    return current_dir, models_dir, data_dir, user_script
 
 
-current_dir, models_dir, data_dir = get_directories()
-user_script = str(current_dir / "user_script.py")
+_current_dir, _models_dir, _data_dir, _user_script = get_directories()
 
 
-def get_accuracy_metric(post_process, dataloader_func="create_dataloader"):
-    accuracy_metric_config = {
-        "user_script": user_script,
-        "post_processing_func": post_process,
-        "data_dir": data_dir,
-        "dataloader_func": dataloader_func,
-    }
+def _get_metric_data_config(name, dataset, post_process=None):
+    data_config = DataConfig(
+        name=name,
+        type="HuggingfaceContainer",
+        user_script=str(_user_script),
+        load_dataset_config=DataComponentConfig(
+            type=dataset,
+            params={"data_dir": str(_data_dir)},
+        ),
+        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
+    )
+    if post_process:
+        data_config.post_process_data_config = DataComponentConfig(type=post_process)
+    return validate_config(data_config, DataConfig)
+
+
+def get_accuracy_metric(post_process, dataset="mnist_dataset_for_docker_eval"):
     sub_types = [{"name": AccuracySubType.ACCURACY_SCORE, "metric_config": {"task": "multiclass", "num_classes": 10}}]
     return Metric(
         name="accuracy",
         type=MetricType.ACCURACY,
         sub_types=sub_types,
-        user_config=accuracy_metric_config,
+        data_config=_get_metric_data_config("accuracy_metric_data_config", dataset, post_process),
     )
 
 
-def get_latency_metric(dataloader_func="create_dataloader"):
-    latency_metric_config = {
-        "user_script": user_script,
-        "data_dir": data_dir,
-        "dataloader_func": dataloader_func,
-    }
+def get_latency_metric(dataset="mnist_dataset_for_docker_eval"):
     return Metric(
         name="latency",
         type=MetricType.LATENCY,
         sub_types=[{"name": LatencySubType.AVG}],
-        user_config=latency_metric_config,
+        data_config=_get_metric_data_config("latency_metric_data_config", dataset),
     )
 
 
@@ -66,18 +74,18 @@ def download_models():
     pytorch_model_config = {
         "container": "olivetest",
         "blob": "models/model.pt",
-        "download_path": models_dir / "model.pt",
+        "download_path": str(_models_dir / "model.pt"),
     }
     download_azure_blob(**pytorch_model_config)
 
     onnx_model_config = {
         "container": "olivetest",
         "blob": "models/model.onnx",
-        "download_path": models_dir / "model.onnx",
+        "download_path": str(_models_dir / "model.onnx"),
     }
     download_azure_blob(**onnx_model_config)
 
-    download_path = models_dir / "openvino.zip"
+    download_path = str(_models_dir / "openvino.zip")
     openvino_model_config = {
         "container": "olivetest",
         "blob": "models/openvino.zip",
@@ -85,12 +93,12 @@ def download_models():
     }
     download_azure_blob(**openvino_model_config)
     with ZipFile(download_path) as zip_ref:
-        zip_ref.extractall(models_dir)
-    return str(models_dir / "openvino")
+        zip_ref.extractall(_models_dir)
+    return str(_models_dir / "openvino")
 
 
 def download_data():
-    datasets.MNIST(data_dir, download=True, transform=ToTensor())
+    datasets.MNIST(str(_data_dir), download=True, transform=ToTensor())
 
 
 def get_huggingface_model():
@@ -98,26 +106,26 @@ def get_huggingface_model():
 
 
 def get_pytorch_model():
-    return {"model_path": str(models_dir / "model.pt")}
+    return {"model_path": str(_models_dir / "model.pt")}
 
 
 def get_onnx_model():
-    return {"model_path": str(models_dir / "model.onnx")}
+    return {"model_path": str(_models_dir / "model.onnx")}
 
 
 def get_openvino_model():
-    return {"model_path": str(models_dir / "openvino")}
+    return {"model_path": str(_models_dir / "openvino")}
 
 
 def delete_directories():
-    shutil.rmtree(data_dir)
-    shutil.rmtree(models_dir)
+    shutil.rmtree(_data_dir)
+    shutil.rmtree(_models_dir)
 
 
 def get_docker_target():
     local_docker_config = LocalDockerConfig(
         image_name="olive",
-        build_context_path=str(current_dir / "dockerfile"),
+        build_context_path=str(_current_dir / "dockerfile"),
         dockerfile="Dockerfile",
     )
     return DockerSystem(local_docker_config=local_docker_config, is_dev=True)

--- a/test/integ_test/evaluator/local_eval/test_local_evaluation.py
+++ b/test/integ_test/evaluator/local_eval/test_local_evaluation.py
@@ -14,8 +14,6 @@ from test.integ_test.evaluator.local_eval.utils import (
     get_onnx_model,
     get_openvino_model,
     get_pytorch_model,
-    openvino_post_process,
-    post_process,
 )
 from typing import ClassVar, List
 
@@ -37,13 +35,18 @@ class TestLocalEvaluation:
         delete_directories()
 
     EVALUATION_TEST_CASE: ClassVar[List] = [
-        ("PyTorchModel", get_pytorch_model, partial(get_accuracy_metric, post_process), 0.99),
+        ("PyTorchModel", get_pytorch_model, partial(get_accuracy_metric, "mnist_post_process_for_local_eval"), 0.99),
         ("PyTorchModel", get_pytorch_model, get_latency_metric, 0.001),
         ("PyTorchModel", get_huggingface_model, get_hf_accuracy_metric, 0.1),
         ("PyTorchModel", get_huggingface_model, get_hf_latency_metric, 0.001),
-        ("ONNXModel", get_onnx_model, partial(get_accuracy_metric, post_process), 0.99),
+        ("ONNXModel", get_onnx_model, partial(get_accuracy_metric, "mnist_post_process_for_local_eval"), 0.99),
         ("ONNXModel", get_onnx_model, get_latency_metric, 0.001),
-        ("OpenVINOModel", get_openvino_model, partial(get_accuracy_metric, openvino_post_process), 0.99),
+        (
+            "OpenVINOModel",
+            get_openvino_model,
+            partial(get_accuracy_metric, "mnist_post_process_openvino_for_local_eval"),
+            0.99,
+        ),
         ("OpenVINOModel", get_openvino_model, get_latency_metric, 0.001),
     ]
 

--- a/test/integ_test/evaluator/local_eval/user_script.py
+++ b/test/integ_test/evaluator/local_eval/user_script.py
@@ -9,24 +9,24 @@ from torchvision.transforms import ToTensor
 from olive.data.registry import Registry
 
 
+@Registry.register_dataset()
+def mnist_dataset_for_local_eval(data_dir):
+    return datasets.MNIST(data_dir, train=True, download=True, transform=ToTensor())
+
+
 @Registry.register_post_process()
-def mnist_post_process_for_docker_eval(res):
+def mnist_post_process_for_local_eval(res):
     return res.argmax(1)
 
 
 @Registry.register_post_process()
-def mnist_post_process_openvino_for_docker_eval(res):
+def mnist_post_process_openvino_for_local_eval(res):
     res = next(iter(res))
     return [res.argmax()]
 
 
-@Registry.register_dataset()
-def mnist_dataset_for_docker_eval(data_dir):
-    return datasets.MNIST(data_dir, transform=ToTensor())
-
-
 @Registry.register_post_process()
-def mnist_post_process_hf_for_docker_eval(res):
+def prajjwal1_post_process_for_local_eval(res):
     import transformers
 
     if isinstance(res, transformers.modeling_outputs.SequenceClassifierOutput):
@@ -37,7 +37,7 @@ def mnist_post_process_hf_for_docker_eval(res):
 
 
 @Registry.register_dataset()
-def prajjwal1_dataset_for_docker_eval(data_dir, *args, **kwargs):
+def prajjwal1_dataset_for_local_eval(data_dir, *args, **kwargs):
     from datasets import load_dataset
     from torch.utils.data import Dataset
     from transformers import AutoTokenizer

--- a/test/integ_test/evaluator/local_eval/utils.py
+++ b/test/integ_test/evaluator/local_eval/utils.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from test.integ_test.utils import download_azure_blob
 from zipfile import ZipFile
 
-import torch
-from torchvision import datasets
-from torchvision.transforms import ToTensor
-
+from olive.common.config_utils import validate_config
+from olive.data.config import DataComponentConfig, DataConfig
 from olive.evaluator.metric import AccuracySubType, LatencySubType, Metric, MetricType
 
 # pylint: disable=redefined-outer-name
@@ -25,115 +23,69 @@ def get_directories():
     data_dir = current_dir / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    return models_dir, data_dir
+    user_script = current_dir / "user_script.py"
+
+    return current_dir, models_dir, data_dir, user_script
 
 
-models_dir, data_dir = get_directories()
+_current_dir, _models_dir, _data_dir, _user_script = get_directories()
 
 
-def post_process(res):
-    return res.argmax(1)
-
-
-def openvino_post_process(res):
-    res = next(iter(res))
-    return [res.argmax()]
-
-
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    dataset = datasets.MNIST(data_dir, train=True, download=True, transform=ToTensor())
-    return torch.utils.data.DataLoader(dataset, batch_size)
-
-
-def hf_post_process(res):
-    import transformers
-
-    if isinstance(res, transformers.modeling_outputs.SequenceClassifierOutput):
-        _, preds = torch.max(res.logits, dim=1)
-    else:
-        _, preds = torch.max(res, dim=1)
-    return preds
-
-
-def create_hf_dataloader(data_dir, batch_size, *args, **kwargs):
-    from datasets import load_dataset
-    from torch.utils.data import Dataset
-    from transformers import AutoTokenizer
-
-    tokenizer = AutoTokenizer.from_pretrained("prajjwal1/bert-tiny")
-    dataset = load_dataset("glue", "mrpc", split="validation")
-
-    class BaseData(Dataset):
-        def __init__(self, data):
-            self.data = data
-
-        def __len__(self):
-            return 10
-
-        def __getitem__(self, idx):
-            data = {k: v for k, v in self.data[idx].items() if k != "label"}
-            return data, self.data[idx]["label"]
-
-    def _map(examples):
-        t_input = tokenizer(examples["sentence1"], examples["sentence2"], truncation=True, padding=True)
-        t_input["label"] = examples["label"]
-        return t_input
-
-    dataset = dataset.map(
-        _map,
-        batched=True,
-        remove_columns=dataset.column_names,
+def _get_metric_data_config(name, dataset, post_process=None):
+    data_config = DataConfig(
+        name=name,
+        type="HuggingfaceContainer",
+        user_script=str(_user_script),
+        load_dataset_config=DataComponentConfig(
+            type=dataset,
+            params={"data_dir": str(_data_dir)},
+        ),
+        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
     )
-    dataset.set_format(type="torch", output_all_columns=True)
-    return torch.utils.data.DataLoader(BaseData(dataset), batch_size)
+    if post_process:
+        data_config.post_process_data_config = DataComponentConfig(type=post_process)
+    return validate_config(data_config, DataConfig)
 
 
-def get_accuracy_metric(post_process, dataloader=create_dataloader):
-    accuracy_metric_config = {
-        "post_processing_func": post_process,
-        "data_dir": data_dir,
-        "dataloader_func": dataloader,
-    }
+def get_accuracy_metric(post_process, dataset="mnist_dataset_for_local_eval"):
     sub_types = [{"name": AccuracySubType.ACCURACY_SCORE, "metric_config": {"task": "multiclass", "num_classes": 10}}]
     return Metric(
         name="accuracy",
         type=MetricType.ACCURACY,
         sub_types=sub_types,
-        user_config=accuracy_metric_config,
+        data_config=_get_metric_data_config("accuracy_metric_data_config", dataset, post_process),
     )
 
 
-def get_latency_metric(dataloader=create_dataloader):
-    latency_metric_config = {
-        "data_dir": data_dir,
-        "dataloader_func": dataloader,
-    }
+def get_latency_metric(dataset="mnist_dataset_for_local_eval"):
     sub_types = [{"name": LatencySubType.AVG}]
     return Metric(
         name="latency",
         type=MetricType.LATENCY,
         sub_types=sub_types,
-        user_config=latency_metric_config,
+        data_config=_get_metric_data_config("latency_metric_data_config", dataset),
     )
 
 
-def get_hf_accuracy_metric(post_process=hf_post_process, dataloader=create_hf_dataloader):
-    return get_accuracy_metric(post_process, dataloader)
+def get_hf_accuracy_metric(
+    post_process="prajjwal1_post_process_for_local_eval", dataset="prajjwal1_dataset_for_local_eval"
+):
+    return get_accuracy_metric(post_process, dataset)
 
 
-def get_hf_latency_metric(dataloader=create_hf_dataloader):
-    return get_latency_metric(dataloader)
+def get_hf_latency_metric(dataset="prajjwal1_dataset_for_local_eval"):
+    return get_latency_metric(dataset)
 
 
 def get_pytorch_model():
-    download_path = models_dir / "model.pt"
+    download_path = str(_models_dir / "model.pt")
     pytorch_model_config = {
         "container": "olivetest",
         "blob": "models/model.pt",
         "download_path": download_path,
     }
     download_azure_blob(**pytorch_model_config)
-    return {"model_path": str(download_path)}
+    return {"model_path": download_path}
 
 
 def get_huggingface_model():
@@ -141,18 +93,18 @@ def get_huggingface_model():
 
 
 def get_onnx_model():
-    download_path = models_dir / "model.onnx"
+    download_path = str(_models_dir / "model.onnx")
     onnx_model_config = {
         "container": "olivetest",
         "blob": "models/model.onnx",
         "download_path": download_path,
     }
     download_azure_blob(**onnx_model_config)
-    return {"model_path": str(download_path)}
+    return {"model_path": download_path}
 
 
 def get_openvino_model():
-    download_path = models_dir / "openvino.zip"
+    download_path = str(_models_dir / "openvino.zip")
     openvino_model_config = {
         "container": "olivetest",
         "blob": "models/openvino.zip",
@@ -160,10 +112,10 @@ def get_openvino_model():
     }
     download_azure_blob(**openvino_model_config)
     with ZipFile(download_path) as zip_ref:
-        zip_ref.extractall(models_dir)
-    return {"model_path": str(models_dir / "openvino")}
+        zip_ref.extractall(_models_dir)
+    return {"model_path": str(_models_dir / "openvino")}
 
 
 def delete_directories():
-    shutil.rmtree(data_dir)
-    shutil.rmtree(models_dir)
+    shutil.rmtree(_data_dir)
+    shutil.rmtree(_models_dir)

--- a/test/multiple_ep/test_docker_system.py
+++ b/test/multiple_ep/test_docker_system.py
@@ -5,6 +5,7 @@
 import logging
 import platform
 from pathlib import Path
+from test.multiple_ep.utils import get_directories
 
 import pytest
 
@@ -35,6 +36,7 @@ class TestOliveManagedDockerSystem:
                 is_dev=True,
             ),
         )
+        get_directories()
         download_models()
         self.input_model_config = ModelConfig.parse_obj(
             {"type": "ONNXModel", "config": {"model_path": get_onnx_model()}}

--- a/test/multiple_ep/user_script.py
+++ b/test/multiple_ep/user_script.py
@@ -2,15 +2,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import torch
 from torchvision import datasets
 from torchvision.transforms import ToTensor
 
+from olive.data.registry import Registry
 
-def post_process(res):
+
+@Registry.register_post_process()
+def mnist_post_process_for_multiple_ep(res):
     return res.argmax(1)
 
 
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    dataset = datasets.MNIST(data_dir, transform=ToTensor())
-    return torch.utils.data.DataLoader(dataset, batch_size)
+@Registry.register_dataset()
+def mnist_dataset_for_multiple_ep(data_dir, *args, **kwargs):
+    return datasets.MNIST(data_dir, transform=ToTensor())

--- a/test/multiple_ep/utils.py
+++ b/test/multiple_ep/utils.py
@@ -8,6 +8,7 @@ from test.integ_test.utils import download_azure_blob
 from torchvision import datasets
 from torchvision.transforms import ToTensor
 
+from olive.data.config import DataComponentConfig, DataConfig
 from olive.engine import Engine
 from olive.engine.cloud_cache_helper import CloudCacheConfig
 from olive.evaluator.metric import LatencySubType, Metric, MetricType
@@ -27,24 +28,31 @@ def get_directories():
     data_dir = current_dir / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    return current_dir, models_dir, data_dir
+    user_script = current_dir / "user_script.py"
+
+    return current_dir, models_dir, data_dir, user_script
 
 
-current_dir, models_dir, data_dir = get_directories()
-user_script = str(current_dir / "user_script.py")
+_current_dir, _models_dir, _data_dir, _user_script = get_directories()
 
 
 def get_latency_metric():
-    latency_metric_config = {
-        "user_script": user_script,
-        "data_dir": str(data_dir),
-        "dataloader_func": "create_dataloader",
-    }
+    data_config = DataConfig(
+        name="latency_metric_data_config",
+        type="HuggingfaceContainer",
+        user_script=str(_user_script),
+        load_dataset_config=DataComponentConfig(
+            type="mnist_dataset_for_multiple_ep",
+            params={"data_dir": str(_data_dir)},
+        ),
+        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
+        post_process_data_config=DataComponentConfig(type="skip_post_process"),
+    )
     return Metric(
         name="latency",
         type=MetricType.LATENCY,
         sub_types=[{"name": LatencySubType.AVG}],
-        user_config=latency_metric_config,
+        data_config=data_config,
     )
 
 
@@ -52,24 +60,24 @@ def download_models():
     pytorch_model_config = {
         "container": "olivetest",
         "blob": "models/model.pt",
-        "download_path": models_dir / "model.pt",
+        "download_path": str(_models_dir / "model.pt"),
     }
     download_azure_blob(**pytorch_model_config)
 
     onnx_model_config = {
         "container": "olivetest",
         "blob": "models/model.onnx",
-        "download_path": models_dir / "model.onnx",
+        "download_path": str(_models_dir / "model.onnx"),
     }
     download_azure_blob(**onnx_model_config)
 
 
 def download_data():
-    datasets.MNIST(data_dir, download=True, transform=ToTensor())
+    datasets.MNIST(str(_data_dir), download=True, transform=ToTensor())
 
 
 def get_onnx_model():
-    return str(models_dir / "model.onnx")
+    return str(_models_dir / "model.onnx")
 
 
 def create_and_run_workflow(tmp_path, system_config, model_config, metric, only_target=False):

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -282,27 +282,6 @@ class TestOliveEvaluator:
         with pytest.raises(ValueError, match="evaluate_func or metric_func is not specified in the metric config"):
             evaluator.evaluate(olive_model, [metric])
 
-    @pytest.mark.parametrize(
-        "dataloader_func_kwargs", [None, {"kwarg_1": "value_1"}, {"kwarg_1": "value_1", "kwarg_2": "value_2"}]
-    )
-    def test_dataloader_func_kwargs(self, dataloader_func_kwargs):
-        # setup
-        dataloader_func = MagicMock(spec=FunctionType)
-        data_dir = None
-        model_framework = "PyTorch"
-        user_config = {"dataloader_func": dataloader_func, "data_dir": data_dir}
-        if dataloader_func_kwargs:
-            user_config["func_kwargs"] = {"dataloader_func": dataloader_func_kwargs}
-        metric = get_latency_metric(LatencySubType.AVG, user_config=user_config)
-
-        # execute
-        OliveEvaluator.get_user_config(model_framework, metric)
-
-        # assert
-        dataloader_func.assert_called_once_with(
-            data_dir, batch_size=1, model_framework=model_framework, **(dataloader_func_kwargs or {})
-        )
-
     # this is enough to test the kwargs for `evaluate_func`, `metric_func` and `post_process_func`
     # since they are all using the same `get_user_config` method
     @pytest.mark.parametrize(
@@ -310,11 +289,10 @@ class TestOliveEvaluator:
     )
     def test_evaluate_func_kwargs(self, evaluate_func_kwargs):
         # setup
-        dataloader_func = MagicMock(spec=FunctionType)
         evaluate_func = MagicMock(spec=FunctionType)
-        user_config = {"dataloader_func": dataloader_func, "evaluate_func": evaluate_func}
+        user_config = {"evaluate_func": evaluate_func}
         if evaluate_func_kwargs:
-            user_config["func_kwargs"] = {"evaluate_func": evaluate_func_kwargs}
+            user_config["evaluate_func_kwargs"] = evaluate_func_kwargs
         metric = get_custom_metric(user_config=user_config)
 
         # execute

--- a/test/unit_test/passes/openvino/test_openvino_quantization.py
+++ b/test/unit_test/passes/openvino/test_openvino_quantization.py
@@ -8,13 +8,27 @@ from pathlib import Path
 import pytest
 import torch
 
-from olive.data.config import DataConfig
+from olive.data.config import DataComponentConfig, DataConfig
 from olive.data.registry import Registry
 from olive.hardware import AcceleratorSpec
 from olive.model import PyTorchModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.openvino.conversion import OpenVINOConversion
 from olive.passes.openvino.quantization import OpenVINOQuantization
+
+
+@Registry.register_dataset()
+def cifar10_dataset(data_dir):
+    from torchvision.datasets import CIFAR10
+    from torchvision.transforms import ToTensor
+
+    return CIFAR10(root=data_dir, train=False, transform=ToTensor(), download=True)
+
+
+def cifar10_dataloader(data_dir, batch_size, *args, **kwargs):
+    from torch.utils.data.dataloader import DataLoader
+
+    return DataLoader(cifar10_dataset(data_dir), batch_size, shuffle=True)
 
 
 @pytest.mark.parametrize("data_source", ["dataloader_func", "data_config"])
@@ -27,7 +41,7 @@ def test_openvino_quantization(data_source, tmp_path):
     if data_source == "dataloader_func":
         config.update(
             {
-                "dataloader_func": create_dataloader,
+                "dataloader_func": cifar10_dataloader,
                 "data_dir": data_dir,
             }
         )
@@ -36,10 +50,11 @@ def test_openvino_quantization(data_source, tmp_path):
             {
                 "data_config": DataConfig(
                     name="test_dc_config",
-                    load_dataset_config={
-                        "type": "cifar10_dataset",
-                        "params": {"data_dir": data_dir},
-                    },
+                    load_dataset_config=DataComponentConfig(
+                        type="cifar10_dataset",
+                        params={"data_dir": data_dir},
+                    ),
+                    dataloader_config=DataComponentConfig(params={"shuffle": True}),
                 )
             }
         )
@@ -74,7 +89,7 @@ def test_openvino_quantization_with_accuracy(data_source, tmp_path):
     if data_source == "dataloader_func":
         config.update(
             {
-                "dataloader_func": create_dataloader,
+                "dataloader_func": cifar10_dataloader,
                 "data_dir": data_dir,
             }
         )
@@ -83,10 +98,11 @@ def test_openvino_quantization_with_accuracy(data_source, tmp_path):
             {
                 "data_config": DataConfig(
                     name="test_dc_config",
-                    load_dataset_config={
-                        "type": "cifar10_dataset",
-                        "params": {"data_dir": data_dir},
-                    },
+                    load_dataset_config=DataComponentConfig(
+                        type="cifar10_dataset",
+                        params={"data_dir": data_dir},
+                    ),
+                    dataloader_config=DataComponentConfig(params={"shuffle": True}),
                 )
             }
         )
@@ -133,20 +149,3 @@ def get_openvino_model(tmp_path):
 
     # execute
     return p.run(pytorch_model, output_folder)
-
-
-@Registry.register_dataset()
-def cifar10_dataset(data_dir):
-    from torchvision.datasets import CIFAR10
-    from torchvision.transforms import ToTensor
-
-    return CIFAR10(root=data_dir, train=False, transform=ToTensor(), download=True)
-
-
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    from torch.utils.data.dataloader import DataLoader
-    from torchvision.datasets import CIFAR10
-    from torchvision.transforms import ToTensor
-
-    dataset = CIFAR10(root=data_dir, train=False, transform=ToTensor(), download=True)
-    return DataLoader(dataset, batch_size, shuffle=True)

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -63,12 +63,8 @@ class TestLocalSystem:
     @patch("olive.evaluator.olive_evaluator.OnnxEvaluator._evaluate_accuracy")
     @patch("olive.evaluator.olive_evaluator.OnnxEvaluator._evaluate_latency")
     @patch("olive.evaluator.olive_evaluator.OnnxEvaluator._evaluate_custom")
-    @patch(
-        "olive.evaluator.olive_evaluator.OliveEvaluator.generate_metric_user_config_with_model_io",
-        side_effect=lambda x, _: x,
-    )
     def test_evaluate_model(
-        self, _, mock_evaluate_custom, mock_evaluate_latency, mock_evaluate_accuracy, mock_get_user_config, metric_func
+        self, mock_evaluate_custom, mock_evaluate_latency, mock_evaluate_accuracy, mock_get_user_config, metric_func
     ):
         # setup
         olive_model_config = MagicMock()

--- a/test/unit_test/workflows/mock_data/transformer_dataset.json
+++ b/test/unit_test/workflows/mock_data/transformer_dataset.json
@@ -29,10 +29,7 @@
                 }
             },
             "pre_process_data_config": {
-                "params": {
-                    "input_cols": [ "sentence1", "sentence2" ],
-                    "label_cols": [ "label" ]
-                }
+                "params": { "input_cols": [ "sentence1", "sentence2" ], "label_cols": [ "label" ] }
             },
             "dataloader_config": { "params": { "batch_size": 1 } }
         }
@@ -79,10 +76,7 @@
             "disable_search": true,
             "config": { "model_type": "bert" }
         },
-        "quantization": {
-            "type": "OnnxQuantization",
-            "config": { "data_config": "glue_mrpc" }
-        },
+        "quantization": { "type": "OnnxQuantization", "config": { "data_config": "glue_mrpc" } },
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {

--- a/test/unit_test/workflows/mock_data/user_script.json
+++ b/test/unit_test/workflows/mock_data/user_script.json
@@ -12,10 +12,7 @@
                 "input_names": [ "input" ],
                 "input_shapes": [ [ 1, 3, 32, 32 ] ],
                 "output_names": [ "output" ],
-                "dynamic_axes": {
-                    "input": { "0": "batch_size" },
-                    "output": { "0": "batch_size" }
-                }
+                "dynamic_axes": { "input": { "0": "batch_size" }, "output": { "0": "batch_size" } }
             }
         }
     },
@@ -23,7 +20,8 @@
         "local_system": { "type": "LocalSystem" },
         "azureml_system": {
             "type": "AzureML",
-            "config": { "accelerators": [ { "device": "CPU", "execution_providers": [ "CPUExecutionProvider" ] } ],
+            "config": {
+                "accelerators": [ { "device": "CPU", "execution_providers": [ "CPUExecutionProvider" ] } ],
                 "aml_compute": "cpu-cluster",
                 "aml_docker_config": {
                     "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
@@ -33,12 +31,40 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "accuracy_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "test/unit_test/assets/user_script.py",
+            "load_dataset_config": {
+                "params": {
+                    "data_dir": {
+                        "type": "azureml_datastore",
+                        "config": { "datastore_name": "my_datastore", "relative_path": "data" }
+                    }
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 16 } }
+        },
+        {
+            "name": "latency_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "test/unit_test/assets/user_script.py",
+            "load_dataset_config": {
+                "params": {
+                    "data_dir": "azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test/test/cifar-10-batches-py"
+                }
+            },
+            "dataloader_config": { "params": { "batch_size": 16 } }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "accuracy",
                     "type": "custom",
+                    "data_config": "accuracy_data_config",
                     "sub_types": [
                         {
                             "name": "top1",
@@ -49,18 +75,14 @@
                         { "name": "top5", "goal": { "type": "max-degradation", "value": 0.01 } }
                     ],
                     "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": {
-                            "type": "azureml_datastore",
-                            "config": { "datastore_name": "my_datastore", "relative_path": "data" }
-                        },
-                        "evaluate_func": "eval_accuracy",
-                        "batch_size": 16
+                        "user_script": "test/unit_test/assets/user_script.py",
+                        "evaluate_func": "eval_accuracy"
                     }
                 },
                 {
                     "name": "latency",
                     "type": "latency",
+                    "data_config": "latency_data_config",
                     "sub_types": [
                         {
                             "name": "avg",
@@ -70,13 +92,7 @@
                         },
                         { "name": "max" },
                         { "name": "min" }
-                    ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "data_dir": "azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test/test/cifar-10-batches-py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 16
-                    }
+                    ]
                 }
             ]
         }
@@ -86,7 +102,7 @@
         "onnx_quantization": {
             "type": "OnnxQuantization",
             "config": {
-                "user_script": "user_script.py",
+                "user_script": "test/unit_test/assets/user_script.py",
                 "data_dir": "data",
                 "dataloader_func": "resnet_calibration_reader",
                 "weight_type": "QUInt8",
@@ -97,7 +113,7 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "user_script": "user_script.py",
+                "user_script": "test/unit_test/assets/user_script.py",
                 "dataloader_func": "create_dataloader",
                 "batch_size": 16,
                 "data_dir": {

--- a/test/unit_test/workflows/test_whisper_workflow.py
+++ b/test/unit_test/workflows/test_whisper_workflow.py
@@ -10,7 +10,6 @@ from test.unit_test.workflows.whisper_utils import (
     get_decoder,
     get_encdec_io_config,
     get_encoder_decoder_init,
-    whisper_audio_decoder_dataloader,
 )
 from urllib import request
 
@@ -67,14 +66,25 @@ def prepare_whisper_config(audio_data, tmp_path):
                 "config": {"accelerators": [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}]},
             }
         },
+        "data_configs": [
+            {
+                "name": "latency_data_config",
+                "type": "HuggingfaceContainer",
+                "user_script": "test/unit_test/workflows/whisper_utils.py",
+                "load_dataset_config": {"type": "whisper_audio_decoder_dataset", "params": {"data_dir": audio_data}},
+                "pre_process_data_config": {"type": "skip_pre_process"},
+                "post_process_data_config": {"type": "skip_post_process"},
+                "dataloader_config": {"type": "no_auto_batch_dataloader"},
+            }
+        ],
         "evaluators": {
             "common_evaluator": {
                 "metrics": [
                     {
                         "name": "latency",
                         "type": "latency",
+                        "data_config": "latency_data_config",
                         "sub_types": [{"name": "avg", "priority": 1}],
-                        "user_config": {"data_dir": audio_data, "dataloader_func": whisper_audio_decoder_dataloader},
                     }
                 ]
             }

--- a/test/unit_test/workflows/test_workflow_run.py
+++ b/test/unit_test/workflows/test_workflow_run.py
@@ -1,5 +1,4 @@
 from test.unit_test.utils import (
-    create_dummy_dataloader,
     get_pytorch_model,
     get_pytorch_model_config,
     get_pytorch_model_io_config,
@@ -30,10 +29,10 @@ EVALUATORS_CONFIG = {
                     "name": "avg",
                 },
             ],
-            "user_config": {"dataloader_func": create_dummy_dataloader},
         }
     ]
 }
+
 PASS_CONFIG = {
     "qat": {
         "type": "QuantizationAwareTraining",
@@ -81,7 +80,7 @@ def test_run_without_ep(mock_model_to_json, mock_model_from_json, mock_run, conf
 
     mock_run.return_value = get_pytorch_model()
     mock_model_from_json.return_value = get_pytorch_model_config()
-    mock_model_to_json.return_value = {"type": "PyTorchModel", "config": {}}
+    mock_model_to_json.return_value = {"type": "PyTorchModel", "config": {"io_config": {}}}
     ret = olive_run(config)
     assert len(ret) == 1
     assert next(iter(ret)) == AcceleratorSpec("cpu")

--- a/test/unit_test/workflows/whisper_utils.py
+++ b/test/unit_test/workflows/whisper_utils.py
@@ -5,6 +5,8 @@ import numpy as np
 import torch
 from transformers import AutoConfig, AutoProcessor, WhisperConfig, file_utils
 
+from olive.data.registry import Registry
+
 if TYPE_CHECKING:
     from olive.model.handler.pytorch import PyTorchModelHandler
 
@@ -165,7 +167,8 @@ def encoder_decoder_init_dummy_inputs(olive_model: "PyTorchModelHandler"):
     return tuple(inputs.to_list())
 
 
-def whisper_audio_decoder_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataset()
+def whisper_audio_decoder_dataset(data_dir, *args, **kwargs):
     return WhisperDataset(data_dir=data_dir, use_audio_decoder=True)
 
 


### PR DESCRIPTION
## Use DataConfig based metric configuration

* Deprecated dataloader_func, func_args, data_dir, batch_size, input_names, input_shapes, and input_types for metric configuration
* Default data component is still a data component and should be registered as such. Also, certain data component can be registered with multiple different names.
* Fixed a bug in docker system where the config wasn't being serialized correctly.
* Added support for DataConfig/user_script and DataConfig/script_dir to both AMLSystem and DockerSystem.
* Updated all examples and tests to use the DataConfig based metric configuration.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
