### PR TITLE
CI: Configurable `torch` version, SD: Pin `transformers` version

### DIFF
--- a/.azure_pipelines/job_templates/olive-build-doc-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-doc-template.yaml
@@ -15,10 +15,11 @@ jobs:
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
 
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.8
-      displayName: Use Python 3.8
+    - template: olive-setup-template.yaml
+      parameters:
+        python_version: '3.8'
+        onnxruntime: 'onnxruntime'
+        torch: 'torch'
 
     # checkout release branch if doc_version provided
     - script: |
@@ -28,9 +29,6 @@ jobs:
         git checkout rel-${{parameters.doc_version}}
       displayName: Checkout release branch
       condition: ne('${{parameters.doc_version}}', 'latest')
-
-    - script: python -m pip install .[cpu]
-      displayName: Install Olive
 
     - script: |
         # set -e, otherwise make html fails but the build continues

--- a/.azure_pipelines/job_templates/olive-build-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-template.yaml
@@ -6,6 +6,7 @@ parameters:
   windows: False
   device: 'cpu'
   onnxruntime: 'onnxruntime'
+  torch: 'torch'
 
 jobs:
 - template: olive-test-template.yaml
@@ -16,6 +17,7 @@ jobs:
     windows: ${{parameters.windows}}
     test_type: 'unit_test'
     onnxruntime: ${{parameters.onnxruntime}}
+    torch: ${{parameters.torch}}
 
 - template: olive-test-template.yaml
   parameters:
@@ -25,3 +27,4 @@ jobs:
     windows: ${{parameters.windows}}
     test_type: 'integ_test'
     onnxruntime: ${{parameters.onnxruntime}}
+    torch: ${{parameters.torch}}

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -5,6 +5,7 @@ parameters:
   pool: ''
   python_version: '3.8'
   onnxruntime: 'onnxruntime'
+  torch: 'torch'
 
 jobs:
   - job: ${{parameters.name}}_Test_Examples
@@ -21,24 +22,11 @@ jobs:
       PYTEST_BASETEMP: $(Pipeline.Workspace)/.pytest_basetemp
 
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: ${{ parameters.python_version }}
-      displayName: Use Python ${{ parameters.python_version }}
-
-    - script: python -m pip install .
-      displayName: Install Olive
-
-    - ${{ if startsWith(parameters.onnxruntime, 'ort-nightly') }}:
-      - script: |
-          pip install onnxruntime
-          pip uninstall -y onnxruntime
-          pip install ${{ parameters.onnxruntime }} --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-        displayName: Install ${{ parameters.onnxruntime }}
-    - ${{ else }}:
-      - script: |
-          pip install ${{ parameters.onnxruntime }}
-        displayName: Install ${{ parameters.onnxruntime }}
+    - template: olive-setup-template.yaml
+      parameters:
+        python_version: ${{ parameters.python_version }}
+        onnxruntime: ${{ parameters.onnxruntime }}
+        torch: ${{ parameters.torch }}
 
     # set exampleRequirements to requirements.txt if user does not specify
     - script:

--- a/.azure_pipelines/job_templates/olive-setup-template.yaml
+++ b/.azure_pipelines/job_templates/olive-setup-template.yaml
@@ -1,0 +1,27 @@
+parameters:
+  python_version: '3.8'
+  onnxruntime: 'onnxruntime'
+  torch: torch
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: ${{ parameters.python_version }}
+  displayName: Use Python ${{ parameters.python_version }}
+
+- script: python -m pip install ${{ parameters.torch }}
+  displayName: Install torch
+
+- script: python -m pip install .
+  displayName: Install Olive
+
+- ${{ if startsWith(parameters.onnxruntime, 'ort-nightly') }}:
+  - script: |
+      pip install onnxruntime
+      pip uninstall -y onnxruntime
+      pip install ${{ parameters.onnxruntime }} --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
+    displayName: Install ${{ parameters.onnxruntime }}
+- ${{ else }}:
+  - script: |
+      pip install ${{ parameters.onnxruntime }}
+    displayName: Install ${{ parameters.onnxruntime }}

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -6,6 +6,7 @@ parameters:
   device: 'cpu'
   python_version: '3.8'
   onnxruntime: 'onnxruntime'
+  torch: 'torch'
   requirements_file: 'requirements-test.txt'
 
 jobs:
@@ -23,29 +24,15 @@ jobs:
     PYTEST_BASETEMP: $(Pipeline.Workspace)/.pytest_basetemp
 
   steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: $(python_version)
-    displayName: Use Python $(python_version)
-
   - script: docker system df && docker system prune -a -f && docker system df
     displayName: Clean docker images
     continueOnError: true
 
-  - script: |
-      python -m pip install .
-    displayName: Install Olive
-
-  - ${{ if startsWith(parameters.onnxruntime, 'ort-nightly') }}:
-    - script: |
-        pip install onnxruntime
-        pip uninstall -y onnxruntime
-        pip install ${{ parameters.onnxruntime }} --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-      displayName: Install ${{ parameters.onnxruntime }}
-  - ${{ else }}:
-    - script: |
-        pip install ${{ parameters.onnxruntime }}
-      displayName: Install ${{ parameters.onnxruntime }}
+  - template: olive-setup-template.yaml
+    parameters:
+      python_version: ${{ parameters.python_version }}
+      onnxruntime: ${{ parameters.onnxruntime }}
+      torch: ${{ parameters.torch }}
 
   - ${{ if and(eq(variables.WINDOWS, 'True'), eq(variables.testType, 'multiple_ep')) }}:
     - script: |

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -159,6 +159,9 @@ jobs:
     name: Linux_GPU_CI
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: onnxruntime-gpu
+    # torch 2.4.0 installs nvidia-cudnn-cu12 9.x but ort-gpu (with cuda 11.x) requires 8.x
+    # pin torch version until os image has its own cudnn installed/updated which ort-gpu can use
+    torch: torch==2.3.1
     examples:
       bert_cuda_gpu:
         exampleFolder: bert

--- a/.azure_pipelines/olive-ort-last.yaml
+++ b/.azure_pipelines/olive-ort-last.yaml
@@ -103,7 +103,12 @@ jobs:
     name: Linux_GPU_CI
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: onnxruntime-gpu==$(OrtVersion)
+    torch: torch==2.3.1
     examples:
       bert_cuda_gpu:
         exampleFolder: bert
         exampleName: bert_cuda_gpu
+      stable_diffusion_cuda_gpu:
+        exampleFolder: stable_diffusion
+        exampleName: stable_diffusion_cuda_gpu
+        exampleRequirements: requirements-common.txt

--- a/.azure_pipelines/olive-ort-nightly.yaml
+++ b/.azure_pipelines/olive-ort-nightly.yaml
@@ -100,6 +100,7 @@ jobs:
     name: Linux_GPU_CI
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: ort-nightly-gpu
+    torch: torch==2.3.1
     examples:
       bert_cuda_gpu:
         exampleFolder: bert

--- a/examples/directml/stable_diffusion_xl/requirements-common.txt
+++ b/examples/directml/stable_diffusion_xl/requirements-common.txt
@@ -6,4 +6,5 @@ optimum
 pillow
 protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 torch
-transformers
+# StableDiffusionSafetyChecker vision_model ignores attn_implementation
+transformers<4.43.0

--- a/examples/stable_diffusion/requirements-common.txt
+++ b/examples/stable_diffusion/requirements-common.txt
@@ -5,4 +5,5 @@ pillow
 protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 tabulate
 torch
-transformers
+# StableDiffusionSafetyChecker vision_model ignores attn_implementation
+transformers<4.43.0


### PR DESCRIPTION
## Describe your changes
CI:
- Based on the cuda setup on the test machine, there might be incompatibilities between the cuda related dependencies between torch and ort-gpu. Allow CI jobs to specify the version of torch they want to run with.
- torch, olive and ort installation steps abstracted into a template.

SD:
- `transformers>=4.43.0` added sdpa and flash attention support to clip models which can be disabled by providing `"attn_implementation" : false` as load kwargs. However, `diffusers` hasn't been updated yet to use this option yet. 
- Pin the version until the issue is resolved.
- Issue tracking this: https://github.com/huggingface/diffusers/issues/8957

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
