### PR TITLE
Text-gen: Remove `pair` dataset_type, `source_max_len` -> `max_seq_len`

### DIFF
--- a/docs/source/features/huggingface_model_optimization.md
+++ b/docs/source/features/huggingface_model_optimization.md
@@ -87,7 +87,7 @@ Example: datasets in `data_configs`:
     "pre_process_data_config": {
         "text_cols": ["text"],
         "corpus_strategy": "line-by-line",
-        "source_max_len": 512,
+        "max_seq_len": 512,
         "pad_to_max_len": false
     }
 }]

--- a/examples/falcon/config.json
+++ b/examples/falcon/config.json
@@ -11,7 +11,7 @@
             "name": "openassistant_train",
             "type": "HuggingfaceContainer",
             "load_dataset_config": { "data_name": "timdettmers/openassistant-guanaco", "split": "train" },
-            "pre_process_data_config": { "source_max_len": 512, "max_samples": 1 }
+            "pre_process_data_config": { "max_seq_len": 512, "max_samples": 1 }
         }
     ],
     "evaluators": {

--- a/examples/llama2/notebook/llama2_multiep/config_multi_ep.json
+++ b/examples/llama2/notebook/llama2_multiep/config_multi_ep.json
@@ -20,7 +20,7 @@
             "name": "wikitext2_train",
             "type": "HuggingfaceContainer",
             "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
-            "pre_process_data_config": { "add_special_tokens": false, "source_max_len": 2048, "max_samples": 128 }
+            "pre_process_data_config": { "add_special_tokens": false, "max_seq_len": 2048, "max_samples": 128 }
         },
         {
             "name": "latency_prompt_processing_data_config",

--- a/examples/open_llama/llama_qlora.json
+++ b/examples/open_llama/llama_qlora.json
@@ -8,7 +8,7 @@
             "load_dataset_config": { "data_name": "timdettmers/openassistant-guanaco", "split": "train" },
             "pre_process_data_config": {
                 "corpus_strategy": "line-by-line",
-                "source_max_len": 512,
+                "max_seq_len": 512,
                 "pad_to_max_len": false
             }
         }

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -9,11 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from olive.common.hf.utils import get_model_config, get_tokenizer
 from olive.data.component.dataset import BaseDataset
-from olive.data.component.text_generation import (
-    TextGenDatasetType,
-    text_gen_corpus_pre_process,
-    text_gen_pair_pre_process,
-)
+from olive.data.component.text_generation import text_gen_pre_process
 from olive.data.registry import Registry
 
 
@@ -164,44 +160,27 @@ def ner_huggingface_preprocess(
 
 @Registry.register_pre_process()
 def text_generation_huggingface_pre_process(
-    dataset,
-    model_name: str,
-    source_max_len: int = 1024,
-    dataset_type: TextGenDatasetType = TextGenDatasetType.CORPUS,
-    max_samples: Optional[int] = None,
-    trust_remote_code: Optional[bool] = None,
-    **kwargs
+    dataset, model_name: str, trust_remote_code: Optional[bool] = None, **kwargs
 ):
     """Pre-process data for text generation task.
 
     Args:
         dataset (object): Data to be pre-processed, reserved for internal dataset assignment.
         model_name (str): Name of the huggingface model.
-        source_max_len (int): Max length of source sequence. For corpus, this is the max length of each sequence.
-            For pair, this is the max length of the input sequence.
-        dataset_type (TextGenDatasetType): Type of the dataset - 'corpus' or 'pair'. Defaults to 'corpus'.
-        max_samples (int, optional): Max number of samples to use. Defaults to None.
         trust_remote_code (bool, optional): Whether or not to allow for custom models defined on the Hub in their own
             modeling files. Defaults to None.
         **kwargs: Additional arguments.
             The common arguments are the fields in olive.data.component.text_generation.TextGenParams.
-            'corpus' arguments are the fields in olive.data.component.text_generation.TextGenCorpusParams.
-            'pair' arguments are the fields in olive.data.component.text_generation.TextGenPairParams.
-            Note: the TextGenCorpusParams and TextGenPairParams subclasses already include the common arguments.
 
     """
     all_kwargs = deepcopy(kwargs)
     # task is not used in the pre-process function. Will pop it so that the config validation doesn't warn about
     # unused kwargs
     all_kwargs.pop("task", None)
-    all_kwargs.update({"max_samples": max_samples, "source_max_len": source_max_len})
 
     tokenizer = get_tokenizer(model_name, trust_remote_code=trust_remote_code)
 
-    if dataset_type == TextGenDatasetType.CORPUS:
-        return text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs)
-    else:
-        return text_gen_pair_pre_process(dataset, tokenizer, all_kwargs)
+    return text_gen_pre_process(dataset, tokenizer, all_kwargs)
 
 
 @Registry.register_pre_process()

--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -18,15 +18,8 @@ from olive.data.component.dataset import BaseDataset
 from olive.data.constants import IGNORE_INDEX
 
 
-class TextGenDatasetType(str, Enum):
-    """Text generation dataset type."""
-
-    CORPUS = "corpus"  # single text source, e.g. a book
-    PAIR = "pair"  # two text sources, e.g. an input and an output
-
-
-class TextGenCorpusStrategy(str, Enum):
-    """Strategy for tokenizing a corpus."""
+class TextGenStrategy(str, Enum):
+    """Strategy for tokenizing a dataset."""
 
     LINE_BY_LINE = "line-by-line"  # each line is a sequence, in order of appearance
     LINE_BY_LINE_RANDOM = "line-by-line-random"  # each line is a sequence, in random order
@@ -37,39 +30,16 @@ class TextGenCorpusStrategy(str, Enum):
     )
 
 
-class TextGenPairFormat(str, Enum):
-    """Format of the pair dataset."""
-
-    # ALPACA format, https://huggingface.co/datasets/tatsu-lab/alpaca
-    # instruction, input (optional), output
-    ALPACA = "alpaca"
-    # OIG chip2 format, https://huggingface.co/datasets/laion/OIG unified_chip2.jsonl
-    # "<human>: ...\n<bot>:..."
-    CHIP2 = "chip2"
-    # self_instruct format, https://huggingface.co/datasets/yizhongw/self_instruct/viewer/self_instruct
-    # prompt, completion
-    SELF_INSTRUCT = "self_instruct"
-    # default format: input, output
-    DEFAULT = "default"
-    # custom, user-defined format. Must provide input_col and output_col in kwargs
-    CUSTOM = "custom"
-
-
-# ruff: noqa: N806
-
-
 class TextGenParams(ConfigBase):
     """Common parameters for text generation tasks.
 
     Base dataclass for text generation tasks.
     """
 
-    # TODO(jambayk): need to plan about supporting user_script and script_dir on remote systems
-    # TODO(jambayk): currently data config in general is not fully supported on remote systems
     user_script: Union[str, Path] = None  # user script use to define formatting functions
     script_dir: Union[str, Path] = None  # directory with user script dependencies
     max_samples: int = None  # max number of samples to use, None for all
-    source_max_len: int = 1024  # max length of source sequence
+    max_seq_len: int = 1024  # max length of sequence
     # TODO(jambayk): currently only support padding to max length since we preprocess all data at once
     # might have to expose collator for dataloader to support dynamic padding of batches
     # if false, cannot guarantee all sequences are same length. data loader will have to handle this during collation
@@ -77,23 +47,6 @@ class TextGenParams(ConfigBase):
     drop_short_sequences: bool = False  # drop sequences shorter than max_len. Mutually exclusive with pad_to_max_len
     add_special_tokens: bool = False  # add bos and eos tokens to each sequence
     use_attention_mask: bool = True  # add attention mask to each example
-
-    @validator("drop_short_sequences", always=True)
-    def _check_padding(cls, v, values):
-        if "pad_to_max_len" not in values:
-            raise ValueError("Invalid pad_to_max_len")
-        if v and values["pad_to_max_len"]:
-            raise ValueError("pad_to_max_len and drop_short_sequences cannot both be True")
-        return v
-
-    def get_user_module_loader(self):
-        """Get user module loader."""
-        return UserModuleLoader(self.user_script, self.script_dir)
-
-
-class TextGenCorpusParams(TextGenParams):
-    """Parameters for text generation task with 'corpus' dataset type."""
-
     # one of text_formatting_func, text_template, or text_cols must be provided
     # priority: text_formatting_func > text_template > text_cols
     # function that formats the text, must take in an example dict and return a string
@@ -103,7 +56,7 @@ class TextGenCorpusParams(TextGenParams):
     # list of text columns, columns are concatenated together using a space
     text_cols: Union[str, List[str]] = "text"
     # in JOIN strategies, the rows of text_cols are concatenated together
-    corpus_strategy: TextGenCorpusStrategy = TextGenCorpusStrategy.JOIN
+    corpus_strategy: TextGenStrategy = TextGenStrategy.JOIN
     stride: int = None  # required when corpus_strategy is JOIN_SLIDING_WINDOW
     # text to join the rows of input columns when corpus_strategy is JOIN
     # add_special_tokens: "{bos_token} {text_col1} {eos_token} {joiner} {bos_token} {text_col2} {eos_token}..."
@@ -116,13 +69,30 @@ class TextGenCorpusParams(TextGenParams):
         10  # number of resamples to try before giving up when a sample is too short for RANDOM strategies
     )
 
+    @validator("drop_short_sequences", always=True)
+    def _check_padding(cls, v, values):
+        if "pad_to_max_len" not in values:
+            raise ValueError("Invalid pad_to_max_len")
+        if v and values["pad_to_max_len"]:
+            raise ValueError("pad_to_max_len and drop_short_sequences cannot both be True")
+        return v
+
     @validator("text_formatting_func")
     def _check_text_formatting_func(cls, v, values, field):
         return validate_object(v, values, field)
 
     @validator("text_cols", always=True)
     def _check_text_cols(cls, v, values):
-        v = validate_text_source(v, values, "text_cols")
+        alternatives = ["text_formatting_func", "text_template"]
+        for alternate in alternatives:
+            # for good validation error, check that all alternates are in values
+            if alternate not in values:
+                raise ValueError(f"Invalid {alternate}")
+
+        if not (v or any(values[option] for option in alternatives)):
+            # check that at least one alternate is specified
+            raise ValueError(f"One of text_cols, {', '.join(alternatives)} must be specified")
+
         if v is not None and isinstance(v, str):
             v = [v]
         return v
@@ -131,7 +101,7 @@ class TextGenCorpusParams(TextGenParams):
     def _check_stride(cls, v, values):
         if "corpus_strategy" not in values:
             raise ValueError("Invalid corpus_strategy")
-        if values["corpus_strategy"] == TextGenCorpusStrategy.JOIN_SLIDING_WINDOW and v is None:
+        if values["corpus_strategy"] == TextGenStrategy.JOIN_SLIDING_WINDOW and v is None:
             raise ValueError("stride must be specified when corpus_strategy is JOIN_SLIDING_WINDOW")
         return v
 
@@ -168,56 +138,20 @@ class TextGenCorpusParams(TextGenParams):
             raise ValueError("random_seed must be specified when corpus_strategy is random")
         return v
 
-
-# TODO(jambayk): absorb pair format into corpus format and drop dataset_type
-# This is because pair format is just a special case of corpus format
-class TextGenPairParams(TextGenParams):
-    """Parameters for text generation task with 'pair' dataset type."""
-
-    pair_format: TextGenPairFormat = TextGenPairFormat.DEFAULT
-    # for custom pair_format, one of input_formatting_func, input_template, or input_col must be provided
-    input_formatting_func: Union[str, Callable] = None  # name of formatting function for input
-    input_template: str = None  # a python f-string template for the input with {column_name} as placeholders
-    input_col: str = None  # column name for input
-    # for custom pair_format, one of output_formatting_func, output_template, or output_col must be provided
-    output_formatting_func: Union[str, Callable] = None  # name of formatting function for output
-    output_template: str = None  # a python f-string template for the output with {column_name} as placeholders
-    output_col: str = None  # column name for output
-    target_max_len: int  # max length of target sequence
-    ignore_source_in_labels: bool = True  # set source tokens to ignore_index in labels
-
-    @validator("input_formatting_func", "output_formatting_func")
-    def _check_formatting_func(cls, v, values, field):
-        return validate_object(v, values, field)
-
-    @validator("input_col", "output_col", always=True)
-    def _check_custom(cls, v, values, field):
-        if "pair_format" not in values:
-            raise ValueError("Invalid pair_format")
-        if values["pair_format"] == TextGenPairFormat.CUSTOM:
-            v = validate_text_source(v, values, field.name)
-        return v
-
-    @validator("use_attention_mask", always=True)
-    def _check_use_attention_mask(cls, v, values):
-        if "pad_to_max_len" not in values:
-            raise ValueError("Invalid pad_to_max_len")
-        if not v and values["pad_to_max_len"]:
-            raise ValueError(
-                "pad_to_max_len is True but use_attention_mask is False. Attention mask is required for padding!"
-            )
-        return v
+    def get_user_module_loader(self):
+        """Get user module loader."""
+        return UserModuleLoader(self.user_script, self.script_dir)
 
 
-def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
-    """Pre-process data for text generation task with 'corpus' dataset type.
+def text_gen_pre_process(dataset, tokenizer, all_kwargs):
+    """Pre-process data for text generation task.
 
     The input dataset is expected to have one or more text columns.
     Depending on the corpus_strategy, the sequences are either joined together or processed individually.
     """
     from datasets import Dataset as HFDataset
 
-    args = validate_config(all_kwargs, TextGenCorpusParams, warn_unused_keys=True)
+    args = validate_config(all_kwargs, TextGenParams, warn_unused_keys=True)
 
     if isinstance(args.text_formatting_func, str):
         # load text_formatting_func
@@ -242,15 +176,15 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
     if "join" in args.corpus_strategy:
         joiner_tokens = tokenizer.encode(args.joiner, add_special_tokens=False) if args.joiner else []
 
-        if args.corpus_strategy != TextGenCorpusStrategy.JOIN_RANDOM:
+        if args.corpus_strategy != TextGenStrategy.JOIN_RANDOM:
             # no randomization, just use contiguous blocks of tokens
-            if args.corpus_strategy == TextGenCorpusStrategy.JOIN_SLIDING_WINDOW:
+            if args.corpus_strategy == TextGenStrategy.JOIN_SLIDING_WINDOW:
                 # we use the stride as both the step between sequences and the context size
-                step, context = args.stride, args.source_max_len - args.stride
+                step, context = args.stride, args.max_seq_len - args.stride
             else:
                 # JOIN corpus_strategy
                 # text is split into non-overlapping sequences and there is no context
-                step, context = args.source_max_len, None
+                step, context = args.max_seq_len, None
 
             example_idx = 0  # index of the first example in the current batch
             num_samples = 0  # samples processed so far
@@ -279,10 +213,10 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
                     joined_input_ids += input_ids + joiner_tokens
 
                 end_loc = 0  # position of unused token in joined_input_ids
-                # '- args.source_max_len' is used to make sure we don't get a sequence that is too short
-                for begin_loc in range(0, len(joined_input_ids) - args.source_max_len, step):
+                # '- args.max_seq_len ' is used to make sure we don't get a sequence that is too short
+                for begin_loc in range(0, len(joined_input_ids) - args.max_seq_len, step):
                     # end_loc is the beginning of the next sequence
-                    end_loc = begin_loc + args.source_max_len
+                    end_loc = begin_loc + args.max_seq_len
                     # get the input sequence
                     input_ids = torch.tensor(joined_input_ids[begin_loc:end_loc])
                     append_text_gen_input_ids(
@@ -323,12 +257,12 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
                             )["input_ids"]
                         joined_input_ids += cache[i] + joiner_tokens
                         # stop if we have enough tokens
-                        if len(joined_input_ids) >= args.source_max_len:
+                        if len(joined_input_ids) >= args.max_seq_len:
                             break
                     # add to samples if we have enough tokens
-                    if len(joined_input_ids) >= args.source_max_len:
+                    if len(joined_input_ids) >= args.max_seq_len:
                         # found a good example
-                        input_ids = torch.tensor(joined_input_ids[: args.source_max_len])
+                        input_ids = torch.tensor(joined_input_ids[: args.max_seq_len])
                         append_text_gen_input_ids(
                             tokenized_inputs, input_ids, tokenizer, use_attention_mask=args.use_attention_mask
                         )
@@ -336,7 +270,7 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
                     resamples += 1
     else:
         # each line is a sequence
-        if args.corpus_strategy == TextGenCorpusStrategy.LINE_BY_LINE:
+        if args.corpus_strategy == TextGenStrategy.LINE_BY_LINE:
             # batched tokenization might be faster so lets tokenize all the text at once
             if not args.max_samples:
                 batched_input_ids = batch_tokenize_text(text_list, tokenizer, args)
@@ -380,7 +314,7 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
                     if i not in cache:
                         encodings = tokenizer(
                             text_list[i],
-                            max_length=args.source_max_len,
+                            max_length=args.max_seq_len,
                             truncation=True,
                             padding="max_length" if args.pad_to_max_len else False,
                             add_special_tokens=False,
@@ -389,7 +323,7 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
                         cache[i] = encodings
                     else:
                         encodings = cache[i]
-                    if not args.drop_short_sequences or encodings.input_ids.shape[1] >= args.source_max_len:
+                    if not args.drop_short_sequences or encodings.input_ids.shape[1] >= args.max_seq_len:
                         # found a good sample
                         break
                     resamples += 1
@@ -406,92 +340,6 @@ def text_gen_corpus_pre_process(dataset, tokenizer, all_kwargs):
 
     # return BaseDataset
     return BaseDataset(hf_dataset, ["labels"], max_samples=args.max_samples)
-
-
-# based on https://github.com/artidoro/qlora/blob/main/qlora.py
-def text_gen_pair_pre_process(dataset, tokenizer, all_kwargs):
-    """Pre-process data for text generation task with 'pair' dataset type.
-
-    Dataset is expected to have two text columns: input and output.
-    An example is a dataset with pairs of prompts and completions.
-
-    The input (truncated to source_max_len) and output (truncated to target_max_len) are concatenated together.
-    """
-    from datasets import Dataset as HFDataset
-
-    args = validate_config(all_kwargs, TextGenPairParams, warn_unused_keys=True)
-
-    if args.max_samples is not None:
-        # truncate dataset to max_samples
-        # makes tokenization faster
-        dataset = dataset.select(range(args.max_samples))
-
-    # format dataset based on pair_format
-    # the formatted dataset has two columns: input and output
-    dataset = format_pair_dataset(dataset, args)
-
-    # extract elements
-    sources = dataset["input"]
-    targets = dataset["output"]
-    if args.add_special_tokens:
-        # add bos and eos tokens
-        # input and output are concatenated, so add the bos and eos tokens to the input and output respectively
-        sources = [f"{tokenizer.bos_token} {source}" for source in sources]
-        targets = [f"{target} {tokenizer.eos_token}" for target in targets]
-
-    # tokenize
-    tokenized_sources = tokenizer(sources, max_length=args.source_max_len, truncation=True, add_special_tokens=False)
-    tokenized_targets = tokenizer(targets, max_length=args.target_max_len, truncation=True, add_special_tokens=False)
-
-    # build tokenized_inputs
-    tokenized_inputs = {
-        "input_ids": [],
-        "labels": [],
-    }
-    if args.use_attention_mask:
-        tokenized_inputs["attention_mask"] = []
-    # max_len is the max length of the concatenated input and output
-    # if pad_to_max_len is True, max_len is the max length of the concatenated input and output
-    max_len = args.source_max_len + args.target_max_len
-    for tokenized_source, tokenized_target in zip(tokenized_sources["input_ids"], tokenized_targets["input_ids"]):
-        # concatenate input and output
-        input_ids = torch.tensor(tokenized_source + tokenized_target)
-        if args.drop_short_sequences and input_ids.shape[0] < max_len:
-            # skip short sequences if drop_short_sequences is True
-            continue
-        if args.pad_to_max_len:
-            if tokenizer.pad_token_id is None:
-                raise ValueError("Tokenizer does not have a pad token")
-            # add padding to max_len
-            # pylint: disable=not-callable
-            input_ids = torch.nn.functional.pad(
-                input_ids, (0, max_len - input_ids.shape[0]), value=tokenizer.pad_token_id
-            )
-        # if ignore_source_in_labels is True, the source tokens are treated as context and set to ignore_index in labels
-        context = len(tokenized_source) if args.ignore_source_in_labels else None
-        append_text_gen_input_ids(
-            tokenized_inputs, input_ids, tokenizer, context=context, use_attention_mask=args.use_attention_mask
-        )
-
-    # convert to HFDataset
-    hf_dataset = HFDataset.from_dict(tokenized_inputs)
-    hf_dataset.set_format("torch", output_all_columns=True)
-
-    return BaseDataset(hf_dataset, ["labels"], max_samples=args.max_samples)
-
-
-def validate_text_source(v, values, field_name):
-    """Check that one of formatting_func, template, or col is specified."""
-    prefix = field_name.split("_")[0]
-    alternatives = [f"{prefix}_formatting_func", f"{prefix}_template"]
-    for alternative in alternatives:
-        # for good validation error, check that all alternates are in values
-        if alternative not in values:
-            raise ValueError(f"Invalid {alternative}")
-    if not (v or any(values[option] for option in alternatives)):
-        # check that at least one alternate is specified
-        raise ValueError(f"One of {field_name}, {', '.join(alternatives)} must be specified")
-    return v
 
 
 def get_text(
@@ -522,14 +370,14 @@ def batch_tokenize_text(text_list, tokenizer, args):
     """Batch tokenize text."""
     batched_encodings = tokenizer(
         text_list,
-        max_length=args.source_max_len,
+        max_length=args.max_seq_len,
         truncation=True,
         padding="max_length" if args.pad_to_max_len else False,
         add_special_tokens=False,
     )
     batched_input_ids = batched_encodings.input_ids
     if args.drop_short_sequences:
-        batched_input_ids = [input_ids for input_ids in batched_input_ids if len(input_ids) >= args.source_max_len]
+        batched_input_ids = [input_ids for input_ids in batched_input_ids if len(input_ids) >= args.max_seq_len]
     return batched_input_ids
 
 
@@ -562,70 +410,3 @@ def append_text_gen_input_ids(
     # add to list
     for k, v in inputs.items():
         tokenized_inputs[k].append(v)
-
-
-# based on https://github.com/artidoro/qlora/blob/main/qlora.py
-def format_pair_dataset(dataset, args):
-    """Format dataset based on pair_format."""
-    # format for input in ALPACA pair format
-    # instruction, input (optional), output
-    ALPACA_PROMPT_DICT = {
-        "prompt_input": (
-            "Below is an instruction that describes a task, paired with an input that provides further context. "
-            "Write a response that appropriately completes the request.\n\n"
-            "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response: "
-        ),
-        "prompt_no_input": (
-            "Below is an instruction that describes a task. "
-            "Write a response that appropriately completes the request.\n\n"
-            "### Instruction:\n{instruction}\n\n### Response: "
-        ),
-    }
-
-    if args.pair_format == TextGenPairFormat.ALPACA:
-
-        def extract_alpaca_dataset(example):
-            # extract new input from instruction and input
-            if example.get("input", "") != "":
-                prompt_format = ALPACA_PROMPT_DICT["prompt_input"]
-            else:
-                prompt_format = ALPACA_PROMPT_DICT["prompt_no_input"]
-            return {"input": prompt_format.formate(**example)}
-
-        # extract new input from instruction and input
-        dataset = dataset.map(extract_alpaca_dataset, remove_columns=["instruction"])
-    elif args.pair_format == TextGenPairFormat.CHIP2:
-        # separate the human and bot text into input and output
-        dataset = dataset.map(
-            lambda x: {
-                "input": x["text"].split("\n<bot>: ")[0].replace("<human>: ", ""),
-                "output": x["text"].split("\n<bot>: ")[1],
-            }
-        )
-    elif args.pair_format == TextGenPairFormat.SELF_INSTRUCT:
-        # rename prompt and completion to input and output
-        dataset = dataset.map(
-            lambda x: {
-                "input": x["prompt"],
-                "output": x["completion"],
-            }
-        )
-    elif args.pair_format == TextGenPairFormat.CUSTOM:
-        if isinstance(args.input_formatting_func, str) or isinstance(args.output_formatting_func, str):
-            user_module_loader = args.get_user_module_loader()
-            args.input_formatting_func = user_module_loader.load_object(args.input_formatting_func)
-            args.output_formatting_func = user_module_loader.load_object(args.output_formatting_func)
-        dataset = dataset.map(
-            lambda x: {
-                "input": get_text(x, args.input_formatting_func, args.input_template, [args.input_col]),
-                "output": get_text(x, args.output_formatting_func, args.output_template, [args.output_col]),
-            }
-        )
-    elif args.pair_format == TextGenPairFormat.DEFAULT:
-        # do nothing
-        pass
-    else:
-        raise ValueError(f"Invalid pair_format: {args.pair_format}")
-
-    # remove unused columns, keep only input and output
-    return dataset.remove_columns([col for col in dataset.column_names if col not in ["input", "output"]])

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -35,7 +35,7 @@ def get_pass_config(model_name, task, **kwargs):
             "params": {
                 "text_cols": ["sentence"],
                 "corpus_strategy": "line-by-line",
-                "source_max_len": 512,
+                "max_seq_len": 512,
                 "max_samples": 10,
                 "pad_to_max_len": False,
                 "trust_remote_code": True,

--- a/test/unit_test/passes/pytorch/test_slicegpt.py
+++ b/test/unit_test/passes/pytorch/test_slicegpt.py
@@ -33,7 +33,7 @@ def test_slicegpt(tmp_path):
                 "text_cols": ["text"],
                 "corpus_strategy": "join",
                 "add_special_tokens": False,
-                "source_max_len": 2048,
+                "max_seq_len": 2048,
                 "max_samples": 128,
                 "joiner": "\n\n",
                 "trust_remote_code": True,

--- a/test/unit_test/passes/pytorch/test_sparsegpt.py
+++ b/test/unit_test/passes/pytorch/test_sparsegpt.py
@@ -26,7 +26,7 @@ def test_sparsegpt(tmp_path):
             "params": {
                 "text_cols": ["sentence"],
                 "corpus_strategy": "join-random",
-                "source_max_len": 1024,
+                "max_seq_len": 1024,
                 "max_samples": 1,
                 "random_seed": 42,
                 "trust_remote_code": True,

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -67,7 +67,7 @@ def test_torch_trt_conversion_success(tmp_path):
             "params": {
                 "text_cols": ["sentence"],
                 "corpus_strategy": "join-random",
-                "source_max_len": 100,
+                "max_seq_len": 100,
                 "max_samples": 1,
                 "random_seed": 42,
                 "trust_remote_code": True,


### PR DESCRIPTION
## Describe your changes
- The `pair` dataset type was originally added to replicate the original qlora implementation's dataprocessing options. However, it is not used and is has limited use case. Drop support for this dataset type and only keep the common `corpus` type.
- Since pair is not a concept anymore, `source_max_len` is renamed to `max_seq_len` to align the parameter name to how it's commonly known as (such as in hf trl, etc).

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
  `pair` dataset type has been removed. `source_max_len` renamed to `max_seq_len`.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
