### PR TITLE
Support for custom evaluators

### DIFF
--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -1079,10 +1079,9 @@ class Engine:
             return signal
 
         # evaluate model
-        metrics = evaluator_config.metrics if evaluator_config else []
         if self.target.system_type != SystemType.AzureML:
             model_config = self.cache.prepare_resources_for_local(model_config)
-        signal = self.target.evaluate_model(model_config, metrics, accelerator_spec)
+        signal = self.target.evaluate_model(model_config, evaluator_config, accelerator_spec)
 
         # cache evaluation
         self._cache_evaluation(model_id_with_accelerator, signal)

--- a/olive/evaluator/__init__.py
+++ b/olive/evaluator/__init__.py
@@ -2,3 +2,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+
+from olive.evaluator.metric import Metric, SubMetric
+from olive.evaluator.metric_result import MetricResult, SubMetricResult, flatten_metric_result
+from olive.evaluator.olive_evaluator import OliveEvaluator
+
+__all__ = [
+    "flatten_metric_result",
+    "Metric",
+    "MetricResult",
+    "OliveEvaluator",
+    "SubMetric",
+    "SubMetricResult",
+]

--- a/olive/evaluator/registry.py
+++ b/olive/evaluator/registry.py
@@ -1,0 +1,68 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import inspect
+import logging
+from typing import ClassVar, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class Registry:
+    """Registry for olive model evaluators."""
+
+    _REGISTRY: ClassVar[Dict] = {}
+
+    @classmethod
+    def register(cls, name: str = None):
+        """Register an evaluator to the registry.
+
+        Args:
+            name (str): the name of the evaluator, if name is None, uses the class name
+
+        Returns:
+            Callable: the decorator function
+
+        """
+
+        def decorator(component):
+            component_name = name if name is not None else component.__name__
+            if component_name in cls._REGISTRY:
+                component_1 = cls._REGISTRY[component_name]
+                component_2 = component
+
+                component_file_1 = inspect.getfile(component_1)
+                component_file_2 = inspect.getfile(component_2)
+
+                _, component_line_no_1 = inspect.getsourcelines(component_1)
+                _, component_line_no_2 = inspect.getsourcelines(component_2)
+
+                if (component_file_1 != component_file_2) or (component_line_no_1 != component_line_no_2):
+                    logger.critical(
+                        "%s: Duplicate evaluator registration.\n"
+                        "\tPrevious Registration: %s:%d\n"
+                        "\tCurrent Registration: %s:%d.",
+                        component_name,
+                        component_file_1,
+                        component_line_no_1,
+                        component_file_2,
+                        component_line_no_2,
+                    )
+            cls._REGISTRY[component_name] = component
+            return component
+
+        return decorator
+
+    @classmethod
+    def get(cls, name: str):
+        """Get an evaluator, by name, from the registry.
+
+        Args:
+            name (str): the name of the evaluator
+
+        Returns:
+            Type: the OliveEvaluator class
+
+        """
+        return cls._REGISTRY.get(name)

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -16,7 +16,7 @@ from olive.common.utils import exclude_keys
 from olive.data.config import DataConfig
 from olive.evaluator.metric import Metric
 from olive.evaluator.metric_result import joint_metric_key
-from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.exception import OlivePassError
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
@@ -337,12 +337,13 @@ class IncQuantization(Pass):
             )
 
             # create evaluator for model
-            evaluator = OliveEvaluatorFactory.create_evaluator_for_model(olive_model)
+            evaluator_config = OliveEvaluatorConfig(metrics=[accuracy_metric])
+            evaluator = evaluator_config.create_evaluator(olive_model)
 
             # evaluate model
             result = evaluator.evaluate(
                 olive_model,
-                [accuracy_metric],
+                evaluator_config.metrics,
                 self.accelerator_spec.accelerator_type,
                 [self.accelerator_spec.execution_provider],
             )

--- a/olive/passes/onnx/perf_tuning.py
+++ b/olive/passes/onnx/perf_tuning.py
@@ -16,6 +16,7 @@ from olive.common.ort_inference import check_and_normalize_provider_args
 from olive.data.config import DataConfig
 from olive.evaluator.metric import LatencySubType, Metric, MetricType
 from olive.evaluator.metric_result import joint_metric_key
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.exception import EXCEPTIONS_TO_RAISE
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec
 from olive.model import ONNXModelHandler
@@ -372,8 +373,6 @@ class PerfTuningRunner:
     ):
         import onnxruntime as ort
 
-        from olive.evaluator.olive_evaluator import OliveEvaluatorFactory
-
         # prepare the inference_settings for metrics.
         tuning_result_file = None
         if test_params:
@@ -405,8 +404,9 @@ class PerfTuningRunner:
             joint_key = joint_metric_key(latency_metric.name, latency_metric.sub_types[0].name)
 
             start_time = time.perf_counter()
-            evaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-            metric_result = evaluator.evaluate(model, [latency_metric], self.config.device, None)
+            evaluator_config = OliveEvaluatorConfig(metrics=[latency_metric])
+            evaluator = evaluator_config.create_evaluator(model)
+            metric_result = evaluator.evaluate(model, evaluator_config.metrics, self.config.device, None)
 
             end_time = time.perf_counter()
             latency_ms = metric_result[joint_key].value

--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -32,6 +32,7 @@ from olive.model import HfModelHandler
 from olive.model.config.hf_config import HfLoadKwargs
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
+from olive.strategy.search_parameter import Categorical
 
 if TYPE_CHECKING:
     from peft import PeftModel
@@ -156,7 +157,12 @@ class LoRABase(Pass):
                     " True. 16+ is required when using bfloat16 and model has operators such as Where."
                 ),
             ),
-            "lora_r": PassConfigParam(type_=int, default_value=64, description="Lora R dimension."),
+            "lora_r": PassConfigParam(
+                type_=int,
+                default_value=64,
+                searchable_values=Categorical([16, 32, 64]),
+                description="Lora R dimension.",
+            ),
             "lora_alpha": PassConfigParam(
                 type_=float, default_value=16, description="The alpha parameter for Lora scaling."
             ),

--- a/olive/systems/azureml/aml_evaluation_runner.py
+++ b/olive/systems/azureml/aml_evaluation_runner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from olive.common.hf.login import aml_runner_hf_login
-from olive.evaluator.metric import Metric
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import AcceleratorSpec
 from olive.logging import set_verbosity_from_env
 from olive.model import ModelConfig
@@ -24,11 +24,11 @@ def main(raw_args=None):
     aml_runner_hf_login()
 
     pipeline_output, resources, model_config, extra_args = get_common_args(raw_args)
-    metric_config, extra_args = parse_config(extra_args, "metric", resources)
+    evaluator_config, extra_args = parse_config(extra_args, "evaluator", resources)
     accelerator_config, extra_args = parse_config(extra_args, "accelerator", resources)
 
-    # load metric
-    metric = Metric.from_json(metric_config)
+    # load evaluator config
+    evaluator_config = OliveEvaluatorConfig.from_json(evaluator_config)
 
     # load model config
     model_config = ModelConfig.from_json(model_config)
@@ -39,7 +39,7 @@ def main(raw_args=None):
     target: OliveSystem = LocalSystem()
 
     # metric result
-    metric_result = target.evaluate_model(model_config, [metric], accelerator_spec)
+    metric_result = target.evaluate_model(model_config, evaluator_config, accelerator_spec)
 
     # save metric result json
     with (Path(pipeline_output) / "metric_result.json").open("w") as f:

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -22,6 +22,7 @@ from olive.common.config_utils import validate_config
 from olive.common.constants import HF_LOGIN, KEYVAULT_NAME, WORKFLOW_ARTIFACTS, WORKFLOW_CONFIG
 from olive.common.utils import copy_dir, get_nested_dict_value, retry_func, set_nested_dict_value
 from olive.evaluator.metric_result import MetricResult
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.model import ModelConfig
 from olive.resource_path import (
     AZUREML_RESOURCE_TYPES,
@@ -38,7 +39,6 @@ from olive.systems.system_config import AzureMLTargetUserConfig
 from olive.workflows.run.config import RunConfig
 
 if TYPE_CHECKING:
-    from olive.evaluator.metric import Metric
     from olive.hardware.accelerator import AcceleratorSpec
     from olive.passes.olive_pass import Pass
 
@@ -573,7 +573,7 @@ class AzureMLSystem(OliveSystem):
         return ModelConfig(**model_json)
 
     def evaluate_model(
-        self, model_config: ModelConfig, metrics: List["Metric"], accelerator: "AcceleratorSpec"
+        self, model_config: ModelConfig, evaluator_config: OliveEvaluatorConfig, accelerator: "AcceleratorSpec"
     ) -> MetricResult:
         if model_config.type.lower() == "SNPEModel".lower():
             raise NotImplementedError("SNPE model does not support azureml evaluation")
@@ -583,14 +583,14 @@ class AzureMLSystem(OliveSystem):
         with tempfile.TemporaryDirectory() as tempdir:
             ml_client = self.azureml_client_config.create_client()
             pipeline_job = self._create_pipeline_for_evaluation(
-                tempdir, model_config.to_json(check_object=True), metrics, accelerator
+                tempdir, model_config.to_json(check_object=True), evaluator_config, accelerator
             )
 
             # submit job
             named_outputs_dir = self._run_job(ml_client, pipeline_job, "olive-evaluation", tempdir)
 
             metric_results = {}
-            for metric in metrics:
+            for metric in evaluator_config.metrics:
                 metric_json = named_outputs_dir / metric.name / "metric_result.json"
                 if metric_json.is_file():
                     with metric_json.open() as f:
@@ -602,7 +602,7 @@ class AzureMLSystem(OliveSystem):
         self,
         tmp_dir: str,
         model_config: dict,
-        metrics: List["Metric"],
+        evaluator_config: OliveEvaluatorConfig,
         accelerator: "AcceleratorSpec",
     ):
         tmp_dir = Path(tmp_dir)
@@ -610,12 +610,12 @@ class AzureMLSystem(OliveSystem):
         @pipeline
         def evaluate_pipeline():
             outputs = {}
-            for metric in metrics:
+            for metric in evaluator_config.metrics:
                 metric_tmp_dir = tmp_dir / metric.name
                 metric_component = self._create_metric_component(
                     metric_tmp_dir,
                     model_config,
-                    metric,
+                    OliveEvaluatorConfig(type=evaluator_config.type, metrics=[metric]).to_json(check_object=True),
                     accelerator.to_json(),
                 )
                 outputs[metric.name] = metric_component.outputs.pipeline_output
@@ -630,10 +630,10 @@ class AzureMLSystem(OliveSystem):
         self,
         tmp_dir: Path,
         model_config: dict,
-        metric: "Metric",
+        evaluator_config: dict,
         accelerator_config: dict,
     ):
-        metric_json = metric.to_json(check_object=True)
+        assert len(evaluator_config["metrics"]) == 1, "Cannot handle more than one metric per component"
 
         # prepare code
         script_name = "aml_evaluation_runner.py"
@@ -651,7 +651,7 @@ class AzureMLSystem(OliveSystem):
 
         # prepare inputs
         inputs, args = self.create_inputs_and_args(
-            {"model": model_config, "metric": metric_json, "accelerator": accelerator_config},
+            {"model": model_config, "evaluator": evaluator_config, "accelerator": accelerator_config},
             tmp_dir,
             ignore_keys=["model_attributes"],
         )
@@ -660,6 +660,7 @@ class AzureMLSystem(OliveSystem):
         outputs = {"pipeline_output": Output(type=AssetTypes.URI_FOLDER)}
 
         # metric type
+        metric_json = evaluator_config["metrics"][0]
         metric_type = metric_json["type"]
         if metric_json["sub_types"] is not None:
             sub_type_name = ",".join([st["name"] for st in metric_json["sub_types"]])

--- a/olive/systems/docker/eval.py
+++ b/olive/systems/docker/eval.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 from olive.common.hf.login import huggingface_login
-from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorConfig, OliveEvaluatorFactory
+from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorConfig
 from olive.logging import set_verbosity_from_env
 from olive.model import ModelConfig
 
@@ -29,7 +29,7 @@ def evaluate_entry(config, output_path, output_name, accelerator_type, execution
 
     model = ModelConfig.from_json(model_json).create_model()
 
-    evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
+    evaluator: OliveEvaluator = evaluator_config.create_evaluator(model)
     metrics_res = evaluator.evaluate(
         model, evaluator_config.metrics, device=accelerator_type, execution_providers=execution_provider
     )

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -4,15 +4,14 @@
 # --------------------------------------------------------------------------
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorFactory
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import ModelConfig
 from olive.systems.common import SystemType
 from olive.systems.olive_system import OliveSystem
 
 if TYPE_CHECKING:
-    from olive.evaluator.metric import Metric
     from olive.evaluator.metric_result import MetricResult
+    from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorConfig
     from olive.passes.olive_pass import Pass
 
 
@@ -32,7 +31,7 @@ class LocalSystem(OliveSystem):
         return ModelConfig.from_json(output_model.to_json())
 
     def evaluate_model(
-        self, model_config: ModelConfig, metrics: List["Metric"], accelerator: AcceleratorSpec
+        self, model_config: ModelConfig, evaluator_config: "OliveEvaluatorConfig", accelerator: AcceleratorSpec
     ) -> "MetricResult":
         """Evaluate the model."""
         if model_config.type.lower() == "compositemodel":
@@ -42,8 +41,10 @@ class LocalSystem(OliveSystem):
         execution_providers = accelerator.execution_provider if accelerator else None
 
         model = model_config.create_model()
-        evaluator: OliveEvaluator = OliveEvaluatorFactory.create_evaluator_for_model(model)
-        return evaluator.evaluate(model, metrics, device=device, execution_providers=execution_providers)
+        evaluator: OliveEvaluator = evaluator_config.create_evaluator(model)
+        return evaluator.evaluate(
+            model, evaluator_config.metrics, device=device, execution_providers=execution_providers
+        )
 
     def get_supported_execution_providers(self) -> List[str]:
         """Get the available execution providers."""

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -10,8 +10,8 @@ from olive.common.config_utils import validate_config
 from olive.systems.common import AcceleratorConfig, SystemType
 
 if TYPE_CHECKING:
-    from olive.evaluator.metric import Metric
     from olive.evaluator.metric_result import MetricResult
+    from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
     from olive.hardware.accelerator import AcceleratorSpec
     from olive.model import ModelConfig
     from olive.passes.olive_pass import Pass
@@ -53,7 +53,7 @@ class OliveSystem(ABC):
 
     @abstractmethod
     def evaluate_model(
-        self, model_config: "ModelConfig", metrics: List["Metric"], accelerator: "AcceleratorSpec"
+        self, model_config: "ModelConfig", evaluator_config: "OliveEvaluatorConfig", accelerator: "AcceleratorSpec"
     ) -> "MetricResult":
         """Evaluate the model."""
         raise NotImplementedError

--- a/olive/systems/python_environment/evaluation_runner.py
+++ b/olive/systems/python_environment/evaluation_runner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from olive.common.utils import set_tempdir
-from olive.evaluator.metric import Metric
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import AcceleratorSpec
 from olive.logging import set_verbosity_from_env
 from olive.model import ModelConfig
@@ -22,7 +22,7 @@ def get_args(raw_args):
     parser = argparse.ArgumentParser(description="Onnx model inference")
 
     parser.add_argument("--model_config", type=str, required=True, help="Path to input model json file")
-    parser.add_argument("--metrics_config", type=str, required=True, help="Path to metrics json file")
+    parser.add_argument("--evaluator_config", type=str, required=True, help="Path to evaluator json file")
     parser.add_argument("--accelerator_config", type=str, required=True, help="Path to accelerator json file")
     parser.add_argument("--tempdir", type=str, required=False, help="Root directory for tempfile directories and files")
     parser.add_argument("--output_path", type=str, required=True, help="Path to metrics result json file")
@@ -38,18 +38,16 @@ def main(raw_args=None):
     set_tempdir(args.tempdir)
 
     model_config = ModelConfig.parse_file(args.model_config)
-    metrics = []
-    with Path(args.metrics_config).open() as f:
-        metrics_json = json.load(f)
-        metrics = [Metric.parse_obj(metric_json) for metric_json in metrics_json]
+    evaluator_config = OliveEvaluatorConfig.parse_file(args.evaluator_config)
+
     with Path(args.accelerator_config).open() as f:
         accelerator_config = json.load(f)
-    accelerator_spec = AcceleratorSpec(**accelerator_config)
+        accelerator_spec = AcceleratorSpec(**accelerator_config)
 
     target: OliveSystem = LocalSystem()
 
     # metric result
-    metric_result = target.evaluate_model(model_config, metrics, accelerator_spec)
+    metric_result = target.evaluate_model(model_config, evaluator_config, accelerator_spec)
 
     # save metric result json
     with Path(args.output_path).open("w") as f:

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -21,7 +21,7 @@ from olive.systems.system_config import PythonEnvironmentTargetUserConfig
 from olive.systems.utils import create_new_environ, get_package_name_from_ep, run_available_providers_runner
 
 if TYPE_CHECKING:
-    from olive.evaluator.metric import Metric
+    from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
     from olive.hardware.accelerator import AcceleratorSpec
     from olive.passes.olive_pass import Pass
 
@@ -130,12 +130,12 @@ class PythonEnvironmentSystem(OliveSystem):
         return ModelConfig.parse_obj(output_model_json)
 
     def evaluate_model(
-        self, model_config: ModelConfig, metrics: List["Metric"], accelerator: "AcceleratorSpec"
+        self, model_config: ModelConfig, evaluator_config: "OliveEvaluatorConfig", accelerator: "AcceleratorSpec"
     ) -> MetricResult:
         """Evaluate the model."""
         config_jsons = {
             "model_config": model_config.to_json(check_object=True),
-            "metrics_config": [metric.to_json(check_object=True) for metric in metrics],
+            "evaluator_config": evaluator_config.to_json(check_object=True),
             "accelerator_config": accelerator.to_json(),
         }
         metric_results = self._run_command(self.evaluation_runner_path, config_jsons, tempdir=tempfile.tempdir)

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -132,8 +132,6 @@ def is_execution_provider_required(run_config: RunConfig, package_config: OliveP
 
 
 def run_engine(package_config: OlivePackageConfig, run_config: RunConfig):
-    import onnxruntime as ort
-
     from olive.passes import Pass
 
     workflow_id = run_config.workflow_id
@@ -144,7 +142,12 @@ def run_engine(package_config: OlivePackageConfig, run_config: RunConfig):
     set_ort_logger_severity(run_config.engine.ort_py_log_severity_level)
 
     # ort_log_severity_level: C++ logging levels
-    ort.set_default_logger_severity(run_config.engine.ort_log_severity_level)
+    try:
+        import onnxruntime as ort
+
+        ort.set_default_logger_severity(run_config.engine.ort_log_severity_level)
+    except Exception:
+        logger.warning("ORT log severity level configuration ignored since the module isn't installed.")
 
     # input model
     input_model = run_config.input_model

--- a/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
+++ b/test/integ_test/evaluator/azureml_eval/test_aml_evaluation.py
@@ -18,6 +18,7 @@ from typing import ClassVar, List
 import pytest
 
 from olive.evaluator.metric_result import joint_metric_key
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.model import ModelConfig
 
@@ -46,8 +47,9 @@ class TestAMLEvaluation:
         aml_target = get_aml_target()
         model_path = model_path_func()
         metric = metric_func()
-        config = ModelConfig.parse_obj({"type": model_type, "config": {"model_path": model_path}})
-        actual_res = aml_target.evaluate_model(config, [metric], DEFAULT_CPU_ACCELERATOR)
+        model_config = ModelConfig.parse_obj({"type": model_type, "config": {"model_path": model_path}})
+        evaluator_config = OliveEvaluatorConfig(metrics=[metric])
+        actual_res = aml_target.evaluate_model(model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
+++ b/test/integ_test/evaluator/docker_eval/test_docker_evaluation.py
@@ -23,6 +23,7 @@ import pytest
 
 from olive.common.constants import OS
 from olive.evaluator.metric_result import joint_metric_key
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.model import ModelConfig
 
@@ -71,8 +72,9 @@ class TestDockerEvaluation:
         docker_target = get_docker_target()
         model_config = model_config_func()
         metric = metric_func()
-        model_conf = ModelConfig.parse_obj({"type": model_type, "config": model_config})
-        actual_res = docker_target.evaluate_model(model_conf, [metric], DEFAULT_CPU_ACCELERATOR)
+        model_config = ModelConfig.parse_obj({"type": model_type, "config": model_config})
+        evaluator_config = OliveEvaluatorConfig(metrics=[metric])
+        actual_res = docker_target.evaluate_model(model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/integ_test/evaluator/local_eval/test_local_evaluation.py
+++ b/test/integ_test/evaluator/local_eval/test_local_evaluation.py
@@ -20,6 +20,7 @@ from typing import ClassVar, List
 import pytest
 
 from olive.evaluator.metric_result import joint_metric_key
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.model import ModelConfig
 from olive.systems.local import LocalSystem
@@ -57,8 +58,9 @@ class TestLocalEvaluation:
     def test_evaluate_model(self, type, model_config_func, metric_func, expected_res):  # noqa: A002
         model_config = model_config_func()
         metric = metric_func()
-        model_conf = ModelConfig.parse_obj({"type": type, "config": model_config})
-        actual_res = LocalSystem().evaluate_model(model_conf, [metric], DEFAULT_CPU_ACCELERATOR)
+        model_config = ModelConfig.parse_obj({"type": type, "config": model_config})
+        evaluator_config = OliveEvaluatorConfig(metrics=[metric])
+        actual_res = LocalSystem().evaluate_model(model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
         for sub_type in metric.sub_types:
             joint_key = joint_metric_key(metric.name, sub_type.name)
             assert actual_res[joint_key].value >= expected_res

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -219,7 +219,7 @@ class TestEngine:
 
         assert system_object.run_pass.call_count == 2
         assert system_object.evaluate_model.call_count == 3
-        system_object.evaluate_model.assert_called_with(onnx_model_config.to_json(), [metric], accelerator_spec)
+        system_object.evaluate_model.assert_called_with(onnx_model_config, evaluator_config, accelerator_spec)
 
     @patch("olive.systems.local.LocalSystem")
     def test_run_no_search_model_components(self, mock_local_system_init, tmpdir):

--- a/test/unit_test/evaluator/test_metric_backend.py
+++ b/test/unit_test/evaluator/test_metric_backend.py
@@ -11,6 +11,7 @@ import pytest
 
 from olive.evaluator.metric_backend import HuggingfaceMetrics
 from olive.evaluator.metric_result import SubMetricResult
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.systems.local import LocalSystem
 
@@ -67,9 +68,10 @@ class TestMetricBackend:
             system = LocalSystem()
 
             # execute
-            model_config = model_config_func()
             metric = metric_func()
-            actual_res = system.evaluate_model(model_config, [metric], DEFAULT_CPU_ACCELERATOR)
+            model_config = model_config_func()
+            evaluator_config = OliveEvaluatorConfig(metrics=[metric])
+            actual_res = system.evaluate_model(model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
 
             # assert
             assert mock_measure.call_count == len(metric.sub_types)

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -458,3 +458,20 @@ class TestOliveEvaluatorConfig:
         evaluator_config = [get_accuracy_metric(*m_arg["args"], **m_arg["kwargs"]) for m_arg in metric_args]
         evaluator_config_instance = OliveEvaluatorConfig(metrics=evaluator_config)
         assert evaluator_config_instance.is_accuracy_drop_tolerance == is_accuracy_drop_tolerance
+
+    @patch("olive.common.import_lib.import_user_module")
+    @patch("olive.evaluator.registry.Registry.get")
+    def test_valid_custom_type_validation(self, registry_get_mock, import_user_module_mock):
+        registry_get_mock.return_value = MagicMock()
+        OliveEvaluatorConfig.from_json({"type": "test_evaluator"})
+        registry_get_mock.called_once_with("test_evaluator")
+
+    @patch("olive.common.import_lib.import_user_module")
+    @patch("olive.evaluator.registry.Registry.get")
+    def test_invalid_custom_type_validation(self, registry_get_mock, import_user_module_mock):
+        registry_get_mock.return_value = None
+
+        with pytest.raises(ValidationError):
+            OliveEvaluatorConfig.from_json({"type": "test_evaluator"})
+
+        registry_get_mock.called_once_with("test_evaluator")

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -32,7 +32,7 @@ class DummyCalibrationDataReader(CalibrationDataReader):
 
 
 @Registry.register_dataloader()
-def _test_nvmo_quat_dataloader(dataset, batch_size, **kwargs):
+def _test_quat_dataloader(dataset, batch_size, **kwargs):
     return DummyCalibrationDataReader(batch_size=batch_size)
 
 
@@ -49,7 +49,7 @@ def test_static_quantization(calibrate_method, tmp_path):
         "data_config": DataConfig(
             name="test_quant_dc_config",
             load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
         ),
         "weight_type": "QUInt8",
         "activation_type": "QUInt8",
@@ -86,7 +86,7 @@ def test_qnn_quantization(tmp_path):
         "data_config": DataConfig(
             name="test_quant_dc_config",
             load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
         ),
         "weight_type": "QUInt8",
         "activation_type": "QUInt16",
@@ -177,7 +177,7 @@ def test_matmul_gptq_with_dataloader(tmp_path):
         "data_config": DataConfig(
             name="test_quant_dc_config",
             load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_nvmo_quat_dataloader"),
+            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
         ),
         "weight_only_quant_configs": {"percdamp": 0.01, "block_size": 128, "use_less_config": 1},
     }

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -13,6 +13,7 @@ import pytest
 
 from olive.evaluator.metric import AccuracySubType
 from olive.evaluator.metric_result import joint_metric_key
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.perf_tuning import OrtPerfTuning
@@ -144,6 +145,7 @@ class TestDockerSystem:
 
         model_config = get_pytorch_model_config()
         metric = get_accuracy_metric(AccuracySubType.ACCURACY_SCORE)
+        evaluator_config = OliveEvaluatorConfig(metrics=[metric])
         docker_config = LocalDockerConfig(
             image_name="image_name", build_context_path="build_context_path", dockerfile="dockerfile"
         )
@@ -154,9 +156,9 @@ class TestDockerSystem:
                 docker.errors.ContainerError,
                 match=r".*returned non-zero exit status 1: Docker container evaluation failed with: mock_error",
             ):
-                _ = docker_system.evaluate_model(model_config, [metric], DEFAULT_CPU_ACCELERATOR)
+                _ = docker_system.evaluate_model(model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
         else:
-            actual_res = docker_system.evaluate_model(model_config, [metric], DEFAULT_CPU_ACCELERATOR)
+            actual_res = docker_system.evaluate_model(model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
 
             container_root_path = Path("/olive-ws/")
             eval_local_path = Path(__file__).resolve().parents[4] / "olive" / "systems" / "docker" / "eval.py"

--- a/test/unit_test/systems/isolated_ort/test_isolated_ort_system.py
+++ b/test/unit_test/systems/isolated_ort/test_isolated_ort_system.py
@@ -77,15 +77,15 @@ class TestIsolatedORTSystem:
         olive_model_config.type = "ONNXModel"
         olive_model = olive_model_config.create_model()
         olive_model.framework = Framework.ONNX
+        evaluator_config = MagicMock()
+        evaluator_config.metrics = MagicMock()
 
-        metric = MagicMock()
-
-        self.system.evaluate_model(olive_model_config, [metric], DEFAULT_CPU_ACCELERATOR)
+        self.system.evaluate_model(olive_model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
 
         # assert
         mock_evaluate.assert_called_once_with(
             olive_model,
-            [metric],
+            evaluator_config.metrics,
             device=DEFAULT_CPU_ACCELERATOR.accelerator_type,
             execution_providers=DEFAULT_CPU_ACCELERATOR.execution_provider,
         )

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -12,6 +12,7 @@ import pytest
 from olive.constants import Framework
 from olive.evaluator.metric import AccuracySubType, LatencySubType, Metric, MetricType
 from olive.evaluator.metric_result import MetricResult, joint_metric_key
+from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.model import PyTorchModelHandler
 from olive.systems.local import LocalSystem
@@ -72,6 +73,7 @@ class TestLocalSystem:
         olive_model.framework = Framework.ONNX
 
         metric = metric_func()
+        evaluator_config = OliveEvaluatorConfig(metrics=[metric])
         # olive_model.framework = Framework.ONNX
         expected_res = MetricResult.parse_obj(
             {
@@ -89,7 +91,7 @@ class TestLocalSystem:
         mock_get_user_config.return_value = (None, None, None)
 
         # execute
-        actual_res = self.system.evaluate_model(olive_model_config, [metric], DEFAULT_CPU_ACCELERATOR)
+        actual_res = self.system.evaluate_model(olive_model_config, evaluator_config, DEFAULT_CPU_ACCELERATOR)
         # assert
         if metric.type == MetricType.ACCURACY:
             mock_evaluate_accuracy.assert_called_once_with(

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -13,17 +13,11 @@ import pytest
 from olive.common.pydantic_v1 import ValidationError
 from olive.data.config import DataConfig
 from olive.data.container.huggingface_container import HuggingfaceContainer
-from olive.data.registry import Registry
 from olive.package_config import OlivePackageConfig
 from olive.workflows.run.config import RunConfig
 from olive.workflows.run.run import get_pass_module_path, is_execution_provider_required
 
 # pylint: disable=attribute-defined-outside-init, unsubscriptable-object
-
-
-@Registry.register_dataloader()
-def _resnet_calibration_dataloader(dataset, **kwargs):
-    return None
 
 
 class TestRunConfig:

--- a/test/unit_test/workflows/test_setup.py
+++ b/test/unit_test/workflows/test_setup.py
@@ -12,7 +12,6 @@ import pytest
 
 from olive.common.constants import OS
 from olive.common.utils import run_subprocess
-from olive.data.registry import Registry
 
 # pylint: disable=redefined-outer-name
 
@@ -23,11 +22,6 @@ class DependencySetupEnvBuilder(venv.EnvBuilder):
         # Install Olive only
         olive_root = str(Path(__file__).parents[3].resolve())
         run_subprocess([context.env_exe, "-Im", "pip", "install", olive_root], check=True)
-
-
-@Registry.register_dataloader()
-def _resnet_calibration_dataloader(dataset, **kwargs):
-    return None
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Support for custom evaluators

* Move evaluation registration out of OliveEvaluator into its own class
* Evaluators are registered using both the Framework and the class name
* Add "type", "type_args", "user_script" and "script_dir" to OliveEvaluationConfig to support user specific custom implementation
* Remove some dead code

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
