### PR TITLE
Deprecate dataloader_func and related config parameters

### DIFF
--- a/docs/source/features/custom_scripts.md
+++ b/docs/source/features/custom_scripts.md
@@ -50,10 +50,8 @@ Use `my_script.py` with Olive workflow configuration json file(sub_types name sh
 "data_configs": [
     {
         "name": "accuracy_data_config",
-        "type": "HuggingfaceContainer",
         "user_script": "user_script.py",
         "load_dataset_config": { "type": "skip_dataset" },
-        "pre_process_data_config": { "type": "skip_pre_process" },
         "post_process_data_config": { "type": "my_post_process" },
         "dataloader_config": { "type": "my_dataloader", "params": { "batch_size": 4 } }
     }
@@ -108,11 +106,9 @@ Use `script_dir` and `my_script.py` with Olive workflow configuration json file:
 "data_configs": [
     {
         "name": "accuracy_data_config",
-        "type": "HuggingfaceContainer",
         "user_script": "user_script.py",
         "script_dir": "my_modules",
         "load_dataset_config": { "type": "skip_dataset" },
-        "pre_process_data_config": { "type": "skip_pre_process" },
         "post_process_data_config": { "type": "my_post_process" },
         "dataloader_config": { "type": "my_dataloader", "params": { "batch_size": 4 } }
     }

--- a/docs/source/features/passes/onnx.md
+++ b/docs/source/features/passes/onnx.md
@@ -240,8 +240,7 @@ a. Tune the parameters of the OlivePass with pre-defined searchable values
 ```json
 {
     "type": "OnnxQuantization",
-    "user_script": "./user_script.py",
-    "dataloader_func": "glue_calibration_reader"
+    "data_config": "calib_data_config"
 }
 ```
 
@@ -252,8 +251,7 @@ b. Select parameters to tune
     // select per_channel to tune with "SEARCHABLE_VALUES".
     // other parameters will use the default value, not to be tuned.
     "per_channel": "SEARCHABLE_VALUES",
-    "user_script": "./user_script.py",
-    "dataloader_func": "glue_calibration_reader",
+    "data_config": "calib_data_config",
     "disable_search": true
 }
 ```
@@ -264,8 +262,7 @@ c. Use default values of the OlivePass (no tuning in this way)
     "type": "OnnxQuantization",
     // set per_channel to "DEFAULT_VALUE"
     "per_channel": "DEFAULT_VALUE",
-    "user_script": "./user_script.py",
-    "dataloader_func": "glue_calibration_reader"
+    "data_config": "calib_data_config",
 }
 ```
 
@@ -275,14 +272,13 @@ d. Specify parameters with user defined values
     "type": "OnnxQuantization",
     // set per_channel to True.
     "per_channel": true,
-    "user_script": "./user_script.py",
-    "dataloader_func": "glue_calibration_reader",
+    "data_config": "calib_data_config",
     "disable_search": true
 }
 ```
 
 Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/bert/user_script.py)
-for an example implementation of `"user_script.py"` and `"glue_calibration_reader"`.
+for an example implementation of `"user_script.py"` and `"calib_data_config/dataloader_config/type"`.
 
 check out [this file](https://github.com/microsoft/Olive/tree/main/examples/bert#bert-optimization-with-intel-neural-compressor-ptq-on-cpu) for an example for Intel® Neural Compressor quantization.
 
@@ -300,13 +296,12 @@ If the user desires to only tune either of dynamic or static quantization, Olive
 ```json
 "inc_quantization": {
     "type": "IncStaticQuantization",
-    "user_script": "user_script.py",
     "approach": "weight_only",
     "weight_only_config": {
         "bits": 4,
         "algorithm": "GPTQ"
     },
-    "dataloader_func": "calib_dataloader",
+    "data_config": "calib_data_config",
     "calibration_sampling_size": [8],
     "save_as_external_data": true,
     "all_tensors_to_one_file": true
@@ -330,9 +325,7 @@ Olive consolidates the Vitis™ AI quantization into a single pass called VitisA
     "quant_format":"QDQ",
     "activation_type":"QUInt8",
     "weight_type":"QInt8",
-    "user_script": "user_script.py",
-    "data_dir": "data",
-    "dataloader_func": "resnet_calibration_reader"
+    "data_config": "calib_data_config",
 }
 ```
 Please refer to [VitisAIQuantization](vitis_ai_quantization) for more details about the pass and its config parameters.
@@ -368,7 +361,7 @@ improve performance.
 ```
 
 Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/bert/user_script.py)
-for an example implementation of `"user_script.py"` and `"create_dataloader"`.
+for an example implementation of `"user_script.py"` and `"calib_data_config/dataloader_config/type"`.
 
 [1]: <https://onnxruntime.ai/docs/performance/quantization.html> "ONNX Runtime Quantization"
 [2]: <https://onnxruntime.ai/docs/performance/quantization.html#dynamic-quantization> "Dynamic Quantization"

--- a/docs/source/features/passes/openvino.md
+++ b/docs/source/features/passes/openvino.md
@@ -48,9 +48,7 @@ Please refer to [OpenVINOQuantization](openvino_quantization) for more details a
 ```json
 {
     "type": "OpenVINOQuantizationWithAccuracy",
-    "data_dir": "data",
-    "user_script": "user_script.py",
-    "dataloader_func": "create_dataloader",
+    "data_config": "calib_data_config",
     "validation_func": "validate",
     "max_drop": 0.01,
     "drop_type": "ABSOLUTE"

--- a/docs/source/features/passes/pytorch.md
+++ b/docs/source/features/passes/pytorch.md
@@ -115,14 +115,13 @@ c. Run QAT training with default training loop.
 ```json
 {
     "type": "QuantizationAwareTraining",
-    "user_script": "user_script.py",
     "num_epochs": 5,
-    "train_dataloader_func": "create_train_dataloader"
+    "train_data_config": "train_data_config"
 }
 ```
 
 Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/resnet/user_script.py)
-for an example implementation of `"user_script.py"` and `"create_train_dataloader"`.
+for an example implementation of `"user_script.py"` and `"train_data_config/dataloader_config/type"`.
 
 ## AutoGPTQ
 Olive also integrates [AutoGPTQ](https://github.com/AutoGPTQ/AutoGPTQ) for quantization.

--- a/docs/source/features/passes/snpe.md
+++ b/docs/source/features/passes/snpe.md
@@ -54,12 +54,10 @@ Please refer to [SNPEQuantization](snpe_quantization) for more details about the
 ```json
 {
     "type": "SNPEQuantization",
-    "data_dir": "data_dir",
-    "user_script": "user_script.py",
-    "dataloader_func": "create_quant_dataloader",
+    "data_config": "quant_data_config",
     "enable_htp": true
 }
 ```
 
 Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/inception/user_script.py)
-for an example implementation of `"user_script.py"` and `"create_quant_dataloader"`.
+for an example implementation of `"user_script.py"` and `"quant_data_config/dataloader_config/type"`.

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -404,9 +404,7 @@ Please also find the detailed options from following table for each pass:
     },
     "onnx_quantization": {
         "type": "OnnxQuantization",
-        "user_script": "user_script.py",
-        "data_dir": "data",
-        "dataloader_func": "resnet_calibration_reader",
+        "data_config": "calib_data_coonfig",
         "weight_type": "QUInt8"
     }
 }
@@ -435,9 +433,7 @@ When `pass_flows` is not specified, the passes are executed in the order of the 
     },
     "onnx_quantization": {
         "type": "OnnxQuantization",
-        "user_script": "user_script.py",
-        "data_dir": "data",
-        "dataloader_func": "resnet_calibration_reader",
+        "data_config": "calib_data_coonfig",
         "weight_type": "QUInt8"
     }
 },

--- a/docs/source/tutorials/advanced_users.md
+++ b/docs/source/tutorials/advanced_users.md
@@ -64,19 +64,12 @@ latency_metric = Metric(
         "priority": 1,
         "metric_config": {"warmup_num": 0, "repeat_test_num": 5, "sleep_num": 2},
     }],
-    user_config={
-        "user_script": "user_script.py",
-        "data_dir": "data",
-        "dataloader_func": "create_dataloader",
-        "batch_size": 16,
-    }
+    data_config="latency_data_config"
 )
 
 # create evaluator configuration
 evaluator_config =  OliveEvaluatorConfig(metrics=[latency_metric])
 ```
-
-`latency_metric` requires you to provide a function as value for `dataloader_func` that returns a dataloader object when called on `data_dir`, `batch_size`, optional positional argument list and keyword argument dictionary. You can provide the function object directly but here, let's give it a function name `"create_dataloader"` that can be imported from `user_script`.
 
 [This file](https://github.com/microsoft/Olive/blob/main/examples/resnet/user_script.py) for
 has an example of how to write user scripts.
@@ -119,9 +112,7 @@ engine.register(OnnxConversion, onnx_conversion_config, False, host=LocalSystem(
 
 # onnx quantization pass
 quantization_config = {
-    "user_script": "user_script.py",
-    "data_dir": "data",
-    "dataloader_func": "resnet_calibration_reader",
+    "data_config": "calib_data_config",
     "weight_type" : "QUInt8"
 }
 # search over the values for the other config parameters

--- a/docs/source/tutorials/configure_pass.rst
+++ b/docs/source/tutorials/configure_pass.rst
@@ -29,8 +29,7 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
             {
                 "type": "OnnxQuantization",
                 "disable_search": false,
-                "user_script": "./user_script.py",
-                "dataloader_func": "glue_calibration_reader",
+                "data_config": "calib_data_config",
                 // set per_channel to "DEFAULT_VALUE"
                 "per_channel": "DEFAULT_VALUE",
                 // set reduce_range to "SEARCHABLE_VALUES" value
@@ -54,8 +53,7 @@ Let's take the example of the :ref:`onnx_quantization` Pass:
 
             onnx_quantization = create_pass_from_dict(OnnxQuantization,
                 config={
-                    "user_script": "./user_script.py",
-                    "dataloader_func": "glue_calibration_reader",
+                    "data_config": "calib_data_config",
                     # set per_channel to "DEFAULT_VALUE" value
                     "per_channel": "DEFAULT_VALUE",
                     # set reduce_range to "SEARCHABLE_VALUES"

--- a/examples/bert/bert_inc_ptq_cpu.json
+++ b/examples/bert/bert_inc_ptq_cpu.json
@@ -13,6 +13,12 @@
             },
             "post_process_data_config": { "type": "bert_post_process" },
             "dataloader_config": { "batch_size": 1 }
+        },
+        {
+            "name": "inc_quat_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "bert_inc_glue_calibration_dataset" },
+            "dataloader_config": { "type": "bert_inc_glue_calibration_dataloader" }
         }
     ],
     "evaluators": {
@@ -51,8 +57,7 @@
         "quantization": {
             "type": "IncQuantization",
             "approach": "SEARCHABLE_VALUES",
-            "user_script": "user_script.py",
-            "dataloader_func": "inc_glue_calibration_reader",
+            "data_config": "inc_quat_data_config",
             "metric": {
                 "name": "accuracy",
                 "type": "accuracy",

--- a/examples/bert/bert_inc_smoothquant_ptq_cpu.json
+++ b/examples/bert/bert_inc_smoothquant_ptq_cpu.json
@@ -13,6 +13,12 @@
             },
             "post_process_data_config": { "type": "bert_post_process" },
             "dataloader_config": { "batch_size": 1 }
+        },
+        {
+            "name": "inc_quat_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "bert_inc_glue_calibration_dataset" },
+            "dataloader_config": { "type": "bert_inc_glue_calibration_dataloader" }
         }
     ],
     "evaluators": {
@@ -48,7 +54,7 @@
             "type": "IncStaticQuantization",
             "quant_format": "QOperator",
             "user_script": "user_script.py",
-            "dataloader_func": "inc_glue_calibration_reader",
+            "data_config": "inc_quat_data_config",
             "recipes": { "smooth_quant": true, "smooth_quant_args": { "alpha": 0.7 } },
             "metric": {
                 "name": "accuracy",

--- a/examples/bert/bert_inc_static_ptq_cpu.json
+++ b/examples/bert/bert_inc_static_ptq_cpu.json
@@ -12,6 +12,12 @@
                 "max_samples": 100
             },
             "dataloader_config": { "batch_size": 1 }
+        },
+        {
+            "name": "inc_quat_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "bert_inc_glue_calibration_dataset" },
+            "dataloader_config": { "type": "bert_inc_glue_calibration_dataloader" }
         }
     ],
     "evaluators": {
@@ -49,7 +55,7 @@
             "type": "IncStaticQuantization",
             "quant_format": "QOperator",
             "user_script": "user_script.py",
-            "dataloader_func": "inc_glue_calibration_reader",
+            "data_config": "inc_quat_data_config",
             "metric": {
                 "name": "accuracy",
                 "type": "custom",

--- a/examples/bert/bert_nvmo_ptq.json
+++ b/examples/bert/bert_nvmo_ptq.json
@@ -3,7 +3,6 @@
     "data_configs": [
         {
             "name": "rotten_tomatoes",
-            "type": "HuggingfaceContainer",
             "user_script": "nv_user_script.py",
             "load_dataset_config": { "data_name": "rotten_tomatoes", "split": "validation[:10%]" },
             "dataloader_config": { "type": "nvmo_calibration_dataloader" },

--- a/examples/bert/user_script.py
+++ b/examples/bert/user_script.py
@@ -160,9 +160,14 @@ class IncBertDataset:
         return input_dict, label
 
 
-def inc_glue_calibration_reader(data_dir, batch_size, **kwargs):
+@Registry.register_dataset()
+def bert_inc_glue_calibration_dataset(data_dir, **kwargs):
     dataset = BertDataset("Intel/bert-base-uncased-mrpc")
-    dataset = IncBertDataset(dataset.get_eval_dataset())
+    return IncBertDataset(dataset.get_eval_dataset())
+
+
+@Registry.register_dataloader()
+def bert_inc_glue_calibration_dataloader(dataset, batch_size, **kwargs):
     return DefaultDataLoader(dataset=dataset, batch_size=batch_size)
 
 

--- a/examples/directml/llm/config_llm.json
+++ b/examples/directml/llm/config_llm.json
@@ -21,18 +21,28 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "decoder_ort_dataloader", "batch_size": 1 }
+        },
+        {
+            "name": "calib_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "directml_llm_calib_dataloader" }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "decoder_ort_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config",
+                    "sub_types": [ { "name": "avg" } ]
                 }
             ]
         }

--- a/examples/directml/llm/user_script.py
+++ b/examples/directml/llm/user_script.py
@@ -17,6 +17,8 @@ from phi import convert_phi_weights
 from phi3 import convert_phi3_weights
 from transformers import AutoConfig, AutoTokenizer
 
+from olive.data.registry import Registry
+
 
 # Helper latency-only dataloader that creates random tensors with no label
 class RandomDataLoader:
@@ -158,7 +160,8 @@ def decoder_ort_inputs(batch_size):
     return inputs
 
 
-def decoder_ort_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def decoder_ort_dataloader(dataset, batch_size, **kwargs):
     return RandomDataLoader(decoder_ort_inputs, batch_size)
 
 
@@ -223,5 +226,6 @@ class PileDataloader:
             yield initial_inputs, 0
 
 
-def calib_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def directml_llm_calib_dataloader(dataset, batch_size, **kwargs):
     return PileDataloader(batch_size=batch_size)

--- a/examples/directml/squeezenet/squeezenet_config.json
+++ b/examples/directml/squeezenet/squeezenet_config.json
@@ -16,12 +16,7 @@
                 {
                     "name": "latency",
                     "type": "latency",
-                    "sub_types": [ { "name": "avg", "priority": 1 }, { "name": "max" }, { "name": "min" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "sub_types": [ { "name": "avg", "priority": 1 }, { "name": "max" }, { "name": "min" } ]
                 }
             ]
         }

--- a/examples/directml/stable_diffusion_xl/config_text_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder.json
@@ -50,6 +50,14 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "text_encoder_dataloader", "batch_size": 1 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -57,11 +65,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "text_encoder_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config"
                 }
             ]
         }

--- a/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
@@ -90,6 +90,14 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "text_encoder_2_dataloader", "batch_size": 1 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -97,11 +105,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "text_encoder_2_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config"
                 }
             ]
         }

--- a/examples/directml/stable_diffusion_xl/config_unet.json
+++ b/examples/directml/stable_diffusion_xl/config_unet.json
@@ -28,6 +28,14 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "unet_dataloader", "batch_size": 2 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -35,11 +43,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "unet_data_loader",
-                        "batch_size": 2
-                    }
+                    "data_config": "latency_data_config"
                 }
             ]
         }

--- a/examples/directml/stable_diffusion_xl/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_decoder.json
@@ -25,6 +25,14 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "vae_decoder_dataloader", "batch_size": 2 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -32,11 +40,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "vae_decoder_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "vae_decoder_dataloader"
                 }
             ]
         }

--- a/examples/directml/stable_diffusion_xl/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_encoder.json
@@ -25,6 +25,14 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "DmlExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "vae_encoder_dataloader", "batch_size": 1 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -32,11 +40,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "vae_encoder_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "vae_encoder_dataloader"
                 }
             ]
         }

--- a/examples/directml/stable_diffusion_xl/user_script.py
+++ b/examples/directml/stable_diffusion_xl/user_script.py
@@ -7,6 +7,8 @@ import torch
 from diffusers import AutoencoderKL, UNet2DConditionModel
 from transformers.models.clip.modeling_clip import CLIPTextModel, CLIPTextModelWithProjection
 
+from olive.data.registry import Registry
+
 
 # Helper latency-only dataloader that creates random tensors with no label
 class RandomDataLoader:
@@ -40,7 +42,8 @@ def text_encoder_conversion_inputs(model):
     return text_encoder_inputs(1, torch.int32)
 
 
-def text_encoder_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def text_encoder_dataloader(dataset, batch_size, **kwargs):
     return RandomDataLoader(text_encoder_inputs, batch_size, torch.int32)
 
 
@@ -64,7 +67,8 @@ def text_encoder_2_conversion_inputs(model):
     return text_encoder_2_inputs(1, torch.int64)
 
 
-def text_encoder_2_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def text_encoder_2_dataloader(dataset, batch_size, **kwargs):
     return RandomDataLoader(text_encoder_2_inputs, batch_size, torch.int64)
 
 
@@ -102,7 +106,8 @@ def unet_conversion_inputs(model):
     return tuple(unet_inputs(1, torch.float32, True).values())
 
 
-def unet_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def unet_data_loader(dataset, batch_size, **kwargs):
     return RandomDataLoader(unet_inputs, batch_size, torch.float16)
 
 
@@ -129,7 +134,8 @@ def vae_encoder_conversion_inputs(model):
     return tuple(vae_encoder_inputs(1, torch.float32).values())
 
 
-def vae_encoder_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def vae_encoder_dataloader(dataset, batch_size, **kwargs):
     return RandomDataLoader(vae_encoder_inputs, batch_size, torch.float16)
 
 
@@ -158,5 +164,6 @@ def vae_decoder_conversion_inputs(model):
     return tuple(vae_decoder_inputs(1, torch.float32).values())
 
 
-def vae_decoder_data_loader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def vae_decoder_dataloader(dataset, batch_size, **kwargs):
     return RandomDataLoader(vae_decoder_inputs, batch_size, torch.float16)

--- a/examples/gptj/gptj_inc_dynamic_ptq_cpu.json
+++ b/examples/gptj/gptj_inc_dynamic_ptq_cpu.json
@@ -1,5 +1,13 @@
 {
     "input_model": { "type": "HfModel", "model_path": "EleutherAI/gpt-j-6B" },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "gptj_dataloader", "batch_size": 1 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -7,11 +15,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg", "priority": 1 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config"
                 }
             ]
         }

--- a/examples/gptj/gptj_inc_static_ptq_cpu.json
+++ b/examples/gptj/gptj_inc_static_ptq_cpu.json
@@ -1,5 +1,13 @@
 {
     "input_model": { "type": "HfModel", "model_path": "EleutherAI/gpt-j-6B" },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "gptj_dataloader", "batch_size": 1 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -7,11 +15,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg", "priority": 1 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_dataloader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config"
                 }
             ]
         }
@@ -28,8 +32,7 @@
             "quant_format": "QDQ",
             "calibration_sampling_size": [ 8 ],
             "recipes": { "optypes_to_exclude_output_quant": [ "MatMul" ] },
-            "user_script": "user_script.py",
-            "dataloader_func": "create_onnx_dataloader",
+            "data_config": "gptj_onnx_dataloader",
             "save_as_external_data": true,
             "all_tensors_to_one_file": true
         }

--- a/examples/gptj/user_script.py
+++ b/examples/gptj/user_script.py
@@ -11,6 +11,7 @@ from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
 
 from olive.constants import Framework
+from olive.data.registry import Registry
 
 ort.set_default_logger_severity(3)
 
@@ -82,19 +83,22 @@ class OnnxDataloader(Dataloader):
             pass
 
 
-def create_pt_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def gptj_pt_dataloader(dataset, batch_size, **kwargs):
     return Dataloader(batch_size=batch_size)
 
 
-def create_onnx_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def gptj_onnx_dataloader(dataset, batch_size, **kwargs):
     return OnnxDataloader(batch_size=batch_size)
 
 
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def gptj_dataloader(dataset, batch_size, **kwargs):
     model_framework = kwargs.pop("model_framework")
     dataloader = None
     if model_framework == Framework.ONNX:
-        dataloader = create_onnx_dataloader(data_dir, batch_size)
+        dataloader = gptj_onnx_dataloader(dataset, batch_size)
     elif model_framework == Framework.PYTORCH:
-        dataloader = create_pt_dataloader(data_dir, batch_size)
+        dataloader = gptj_pt_dataloader(dataset, batch_size)
     return dataloader

--- a/examples/llama2/notebook/llama2_multiep/config_multi_ep.json
+++ b/examples/llama2/notebook/llama2_multiep/config_multi_ep.json
@@ -20,7 +20,13 @@
             "name": "wikitext2_train",
             "type": "HuggingfaceContainer",
             "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
-            "pre_process_data_config": { "max_samples": 128 }
+            "pre_process_data_config": { "add_special_tokens": false, "source_max_len": 2048, "max_samples": 128 }
+        },
+        {
+            "name": "latency_prompt_processing_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "gptj_dataloader", "batch_size": 1 }
         }
     ],
     "systems": {
@@ -40,39 +46,14 @@
                     "name": "latency_prompt_processing",
                     "type": "latency",
                     "sub_types": [ { "name": "avg", "priority": 1 } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "dataloader_func_for_merged",
-                        "func_kwargs": {
-                            "dataloader_func": {
-                                "model_id": "meta-llama/Llama-2-7b-hf",
-                                "past_seq_length": 0,
-                                "seq_length": 8,
-                                "max_seq_length": 2048
-                            }
-                        },
-                        "batch_size": 2,
-                        "io_bind": false
-                    }
+                    "data_config": "latency_prompt_processing_data_config",
+                    "user_config": { "io_bind": false }
                 },
                 {
                     "name": "latency_token_generation",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "dataloader_func_for_merged",
-                        "func_kwargs": {
-                            "dataloader_func": {
-                                "model_id": "meta-llama/Llama-2-7b-hf",
-                                "past_seq_length": 8,
-                                "seq_length": 1,
-                                "max_seq_length": 2048
-                            }
-                        },
-                        "batch_size": 2,
-                        "io_bind": false
-                    }
+                    "user_config": { "io_bind": false }
                 }
             ]
         }

--- a/examples/mistral/mistral_int4_optimize.json
+++ b/examples/mistral/mistral_int4_optimize.json
@@ -6,7 +6,15 @@
             "accelerators": [ { "device": "cpu", "execution_providers": [ "CPUExecutionProvider" ] } ]
         }
     },
-    "data_configs": [ { "name": "transformer_token_dummy_data", "type": "TransformersTokenDummyDataContainer" } ],
+    "data_configs": [
+        { "name": "transformer_token_dummy_data", "type": "TransformersTokenDummyDataContainer" },
+        {
+            "name": "inc_static_quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "mistralai_calib_dataloader", "batch_size": 1 }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -43,7 +51,7 @@
             "approach": "weight_only",
             "weight_only_config": { "bits": 4, "algorithm": "GPTQ" },
             "recipes": { "gptq_args": { "accuracy_level": 0 } },
-            "dataloader_func": "calib_dataloader",
+            "data_config": "inc_static_quant_data_config",
             "calibration_sampling_size": [ 8 ],
             "save_as_external_data": true,
             "all_tensors_to_one_file": true,

--- a/examples/mistral/user_script.py
+++ b/examples/mistral/user_script.py
@@ -10,13 +10,16 @@ import torch
 from datasets import load_dataset
 from transformers import AutoConfig, LlamaTokenizer
 
+from olive.data.registry import Registry
+
 # pylint: disable=redefined-outer-name
 
 model_id = "mistralai/Mistral-7B-v0.1"
 config = AutoConfig.from_pretrained(model_id)
 
 
-def calib_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def mistralai_calib_dataloader(data_dir, batch_size, *args, **kwargs):
     model_path = kwargs.pop("model_path")
     return PileDataloader(model_path, batch_size=batch_size)
 

--- a/examples/mobilenet/mobilenet_qnn_ep_template.json
+++ b/examples/mobilenet/mobilenet_qnn_ep_template.json
@@ -15,12 +15,16 @@
     "data_configs": [
         {
             "name": "metric_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "qnn_evaluation_dataset", "params": { "data_dir": "data/eval" } },
-            "pre_process_data_config": { "type": "skip_pre_process" },
+            "load_dataset_config": { "type": "qnn_evaluation_dataset", "data_dir": "data/eval" },
             "post_process_data_config": { "type": "qnn_post_process" },
-            "dataloader_config": { "params": { "batch_size": 1 } }
+            "dataloader_config": { "batch_size": 1 }
+        },
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "mobilenet_calibration_reader", "data_dir": "data/eval" }
         }
     ],
     "evaluators": {
@@ -51,9 +55,7 @@
         "qnn_preprocess": { "type": "QNNPreprocess" },
         "quantization": {
             "type": "OnnxStaticQuantization",
-            "user_script": "user_script.py",
-            "dataloader_func": "mobilenet_calibration_reader",
-            "data_dir": "data/eval",
+            "data_config": "quant_data_config",
             "activation_type": "QUInt16",
             "weight_type": "QUInt8"
         }

--- a/examples/mobilenet/raw_qnn_sdk_template.json
+++ b/examples/mobilenet/raw_qnn_sdk_template.json
@@ -4,21 +4,16 @@
     "data_configs": [
         {
             "name": "accuracy_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
             "dataloader_config": { "type": "qnn_dataloader", "data_dir": "data", "batch_size": 1 },
-            "pre_process_data_config": { "type": "skip_pre_process" },
             "post_process_data_config": { "type": "qnn_sdk_post_process" }
         },
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
-            "dataloader_config": { "type": "qnn_dataloader", "data_dir": "data", "batch_size": 1 },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "dataloader_config": { "type": "qnn_dataloader", "data_dir": "data", "batch_size": 1 }
         }
     ],
     "evaluators": {

--- a/examples/open_llama/README.md
+++ b/examples/open_llama/README.md
@@ -122,10 +122,8 @@ To compress model with 4-bits weight-only quantization, you may need
     "type": "IncStaticQuantization",
     "user_script": "user_script.py",
     "approach": "weight_only",
-    "weight_only_config":{
-        "algorithm": "GPTQ"
-    },
-    "dataloader_func": "calib_dataloader",
+    "data_config": "calib_data_config",
+    "weight_only_config": { "algorithm": "GPTQ" },
 }
 ```
 ```python

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -14,6 +14,14 @@
             }
         }
     },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "open_llama_calib_dataloader" }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -50,10 +58,9 @@
         },
         "quantization": {
             "type": "IncStaticQuantization",
-            "user_script": "user_script.py",
             "approach": "weight_only",
             "weight_only_config": { "bits": 4, "algorithm": "GPTQ" },
-            "dataloader_func": "calib_dataloader",
+            "data_config": "quant_data_config",
             "calibration_sampling_size": [ 8 ],
             "save_as_external_data": true,
             "all_tensors_to_one_file": true

--- a/examples/open_llama/user_script.py
+++ b/examples/open_llama/user_script.py
@@ -12,6 +12,7 @@ from datasets import load_dataset
 from transformers import AutoConfig, LlamaTokenizer
 
 from olive.constants import Framework
+from olive.data.registry import Registry
 from olive.model import OliveModelHandler
 
 model_id = "openlm-research/open_llama_3b"
@@ -80,7 +81,8 @@ class PileDataloader:
             pass
 
 
-def calib_dataloader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def open_llama_calib_dataloader(dataset, batch_size, **kwargs):
     model_path = kwargs.pop("model_path")
     return PileDataloader(model_path, batch_size=batch_size)
 

--- a/examples/red_pajama/config.json
+++ b/examples/red_pajama/config.json
@@ -1,6 +1,17 @@
 {
     "input_model": { "type": "HfModel", "model_path": "togethercomputer/RedPajama-INCITE-Base-3B-v1" },
     "systems": { "local_system": { "type": "LocalSystem", "accelerators": [ { "device": "gpu" } ] } },
+    "data_configs": [
+        {
+            "name": "latency_data_config",
+            "type": "DummyDataContainer",
+            "load_dataset_config": {
+                "input_shapes": [ [ 10000, [ 1, 2 ] ], [ 1, 1 ] ],
+                "input_types": [ "int64", "int64" ],
+                "input_names": [ "input_ids", "attention_mask" ]
+            }
+        }
+    ],
     "evaluators": {
         "common_evaluator": {
             "metrics": [
@@ -8,11 +19,7 @@
                     "name": "latency",
                     "type": "latency",
                     "sub_types": [ { "name": "avg" } ],
-                    "user_config": {
-                        "user_script": "user_script.py",
-                        "dataloader_func": "create_data_loader",
-                        "batch_size": 1
-                    }
+                    "data_config": "latency_data_config"
                 }
             ]
         }

--- a/examples/red_pajama/user_script.py
+++ b/examples/red_pajama/user_script.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import torch
 import transformers
 
 MIN_TRANSFORMERS_VERSION = "4.30.2"
@@ -11,31 +10,3 @@ MIN_TRANSFORMERS_VERSION = "4.30.2"
 assert (
     transformers.__version__ >= MIN_TRANSFORMERS_VERSION
 ), f"Please upgrade transformers to version {MIN_TRANSFORMERS_VERSION} or higher."
-
-
-def _get_inputs(batch_size, torch_dtype, device):
-    attention_mask_sequence_length = 1
-    sequence_length = 2
-
-    return {
-        "input_ids": torch.randint(10000, (batch_size, sequence_length), dtype=torch.int64, device=device),
-        "attention_mask": torch.ones((batch_size, attention_mask_sequence_length), dtype=torch.int64, device=device),
-    }
-
-
-# Helper latency-only dataloader that creates random tensors with no label
-class RandomDataLoader:
-    def __init__(self, batch_size, torch_dtype, torch_device):
-        self.batch_size = batch_size
-        self.torch_dtype = torch_dtype
-        self.torch_device = torch_device
-
-    def __getitem__(self, idx):
-        return (
-            _get_inputs(self.batch_size, self.torch_dtype, self.torch_device),
-            None,
-        )
-
-
-def create_data_loader(data_dir, batch_size, *args, **kwargs):
-    return RandomDataLoader(batch_size, torch.float16, "cuda")

--- a/examples/resnet/resnet_dynamic_ptq_cpu.json
+++ b/examples/resnet/resnet_dynamic_ptq_cpu.json
@@ -18,12 +18,9 @@
     "data_configs": [
         {
             "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 16, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 16, "drop_last": true }
         }
     ],
     "evaluators": {

--- a/examples/resnet/resnet_multiple_ep.json
+++ b/examples/resnet/resnet_multiple_ep.json
@@ -13,21 +13,22 @@
     "data_configs": [
         {
             "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 1, "drop_last": true }
         },
         {
             "name": "cifar10_accuracy_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
             "dataloader_config": { "batch_size": 1, "drop_last": true },
             "post_process_data_config": { "type": "cifar10_post_process" }
+        },
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "resnet_calibration_dataloader", "data_dir": "data" }
         }
     ],
     "evaluators": {
@@ -57,9 +58,7 @@
     "passes": {
         "onnx_quantization": {
             "type": "OnnxQuantization",
-            "user_script": "user_script.py",
-            "data_dir": "data",
-            "dataloader_func": "resnet_calibration_reader",
+            "data_config": "quant_data_config",
             "weight_type": "QUInt8",
             "activation_type": "QUInt8",
             "quant_preprocess": true

--- a/examples/resnet/resnet_ptq_cpu.json
+++ b/examples/resnet/resnet_ptq_cpu.json
@@ -18,12 +18,15 @@
     "data_configs": [
         {
             "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 16, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 16, "drop_last": true }
+        },
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "resnet_calibration_dataloader", "data_dir": "data" }
         }
     ],
     "evaluators": {
@@ -61,9 +64,7 @@
         "onnx_conversion": { "type": "OnnxConversion", "target_opset": 13 },
         "onnx_quantization": {
             "type": "OnnxQuantization",
-            "user_script": "user_script.py",
-            "data_dir": "data",
-            "dataloader_func": "resnet_calibration_reader",
+            "data_config": "quant_data_config",
             "weight_type": "QUInt8",
             "activation_type": "QUInt8",
             "quant_preprocess": true

--- a/examples/resnet/resnet_ptq_cpu_aml_dataset.json
+++ b/examples/resnet/resnet_ptq_cpu_aml_dataset.json
@@ -17,19 +17,28 @@
     "data_configs": [
         {
             "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": {
-                "type": "cifar10_dataset",
+                "type": "cifar10_val_dataset",
                 "data_dir": {
                     "type": "azureml_datastore",
                     "datastore_name": "workspaceblobstore",
                     "relative_path": "LocalUpload/cifar-10"
                 }
             },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 16, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "dataloader_config": { "batch_size": 16, "drop_last": true }
+        },
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": {
+                "type": "resnet_calibration_dataloader",
+                "data_dir": {
+                    "type": "azureml_datastore",
+                    "config": { "datastore_name": "workspaceblobstore", "relative_path": "LocalUpload/cifar-10" }
+                }
+            }
         }
     ],
     "evaluators": {
@@ -64,13 +73,7 @@
         "onnx_conversion": { "type": "OnnxConversion", "target_opset": 13 },
         "onnx_quantization": {
             "type": "OnnxQuantization",
-            "user_script": "user_script.py",
-            "data_dir": {
-                "type": "azureml_datastore",
-                "datastore_name": "workspaceblobstore",
-                "relative_path": "LocalUpload/cifar-10"
-            },
-            "dataloader_func": "resnet_calibration_reader",
+            "data_config": "quant_data_config",
             "weight_type": "QUInt8",
             "activation_type": "QUInt8",
             "quant_preprocess": true

--- a/examples/resnet/resnet_qat_default_train_loop_cpu.json
+++ b/examples/resnet/resnet_qat_default_train_loop_cpu.json
@@ -11,22 +11,28 @@
     },
     "data_configs": [
         {
-            "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
+            "name": "latency_data_config",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 1, "drop_last": true }
         },
         {
-            "name": "cifar10_accuracy_data_config",
-            "type": "HuggingfaceContainer",
+            "name": "accuracy_data_config",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
             "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "pre_process_data_config": { "type": "skip_pre_process" },
             "post_process_data_config": { "type": "cifar10_post_process" }
+        },
+        {
+            "name": "quant_train_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_train_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 100 }
+        },
+        {
+            "name": "quant_val_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" }
         }
     ],
     "evaluators": {
@@ -35,7 +41,7 @@
                 {
                     "name": "accuracy",
                     "type": "accuracy",
-                    "data_config": "cifar10_accuracy_data_config",
+                    "data_config": "accuracy_data_config",
                     "sub_types": [
                         {
                             "name": "accuracy_score",
@@ -47,7 +53,7 @@
                 {
                     "name": "latency",
                     "type": "latency",
-                    "data_config": "cifar10_data_config",
+                    "data_config": "latency_data_config",
                     "sub_types": [ { "name": "avg", "priority": 2 } ]
                 }
             ]
@@ -57,16 +63,14 @@
         "quantization_aware_training": {
             "type": "QuantizationAwareTraining",
             "user_script": "user_script.py",
-            "train_data_dir": "data",
-            "val_data_dir": "data",
+            "train_data_config": "quant_train_data_config",
+            "val_data_config": "quant_val_data_config",
             "num_epochs": 1,
-            "train_dataloader_func": "create_train_dataloader",
-            "train_batch_size": 100,
             "modules_to_fuse": [ [ "conv1", "bn1" ], [ "conv2", "bn2" ], [ "conv3", "bn3" ] ],
             "qconfig_func": "create_qat_config"
         },
         "conversion": { "type": "OnnxConversion", "target_opset": 17 },
-        "perf_tuning": { "type": "OrtPerfTuning", "data_config": "cifar10_data_config" }
+        "perf_tuning": { "type": "OrtPerfTuning", "data_config": "latency_data_config" }
     },
     "evaluator": "common_evaluator",
     "cache_dir": "cache",

--- a/examples/resnet/resnet_qat_lightning_module_cpu.json
+++ b/examples/resnet/resnet_qat_lightning_module_cpu.json
@@ -12,21 +12,26 @@
     "data_configs": [
         {
             "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 1, "drop_last": true }
         },
         {
             "name": "cifar10_accuracy_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
             "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "pre_process_data_config": { "type": "skip_pre_process" },
             "post_process_data_config": { "type": "cifar10_post_process" }
+        },
+        {
+            "name": "quant_train_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_train_dataset", "data_dir": "data" }
+        },
+        {
+            "name": "quant_val_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" }
         }
     ],
     "evaluators": {
@@ -57,9 +62,9 @@
         "quantization_aware_training": {
             "type": "QuantizationAwareTraining",
             "user_script": "user_script.py",
+            "train_data_config": "quant_train_data_config",
+            "val_data_config": "quant_val_data_config",
             "num_epochs": 1,
-            "train_data_dir": "data",
-            "val_data_dir": "data",
             "ptl_data_module": "PTLDataModule",
             "ptl_module": "PTLModule",
             "pl_extra_args": { "accelerator": "gpu", "enable_checkpointing": true, "devices": 1 },

--- a/examples/resnet/resnet_static_ptq_cpu.json
+++ b/examples/resnet/resnet_static_ptq_cpu.json
@@ -17,13 +17,16 @@
     },
     "data_configs": [
         {
-            "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
+            "name": "perf_tuning_data_config",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 1, "drop_last": true }
+        },
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "resnet_calibration_dataloader", "data_dir": "data" }
         }
     ],
     "evaluators": {
@@ -56,13 +59,8 @@
     },
     "passes": {
         "onnx_conversion": { "type": "OnnxConversion", "target_opset": 13 },
-        "onnx_static_quantization": {
-            "type": "OnnxStaticQuantization",
-            "user_script": "user_script.py",
-            "data_dir": "data",
-            "dataloader_func": "resnet_calibration_reader"
-        },
-        "perf_tuning": { "type": "OrtPerfTuning", "data_config": "cifar10_data_config" }
+        "onnx_static_quantization": { "type": "OnnxStaticQuantization", "data_config": "quant_data_config" },
+        "perf_tuning": { "type": "OrtPerfTuning", "data_config": "perf_tuning_data_config" }
     },
     "search_strategy": { "execution_order": "joint", "search_algorithm": "exhaustive" },
     "host": "local_system",

--- a/examples/resnet/resnet_vitis_ai_ptq_cpu.json
+++ b/examples/resnet/resnet_vitis_ai_ptq_cpu.json
@@ -17,13 +17,16 @@
     },
     "data_configs": [
         {
-            "name": "cifar10_data_config",
-            "type": "HuggingfaceContainer",
+            "name": "latency_data_config",
             "user_script": "user_script.py",
-            "load_dataset_config": { "type": "cifar10_dataset", "data_dir": "data" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "dataloader_config": { "batch_size": 1, "drop_last": true },
-            "post_process_data_config": { "type": "skip_post_process" }
+            "load_dataset_config": { "type": "cifar10_val_dataset", "data_dir": "data" },
+            "dataloader_config": { "batch_size": 1, "drop_last": true }
+        },
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": { "type": "simple_dataset" },
+            "dataloader_config": { "type": "resnet_calibration_dataloader", "data_dir": "data" }
         }
     ],
     "evaluators": {
@@ -49,7 +52,7 @@
                 {
                     "name": "latency",
                     "type": "latency",
-                    "data_config": "cifar10_data_config",
+                    "data_config": "latency_data_config",
                     "sub_types": [
                         { "name": "avg", "priority": 2, "goal": { "type": "percent-min-improvement", "value": 10 } }
                     ]
@@ -65,9 +68,7 @@
             "quant_format": "QDQ",
             "activation_type": "QUInt8",
             "weight_type": "QInt8",
-            "user_script": "user_script.py",
-            "data_dir": "data",
-            "dataloader_func": "resnet_calibration_reader"
+            "data_config": "quant_data_config"
         }
     },
     "log_severity_level": 0,

--- a/examples/stable_diffusion/config_safety_checker.json
+++ b/examples/stable_diffusion/config_safety_checker.json
@@ -23,11 +23,8 @@
     "data_configs": [
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" },
             "dataloader_config": { "type": "safety_checker_data_loader", "batch_size": 1 }
         }
     ],

--- a/examples/stable_diffusion/config_text_encoder.json
+++ b/examples/stable_diffusion/config_text_encoder.json
@@ -20,11 +20,8 @@
     "data_configs": [
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" },
             "dataloader_config": { "type": "text_encoder_data_loader", "batch_size": 1 }
         }
     ],

--- a/examples/stable_diffusion/config_unet.json
+++ b/examples/stable_diffusion/config_unet.json
@@ -29,11 +29,8 @@
     "data_configs": [
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" },
             "dataloader_config": { "type": "unet_data_loader", "batch_size": 1 }
         }
     ],

--- a/examples/stable_diffusion/config_vae_decoder.json
+++ b/examples/stable_diffusion/config_vae_decoder.json
@@ -20,11 +20,8 @@
     "data_configs": [
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" },
             "dataloader_config": { "type": "vae_decoder_data_loader", "batch_size": 1 }
         }
     ],

--- a/examples/stable_diffusion/config_vae_encoder.json
+++ b/examples/stable_diffusion/config_vae_encoder.json
@@ -20,11 +20,8 @@
     "data_configs": [
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "user_script.py",
             "load_dataset_config": { "type": "local_dataset" },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" },
             "dataloader_config": { "type": "vae_encoder_data_loader", "batch_size": 1 }
         }
     ],

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -33,7 +33,6 @@
     "data_configs": [
         {
             "name": "latency_data_config",
-            "type": "HuggingfaceContainer",
             "user_script": "code/user_script.py",
             "script_dir": "code",
             "load_dataset_config": {
@@ -42,8 +41,6 @@
                 "model_name": "<place_holder>",
                 "use_audio_decoder": "<place_holder>"
             },
-            "pre_process_data_config": { "type": "skip_pre_process" },
-            "post_process_data_config": { "type": "skip_post_process" },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         }
     ],

--- a/olive/passes/onnx/nvmo_quantization.py
+++ b/olive/passes/onnx/nvmo_quantization.py
@@ -6,14 +6,16 @@ import logging
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, Union
+from typing import Any, Dict, Union
 
+from olive.common.config_utils import validate_config
+from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import OliveModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import model_proto_to_olive_model
-from olive.passes.pass_config import ParamCategory, PassConfigParam
+from olive.passes.pass_config import PassConfigParam
 from olive.strategy.search_parameter import Categorical
 
 logger = logging.getLogger(__name__)
@@ -21,35 +23,16 @@ logger = logging.getLogger(__name__)
 
 # static quantization specific config
 _dataloader_config = {
-    "batch_size": PassConfigParam(
-        type_=int,
-        default_value=1,
-        description="Batch size for calibration.",
-    ),
-    "calib_size": PassConfigParam(
-        type_=int,
-        default_value=64,
-        description="Calibration data size.",
-    ),
-    "dataloader_func": PassConfigParam(
-        type_=Union[Callable, str],
-        category=ParamCategory.OBJECT,
+    "data_config": PassConfigParam(
+        type_=Union[DataConfig, Dict],
         required=True,
-        description="Function/function name to generate dataloader for calibration.",
-    ),
-    "dataloader_func_kwargs": PassConfigParam(
-        type_=Dict[str, Any],
-        description="Keyword arguments for dataloader_func.",
+        description="Data config to load data for computing latency.",
     ),
 }
 
 
 class NVModelOptQuantization(Pass):
     """Quantize ONNX model with Nvidia-ModelOpt."""
-
-    # set this to True if the pass has parameters that are functions or objects and the user script is required
-    # to import the module containing the function or object
-    _requires_user_script: bool = True
 
     class Precision(str, Enum):
         FP8 = "fp8"
@@ -68,7 +51,7 @@ class NVModelOptQuantization(Pass):
 
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
-        config = {
+        return {
             "precision": PassConfigParam(
                 type_=NVModelOptQuantization.Precision,
                 default_value="int4",
@@ -81,10 +64,8 @@ class NVModelOptQuantization(Pass):
                 searchable_values=Categorical(["RTN", "AWQ"]),
                 description="Algorithm of weight only quantization. Support 'RTN' and 'AWQ'.",
             ),
+            **deepcopy(_dataloader_config),
         }
-
-        config.update(deepcopy(_dataloader_config))
-        return config
 
     def validate_search_point(
         self, search_point: Dict[str, Any], accelerator_spec: AcceleratorSpec, with_fixed_value: bool = False
@@ -111,13 +92,8 @@ class NVModelOptQuantization(Pass):
                 "Please install `olive-ai[nvmo]` or `nvidia-modelopt[onnx]` to use INT4 AWQ quantization!"
             ) from exc
 
-        calib_dataloader = self._user_module_loader.call_object(
-            config["dataloader_func"],
-            config["batch_size"],
-            config["calib_size"],
-            model_path=model.model_path,
-            **(config["dataloader_func_kwargs"] or {}),
-        )
+        data_config = validate_config(config["data_config"], DataConfig)
+        calib_dataloader = data_config.to_data_container().create_dataloader()
 
         quantize_mode = (
             "int4_awq_clip" if config["algorithm"] == NVModelOptQuantization.Algorithm.AWQ else "int4_rtn_dq"

--- a/olive/passes/pytorch/qat_utils.py
+++ b/olive/passes/pytorch/qat_utils.py
@@ -11,7 +11,9 @@ from packaging import version
 from pytorch_lightning import LightningModule, seed_everything
 from torch.ao.quantization.fake_quantize import FakeQuantize, MovingAverageMinMaxObserver
 
+from olive.common.config_utils import validate_config
 from olive.constants import ModelFileFormat
+from olive.data.config import DataConfig
 from olive.model import PyTorchModelHandler
 from olive.passes.pytorch.cluster import barrier, create_cluster, is_master_proc
 from olive.passes.pytorch.pytorch_lightning_utils import create_ddp_strategy, create_trainer
@@ -70,10 +72,9 @@ class QatTrainer:
                 if self.config.ptl_data_module:
                     ptl_data_module = self.config.ptl_data_module()
             else:
-                train_dataloader_func = self.config.train_dataloader_func(
-                    self.config.train_data_dir, batch_size=self.config.train_batch_size
-                )
-                ptl_module = DefaultPTLModule(model=quan_model, training_dataloader=train_dataloader_func)
+                train_data_config = validate_config(self.config.train_data_config, DataConfig)
+                train_dataloader = train_data_config.to_data_container().create_dataloader()
+                ptl_module = DefaultPTLModule(model=quan_model, training_dataloader=train_dataloader)
 
             kwargs = {}
             if run_on_gpus:

--- a/olive/passes/pytorch/quantization_aware_training.py
+++ b/olive/passes/pytorch/quantization_aware_training.py
@@ -5,6 +5,8 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Union
 
+from olive.common.config_utils import validate_config
+from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import PyTorchModelHandler
 from olive.passes import Pass
@@ -26,18 +28,14 @@ class QuantizationAwareTraining(Pass):
         else:
             from pytorch_lightning.loggers import LightningLoggerBase as Logger
         return {
-            "train_data_dir": PassConfigParam(
-                type_=str, description="Directory of training data.", category=ParamCategory.DATA
+            "train_data_config": PassConfigParam(
+                type_=Union[DataConfig, Dict],
+                required=True,
+                description="Data config for training.",
             ),
-            "val_data_dir": PassConfigParam(
-                type_=str, description="Directory of validation data.", category=ParamCategory.DATA
-            ),
-            "train_dataloader_func": PassConfigParam(
-                type_=Union[Callable, str],
-                category=ParamCategory.OBJECT,
-                description=(
-                    "Dataloader function to load training data from given train_data_dir with given train_batch_size."
-                ),
+            "val_data_config": PassConfigParam(
+                type_=Union[DataConfig, Dict],
+                description="Data config for validation.",
             ),
             "training_loop_func": PassConfigParam(
                 type_=Union[Callable, str],
@@ -62,7 +60,6 @@ class QuantizationAwareTraining(Pass):
                     "https://pytorch-lightning.readthedocs.io/en/stable/data/datamodule.html for more details."
                 ),
             ),
-            "train_batch_size": PassConfigParam(type_=int, description="Batch size for training."),
             "num_epochs": PassConfigParam(type_=int, description="Maximum number of epochs for training."),
             "num_steps": PassConfigParam(
                 type_=int, default_value=-1, description="Maximum number of steps for training."
@@ -105,11 +102,9 @@ class QuantizationAwareTraining(Pass):
         if Path(output_model_path).suffix != ".pt":
             output_model_path += ".pt"
 
-        if config["train_dataloader_func"]:
-            qat_trainer_config.train_dataloader_func = self._user_module_loader.load_object(
-                config["train_dataloader_func"]
-            )
-
+        qat_trainer_config.train_data_config = validate_config(config["train_data_config"], DataConfig)
+        if config["val_data_config"]:
+            qat_trainer_config.val_data_config = validate_config(config["val_data_config"], DataConfig)
         if config["training_loop_func"]:
             qat_trainer_config.training_loop_func = self._user_module_loader.load_object(config["training_loop_func"])
         if config["ptl_module"]:

--- a/test/integ_test/evaluator/azureml_eval/utils.py
+++ b/test/integ_test/evaluator/azureml_eval/utils.py
@@ -38,13 +38,11 @@ _current_dir, _models_dir, _data_dir, _user_script = get_directories()
 def _get_metric_data_config(name, post_process="skip_post_process"):
     data_config = DataConfig(
         name=name,
-        type="HuggingfaceContainer",
         user_script=str(_user_script),
         load_dataset_config=DataComponentConfig(
             type="mnist_dataset_for_azureml_eval",
             params={"data_dir": str(_data_dir)},
         ),
-        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
         post_process_data_config=DataComponentConfig(type=post_process),
     )
     return validate_config(data_config, DataConfig)

--- a/test/integ_test/evaluator/docker_eval/utils.py
+++ b/test/integ_test/evaluator/docker_eval/utils.py
@@ -38,13 +38,11 @@ _current_dir, _models_dir, _data_dir, _user_script = get_directories()
 def _get_metric_data_config(name, dataset, post_process=None):
     data_config = DataConfig(
         name=name,
-        type="HuggingfaceContainer",
         user_script=str(_user_script),
         load_dataset_config=DataComponentConfig(
             type=dataset,
             params={"data_dir": str(_data_dir)},
         ),
-        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
     )
     if post_process:
         data_config.post_process_data_config = DataComponentConfig(type=post_process)

--- a/test/integ_test/evaluator/local_eval/utils.py
+++ b/test/integ_test/evaluator/local_eval/utils.py
@@ -34,13 +34,11 @@ _current_dir, _models_dir, _data_dir, _user_script = get_directories()
 def _get_metric_data_config(name, dataset, post_process=None):
     data_config = DataConfig(
         name=name,
-        type="HuggingfaceContainer",
         user_script=str(_user_script),
         load_dataset_config=DataComponentConfig(
             type=dataset,
             params={"data_dir": str(_data_dir)},
         ),
-        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
     )
     if post_process:
         data_config.post_process_data_config = DataComponentConfig(type=post_process)

--- a/test/multiple_ep/utils.py
+++ b/test/multiple_ep/utils.py
@@ -39,14 +39,11 @@ _current_dir, _models_dir, _data_dir, _user_script = get_directories()
 def get_latency_metric():
     data_config = DataConfig(
         name="latency_metric_data_config",
-        type="HuggingfaceContainer",
         user_script=str(_user_script),
         load_dataset_config=DataComponentConfig(
             type="mnist_dataset_for_multiple_ep",
             params={"data_dir": str(_data_dir)},
         ),
-        pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
-        post_process_data_config=DataComponentConfig(type="skip_post_process"),
     )
     return Metric(
         name="latency",

--- a/test/unit_test/passes/inc/test_inc_quantization.py
+++ b/test/unit_test/passes/inc/test_inc_quantization.py
@@ -12,7 +12,8 @@ from torchvision import transforms
 from torchvision.datasets import CIFAR10
 
 from olive.common.constants import OS
-from olive.data.config import DataConfig
+from olive.data.config import DataComponentConfig, DataConfig
+from olive.data.registry import Registry
 from olive.model import PyTorchModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.conversion import OnnxConversion
@@ -26,7 +27,13 @@ def test_inc_quantization(tmp_path):
     ov_model = get_onnx_model(tmp_path)
     data_dir = tmp_path / "data"
     data_dir.mkdir(exist_ok=True)
-    config = {"data_dir": data_dir, "dataloader_func": create_dataloader}
+    config = {
+        "data_config": DataConfig(
+            name="test_inc_quant_dc_config",
+            load_dataset_config=DataComponentConfig(type="_cifar10_val_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(type="_cifar10_val_dataloader", params={"batch_size": 1}),
+        )
+    }
     output_folder = str(tmp_path / "quantized")
 
     # create IncQuantization pass
@@ -71,7 +78,14 @@ def test_inc_weight_only_quantization(tmp_path):
     ov_model = get_onnx_model(tmp_path)
     data_dir = tmp_path / "data"
     data_dir.mkdir(exist_ok=True)
-    config = {"approach": "weight_only", "data_dir": data_dir, "dataloader_func": create_dataloader}
+    config = {
+        "approach": "weight_only",
+        "data_config": DataConfig(
+            name="test_inc_quant_dc_config",
+            load_dataset_config=DataComponentConfig(type="_cifar10_val_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(type="_cifar10_val_dataloader"),
+        ),
+    }
     output_folder = str(tmp_path / "quantized")
 
     # create IncQuantization pass
@@ -136,15 +150,20 @@ def get_onnx_model(tmp_path):
     return p.run(pytorch_model, output_folder)
 
 
-def create_dataloader(data_dir, batch_size, *args, **kwargs):
-    # import neural_compressor here to avoid hanging on Windows
-    from neural_compressor.data import DefaultDataLoader
-
+@Registry.register_dataset()
+def _cifar10_val_dataset(data_dir, **kwargs):
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))]
     )
-    dataset = CifarDataset(CIFAR10(root=data_dir, train=False, transform=transform, download=True))
-    return DefaultDataLoader(dataset=dataset, batch_size=batch_size)
+    return CIFAR10(root=data_dir, train=False, transform=transform, download=True)
+
+
+@Registry.register_dataloader()
+def _cifar10_val_dataloader(dataset, batch_size, **kwargs):
+    # import neural_compressor here to avoid hanging on Windows
+    from neural_compressor.data import DefaultDataLoader
+
+    return DefaultDataLoader(dataset=CifarDataset(dataset), batch_size=batch_size)
 
 
 class CifarDataset:

--- a/test/unit_test/passes/onnx/test_nvmo_quantization.py
+++ b/test/unit_test/passes/onnx/test_nvmo_quantization.py
@@ -8,12 +8,14 @@ from typing import Any, Dict, Optional
 
 from onnxruntime.quantization.calibrate import CalibrationDataReader  # type: ignore[import]
 
+from olive.data.config import DataComponentConfig, DataConfig
+from olive.data.registry import Registry
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.nvmo_quantization import NVModelOptQuantization
 
 
 class DummyCalibrationDataReader(CalibrationDataReader):
-    def __init__(self, data_dir: str, batch_size: int = 16):
+    def __init__(self, batch_size: int = 16):
         super().__init__()
         self.sample_counter = 64
 
@@ -30,15 +32,22 @@ class DummyCalibrationDataReader(CalibrationDataReader):
             return None
 
 
-def dummpy_dataloader_func(data_dir, batch_size, *args, **kwargs):
-    return DummyCalibrationDataReader(data_dir, batch_size=batch_size)
+@Registry.register_dataloader()
+def _test_nvmo_quat_dataloader(dataset, batch_size, **kwargs):
+    return DummyCalibrationDataReader(batch_size=batch_size)
 
 
 def test_nvmo_quantization(tmp_path):
     ov_model = get_onnx_model()
     data_dir = tmp_path / "data"
     data_dir.mkdir(exist_ok=True)
-    config = {"data_dir": data_dir, "dataloader_func": dummpy_dataloader_func}
+    config = {
+        "data_config": DataConfig(
+            name="test_nvmo_quant_dc_config",
+            load_dataset_config=DataComponentConfig(type="simple_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+        )
+    }
     output_folder = str(tmp_path / "quantized")
 
     # create NVModelOptQuantization pass and run quantization

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -6,13 +6,15 @@ from onnxruntime.quantization.calibrate import CalibrationDataReader
 from packaging import version
 
 from olive.common.pydantic_v1 import ValidationError
+from olive.data.config import DataComponentConfig, DataConfig
+from olive.data.registry import Registry
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.quantization import OnnxMatMul4Quantizer, OnnxQuantization, OnnxStaticQuantization
 
 
 class DummyCalibrationDataReader(CalibrationDataReader):
-    def __init__(self, data_dir: str, batch_size: int = 16):
+    def __init__(self, batch_size: int = 16):
         super().__init__()
         self.sample_counter = 500
 
@@ -22,15 +24,16 @@ class DummyCalibrationDataReader(CalibrationDataReader):
 
         data = get_pytorch_model_dummy_input()
         try:
-            item = {"input": data.numpy()}
+            item = {"input": data}
             self.sample_counter -= 1
             return item
         except Exception:
             return None
 
 
-def dummpy_dataloader_func(data_dir, batch_size, *args, **kwargs):
-    return DummyCalibrationDataReader(data_dir, batch_size=batch_size)
+@Registry.register_dataloader()
+def _test_nvmo_quat_dataloader(dataset, batch_size, **kwargs):
+    return DummyCalibrationDataReader(batch_size=batch_size)
 
 
 @pytest.mark.parametrize("calibrate_method", ["MinMax", "Entropy", "Percentile"])
@@ -43,7 +46,11 @@ def test_static_quantization(calibrate_method, tmp_path):
         "MatMulConstBOnly": False,
         "per_channel": True,
         "reduce_range": True,
-        "dataloader_func": dummpy_dataloader_func,
+        "data_config": DataConfig(
+            name="test_quant_dc_config",
+            load_dataset_config=DataComponentConfig(type="simple_dataset"),
+            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+        ),
         "weight_type": "QUInt8",
         "activation_type": "QUInt8",
         "quant_preprocess": True,
@@ -76,7 +83,11 @@ def test_qnn_quantization(tmp_path):
     input_model = get_onnx_model()
     config = {
         "quant_format": "QDQ",
-        "dataloader_func": dummpy_dataloader_func,
+        "data_config": DataConfig(
+            name="test_quant_dc_config",
+            load_dataset_config=DataComponentConfig(type="simple_dataset"),
+            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+        ),
         "weight_type": "QUInt8",
         "activation_type": "QUInt16",
         "WeightSymmetric": None,
@@ -163,7 +174,11 @@ def test_matmul_gptq_with_dataloader(tmp_path):
         "nodes_to_exclude": [],
         "accuracy_level": 4,
         "algorithm": "GPTQ",
-        "dataloader_func": dummpy_dataloader_func,
+        "data_config": DataConfig(
+            name="test_quant_dc_config",
+            load_dataset_config=DataComponentConfig(type="simple_dataset"),
+            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+        ),
         "weight_only_quant_configs": {"percdamp": 0.01, "block_size": 128, "use_less_config": 1},
     }
     accelerator_spec = AcceleratorSpec(

--- a/test/unit_test/passes/pytorch/test_quantization_aware_training.py
+++ b/test/unit_test/passes/pytorch/test_quantization_aware_training.py
@@ -2,24 +2,35 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from test.unit_test.utils import create_dummy_dataloader, get_pytorch_model
+from test.unit_test.utils import get_pytorch_model
 
+from torch.utils.data import DataLoader
+
+from olive.data.component.dataset import DummyDataset
+from olive.data.registry import Registry
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.passes.olive_pass import FullPassConfig, create_pass_from_dict
 from olive.passes.pytorch.quantization_aware_training import QuantizationAwareTraining
 
 
-# TODO(shaahji): Remove this once QuantizationAwareTraining pass supports DataConfig
-def _create_dummy_dataloader(data_dir, **kwargs):
+@Registry.register_dataloader()
+def _dummy_qat_dataloader(dataset, batch_size=1, max_samples=1, **kwargs):
     kwargs.pop("batch_size", None)
-    return create_dummy_dataloader(data_dir, max_samples=1, batch_size=1, **kwargs)
+    return DataLoader(DummyDataset([(batch_size or 1, 1)], max_samples=max_samples), batch_size=None)
 
 
 def test_quantization_aware_training_pass_default(tmp_path):
     # setup
     input_model = get_pytorch_model()
     config = {
-        "train_dataloader_func": _create_dummy_dataloader,
+        "train_data_config": {
+            "name": "train_data_config",
+            "type": "DummyDataContainer",
+            "load_dataset_config": {"type": "simple_dataset"},
+            "pre_process_data_config": {"type": "skip_pre_process"},
+            "post_process_data_config": {"type": "skip_post_process"},
+            "dataloader_config": {"type": "_dummy_qat_dataloader"},
+        },
         "checkpoint_path": str(tmp_path / "checkpoint"),
     }
 
@@ -32,14 +43,17 @@ def test_quantization_aware_training_pass_default(tmp_path):
 
 def test_optional_ep(tmp_path):
     accl = AcceleratorSpec("cpu", None)
-    script_path = tmp_path / "user_script.py"
-    with script_path.open("w"):
-        pass
-    p = create_pass_from_dict(
-        QuantizationAwareTraining,
-        {"train_dataloader_func": "create_dataloader", "user_script": str(script_path)},
-        accelerator_spec=accl,
-    )
+    config = {
+        "train_data_config": {
+            "name": "train_data_config",
+            "type": "DummyDataContainer",
+            "load_dataset_config": {"type": "simple_dataset"},
+            "pre_process_data_config": {"type": "skip_pre_process"},
+            "post_process_data_config": {"type": "skip_post_process"},
+            "dataloader_config": {"type": "_dummy_qat_dataloader"},
+        },
+    }
+    p = create_pass_from_dict(QuantizationAwareTraining, config, accelerator_spec=accl)
     qat_json = p.to_json()
     pass_config = FullPassConfig.from_json(qat_json)
     sp = pass_config.create_pass()

--- a/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
+++ b/test/unit_test/passes/vitis_ai/test_vitis_ai_quantization.py
@@ -5,10 +5,12 @@
 from pathlib import Path
 from test.unit_test.utils import get_onnx_model
 
-import numpy as np
 import pytest
+import torch
 from onnxruntime.quantization.calibrate import CalibrationDataReader
 
+from olive.data.config import DataComponentConfig, DataConfig
+from olive.data.registry import Registry
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.vitis_ai_quantization import VitisAIQuantization
 
@@ -23,14 +25,15 @@ class RandomDataReader(CalibrationDataReader):
             self.flag = False
             input_shape = [1, 1]
             data = []
-            dummy_data = np.random.random(input_shape).astype(np.float32)
+            dummy_data = torch.rand(input_shape).to(torch.float32)
             data.append({"input": dummy_data})
 
             self.enum_data_dicts = iter(data)
         return next(self.enum_data_dicts, None)
 
 
-def dummy_calibration_reader(data_dir, batch_size, *args, **kwargs):
+@Registry.register_dataloader()
+def dummy_calibration_reader(dataset, batch_size, **kwargs):
     return RandomDataReader()
 
 
@@ -38,17 +41,12 @@ def dummy_calibration_reader(data_dir, batch_size, *args, **kwargs):
 def test_vitis_ai_quantization_pass(calibrate_method, tmp_path):
     # setup
     input_model = get_onnx_model()
-    dummy_user_script = tmp_path / "dummy_user_script.py"
-    dummy_data: Path = tmp_path / "dummy_data"
-    with dummy_user_script.open("w") as f:
-        f.write(" ")
-    if not dummy_data.exists():
-        dummy_data.mkdir()
-
     config = {
-        "user_script": str(dummy_user_script),
-        "data_dir": str(dummy_data),
-        "dataloader_func": dummy_calibration_reader,
+        "data_config": DataConfig(
+            name="test_vitis_ai_dc_config",
+            load_dataset_config=DataComponentConfig(type="simple_dataset"),
+            dataloader_config=DataComponentConfig(type="dummy_calibration_reader"),
+        ),
         "calibrate_method": calibrate_method,
     }
     output_folder = str(tmp_path / "vitis_ai_quantized")

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -9,11 +9,9 @@ from unittest.mock import MagicMock
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
 
 from olive.common.config_utils import validate_config
 from olive.constants import Framework
-from olive.data.component.dataset import DummyDataset
 from olive.data.config import DataComponentConfig, DataConfig
 from olive.data.registry import Registry
 from olive.evaluator.metric import AccuracySubType, LatencySubType, Metric, MetricType
@@ -31,11 +29,6 @@ class DummyModel(nn.Module):
 
     def forward(self, x):
         return torch.sigmoid(self.fc1(x))
-
-
-# TODO(shaahji): Remove this once perf_tuning pass supports DataConfig
-def create_dummy_dataloader(data_dir, batch_size=1, max_samples=32, **kwargs):
-    return DataLoader(DummyDataset([(batch_size or 1, 1)], max_samples=max_samples), batch_size=None)
 
 
 def pytorch_model_loader(model_path):

--- a/test/unit_test/workflows/mock_data/user_script.json
+++ b/test/unit_test/workflows/mock_data/user_script.json
@@ -23,18 +23,10 @@
     },
     "data_configs": [
         {
-            "name": "accuracy_data_config",
-            "type": "HuggingfaceContainer",
-            "load_dataset_config": {
-                "data_dir": { "type": "azureml_datastore", "datastore_name": "my_datastore", "relative_path": "data" }
-            },
-            "dataloader_config": { "batch_size": 16 }
-        },
-        {
             "name": "latency_data_config",
             "type": "HuggingfaceContainer",
             "load_dataset_config": {
-                "data_dir": "azureml://subscriptions/test/resourcegroups/test/workspaces/test/datastores/test/test/cifar-10-batches-py"
+                "data_dir": { "type": "azureml_datastore", "datastore_name": "my_datastore", "relative_path": "data" }
             },
             "dataloader_config": { "batch_size": 16 }
         }
@@ -45,7 +37,6 @@
                 {
                     "name": "accuracy",
                     "type": "custom",
-                    "data_config": "accuracy_data_config",
                     "sub_types": [
                         {
                             "name": "top1",
@@ -55,7 +46,17 @@
                         },
                         { "name": "top5", "goal": { "type": "max-degradation", "value": 0.01 } }
                     ],
-                    "user_config": { "user_script": "user_script.py", "evaluate_func": "eval_accuracy" }
+                    "user_config": {
+                        "user_script": "user_script.py",
+                        "evaluate_func": "eval_accuracy",
+                        "evaluate_func_kwargs": {
+                            "batch_size": 16,
+                            "data_dir": {
+                                "type": "azureml_datastore",
+                                "config": { "datastore_name": "my_datastore", "relative_path": "data" }
+                            }
+                        }
+                    }
                 },
                 {
                     "name": "latency",

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -13,11 +13,17 @@ import pytest
 from olive.common.pydantic_v1 import ValidationError
 from olive.data.config import DataConfig
 from olive.data.container.huggingface_container import HuggingfaceContainer
+from olive.data.registry import Registry
 from olive.package_config import OlivePackageConfig
 from olive.workflows.run.config import RunConfig
 from olive.workflows.run.run import get_pass_module_path, is_execution_provider_required
 
 # pylint: disable=attribute-defined-outside-init, unsubscriptable-object
+
+
+@Registry.register_dataloader()
+def _resnet_calibration_dataloader(dataset, **kwargs):
+    return None
 
 
 class TestRunConfig:

--- a/test/unit_test/workflows/test_setup.py
+++ b/test/unit_test/workflows/test_setup.py
@@ -12,6 +12,7 @@ import pytest
 
 from olive.common.constants import OS
 from olive.common.utils import run_subprocess
+from olive.data.registry import Registry
 
 # pylint: disable=redefined-outer-name
 
@@ -22,6 +23,11 @@ class DependencySetupEnvBuilder(venv.EnvBuilder):
         # Install Olive only
         olive_root = str(Path(__file__).parents[3].resolve())
         run_subprocess([context.env_exe, "-Im", "pip", "install", olive_root], check=True)
+
+
+@Registry.register_dataloader()
+def _resnet_calibration_dataloader(dataset, **kwargs):
+    return None
 
 
 @pytest.fixture()

--- a/test/unit_test/workflows/test_workflow_run.py
+++ b/test/unit_test/workflows/test_workflow_run.py
@@ -8,8 +8,15 @@ from unittest.mock import patch
 
 import pytest
 
+from olive.data.registry import Registry
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.workflows import run as olive_run
+
+
+@Registry.register_dataloader()
+def workflow_run_test_dataloader(dataset, batch_size):
+    return None
+
 
 INPUT_MODEL_CONFIG = {
     "type": "PyTorchModel",
@@ -33,15 +40,32 @@ EVALUATORS_CONFIG = {
     ]
 }
 
+DATA_CONFIGS = [
+    {
+        "name": "qat_train_data_config",
+        "type": "DummyDataContainer",
+        "load_dataset_config": {"type": "simple_dataset", "params": {"data_dir": "data"}},
+        "pre_process_data_config": {"type": "skip_pre_process"},
+        "post_process_data_config": {"type": "skip_post_process"},
+        "dataloader_config": {"type": "workflow_run_test_dataloader", "params": {"batch_size": 100}},
+    },
+    {
+        "name": "qat_val_data_config",
+        "type": "DummyDataContainer",
+        "load_dataset_config": {"type": "simple_dataset", "params": {"data_dir": "data"}},
+        "pre_process_data_config": {"type": "skip_pre_process"},
+        "post_process_data_config": {"type": "skip_post_process"},
+        "dataloader_config": {"type": "workflow_run_test_dataloader", "params": {"batch_size": 100}},
+    },
+]
+
 PASS_CONFIG = {
     "qat": {
         "type": "QuantizationAwareTraining",
         "config": {
-            "train_data_dir": "data",
-            "val_data_dir": "data",
+            "train_data_config": "qat_train_data_config",
+            "val_data_config": "qat_val_data_config",
             "num_epochs": 1,
-            "train_dataloader_func": "create_train_dataloader",
-            "train_batch_size": 100,
             "modules_to_fuse": [["conv1", "bn1"], ["conv2", "bn2"], ["conv3", "bn3"]],
             "qconfig_func": "create_qat_config",
         },
@@ -54,12 +78,14 @@ PASS_CONFIG = {
     [
         {
             "input_model": INPUT_MODEL_CONFIG,
+            "data_configs": DATA_CONFIGS,
             "evaluators": {"common_evaluator": EVALUATORS_CONFIG},
             "passes": PASS_CONFIG,
             "engine": {"evaluator": "common_evaluator"},
         },
         {
             "input_model": INPUT_MODEL_CONFIG,
+            "data_configs": DATA_CONFIGS,
             "passes": PASS_CONFIG,
             "engine": {"evaluator": EVALUATORS_CONFIG},
         },


### PR DESCRIPTION
## Deprecate dataloader_func and related config parameters

* Update quantization passes to use DataConfig
* Update relevant tests, examples and docs

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
