### PR TITLE
Docs: Custom CSS for header tags

### DIFF
--- a/docs/source/_static/css/header.css
+++ b/docs/source/_static/css/header.css
@@ -1,0 +1,16 @@
+h1 {
+    font-size: 175%;
+}
+
+h2 {
+    font-size: 150%;
+}
+
+h3 {
+    font-size: 130%;
+}
+
+h4 {
+    font-size: 100%;
+    font-weight: 600;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_static_path = ["_static"]
 html_css_files = [
+    # better contrast between h3 and h4, high priority so that it overrides the theme
+    ("css/header.css", {"priority": 1000}),
     "css/width.css",
 ]
 html_js_files = [


### PR DESCRIPTION
## Describe your changes
Use custom cuss for header tags for between contrast between levels. Especially between h3 and h4 which are used in the cli command auto docs.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
