### PR TITLE
Finetune: Add remote workflow support

### DIFF
--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -3,15 +3,19 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import codecs
+import json
 import logging
+import re
 import tempfile
 from argparse import ArgumentParser
 from copy import deepcopy
 from pathlib import Path
 from typing import ClassVar, Dict
 
+import yaml
+
 from olive.cli.base import BaseOliveCLICommand
-from olive.common.utils import hardlink_copy_dir, set_nested_dict_value, set_tempdir
+from olive.common.utils import hardlink_copy_dir, hash_dict, set_nested_dict_value, set_tempdir
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +48,10 @@ class FineTuneCommand(BaseOliveCLICommand):
             "--model_name_or_path",
             type=str,
             required=True,
-            help="The model checkpoint for weights initialization.",
+            help=(
+                "The model checkpoint for weights initialization. If running remotely on AzureML, this must be an"
+                " AzureML registry model of the form 'registry_name:model_name:version'."
+            ),
         )
         model_group.add_argument(
             "--trust_remote_code", action="store_true", help="Trust remote code when loading a model."
@@ -127,6 +134,23 @@ class FineTuneCommand(BaseOliveCLICommand):
         # TODO(jambayk): what about checkpoint_dir and resume from checkpoint support? clean checkpoint dir?
         sub_parser.add_argument("--clean", action="store_true", help="Run in a clean cache directory")
 
+        # remote options
+        remote_group = sub_parser.add_argument_group("remote options")
+        remote_group.add_argument(
+            "--azureml_config",
+            type=str,
+            help=(
+                "Path to the azureml config file for remote run. Recommended to log in using `az login` before running."
+            ),
+        )
+        remote_group.add_argument(
+            "--azureml_cluster",
+            type=str,
+            help="The azureml cluster to use for remote run. Must be provided if using azureml_config.",
+        )
+        # TODO(jambayk): do we need to support key vault for hf token?
+        # Cloud cache doesn't support azureml resources yet, only hf-id
+
         sub_parser.set_defaults(func=FineTuneCommand)
 
     def run(self):
@@ -134,10 +158,15 @@ class FineTuneCommand(BaseOliveCLICommand):
 
         set_tempdir(self.args.tempdir)
 
-        run_config = self.get_run_config()
         with tempfile.TemporaryDirectory() as tempdir:
-            run_config["output_dir"] = tempdir
+            run_config = self.get_run_config(tempdir)
+
             olive_run(run_config)
+
+            if self.args.azureml_config:
+                # TODO(jambayk): point user to datastore with outputs or download outputs
+                # both are not implemented yet
+                return
 
             # need to improve the output structure of olive run
             output_path = Path(self.args.output_path)
@@ -161,7 +190,7 @@ class FineTuneCommand(BaseOliveCLICommand):
 
         return {k: v for k, v in vars(training_args).items() if k in arg_keys}
 
-    def get_run_config(self) -> Dict:
+    def get_run_config(self, tempdir: str) -> Dict:
         load_key = ("data_configs", 0, "load_dataset_config")
         preprocess_key = ("data_configs", 0, "pre_process_data_config")
         finetune_key = ("passes", "f")
@@ -185,10 +214,11 @@ class FineTuneCommand(BaseOliveCLICommand):
             # make the mapping of precisions better
             (("passes", "m", "precision"), "fp16" if self.args.precision == "float16" else "fp32"),
             (("clean_cache",), self.args.clean),
+            ("output_dir", tempdir),
         ]
         if self.args.trust_remote_code:
             to_replace.append((("input_model", "load_kwargs", "trust_remote_code"), True))
-        if self.args.method == "lora":
+        if self.args.method == "lora" and self.args.target_modules:
             to_replace.append(((*finetune_key, "target_modules"), self.args.target_modules.split(",")))
 
         config = deepcopy(TEMPLATE)
@@ -204,7 +234,46 @@ class FineTuneCommand(BaseOliveCLICommand):
             config["data_configs"].append(eval_data_config)
             config["passes"]["f"]["eval_data_config"] = "eval_data"
 
+        if self.args.azureml_config:
+            assert self.args.azureml_cluster, "AzureML cluster must be provided if using azureml_config."
+            config["input_model"]["model_path"] = self.get_azureml_model_path()
+
+            # set the workflow id to be unique
+            # add before setting up the remote host since that's independent of the workflow
+            config["workflow_id"] = f"finetune-{hash_dict(config)}"
+
+            with open(self.args.azureml_config) as f:
+                azureml_client = json.load(f)
+                # don't use managed identity credential, instead use azure cli login or interactive login
+                azureml_client["default_auth_params"] = {"exclude_managed_identity_credential": True}
+                config["azureml_client"] = azureml_client
+
+            # update config for azureml run
+            config["systems"]["aml_system"] = deepcopy(AZUREML_SYSTEM_TEMPLATE)
+            config["systems"]["aml_system"]["aml_compute"] = self.args.azureml_cluster
+
+            conda_file_path = Path(tempdir) / "conda_gpu.yaml"
+            with open(conda_file_path, "w") as f:
+                yaml.dump(CONDA_CONFIG, f)
+            config["systems"]["aml_system"]["aml_docker_config"]["conda_file_path"] = str(conda_file_path)
+
+            # set the workflow host to azureml
+            config["workflow_host"] = "aml_system"
+
         return config
+
+    def get_azureml_model_path(self):
+        pattern = r"(?P<registry_name>[^:]+):(?P<model_name>[^:]+):(?P<version>[^:]+)"
+        match = re.match(pattern, self.args.model_name_or_path)
+        if not match:
+            raise ValueError("Model path must be of the form 'registry_name:model_name:version'.")
+
+        return {
+            "type": "azureml_registry_model",
+            "registry_name": match.group("registry_name"),
+            "name": match.group("model_name"),
+            "version": match.group("version"),
+        }
 
 
 TEMPLATE = {
@@ -260,6 +329,41 @@ TEMPLATE = {
     },
     "host": "local_system",
     "target": "local_system",
+}
+
+AZUREML_SYSTEM_TEMPLATE = {
+    "type": "AzureML",
+    "accelerators": [{"device": "GPU", "execution_providers": ["CUDAExecutionProvider"]}],
+    "aml_docker_config": {"base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04"},
+}
+
+CONDA_CONFIG = {
+    "name": "olive_finetune",
+    "channels": ["defaults"],
+    "dependencies": [
+        "python=3.8.13",
+        "pip=22.3.1",
+        {
+            "pip": [
+                "accelerate",
+                "bitsandbytes",
+                "peft",
+                "scikit-learn",
+                "sentencepiece",
+                "datasets",
+                "evaluate",
+                "psutil",
+                "optimum",
+                "scipy",
+                "scikit-learn",
+                "torch",
+                "onnxruntime-genai",
+                "--extra-index-url https://download.pytorch.org/whl/cu118",
+                "transformers>=4.41.1",
+                "git+https://github.com/microsoft/Olive#egg=olive-ai[gpu,azureml]",
+            ]
+        },
+    ],
 }
 
 

--- a/olive/package_config.py
+++ b/olive/package_config.py
@@ -38,7 +38,7 @@ class OlivePackageConfig(ConfigBase):
         module = importlib.import_module(module_path, module_name)
         return getattr(module, module_name)
 
-    def get_pass_module_config(self, pass_type: str):
+    def get_pass_module_config(self, pass_type: str) -> PassModuleConfig:
         if "." in pass_type:
             _, module_name = pass_type.rsplit
             return self.get_pass_module_config(module_name)

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -44,7 +44,7 @@ def get_required_packages(package_config: OlivePackageConfig, run_config: RunCon
         return extra_name
 
     def get_pass_extras(pass_type):
-        pass_module_config = package_config.passes.get(pass_type)
+        pass_module_config = package_config.get_pass_module_config(pass_type)
 
         extra_results = []
         extra_results.extend(pass_module_config.module_dependencies)

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -96,5 +96,43 @@ def test_configure_qualcomm_sdk_command(mock_configure):
     mock_configure.assert_called_once_with("3.6", "snpe")
 
 
+@patch("olive.workflows.run")
+@patch("olive.cli.finetune.tempfile.TemporaryDirectory")
+def test_finetune_command(mock_tempdir, mock_run, tmp_path):
+    # some directories
+    tmpdir = tmp_path / "tmpdir"
+    tmpdir.mkdir()
+
+    output_dir = tmp_path / "output_dir"
+
+    # setup
+    mock_tempdir.return_value = tmpdir.resolve()
+    workflow_output_dir = tmpdir / "f-c-o-e-m" / "gpu-cuda_model"
+    workflow_output_dir.mkdir(parents=True)
+    dummy_output = workflow_output_dir / "dummy_output"
+    with open(dummy_output, "w") as f:
+        f.write("dummy_output")
+
+    # setup
+    command_args = [
+        "finetune",
+        "-m",
+        "dummy_model",
+        "-d",
+        "dummy_dataset",
+        "--text_field",
+        "dummy_text_field",
+        "-o",
+        str(output_dir),
+    ]
+
+    # execute
+    cli_main(command_args)
+
+    config = mock_run.call_args[0][0]
+    assert config["input_model"]["model_path"] == "dummy_model"
+    assert {el.name for el in output_dir.iterdir()} == {dummy_output.name}
+
+
 # TODO(anyone): Add tests for ManageAMLComputeCommand
 # Test for ExportAdaptersCommand is added as part of test/unit_test/passes/onnx/test_export_adapters.py


### PR DESCRIPTION
## Describe your changes
Add remote config support to `finetune` cli. 
- cloud cache is not supported yet since it only works for huggingface-id models. It does not work for locally saved models or azureml registry models (which to the aml workflow host appears as local model). Will be added later
 
**Example usage:**
```bash
olive finetune -m azureml-meta:Llama-2-7b:22 --method qlora \
    -d json --data_files data/phrase_classification_dataset.json \
    --text_template "<|user|>\n{phrase}<|end|>\n<|assistant|>\n{tone}<|end|>" \
    --train_split "train[:70%]" --eval_split "train[70%:]" \
    --per_device_train_batch_size 4 --per_device_eval_batch_size 4 \
    --max_steps 200 --logging_steps 50 \
    --learning_rate 0.0001 \
    --azureml_config aml-workspace.json --azureml_cluster gpu-cluster
```

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
