### PR TITLE
CI: Separate Bert CUDA local and aml test

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -94,6 +94,10 @@ jobs:
       bert_ptq_cpu_docker:
         exampleFolder: bert
         exampleName: bert_ptq_cpu_docker
+      # running on linux is enough, only testing cuda ep on aml
+      bert_cuda_gpu_aml:
+        exampleFolder: bert
+        exampleName: bert_cuda_gpu_aml
       resnet_ptq_cpu:
         exampleFolder: resnet
         exampleName: resnet_ptq_cpu

--- a/docs/source/tutorials/configure_systems.rst
+++ b/docs/source/tutorials/configure_systems.rst
@@ -384,7 +384,7 @@ Native AzureML System
             ],
             "aml_compute": "gpu-cluster",
             "aml_docker_config": {
-                "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04",
+                "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04",
                 "conda_file_path": "conda.yaml"
             },
             "aml_environment_config": {

--- a/examples/bert/bert_cuda_gpu.json
+++ b/examples/bert/bert_cuda_gpu.json
@@ -118,7 +118,6 @@
         "perf_tuning": {
             "type": "OrtPerfTuning",
             "config": {
-                "enable_cuda_graph": true,
                 "data_config": "glue_mrpc"
             }
         }

--- a/examples/bert/conda.yaml
+++ b/examples/bert/conda.yaml
@@ -11,6 +11,6 @@ dependencies:
       - scipy
       - scikit-learn
       - torch
-      - --index-url https://download.pytorch.org/whl/cpu
+      - --extra-index-url https://download.pytorch.org/whl/cpu
       - transformers>=4.41.1
       - git+https://github.com/microsoft/Olive#egg=olive-ai[cpu]

--- a/examples/bert/conda.yaml
+++ b/examples/bert/conda.yaml
@@ -10,6 +10,7 @@ dependencies:
       - psutil
       - scipy
       - scikit-learn
-      - tabulate
+      - torch
+      - --index-url https://download.pytorch.org/whl/cpu
       - transformers>=4.41.1
       - git+https://github.com/microsoft/Olive#egg=olive-ai[cpu]

--- a/examples/bert/conda_gpu.yaml
+++ b/examples/bert/conda_gpu.yaml
@@ -10,6 +10,7 @@ dependencies:
       - psutil
       - scipy
       - scikit-learn
-      - tabulate
-      - transformers
+      - torch
+      - --extra-index-url https://download.pytorch.org/whl/cu118
+      - transformers>=4.41.1
       - git+https://github.com/microsoft/Olive#egg=olive-ai[gpu]

--- a/examples/test/test_bert_cuda_gpu_aml.py
+++ b/examples/test/test_bert_cuda_gpu_aml.py
@@ -19,16 +19,17 @@ def setup():
     os.chdir(cur_dir)
 
 
+# NOTE: this doesn't need to run on a host with a GPU, as it's testing the CUDA EP on AML
 @pytest.mark.parametrize("search_algorithm", ["tpe"])
-@pytest.mark.parametrize("execution_order", ["joint", "pass-by-pass"])
-@pytest.mark.parametrize("system", ["local_system"])
+@pytest.mark.parametrize("execution_order", ["joint"])
+@pytest.mark.parametrize("system", ["aml_system"])
 @pytest.mark.parametrize("olive_json", ["bert_cuda_gpu.json"])
-@pytest.mark.parametrize("enable_cuda_graph", [True, False])
-def test_bert(search_algorithm, execution_order, system, olive_json, enable_cuda_graph):
+def test_bert(search_algorithm, execution_order, system, olive_json):
     from olive.workflows import run as olive_run
 
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system, is_gpu=True)
-    olive_config["passes"]["perf_tuning"]["config"]["enable_cuda_graph"] = enable_cuda_graph
+    # no need to run both pass_flows, only testing cuda ep on aml
+    del olive_config["pass_flows"]
 
     footprint = olive_run(olive_config, tempdir=os.environ.get("OLIVE_TEMPDIR", None))
     check_output(footprint)

--- a/examples/test/utils.py
+++ b/examples/test/utils.py
@@ -104,7 +104,7 @@ def set_aml_system(olive_config, is_gpu=False):
                 "accelerators": [{"device": "GPU", "execution_providers": ["CUDAExecutionProvider"]}],
                 "aml_compute": "gpu-cluster",
                 "aml_docker_config": {
-                    "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04",
+                    "base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04",
                     "conda_file_path": "conda_gpu.yaml",
                 },
                 "is_dev": True,


### PR DESCRIPTION
## Describe your changes
- Separate the bert cuda example test into local and aml tests
- AML test:
  - doesn't require to be run on a GPU pipeline agent. 
  - Reduced the cases since we only want to test CUDA EP on aml. No need to test the pass_flows or search strategies. Saves test time since the aml gpu cluster is small and has longer queue times.
  - Updated base image with cuda 11.8. Both torch and ort don't support 11.6 anymore
  - Updated the conda yamls

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
