### PR TITLE
Make config types case insensitive

### DIFF
--- a/docs/source/exts/auto_config_doc/__init__.py
+++ b/docs/source/exts/auto_config_doc/__init__.py
@@ -23,7 +23,7 @@ from olive.passes import Pass
 
 def import_class(class_name: str, package_config: OlivePackageConfig):
     module_path, module_name = class_name.rsplit(".", 1)
-    if module_name in package_config.passes:
+    if module_name.lower() in package_config.passes:
         return package_config.import_pass_module(module_name)
 
     module = import_module(module_path)

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -212,8 +212,24 @@ class NestedConfig(ConfigBase):
         return values
 
 
+class CaseInsensitiveEnum(str, Enum):
+    """StrEnum class that is insensitive to the case of the input string.
+
+    Note: Only insensitive when creating the enum object like `CaseInsensitiveEnum("value")`.
+    The values of the enum are still case-sensitive.
+    """
+
+    @classmethod
+    def _missing_(cls, value):
+        value = value.lower()
+        for member in cls:
+            if member.lower() == value:
+                return member
+        return None
+
+
 # TODO(jambayk): remove ParamCategory once validate object is removed or updated
-class ParamCategory(str, Enum):
+class ParamCategory(CaseInsensitiveEnum):
     NONE = "none"
     OBJECT = "object"
     PATH = "path"
@@ -259,6 +275,13 @@ def validate_object(v, values, field):
         raise ValueError("Invalid user_script")
     if isinstance(v, str) and values["user_script"] is None:
         raise ValueError(f"user_script must be provided if {field.name} is a name string")
+    return v
+
+
+# validator that always converts string to lowercase
+def validate_lowercase(v):
+    if isinstance(v, str):
+        return v.lower()
     return v
 
 

--- a/olive/data/config.py
+++ b/olive/data/config.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Union
 
-from olive.common.config_utils import ConfigBase, NestedConfig
+from olive.common.config_utils import ConfigBase, NestedConfig, validate_lowercase
 from olive.common.import_lib import import_user_module
 from olive.common.pydantic_v1 import Field, validator
 from olive.data.constants import DataComponentType, DefaultDataComponent, DefaultDataContainer
@@ -25,6 +25,10 @@ class DataComponentConfig(NestedConfig):
 
     type: str = None
     params: Dict = Field(default_factory=dict)
+
+    @validator("type", pre=True)
+    def validate_type(cls, v):
+        return validate_lowercase(v)
 
 
 DefaultDataComponentCombos = {
@@ -54,6 +58,10 @@ class DataConfig(ConfigBase):
         if not re.match(pattern, v):
             raise ValueError(f"DataConfig name {v} should only contain letters, numbers and underscore.")
         return v
+
+    @validator("type", pre=True)
+    def validate_type(cls, v):
+        return validate_lowercase(v)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/olive/data/registry.py
+++ b/olive/data/registry.py
@@ -12,7 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 class Registry:
-    """Registry for data components and data containers."""
+    """Registry for data components and data containers.
+
+    All component names are case insensitive and stored in lower case.
+    """
 
     _REGISTRY: ClassVar[Dict] = {
         DataComponentType.LOAD_DATASET.value: {},
@@ -36,7 +39,8 @@ class Registry:
         """
 
         def decorator(component):
-            component_name = name if name is not None else component.__name__
+            # make the component name case insensitive
+            component_name = (name if name is not None else component.__name__).lower()
             if component_name in cls._REGISTRY[sub_type.value]:
                 component_1 = cls._REGISTRY[sub_type.value][component_name]
                 component_2 = component
@@ -167,11 +171,11 @@ class Registry:
             Type: the component class
 
         """
-        return cls._REGISTRY[sub_type][name]
+        return cls._REGISTRY[sub_type][name.lower()]
 
     @classmethod
     def get_component(cls, component: str, name: str):
-        return cls._REGISTRY[component][name]
+        return cls._REGISTRY[component][name.lower()]
 
     @classmethod
     def get_load_dataset_component(cls, name: str):
@@ -234,7 +238,7 @@ class Registry:
 
         """
         name = name or DefaultDataContainer.DATA_CONTAINER.value
-        return cls._REGISTRY[DataContainerType.DATA_CONTAINER.value][name]
+        return cls._REGISTRY[DataContainerType.DATA_CONTAINER.value][name.lower()]
 
     @classmethod
     def get_default_load_dataset_component(cls):

--- a/olive/engine/packaging/packaging_config.py
+++ b/olive/engine/packaging/packaging_config.py
@@ -5,12 +5,12 @@
 from enum import Enum
 from typing import Optional, Union
 
-from olive.common.config_utils import ConfigBase, NestedConfig, validate_config
+from olive.common.config_utils import CaseInsensitiveEnum, ConfigBase, NestedConfig, validate_config
 from olive.common.constants import BASE_IMAGE
 from olive.common.pydantic_v1 import validator
 
 
-class PackagingType(str, Enum):
+class PackagingType(CaseInsensitiveEnum):
     """Output Artifacts type."""
 
     Zipfile = "Zipfile"

--- a/olive/model/config/model_config.py
+++ b/olive/model/config/model_config.py
@@ -18,7 +18,7 @@ class ModelConfig(NestedConfig):
     def validate_type(cls, v):
         if not is_valid_model_type(v):
             raise ValueError(f"Unknown model type {v}")
-        return v
+        return v.lower()
 
     def get_resource_strings(self):
         cls = get_model_handler(self.type)

--- a/olive/model/config/registry.py
+++ b/olive/model/config/registry.py
@@ -9,18 +9,19 @@ def model_handler_registry(model_type):
     """Decorate and register all OliveModelHandler subclasses.
 
     Args:
-        model_type (str): The model type registration name
+        model_type (str): The model type registration name. Is case-insensitive and stored in lowercase.
 
     Returns:
         cls: The class of register.
 
     """
+    model_type = model_type.lower()
 
     def decorator_model_class(cls):
         if model_type in REGISTRY:
             raise ValueError("Cannot have two model handlers with the same name")
 
-        REGISTRY[model_type.lower()] = cls
+        REGISTRY[model_type] = cls
         cls.model_type = model_type
         return cls
 

--- a/olive/package_config.py
+++ b/olive/package_config.py
@@ -7,12 +7,22 @@ from pathlib import Path
 from typing import Dict, List
 
 from olive.common.config_utils import ConfigBase
+from olive.common.pydantic_v1 import validator
 from olive.passes import PassModuleConfig
 
 
 class OlivePackageConfig(ConfigBase):
+    """Configuration for an Olive package.
+
+    passes key is case-insensitive and stored in lowercase.
+    """
+
     passes: Dict[str, PassModuleConfig]
     extra_dependencies: Dict[str, List[str]]
+
+    @validator("passes")
+    def validate_passes(cls, values):
+        return {key.lower(): value for key, value in values.items()}
 
     @staticmethod
     def get_default_config_path() -> str:
@@ -22,15 +32,19 @@ class OlivePackageConfig(ConfigBase):
     def load_default_config() -> "OlivePackageConfig":
         return OlivePackageConfig.parse_file(OlivePackageConfig.get_default_config_path())
 
-    def import_pass_module(self, pass_type):
-        if "." in pass_type:
-            _, module_name = pass_type.rsplit(".", 1)
-            return self.import_pass_module(module_name)
+    def import_pass_module(self, pass_type: str):
+        pass_module_config = self.get_pass_module_config(pass_type)
+        module_path, module_name = pass_module_config.module_path.rsplit(".", 1)
+        module = importlib.import_module(module_path, module_name)
+        return getattr(module, module_name)
 
+    def get_pass_module_config(self, pass_type: str):
+        if "." in pass_type:
+            _, module_name = pass_type.rsplit
+            return self.get_pass_module_config(module_name)
+
+        pass_type = pass_type.lower()
         if pass_type in self.passes:
-            pass_module_config = self.passes.get(pass_type)
-            module_path, module_name = pass_module_config.module_path.rsplit(".", 1)
-            module = importlib.import_module(module_path, module_name)
-            return getattr(module, module_name)
+            return self.passes.get(pass_type)
 
         raise ValueError(f"Package configuration for pass of type '{pass_type}' not found")

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -9,8 +9,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, Optional, Tuple, Type, Union, get_args
 
-from olive.common.config_utils import NestedConfig, ParamCategory, validate_config
-from olive.common.pydantic_v1 import Field
+from olive.common.config_utils import NestedConfig, ParamCategory, validate_config, validate_lowercase
+from olive.common.pydantic_v1 import Field, validator
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.config import DataConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
@@ -472,6 +472,10 @@ class AbstractPassConfig(NestedConfig):
             " provided."
         ),
     )
+
+    @validator("type", pre=True)
+    def validate_type(cls, v):
+        return validate_lowercase(v)
 
 
 # TODO(jambayk): rename. We are using FullPassConfig since PassConfigBase already refers to inner config

--- a/olive/resource_path.py
+++ b/olive/resource_path.py
@@ -8,20 +8,26 @@ import shutil
 import tempfile
 from abc import abstractmethod
 from copy import deepcopy
-from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
 
 from olive.azureml.azureml_client import AzureMLClientConfig
 from olive.common.auto_config import AutoConfigClass
-from olive.common.config_utils import ConfigBase, ConfigParam, NestedConfig, serialize_to_json, validate_config
+from olive.common.config_utils import (
+    CaseInsensitiveEnum,
+    ConfigBase,
+    ConfigParam,
+    NestedConfig,
+    serialize_to_json,
+    validate_config,
+)
 from olive.common.pydantic_v1 import Field, validator
 from olive.common.utils import copy_dir, retry_func
 
 logger = logging.getLogger(__name__)
 
 
-class ResourceType(str, Enum):
+class ResourceType(CaseInsensitiveEnum):
     LocalFile = "file"
     LocalFolder = "folder"
     StringName = "string_name"

--- a/olive/systems/common.py
+++ b/olive/systems/common.py
@@ -2,16 +2,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Union
 
-from olive.common.config_utils import ConfigBase
+from olive.common.config_utils import CaseInsensitiveEnum, ConfigBase
 from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import Device
 
 
-class SystemType(str, Enum):
+class SystemType(CaseInsensitiveEnum):
     Docker = "Docker"
     Local = "LocalSystem"
     AzureML = "AzureML"

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -121,8 +121,7 @@ def dependency_setup(package_config: OlivePackageConfig, run_config: RunConfig):
 
 
 def get_pass_module_path(pass_type: str, package_config: OlivePackageConfig) -> str:
-    pass_module_config = package_config.passes.get(pass_type)
-    return pass_module_config.module_path
+    return package_config.get_pass_module_config(pass_type).module_path
 
 
 def is_execution_provider_required(run_config: RunConfig, package_config: OlivePackageConfig) -> bool:

--- a/test/unit_test/systems/azureml/test_aml_system.py
+++ b/test/unit_test/systems/azureml/test_aml_system.py
@@ -541,7 +541,7 @@ class TestAzureMLSystem:
         mock_conversion_run.assert_called_once()
         with (output_dir / "output_model_config.json").open() as f:
             output_model_json = json.load(f)
-            assert output_model_json["type"] == "ONNXModel"
+            assert output_model_json["type"] == ONNXModelHandler.model_type
             assert output_model_json["config"]["model_path"]["type"] == "file"
             assert output_model_json["config"]["model_path"]["config"]["path"] == ONNX_MODEL_PATH.name
 

--- a/test/unit_test/test_package_config.py
+++ b/test/unit_test/test_package_config.py
@@ -11,5 +11,5 @@ class TestPackageConfig:
         package_config = OlivePackageConfig.load_default_config()
         for pass_module_name, pass_module_config in package_config.passes.items():
             assert pass_module_config.module_path
-            assert pass_module_config.module_path.endswith(pass_module_name)
+            assert pass_module_config.module_path[-len(pass_module_name) :].lower() == pass_module_name
             package_config.import_pass_module(pass_module_name)


### PR DESCRIPTION
## Describe your changes
Make the `type` fields in configs case insensitive.
- `str` types are all stored in lowercase and indexed using the same.
- `str,Enum` types inherit `CaseInsensitiveEnum` which can accept any case value.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
