### PR TITLE
AzureMLSystem: Generalize resource mount

### DIFF
--- a/examples/test/test_resnet_ptq_cpu.py
+++ b/examples/test/test_resnet_ptq_cpu.py
@@ -31,7 +31,7 @@ def setup():
 
 @pytest.mark.parametrize("search_algorithm", ["random"])
 @pytest.mark.parametrize("execution_order", ["pass-by-pass"])
-@pytest.mark.parametrize("system", ["aml_system"])
+@pytest.mark.parametrize("system", ["local_system", "aml_system"])
 @pytest.mark.parametrize(
     "olive_json",
     [

--- a/examples/test/test_resnet_ptq_cpu.py
+++ b/examples/test/test_resnet_ptq_cpu.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from onnxruntime import __version__ as OrtVersion
 from packaging import version
-from utils import check_output, patch_config, set_azure_identity_logging
+from utils import check_output, patch_config
 
 from olive.common.utils import retry_func, run_subprocess
 
@@ -24,14 +24,14 @@ def setup():
     # retry since it fails randomly
     retry_func(run_subprocess, kwargs={"cmd": "python prepare_model_data.py", "check": True})
 
-    set_azure_identity_logging()
+    # set_azure_identity_logging()
     yield
     os.chdir(cur_dir)
 
 
 @pytest.mark.parametrize("search_algorithm", ["random"])
 @pytest.mark.parametrize("execution_order", ["pass-by-pass"])
-@pytest.mark.parametrize("system", ["local_system", "aml_system"])
+@pytest.mark.parametrize("system", ["aml_system"])
 @pytest.mark.parametrize(
     "olive_json",
     [

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -79,8 +79,12 @@ def update_azureml_config(olive_config):
     if workspace_name is None:
         raise Exception("Please set the environment variable WORKSPACE_NAME")
 
+    exclude_managed_identity_credential = (
+        {"exclude_managed_identity_credential": True} if "EXCLUDE_MANAGED_IDENTITY_CREDENTIAL" in os.environ else {}
+    )
+
     client_id = os.environ.get("MANAGED_IDENTITY_CLIENT_ID")
-    if client_id is None:
+    if client_id is None and not exclude_managed_identity_credential:
         raise Exception("Please set the environment variable MANAGED_IDENTITY_CLIENT_ID")
 
     olive_config["azureml_client"] = {
@@ -88,7 +92,7 @@ def update_azureml_config(olive_config):
         "resource_group": resource_group,
         "workspace_name": workspace_name,
         # pipeline agents have multiple managed identities, so we need to specify the client_id
-        "default_auth_params": {"managed_identity_client_id": client_id},
+        "default_auth_params": {"managed_identity_client_id": client_id, **exclude_managed_identity_credential},
     }
 
 

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -210,6 +210,7 @@ class ConfigWithExtraArgs(ConfigBase):
         return values
 
 
+# TODO(jambayk): remove ParamCategory once validate object is removed or updated
 class ParamCategory(str, Enum):
     NONE = "none"
     OBJECT = "object"

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -151,7 +151,17 @@ def flatten_dict(dictionary, stop_condition=None):  # pragma: no cover
     return result
 
 
-def replace_dict_value(dictionary: Dict, key: Union[str, Tuple, List[str]], new_value):
+def get_dict_value(dictionary: dict, key: Union[str, Tuple, List[str]]):
+    """Get value from a nested dictionary."""
+    if isinstance(key, str):
+        key = [key]
+
+    for k in key:
+        dictionary = dictionary[k]
+    return dictionary
+
+
+def set_dict_value(dictionary: dict, key: Union[str, Tuple, List[str]], new_value):
     """Replace value in a nested dictionary."""
     if isinstance(key, str):
         key = [key]

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -151,6 +151,16 @@ def flatten_dict(dictionary, stop_condition=None):  # pragma: no cover
     return result
 
 
+def replace_dict_value(dictionary: Dict, key: Union[str, Tuple, List[str]], new_value):
+    """Replace value in a nested dictionary."""
+    if isinstance(key, str):
+        key = [key]
+
+    for k in key[:-1]:
+        dictionary = dictionary[k]
+    dictionary[key[-1]] = new_value
+
+
 def retry_func(func, args=None, kwargs=None, max_tries=3, delay=5, backoff=2, exceptions=None):
     """Retry a function call using an exponential backoff.
 

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -107,32 +107,32 @@ class ResourcePathConfig(ConfigBase):
         return ResourcePath.registry[self.type](self.config)
 
 
+VALID_RESOURCE_CONFIGS = (str, Path, dict, ResourcePathConfig, ResourcePath)
+OLIVE_RESOURCE_ANNOTATIONS = Optional[Union[str, Path, dict, ResourcePathConfig, ResourcePath]]
+
+
 def create_resource_path(
-    resource_path: Optional[Union[str, Path, Dict[str, Any], ResourcePathConfig, ResourcePath]]
+    resource_path: OLIVE_RESOURCE_ANNOTATIONS,
 ) -> Optional[Union[ResourcePath, List[ResourcePath]]]:
     """Create a resource path from a string or a dict.
 
-    If a string is provided, it is inferred to be a file, folder, or string name.
-    If a Path is provided, it is inferred to be a file or folder.
+    If a string or Path is provided, it is inferred to be a file, folder, or string name.
     If a dict is provided, it must have "type" and "config" fields. The "type" field must be one of the
     values in the ResourceType enum. The "config" field must be a dict that can be used to create a resource
     config of the specified type.
 
-    :param resource_path: A string, a Path, or a dict.
+    :param resource_path:
     :return: A resource path.
     """
     if resource_path is None:
         return None
     if isinstance(resource_path, ResourcePath):
         return resource_path
-    if isinstance(resource_path, list):
-        return [create_resource_path(rp) for rp in resource_path]
     if isinstance(resource_path, (ResourcePathConfig, dict)):
         resource_path_config = validate_config(resource_path, ResourcePathConfig)
         return resource_path_config.create_resource_path()
 
     # check if the resource path is a file, folder, azureml datastore, or a string name
-    is_local_file = True
     resource_type: ResourceType = None
     config_key = None
     if Path(resource_path).is_file():
@@ -144,16 +144,10 @@ def create_resource_path(
     elif str(resource_path).startswith("azureml://"):
         resource_type = ResourceType.AzureMLDatastore
         config_key = "datastore_url"
-        is_local_file = False
     else:
         resource_type = ResourceType.StringName
         config_key = "name"
-        is_local_file = False
 
-    if is_local_file and isinstance(resource_path, Path) and not resource_path.exists():
-        raise ValueError(f"Resource path {resource_path} of type Path does not exist.")
-
-    logger.debug("Resource path %s is inferred to be of type %s.", resource_path, resource_type)
     return ResourcePathConfig(type=resource_type, config={config_key: resource_path}).create_resource_path()
 
 
@@ -163,6 +157,31 @@ def validate_resource_path(v, values, field):
     except ValueError as e:
         raise ValueError(f"Invalid resource path '{v}': {e}") from None
     return v
+
+
+def find_all_resources(config) -> Dict[str, ResourcePath]:
+    """Find all resources in a config.
+
+    :param config: The config to search for resources.
+    :return: A dictionary of all resources found in the config.
+        keys are tuples representing the path to the resource in the config and the values are
+        the resource paths.
+    """
+    if isinstance(config, VALID_RESOURCE_CONFIGS):
+        try:
+            resource_path = create_resource_path(config)
+            if resource_path.is_string_name():
+                return {}
+            return {(): resource_path}
+        except ValueError:
+            pass
+
+    resources = {}
+    if isinstance(config, (dict, list)):
+        for k, v in config.items() if isinstance(config, dict) else enumerate(config):
+            resources.update({(k, *k2): v2 for k2, v2 in find_all_resources(v).items()})
+
+    return resources
 
 
 def _overwrite_helper(new_path: Union[Path, str], overwrite: bool):
@@ -593,6 +612,3 @@ class AzureMLJobOutput(ResourcePath):
             new_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(temp_dir / "named-outputs" / self.config.output_name / self.config.relative_path, new_path)
         return str(new_path)
-
-
-OLIVE_RESOURCE_ANNOTATIONS = Optional[Union[str, Path, ResourcePath, ResourcePathConfig]]

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -159,10 +159,11 @@ def validate_resource_path(v, values, field):
     return v
 
 
-def find_all_resources(config) -> Dict[str, ResourcePath]:
+def find_all_resources(config, ignore_keys: Optional[List[str]] = None) -> Dict[str, ResourcePath]:
     """Find all resources in a config.
 
     :param config: The config to search for resources.
+    :param ignore_keys: A list of keys to ignore when searching for resources.
     :return: A dictionary of all resources found in the config.
         keys are tuples representing the path to the resource in the config and the values are
         the resource paths.
@@ -179,7 +180,9 @@ def find_all_resources(config) -> Dict[str, ResourcePath]:
     resources = {}
     if isinstance(config, (dict, list)):
         for k, v in config.items() if isinstance(config, dict) else enumerate(config):
-            resources.update({(k, *k2): v2 for k2, v2 in find_all_resources(v).items()})
+            if ignore_keys and k in ignore_keys:
+                continue
+            resources.update({(k, *k2): v2 for k2, v2 in find_all_resources(v, ignore_keys=ignore_keys).items()})
 
     return resources
 

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import argparse
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,40 +11,10 @@ from olive.hardware import AcceleratorSpec
 from olive.logging import set_verbosity_from_env
 from olive.model import ModelConfig
 from olive.systems.local import LocalSystem
-from olive.systems.utils import get_common_args
+from olive.systems.utils import get_common_args, parse_config
 
 if TYPE_CHECKING:
     from olive.systems.olive_system import OliveSystem
-
-
-def parse_metric_args(raw_args):
-    # TODO(xiaoyu): add support for metric datafiles if needed.
-    parser = argparse.ArgumentParser("Metric config")
-
-    parser.add_argument("--metric_config", type=str, help="pass config", required=True)
-    parser.add_argument("--metric_user_script", type=str, help="metric user script")
-    parser.add_argument("--metric_script_dir", type=str, help="metric script dir")
-    parser.add_argument("--metric_data_dir", type=str, help="metric data dir")
-
-    return parser.parse_known_args(raw_args)
-
-
-def parse_accelerator_args(raw_args):
-    parser = argparse.ArgumentParser("Accelerator config")
-    parser.add_argument("--accelerator_config", type=str, help="accelerator config", required=True)
-
-    return parser.parse_args(raw_args)
-
-
-def create_metric(metric_config, metric_args):
-    for key, value in vars(metric_args).items():
-        if key == "metric_config":
-            continue
-        if value is not None:
-            key_mod = key.replace("metric_", "")
-            metric_config["user_config"][key_mod] = value
-
-    return Metric.from_json(metric_config)
 
 
 def main(raw_args=None):
@@ -56,19 +24,16 @@ def main(raw_args=None):
     aml_runner_hf_login()
 
     model_config, pipeline_output, extra_args = get_common_args(raw_args)
-    metric_args, extra_args = parse_metric_args(extra_args)
-    accelerator_args = parse_accelerator_args(extra_args)
+    metric_config, extra_args = parse_config(extra_args, "metric")
+    accelerator_config, extra_args = parse_config(extra_args, "accelerator")
 
     # load metric
-    with open(metric_args.metric_config) as f:
-        metric_config = json.load(f)
-    metric = create_metric(metric_config, metric_args)
+    metric = Metric.from_json(metric_config)
 
     # load model config
     model_config = ModelConfig.from_json(model_config)
 
-    with open(accelerator_args.accelerator_config) as f:
-        accelerator_config = json.load(f)
+    # load accelerator spec
     accelerator_spec = AcceleratorSpec(**accelerator_config)
 
     target: OliveSystem = LocalSystem()

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -48,11 +48,10 @@ def main(raw_args=None):
     model_json["resources"] = []
     # keep track of the resource names that are the same as the input model
     model_json["same_resources_as_input"] = []
-    # resources
-    # hf model attributes has a special key "_model_name_or_path" that should be ignored since it points to
-    # where the config was loaded from
-    input_model_resources = find_all_resources(input_model_config, ignore_keys=["_model_name_or_path"])
-    output_model_resources = find_all_resources(model_json, ignore_keys=["_model_name_or_path"])
+    # resources, no need to look at model_attributes. It might have unintended resources like
+    # _model_name_or_path from hf config which points to where the config was loaded from
+    input_model_resources = find_all_resources(input_model_config, ignore_keys=["model_attributes"])
+    output_model_resources = find_all_resources(model_json, ignore_keys=["model_attributes"])
     for resource_key, resource_path in output_model_resources.items():
         input_model_resource_path = input_model_resources.get(resource_key)
         if resource_path.get_path() == (input_model_resource_path.get_path() if input_model_resource_path else None):

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -49,8 +49,10 @@ def main(raw_args=None):
     # keep track of the resource names that are the same as the input model
     model_json["same_resources_as_input"] = []
     # resources
-    input_model_resources = find_all_resources(input_model_config)
-    output_model_resources = find_all_resources(model_json)
+    # hf model attributes has a special key "_model_name_or_path" that should be ignored since it points to
+    # where the config was loaded from
+    input_model_resources = find_all_resources(input_model_config, ignore_keys=["_model_name_or_path"])
+    output_model_resources = find_all_resources(model_json, ignore_keys=["_model_name_or_path"])
     for resource_key, resource_path in output_model_resources.items():
         input_model_resource_path = input_model_resources.get(resource_key)
         if resource_path.get_path() == (input_model_resource_path.get_path() if input_model_resource_path else None):

--- a/olive/systems/azureml/aml_pass_runner.py
+++ b/olive/systems/azureml/aml_pass_runner.py
@@ -2,93 +2,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import argparse
 import json
-import shutil
-import tempfile
 from pathlib import Path
 
-from onnxruntime import __version__ as ort_version
-from packaging import version
-
-from olive.common.config_utils import ParamCategory, validate_config
-from olive.common.utils import aml_runner_hf_login, copy_dir
-from olive.data.config import DataConfig
-from olive.hardware import AcceleratorSpec
+from olive.common.utils import aml_runner_hf_login, set_dict_value
 from olive.logging import set_verbosity_from_env
 from olive.model import ModelConfig
 from olive.package_config import OlivePackageConfig
-from olive.passes import REGISTRY as PASS_REGISTRY
-from olive.passes import FullPassConfig, Pass
-from olive.resource_path import create_resource_path
-from olive.systems.utils import get_common_args
-
-
-def parse_pass_config_arg(raw_args):
-    parser = argparse.ArgumentParser("Pass config")
-
-    # parse config arg
-    parser.add_argument("--pass_config", type=str, help="pass config", required=True)
-
-    return parser.parse_known_args(raw_args)
-
-
-def parse_pass_args(pass_type, accelerator_spec, raw_args):
-    pass_class = PASS_REGISTRY[pass_type]
-
-    parser = argparse.ArgumentParser(f"{pass_type} pass args")
-
-    # parse pass args
-    for param, param_config in pass_class.default_config(accelerator_spec).items():
-        if param_config.category in (ParamCategory.PATH, ParamCategory.DATA):
-            parser.add_argument(f"--pass_{param}", type=str, help=f"pass {param}", required=param_config.required)
-
-    return parser.parse_known_args(raw_args)
-
-
-def create_pass(pass_config, pass_args):
-    for key, value in vars(pass_args).items():
-        if value is not None:
-            # remove the pass_ prefix, the 1 is to only replace the first occurrence
-            normalized_key = key.replace("pass_", "", 1)
-            pass_config["config"][normalized_key] = value
-
-    return FullPassConfig.from_json(pass_config).create_pass()
-
-
-def parse_data_item(data_name, item, extra_args):
-    data_config_parser = argparse.ArgumentParser(f"Data {item} parser")
-    data_config_parser.add_argument(f"--{data_name}_{item}", type=str, help=f"{data_name} {item}")
-
-    item_args, extra_args = data_config_parser.parse_known_args(extra_args)
-
-    for key, value in vars(item_args).items():
-        if item in key:
-            return value
-    return None
-
-
-def update_data_config(p: "Pass", extra_args):
-    data_map = {}
-    for param, param_config in p.config.items():
-        if param.endswith("data_config") and param_config is not None:
-            data_name = param_config["name"]
-            if data_map.get(data_name):
-                user_script, script_dir, data_dir, data_files = data_map[data_name]
-            else:
-                user_script = parse_data_item(data_name, "user_script", extra_args)
-                script_dir = parse_data_item(data_name, "script_dir", extra_args)
-                data_dir = parse_data_item(data_name, "data_dir", extra_args)
-                data_files = parse_data_item(data_name, "data_files", extra_args)
-                data_map[data_name] = (user_script, script_dir, data_dir, data_files)
-
-            param_config["user_script"] = user_script
-            param_config["script_dir"] = script_dir
-            if param_config.get("load_dataset_config"):
-                param_config["load_dataset_config"]["params"]["data_dir"] = data_dir
-                param_config["load_dataset_config"]["params"]["data_files"] = data_files
-
-            p.config[param] = validate_config(param_config, DataConfig)
+from olive.passes import FullPassConfig
+from olive.resource_path import find_all_resources
+from olive.systems.utils import get_common_args, parse_config
 
 
 def main(raw_args=None):
@@ -98,49 +21,17 @@ def main(raw_args=None):
     aml_runner_hf_login()
 
     input_model_config, pipeline_output, extra_args = get_common_args(raw_args)
-    pass_config_arg, extra_args = parse_pass_config_arg(extra_args)
-
-    # pass config
-    with open(pass_config_arg.pass_config) as f:
-        pass_config = json.load(f)
-    pass_type = pass_config["type"].lower()
+    pass_config, extra_args = parse_config(extra_args, "pass")
 
     # Import the pass package configuration from the package_config
     package_config = OlivePackageConfig.load_default_config()
     package_config.import_pass_module(pass_config["type"])
 
-    if version.parse(ort_version) < version.parse("1.16.0"):
-        # In onnxruntime, the following PRs will make the optimize_model save external data in the temporary folder
-        # * https://github.com/microsoft/onnxruntime/pull/16531
-        # * https://github.com/microsoft/onnxruntime/pull/16716
-        # * https://github.com/microsoft/onnxruntime/pull/16912
-        # So, in 1.16.0 afterwards, we don't need to copy the model to a temp directory
-
-        # Some passes create temporary files in the same directory as the model
-        # original directory for model path is read only, so we need to copy the model to a temp directory
-        input_model_path = input_model_config["config"].get("model_path")
-        if input_model_path is not None:
-            tmp_dir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-            old_path = Path(input_model_path).resolve()
-            new_path = Path(tmp_dir.name).resolve() / old_path.name
-            if old_path.is_file():
-                shutil.copy(old_path, new_path)
-            else:
-                new_path.mkdir(parents=True, exist_ok=True)
-                copy_dir(old_path, new_path, dirs_exist_ok=True)
-            input_model_config["config"]["model_path"] = str(new_path)
-
-    # pass specific args
-    accelerator_spec = AcceleratorSpec(**pass_config["accelerator"])
-    pass_args, extra_args = parse_pass_args(pass_type, accelerator_spec, extra_args)
-
     # load input_model
     input_model = ModelConfig.from_json(input_model_config).create_model()
 
     # load pass
-    p = create_pass(pass_config, pass_args)
-
-    update_data_config(p, extra_args)
+    p = FullPassConfig.from_json(pass_config).create_pass()
 
     # output model path
     output_model_path = str(Path(pipeline_output) / "output_model")
@@ -154,34 +45,27 @@ def main(raw_args=None):
     # Replace local paths with relative paths
     # keep track of the resource names that are relative paths
     # during download in aml system, the relative paths will be resolved to the pipeline output
-    model_json["resource_names"] = []
+    model_json["resources"] = []
     # keep track of the resource names that are the same as the input model
     model_json["same_resources_as_input"] = []
-    for resource_name, resource_path_value in output_model.resource_paths.items():
-        resource_path = create_resource_path(resource_path_value)  # just in case
-        if not resource_path or resource_path.is_string_name():
-            # nothing to do if the path is None or a string name
-            continue
-        # check if the path is the same as the input model's path
-        resource_path_str = resource_path.get_path()
-        # input model might not have the resource, e.g. pytorch model -> onnx model
-        input_resource_path = create_resource_path(input_model.resource_paths.get(resource_name))
-        input_resource_path_str = input_resource_path.get_path() if input_resource_path else None
-        if input_resource_path_str == resource_path_str:
-            # if the path is the same as the input path, set the path to None
-            # and add the resource name to the same_resources_as_input list
-            model_json["config"][resource_name] = None
-            model_json["same_resources_as_input"].append(resource_name)
+    # resources
+    input_model_resources = find_all_resources(input_model_config)
+    output_model_resources = find_all_resources(model_json)
+    for resource_key, resource_path in output_model_resources.items():
+        input_model_resource_path = input_model_resources.get(resource_key)
+        if resource_path.get_path() == (input_model_resource_path.get_path() if input_model_resource_path else None):
+            set_dict_value(model_json, resource_key, None)
+            model_json["same_resources_as_input"].append(resource_key)
             continue
         # need to ensure that the path is a local resource
         assert resource_path.is_local_resource(), f"Expected local resource, got {resource_path.type}"
         # if the model is a local file or folder, set the model path to be relative to the pipeline output
         # the aml system will resolve the relative path to the pipeline output during download
-        relative_path = str(Path(resource_path_str).relative_to(Path(pipeline_output)))
+        relative_path = str(Path(resource_path.get_path()).relative_to(Path(pipeline_output)))
         path_json = resource_path.to_json()
         path_json["config"]["path"] = relative_path
-        model_json["config"][resource_name] = path_json
-        model_json["resource_names"].append(resource_name)
+        set_dict_value(model_json, resource_key, path_json)
+        model_json["resources"].append(resource_key)
 
     # save model json
     with (Path(pipeline_output) / "output_model_config.json").open("w") as f:

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -204,13 +204,13 @@ class AzureMLSystem(OliveSystem):
         if resource_map:
             resource_map_path = tmp_dir / f"{name}_resource_map.json"
             with resource_map_path.open("w") as f:
-                json.dump(resource_map, f)
+                json.dump(resource_map, f, sort_keys=True, indent=4)
             inputs[f"{name}_resource_map"] = Input(type=AssetTypes.URI_FILE)
             args[f"{name}_resource_map"] = Input(type=AssetTypes.URI_FILE, path=resource_map_path)
 
         config_path = tmp_dir / f"{name}_config.json"
         with config_path.open("w") as f:
-            json.dump(config_json, f, indent=4)
+            json.dump(config_json, f, sort_keys=True, indent=4)
         args[f"{name}_config"] = Input(type=AssetTypes.URI_FILE, path=config_path)
 
         return inputs, args
@@ -269,7 +269,7 @@ class AzureMLSystem(OliveSystem):
 
         olive_config_path = tmp_dir / "olive_config.json"
         with olive_config_path.open("w") as f:
-            json.dump(olive_config, f, indent=4)
+            json.dump(olive_config, f, sort_keys=True, indent=4)
         return olive_config_path
 
     def _create_step(
@@ -344,7 +344,7 @@ class AzureMLSystem(OliveSystem):
         inputs, args = {}, {}
         for name, config_json in [("model", model_config), ("pass", pass_config)]:
             name_inputs, name_args = self.create_inputs_and_args(
-                name, config_json, tmp_dir, ignore_keys=["_model_name_or_path"] if name == "model" else None
+                name, config_json, tmp_dir, ignore_keys=["model_attributes"] if name == "model" else None
             )
             inputs.update(name_inputs)
             args.update(name_args)
@@ -501,7 +501,7 @@ class AzureMLSystem(OliveSystem):
 
         # model args
         model_inputs, model_args = self.create_inputs_and_args(
-            "model", model_config, tmp_dir, ignore_keys=["_model_name_or_path"]
+            "model", model_config, tmp_dir, ignore_keys=["model_attributes"]
         )
 
         accelerator_config_path: Path = tmp_dir / "accelerator_config.json"

--- a/olive/systems/utils/__init__.py
+++ b/olive/systems/utils/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.systems.utils.arg_parser import get_common_args
+from olive.systems.utils.arg_parser import get_common_args, parse_config
 from olive.systems.utils.misc import (
     create_managed_system,
     create_managed_system_with_cache,
@@ -17,5 +17,6 @@ __all__ = [
     "create_new_environ",
     "get_common_args",
     "get_package_name_from_ep",
+    "parse_config",
     "run_available_providers_runner",
 ]

--- a/test/integ_test/utils.py
+++ b/test/integ_test/utils.py
@@ -20,13 +20,13 @@ def get_olive_workspace_config():
     if workspace_name is None:
         raise Exception("Please set the environment variable WORKSPACE_NAME")
 
-    client_id = os.environ.get("MANAGED_IDENTITY_CLIENT_ID")
-    if client_id is None:
-        raise Exception("Please set the environment variable MANAGED_IDENTITY_CLIENT_ID")
-
     exclude_managed_identity_credential = (
         {"exclude_managed_identity_credential": True} if "EXCLUDE_MANAGED_IDENTITY_CREDENTIAL" in os.environ else {}
     )
+
+    client_id = os.environ.get("MANAGED_IDENTITY_CLIENT_ID")
+    if client_id is None and not exclude_managed_identity_credential:
+        raise Exception("Please set the environment variable MANAGED_IDENTITY_CLIENT_ID")
 
     return {
         "subscription_id": subscription_id,

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -10,10 +10,12 @@ from pathlib import Path
 from test.unit_test.utils import (
     ONNX_MODEL_PATH,
     get_accuracy_metric,
+    get_custom_metric,
     get_glue_latency_metric,
+    get_hf_model_config,
     get_latency_metric,
+    get_onnx_model_config,
     get_onnxconversion_pass,
-    get_pytorch_model_config,
 )
 from typing import ClassVar, List
 from unittest.mock import ANY, MagicMock, Mock, patch
@@ -32,7 +34,7 @@ from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.model import ONNXModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.conversion import OnnxConversion
-from olive.resource_path import AzureMLModel, ResourcePath, ResourceType, create_resource_path
+from olive.resource_path import ResourcePath, ResourceType
 from olive.systems.azureml.aml_evaluation_runner import main as aml_evaluation_runner_main
 from olive.systems.azureml.aml_pass_runner import main as aml_pass_runner_main
 from olive.systems.azureml.aml_system import AzureMLSystem
@@ -100,7 +102,7 @@ class TestAzureMLSystem:
     @patch("olive.systems.azureml.aml_system.tempfile.TemporaryDirectory")
     def test_evaluate_model(self, mock_tempdir, mock_create_pipeline, mock_retry_func, metric_func):
         # setup
-        model_config = get_pytorch_model_config()
+        model_config = get_onnx_model_config()
         output_folder = Path(__file__).absolute().parent / "output_metrics"
         mock_tempdir.return_value.__enter__.return_value = output_folder
         ml_client = MagicMock()
@@ -114,7 +116,7 @@ class TestAzureMLSystem:
 
         # assert
         mock_create_pipeline.assert_called_once_with(
-            None, output_folder, model_config, [metric], DEFAULT_CPU_ACCELERATOR
+            output_folder, model_config.to_json(check_object=True), [metric], DEFAULT_CPU_ACCELERATOR
         )
         ml_client.jobs.stream.assert_called_once()
         assert mock_retry_func.call_count == 2
@@ -144,7 +146,7 @@ class TestAzureMLSystem:
                 "inference_settings": None,
             },
             "same_resources_as_input": [],
-            "resource_names": ["model_path"],
+            "resources": [["config", "model_path"]],
         }
         dummy_config_path = pipeline_output_path / "output_model_config.json"
         with dummy_config_path.open("w") as f:
@@ -152,7 +154,7 @@ class TestAzureMLSystem:
 
         onnx_conversion_config = {}
         p = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
-        model_config = get_pytorch_model_config()
+        model_config = get_hf_model_config()
         output_model_path = tmp_path / "output_folder" / "output_model_path"
         output_model_path.mkdir(parents=True, exist_ok=True)
         # create dummy output model so that ONNXModel can be created with the same path
@@ -173,7 +175,7 @@ class TestAzureMLSystem:
 
         # assert
         mock_create_pipeline.assert_called_once_with(
-            None, output_folder, model_config, p.to_json(), p.path_params, ({}, {})
+            output_folder, model_config.to_json(check_object=True), p.to_json()
         )
         assert mock_retry_func.call_count == 2
         ml_client.jobs.stream.assert_called_once()
@@ -186,7 +188,7 @@ class TestAzureMLSystem:
         "model_resource_type",
         [ResourceType.AzureMLModel, ResourceType.LocalFile, ResourceType.StringName],
     )
-    def test__create_model_args(self, model_resource_type, tmp_path):
+    def test_model_inputs_and_args(self, model_resource_type, tmp_path):
         # setup
         ws_config = {
             "workspace_name": "workspace_name",
@@ -213,24 +215,35 @@ class TestAzureMLSystem:
                     "model_path": resource_paths[model_resource_type],
                 },
             }
-            tem_dir_path = tmp_path
-            model_config_path = tem_dir_path / "model_config.json"
+
+            expected_inputs = {
+                "model_config": Input(type=AssetTypes.URI_FILE),
+                "model_resource_map": Input(type=AssetTypes.URI_FILE),
+            }
+            expected_args = {
+                "model_config": Input(type=AssetTypes.URI_FILE, path=tmp_path / "model_config.json"),
+                "model_resource_map": Input(type=AssetTypes.URI_FILE, path=tmp_path / "model_resource_map.json"),
+            }
+
             if model_resource_type == ResourceType.AzureMLModel:
-                expected_model_path = Input(type=AssetTypes.CUSTOM_MODEL, path="azureml:model_name:version")
+                expected_inputs["model__config__model_path"] = Input(type=AssetTypes.CUSTOM_MODEL)
+                expected_args["model__config__model_path"] = Input(
+                    type=AssetTypes.CUSTOM_MODEL, path="azureml:model_name:version"
+                )
             elif model_resource_type == ResourceType.LocalFile:
-                expected_model_path = Input(type=AssetTypes.URI_FILE, path=Path(temp_model.name).resolve())
+                expected_inputs["model__config__model_path"] = Input(type=AssetTypes.URI_FILE)
+                expected_args["model__config__model_path"] = Input(
+                    type=AssetTypes.URI_FILE, path=Path(temp_model.name).resolve()
+                )
             else:
-                expected_model_path = None
-            expected_model_config = Input(type=AssetTypes.URI_FILE, path=model_config_path)
-            expected_res = {"model_config": expected_model_config, "model_model_path": expected_model_path}
+                del expected_inputs["model_resource_map"], expected_args["model_resource_map"]
 
             # execute
-            actual_res = self.system._create_model_args(
-                model_json, {"model_path": create_resource_path(model_json["config"]["model_path"])}, tem_dir_path
-            )
+            actual_inputs, actual_args = self.system.create_inputs_and_args("model", model_json, tmp_path)
 
         # assert
-        assert actual_res == expected_res
+        assert actual_inputs == expected_inputs
+        assert actual_args == expected_args
         if model_resource_type != ResourceType.StringName:
             assert model_json["config"]["model_path"] is None
         else:
@@ -299,7 +312,7 @@ class TestAzureMLSystem:
             identity=UserIdentityConfiguration(),
         )
 
-    def test__create_data_script_inputs_and_args(self):
+    def test_pass_inputs_and_args(self, tmp_path):
         # setup
         script_dir_path = Path(__file__).absolute().parent / "script_dir"
         user_script_path = script_dir_path / "user_script.py"
@@ -312,92 +325,56 @@ class TestAzureMLSystem:
             script_dir=str(script_dir_path),
             load_dataset_config={"params": {"data_dir": data_dir_path, "data_files": data_files_path}},
         )
-        pass_config = {"data_config": data_config}
-        the_pass = MagicMock()
-        the_pass.config = pass_config
-        expected_data_inputs = {
-            "data_name_user_script": Input(type=AssetTypes.URI_FILE, optional=True),
-            "data_name_script_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
-            "data_name_data_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
-            "data_name_data_files": Input(type=AssetTypes.URI_FILE, optional=True),
+        pass_config = {"data_config": data_config.to_json()}
+
+        expected_inputs = {
+            "pass_config": Input(type=AssetTypes.URI_FILE),
+            "pass_resource_map": Input(type=AssetTypes.URI_FILE),
+            "pass__data_config__user_script": Input(type=AssetTypes.URI_FILE),
+            "pass__data_config__script_dir": Input(type=AssetTypes.URI_FOLDER),
+            "pass__data_config__load_dataset_config__params__data_dir": Input(type=AssetTypes.URI_FOLDER),
+            "pass__data_config__load_dataset_config__params__data_files": Input(type=AssetTypes.URI_FILE),
         }
-        expected_data_args = {
-            "data_name_user_script": Input(type=AssetTypes.URI_FILE, path=str(user_script_path)),
-            "data_name_script_dir": Input(type=AssetTypes.URI_FOLDER, path=str(script_dir_path)),
-            "data_name_data_dir": Input(type=AssetTypes.URI_FOLDER, path=str(data_dir_path)),
-            "data_name_data_files": Input(type=AssetTypes.URI_FILE, path=str(data_files_path)),
+        expected_args = {
+            "pass_config": Input(type=AssetTypes.URI_FILE, path=(tmp_path / "pass_config.json").resolve()),
+            "pass_resource_map": Input(type=AssetTypes.URI_FILE, path=(tmp_path / "pass_resource_map.json").resolve()),
+            "pass__data_config__user_script": Input(type=AssetTypes.URI_FILE, path=str(user_script_path)),
+            "pass__data_config__script_dir": Input(type=AssetTypes.URI_FOLDER, path=str(script_dir_path)),
+            "pass__data_config__load_dataset_config__params__data_dir": Input(
+                type=AssetTypes.URI_FOLDER, path=str(data_dir_path)
+            ),
+            "pass__data_config__load_dataset_config__params__data_files": Input(
+                type=AssetTypes.URI_FILE, path=str(data_files_path)
+            ),
         }
 
         # execute
-        actual_data_params = self.system._create_data_script_inputs_and_args(None, the_pass)
+        actual_inputs, actual_args = self.system.create_inputs_and_args("pass", pass_config, tmp_path)
 
         # assert
-        assert actual_data_params.data_inputs == expected_data_inputs
-        # assert actual_data_params.data_args == expected_data_args
-        # I deliberately use the Path.__eq__ to compare path since sometimes in Windows, the path root
+        assert actual_inputs == expected_inputs
+        # use the Path.__eq__ to compare path since sometimes in Windows, the path root
         # will be changed to uppercase, which will cause the test to fail.
-        for k, v in actual_data_params.data_args.items():
-            assert v.type == expected_data_args[k].type
-            assert Path(v.path) == Path(expected_data_args[k].path)
+        assert actual_args.keys() == expected_args.keys()
+        for k, v in actual_args.items():
+            assert v.type == expected_args[k].type
+            assert Path(v.path) == Path(expected_args[k].path)
 
-    def test__create_metric_args(self, tmp_path):
-        # setup
-        # the reason why we need resolve: sometimes, windows system would change c:\\ to C:\\ when calling resolve.
-        metric_config = {
-            "user_config": {
-                "user_script": "user_script",
-                "script_dir": "script_dir",
-                "data_dir": tmp_path,
-            }
-        }
-        metric_config_path = tmp_path / "metric_config.json"
-
-        expected_metric_config = Input(type=AssetTypes.URI_FILE, path=metric_config_path)
-        expected_metric_user_script = Input(type=AssetTypes.URI_FILE, path="user_script")
-        expected_metric_script_dir = Input(type=AssetTypes.URI_FOLDER, path="script_dir")
-        expected_metric_data_dir = Input(type=AssetTypes.URI_FOLDER, path=str(tmp_path))
-        expected_res = {
-            "metric_config": expected_metric_config,
-            "metric_user_script": expected_metric_user_script,
-            "metric_script_dir": expected_metric_script_dir,
-            "metric_data_dir": expected_metric_data_dir,
-        }
-
-        # execute
-        actual_res = self.system._create_metric_args(None, metric_config, tmp_path)
-
-        # assert
-        assert actual_res == expected_res
-        assert metric_config["user_config"]["user_script"] is None
-        assert metric_config["user_config"]["script_dir"] is None
-        assert metric_config["user_config"]["data_dir"] is None
-
-    @pytest.mark.parametrize(
-        "model_resource_type",
-        [ResourceType.AzureMLModel, ResourceType.LocalFile],
-    )
     @patch("olive.systems.azureml.aml_system.command")
-    @patch("olive.systems.azureml.aml_system.AzureMLSystem._create_metric_args")
-    def test__create_metric_component(self, mock_create_metric_args, mock_command, model_resource_type, tmp_path):
+    def test__create_metric_component(self, mock_command, tmp_path):
         # setup
-        metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
-        metric.user_config = {}
+        metric = get_custom_metric()
         model_args = {"input": Input(type=AssetTypes.URI_FILE, path="path")}
         sub_type_name = ",".join([st.name for st in metric.sub_types])
         metric_type = f"{metric.type}-{sub_type_name}"
-        model_inputs = {
-            "model_config": Input(type=AssetTypes.URI_FILE),
-            "model_model_path": (
-                Input(type=AssetTypes.CUSTOM_MODEL, optional=True)
-                if model_resource_type == ResourceType.AzureMLModel
-                else Input(type=AssetTypes.URI_FILE, optional=True)
-            ),
-        }
+
+        model_inputs = {"model_config": Input(type=AssetTypes.URI_FILE)}
+        model_args = {"model_config": Input(type=AssetTypes.URI_FILE, path=(tmp_path / "model_config.json").resolve())}
+
         metric_inputs = {
             "metric_config": Input(type=AssetTypes.URI_FILE),
-            "metric_user_script": Input(type=AssetTypes.URI_FILE, optional=True),
-            "metric_script_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
-            "metric_data_dir": Input(type=AssetTypes.URI_FOLDER, optional=True),
+            "metric__user_config__user_script": Input(type=AssetTypes.URI_FILE),
+            "metric_resource_map": Input(type=AssetTypes.URI_FILE),
         }
         accelerator_config_path = tmp_path / "accelerator_config.json"
         inputs = {
@@ -410,27 +387,11 @@ class TestAzureMLSystem:
         mock_command.return_value.return_value = expected_res
 
         # execute
-        model_resource_path = None
-        if model_resource_type == ResourceType.AzureMLModel:
-            model_resource_path = AzureMLModel(
-                {
-                    "azureml_client": {
-                        "subscription_id": "subscription_id",
-                        "resource_group": "resource_group",
-                        "workspace_name": "workspace_name",
-                    },
-                    "name": "test",
-                    "version": "1",
-                }
-            )
-        else:
-            model_resource_path = create_resource_path(ONNX_MODEL_PATH)
         actual_res = self.system._create_metric_component(
-            data_root=None,
             tmp_dir=tmp_path,
             metric=metric,
+            model_inputs=model_inputs,
             model_args=model_args,
-            model_resource_paths={"model_path": model_resource_path},
             accelerator_config_path=accelerator_config_path,
         )
 

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -70,6 +70,10 @@ def get_hf_model():
     )
 
 
+def get_hf_model_config():
+    return ModelConfig.parse_obj(get_hf_model().to_json())
+
+
 def get_hf_model_with_past():
     return PyTorchModelHandler(
         hf_config={


### PR DESCRIPTION
## Describe your changes
- Implemented a `resource_path` utils called `find_all_resources` which traverses a config dictionary and returns all resources (local files/folders, aml resources)
- Instead of hard coding expected resource params or inferring them from `ParamCategory`, the AMLSystem now uses automatically finds the resources and mounts them. It also keeps tracks of the dict keys to update them in the runners.
- Removed the ort version check in aml pass runner since 1.16 is too old so we don't need to officially support it.

In follow up PRs:
- the DockerSystem will also be updated to use the same logic. 
- Migrate the `_prepare_non_local_model` logic from engine into the DockerSystem and LocalSystem so that the engine is agnostic to resources completely.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
