### PR TITLE
INC: Remove `diagnosis` config param

### DIFF
--- a/examples/mistral/mistral_int4_optimize.json
+++ b/examples/mistral/mistral_int4_optimize.json
@@ -54,8 +54,7 @@
             "data_config": "inc_static_quant_data_config",
             "calibration_sampling_size": [ 8 ],
             "save_as_external_data": true,
-            "all_tensors_to_one_file": true,
-            "diagnosis": false
+            "all_tensors_to_one_file": true
         }
     },
     "pass_flows": [ [ "convert", "optimize", "quantization" ] ],

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -521,9 +521,6 @@ class IncQuantization(Pass):
             #  which is data_config's create_dataloader but not create_calibration_dataloader
             inc_calib_dataloader = data_config.to_data_container().create_dataloader()
 
-        if run_config.get("diagnosis", False):
-            assert inc_calib_dataloader is not None, "diagnosis mode requires dataloader"
-
         q_model = quantization.fit(
             model.model_path, ptq_config, calib_dataloader=inc_calib_dataloader, eval_func=eval_func
         )
@@ -571,13 +568,7 @@ class IncStaticQuantization(IncQuantization):
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, Any]:
         config = {
-            "approach": PassConfigParam(type_=str, default_value="static", description="static quantization mode"),
-            "diagnosis": PassConfigParam(
-                type_=bool,
-                default_value=False,
-                description="""Whether to enable diagnosis mode. If enabled,
-                Intel® Neural Compressor will print the quantization summary.""",
-            ),
+            "approach": PassConfigParam(type_=str, default_value="static", description="static quantization mode")
         }
         # common quantization config
         config.update(deepcopy(_inc_quantization_config))


### PR DESCRIPTION
## Describe your changes
`diagnosis` option is no longer supported by `neural-compressor>=3.0`. It was not being used before either so there is no regression. It only prints the quantization summary using neural-insights (which has been deprecated from inc) so should not affect the quantized model.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
