### PR TITLE
Rename onnxruntime_extensions

### DIFF
--- a/examples/mistral/requirements.txt
+++ b/examples/mistral/requirements.txt
@@ -1,7 +1,7 @@
 datasets
 neural-compressor>=2.4.1
-onnxruntime-extensions
 onnxruntime-gpu
+onnxruntime_extensions
 # optimum 1.17.0 for fp16 inference
 optimum>=1.17.0
 tabulate

--- a/examples/super_resolution/requirements.txt
+++ b/examples/super_resolution/requirements.txt
@@ -1,1 +1,1 @@
-onnxruntime-extensions
+onnxruntime_extensions

--- a/examples/whisper/requirements.txt
+++ b/examples/whisper/requirements.txt
@@ -1,5 +1,5 @@
 neural-compressor
-onnxruntime-extensions>=0.9.0
+onnxruntime_extensions>=0.9.0
 tabulate
 torch>=1.13.1
 transformers>=4.23.1

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -52,7 +52,7 @@ def get_ort_inference_session(
 
     sess_options = ort.SessionOptions()
     if use_ort_extensions:
-        # register custom ops for onnxruntime-extensions
+        # register custom ops for onnxruntime_extensions
         from onnxruntime_extensions import get_library_path
 
         sess_options.register_custom_ops_library(get_library_path())

--- a/olive/engine/packaging/packaging_generator.py
+++ b/olive/engine/packaging/packaging_generator.py
@@ -765,7 +765,7 @@ def _download_ort_extensions_package(use_ort_extensions: bool, download_path: st
             if system == OS.WINDOWS:
                 NIGHTLY_URL = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/"
                 download_command = create_python_download_command(NIGHTLY_URL).substitute(
-                    package_name="onnxruntime-extensions",
+                    package_name="onnxruntime_extensions",
                     version=version,
                     python_download_path=download_path,
                     python_version=python_version,
@@ -778,7 +778,7 @@ def _download_ort_extensions_package(use_ort_extensions: bool, download_path: st
                 )
         else:
             download_command = create_python_download_command().substitute(
-                package_name="onnxruntime-extensions",
+                package_name="onnxruntime_extensions",
                 version=version,
                 python_download_path=download_path,
                 python_version=python_version,

--- a/olive/model/handler/mixin/onnx_ep.py
+++ b/olive/model/handler/mixin/onnx_ep.py
@@ -17,7 +17,7 @@ class OnnxEpValidateMixin:
 
         sess_options = ort.SessionOptions()
         if self.use_ort_extensions:
-            # register custom ops for onnxruntime-extensions
+            # register custom ops for onnxruntime_extensions
             from onnxruntime_extensions import get_library_path
 
             sess_options.register_custom_ops_library(get_library_path())

--- a/olive/passes/onnx/append_pre_post_processing_ops.py
+++ b/olive/passes/onnx/append_pre_post_processing_ops.py
@@ -94,7 +94,7 @@ class AppendPrePostProcessingOps(Pass):
 
                 assert version.parse(ortext_version) >= version.parse(
                     "0.9.0"
-                ), "Whisper pre-post processing requires onnxruntime-extensions>=0.9.0"
+                ), "Whisper pre-post processing requires onnxruntime_extensions>=0.9.0"
 
                 from olive.passes.utils.whisper_prepost import add_pre_post_processing_to_model
 

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -377,7 +377,7 @@ def get_local_ort_packages() -> List[str]:
     local_ort_packages = []
     for package in all_packages:
         package_name = package.metadata["Name"]
-        if package_name == "onnxruntime-extensions" or package_name.startswith("onnxruntime-genai"):
+        if package_name == "onnxruntime_extensions" or package_name.startswith("onnxruntime-genai"):
             # onnxruntime-packages is under onnxruntime_extensions namespace
             # onnxruntime-genai is under onnxruntime_genai namespace
             # not onnxruntime packages

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -18,7 +18,7 @@ nncf==2.7.0
 nvidia-modelopt~=0.11.0
 onnx-graphsurgeon
 onnxconverter_common
-onnxruntime-extensions
+onnxruntime_extensions
 openvino==2023.2.0
 optimum>=1.17.0
 pandas


### PR DESCRIPTION
## Describe your changes

onnxruntime extensions package had been updated to `onnxruntime_extensions`. Though `pip install onnxruntime-extensions` still works, the installed package name is `onnxruntime_extensions`.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
https://github.com/microsoft/Olive/issues/1264