### PR TITLE
Remove sort for aml config map

### DIFF
--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -301,7 +301,7 @@ class AzureMLSystem(OliveSystem):
             # input for the config
             config_path = tmp_dir / f"{name}_config.json"
             with config_path.open("w") as f:
-                json.dump(config_copy, f, sort_keys=True, indent=4)
+                json.dump(config_copy, f, indent=4)
             inputs[f"{name}_config"] = Input(type=AssetTypes.URI_FILE)
             args[f"{name}_config"] = Input(type=AssetTypes.URI_FILE, path=config_path)
 
@@ -309,7 +309,7 @@ class AzureMLSystem(OliveSystem):
             if resource_map:
                 resource_map_path = tmp_dir / f"{name}_resource_map.json"
                 with resource_map_path.open("w") as f:
-                    json.dump(resource_map, f, sort_keys=True, indent=4)
+                    json.dump(resource_map, f, indent=4)
                 inputs[f"{name}_resource_map"] = Input(type=AssetTypes.URI_FILE)
                 args[f"{name}_resource_map"] = Input(type=AssetTypes.URI_FILE, path=resource_map_path)
 
@@ -374,7 +374,7 @@ class AzureMLSystem(OliveSystem):
 
         olive_config_path = tmp_dir / "olive_config.json"
         with olive_config_path.open("w") as f:
-            json.dump(olive_config, f, sort_keys=True, indent=4)
+            json.dump(olive_config, f, indent=4)
         return olive_config_path
 
     def _create_step(


### PR DESCRIPTION
## Describe your changes

For some of configs, the sort of keys matters. Since now we add olive configs here, no need to sort the passes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
