### PR TITLE
CI: Only run component governance in package publish pipeline

### DIFF
--- a/.azure_pipelines/build-doc.yaml
+++ b/.azure_pipelines/build-doc.yaml
@@ -11,6 +11,10 @@ trigger:
     - main
 pr: none
 
+variables:
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
+
 stages:
   - stage: Build_Docs
     jobs:

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         ${{ insert }}: ${{ parameters.examples }}
     variables:
-      runCodesignValidationInjection: false
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
       HF_HOME: $(Pipeline.Workspace)/.cache/huggingface
       OLIVE_TEMPDIR: $(Pipeline.Workspace)/.olive_tempdir

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -59,13 +59,6 @@ jobs:
         WORKSPACE_NAME: $(workspace-name)
         MANAGED_IDENTITY_CLIENT_ID: $(olive-1es-identity-client-id)
 
-    - task: ComponentGovernanceComponentDetection@0
-      inputs:
-        scanType: 'Register'
-        verbosity: 'Verbose'
-        alertWarningLevel: 'High'
-      displayName: Component Detection
-
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:

--- a/.azure_pipelines/job_templates/olive-performance-template.yaml
+++ b/.azure_pipelines/job_templates/olive-performance-template.yaml
@@ -13,7 +13,6 @@ jobs:
       ${{ insert }}: ${{ parameters.examples }}
   variables:
     WINDOWS: ${{ parameters.windows }}
-    runCodesignValidationInjection: false
     device: ${{ parameters.device }}
     PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
     HF_HOME: $(Pipeline.Workspace)/.cache/huggingface

--- a/.azure_pipelines/job_templates/olive-performance-template.yaml
+++ b/.azure_pipelines/job_templates/olive-performance-template.yaml
@@ -44,13 +44,6 @@ jobs:
       debugMode: false
     continueOnError: true
 
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
-    displayName: Component Detection
-
   - script: git clean -dfX
     condition: always()
     displayName: Clean remaining artifacts

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -15,7 +15,6 @@ jobs:
     name: ${{ parameters.pool}}
   variables:
     WINDOWS: ${{ parameters.windows}}
-    runCodesignValidationInjection: false
     testType: ${{ parameters.test_type }}
     python_version: ${{ parameters.python_version }}
     requirements_file: ${{ parameters.requirements_file }}
@@ -82,13 +81,6 @@ jobs:
     inputs:
       debugMode: false
     continueOnError: true
-
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
-    displayName: Component Detection
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -48,7 +48,8 @@ pr:
     - examples/phi2/*
 
 variables:
-    ComponentDetection.Timeout: 2400
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
 
 jobs:
 # Linux unit test and integration test

--- a/.azure_pipelines/olive-ort-last.yaml
+++ b/.azure_pipelines/olive-ort-last.yaml
@@ -10,7 +10,8 @@ schedules:
     - main
 
 variables:
-    ComponentDetection.Timeout: 2400
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
 
 jobs:
 # Linux unit test

--- a/.azure_pipelines/olive-ort-nightly.yaml
+++ b/.azure_pipelines/olive-ort-nightly.yaml
@@ -10,7 +10,8 @@ schedules:
     - main
 
 variables:
-    ComponentDetection.Timeout: 2400
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
 
 jobs:
 # Linux unit test

--- a/.azure_pipelines/package_publish.yaml
+++ b/.azure_pipelines/package_publish.yaml
@@ -21,6 +21,14 @@ steps:
     debugMode: false
   continueOnError: true
 
+- task: ComponentGovernanceComponentDetection@0
+  displayName: Component Detection
+  inputs:
+    # ignore docs and examples directories. They are not part of the package.
+    ignoreDirectories:
+      $(Build.SourcesDirectory)/docs
+      $(Build.SourcesDirectory)/examples
+
 - task: CopyFiles@2
   displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
   inputs:

--- a/.azure_pipelines/performance.yaml
+++ b/.azure_pipelines/performance.yaml
@@ -9,6 +9,10 @@ schedules:
     - main
   always: true
 
+variables:
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
+
 
 jobs:
 - template: job_templates/olive-performance-template.yaml


### PR DESCRIPTION
## Describe your changes
- Remove component governance step from the test pipelines. We don't publish anything in these pipelines, so it is not necessary. This task is flaky sometimes and fails due to out of disk error. There is no option to set a different directory to fix this.
- Added the step to the `package_publish` pipeline which is used to generate the wheel for pypi release. Ignore the docs and examples directories since those are not part of the package.
- Added the pipeline specific variables in the pipeline yamls instead of the job templates for easier maintenance.
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
