### PR TITLE
Handle metric priority correctly so validation can pass

### DIFF
--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -612,10 +612,15 @@ class AzureMLSystem(OliveSystem):
             outputs = {}
             for metric in evaluator_config.metrics:
                 metric_tmp_dir = tmp_dir / metric.name
+                metric_clone = deepcopy(metric)
+                if metric_clone.sub_types:
+                    metric_clone.sub_types = sorted(metric_clone.sub_types, key=lambda st: st.priority, reverse=True)
+                    for priority, sub_type in enumerate(metric_clone.sub_types):
+                        sub_type.priority = priority + 1
                 metric_component = self._create_metric_component(
                     metric_tmp_dir,
                     model_config,
-                    OliveEvaluatorConfig(type=evaluator_config.type, metrics=[metric]).to_json(check_object=True),
+                    OliveEvaluatorConfig(type=evaluator_config.type, metrics=[metric_clone]).to_json(check_object=True),
                     accelerator.to_json(),
                 )
                 outputs[metric.name] = metric_component.outputs.pipeline_output


### PR DESCRIPTION
## Handle metric priority correctly so validation can pass

priority works across metrics, however, aml evaluation works only a single metric at a time. So, metric validation was failing.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
