### PR TITLE
Whisper: pin `transformers` version

### DIFF
--- a/examples/whisper/requirements.txt
+++ b/examples/whisper/requirements.txt
@@ -2,4 +2,6 @@ neural-compressor
 onnxruntime_extensions>=0.9.0
 tabulate
 torch>=1.13.1
-transformers>=4.23.1
+# exported model is incompatible after transformers 4.43.0
+# produces empty text
+transformers>=4.23.1,<4.43.0

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -118,8 +118,10 @@ def main(raw_args=None):
     # get output
     input_data, _ = dataset[0]
     input_data = OnnxEvaluator.format_input(input_data, olive_model.io_config)
+    # output is an list of numpy arrays, first element is the transcription 1Xnum_return_sequences
+    # [["transcription1", "transcription2"]]
     output = olive_model.run_session(session, input_data)
-    return output[0][0]
+    return output[0][0][0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes
`transformers>=4.33.0` produces an invalid model that outputs empty strings. The exported model doesn't appear to be compatible with the workflow anymore. 
Fixed the whisper example test to catch empty strings.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes #1291