### PR TITLE
CI: Make compatible with `ort>=1.19.0`

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -142,9 +142,6 @@ jobs:
     name: Linux_GPU_CI
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     onnxruntime: onnxruntime-gpu
-    # torch 2.4.0 installs nvidia-cudnn-cu12 9.x but ort-gpu (with cuda 11.x) requires 8.x
-    # pin torch version until os image has its own cudnn installed/updated which ort-gpu can use
-    torch: torch==2.3.1
     examples:
       bert_cuda_gpu:
         exampleFolder: bert

--- a/examples/AST/ast.json
+++ b/examples/AST/ast.json
@@ -54,14 +54,7 @@
     "passes": {
         "conversion": { "type": "OnnxConversion" },
         "transformers_optimization": { "type": "OrtTransformersOptimization", "model_type": "vit" },
-        "quantization": {
-            "type": "OnnxQuantization",
-            "quant_mode": "static",
-            "quant_preprocess": true,
-            "per_channel": false,
-            "reduce_range": false,
-            "data_config": "speech_commands_v0.02"
-        },
+        "quantization": { "type": "OnnxQuantization", "data_config": "speech_commands_v0.02" },
         "perf_tuning": { "type": "OrtPerfTuning", "data_config": "speech_commands_v0.02" }
     },
     "evaluator": "common_evaluator",

--- a/examples/bert/bert_ptq_cpu_aml.json
+++ b/examples/bert/bert_ptq_cpu_aml.json
@@ -43,14 +43,7 @@
             "float16": false,
             "only_onnxruntime": false
         },
-        "quantization": {
-            "type": "OnnxQuantization",
-            "quant_preprocess": true,
-            "per_channel": false,
-            "reduce_range": false,
-            "calibrate_method": "MinMax",
-            "data_config": "glue_mrpc"
-        },
+        "quantization": { "type": "OnnxQuantization", "data_config": "glue_mrpc" },
         "perf_tuning": { "type": "OrtPerfTuning", "data_config": "glue_mrpc" }
     },
     "evaluator": "common_evaluator",

--- a/examples/resnet/resnet_multiple_ep.json
+++ b/examples/resnet/resnet_multiple_ep.json
@@ -61,6 +61,7 @@
             "data_config": "quant_data_config",
             "weight_type": "QUInt8",
             "activation_type": "QUInt8",
+            "calibrate_method": "MinMax",
             "quant_preprocess": true
         },
         "perf_tuning": { "type": "OrtPerfTuning", "data_config": "cifar10_data_config" }

--- a/examples/resnet/resnet_multiple_ep.json
+++ b/examples/resnet/resnet_multiple_ep.json
@@ -60,9 +60,7 @@
             "type": "OnnxQuantization",
             "data_config": "quant_data_config",
             "weight_type": "QUInt8",
-            "activation_type": "QUInt8",
-            "calibrate_method": "MinMax",
-            "quant_preprocess": true
+            "activation_type": "QUInt8"
         },
         "perf_tuning": { "type": "OrtPerfTuning", "data_config": "cifar10_data_config" }
     },

--- a/examples/resnet/resnet_ptq_cpu.json
+++ b/examples/resnet/resnet_ptq_cpu.json
@@ -67,6 +67,7 @@
             "data_config": "quant_data_config",
             "weight_type": "QUInt8",
             "activation_type": "QUInt8",
+            "calibrate_method": "MinMax",
             "quant_preprocess": true
         },
         "perf_tuning": { "type": "OrtPerfTuning", "data_config": "cifar10_data_config" }

--- a/examples/resnet/resnet_ptq_cpu_aml_dataset.json
+++ b/examples/resnet/resnet_ptq_cpu_aml_dataset.json
@@ -76,6 +76,7 @@
             "data_config": "quant_data_config",
             "weight_type": "QUInt8",
             "activation_type": "QUInt8",
+            "calibrate_method": "MinMax",
             "quant_preprocess": true
         },
         "perf_tuning": { "type": "OrtPerfTuning", "data_config": "cifar10_data_config" }

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -38,6 +38,12 @@ def _test_quat_dataloader(dataset, batch_size, **kwargs):
 
 @pytest.mark.parametrize("calibrate_method", ["MinMax", "Entropy", "Percentile"])
 def test_static_quantization(calibrate_method, tmp_path):
+    if version.parse(OrtVersion) >= version.parse("1.19.0") and calibrate_method != "MinMax":
+        pytest.skip(
+            "Entropy and Percentile calibration methods sometimes hit nan issue during histogram computation in"
+            " onnxruntime>=1.19.0"
+        )
+
     input_model = get_onnx_model()
     config = {
         "quant_mode": "static",

--- a/test/unit_test/snpe/test_adb_run.py
+++ b/test/unit_test/snpe/test_adb_run.py
@@ -18,7 +18,7 @@ from olive.platform_sdk.qualcomm.snpe.utils.adb import run_adb_command
 # pylint: disable=redefined-outer-name, unused-variable
 
 
-@pytest.fixture()
+@pytest.fixture
 def android_target():
     return "emulator-5554"
 

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -103,7 +103,7 @@ class TestDockerSystem:
             buildargs=docker_config.build_args,
         )
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_docker_system_info(self):
         self.mock_from_env = patch("olive.systems.docker.docker_system.docker.from_env").start()
         self.mock_tempdir = patch("olive.systems.docker.docker_system.tempfile.TemporaryDirectory").start()

--- a/test/unit_test/workflows/test_run_config.py
+++ b/test/unit_test/workflows/test_run_config.py
@@ -51,7 +51,7 @@ class TestRunConfig:
             RunConfig.parse_obj(user_script_config)
         assert "azureml_client is required for AzureML System but not provided." in str(e.value)
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_aml_credentials(self):
         # we need to mock all the credentials because the default credential will get tokens from all of them
         self.mocked_env_credentials = patch("azure.identity._credentials.default.EnvironmentCredential").start()

--- a/test/unit_test/workflows/test_setup.py
+++ b/test/unit_test/workflows/test_setup.py
@@ -24,7 +24,7 @@ class DependencySetupEnvBuilder(venv.EnvBuilder):
         run_subprocess([context.env_exe, "-Im", "pip", "install", olive_root], check=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_json(tmp_path):
     if platform.system() == OS.WINDOWS:
         ep = "DmlExecutionProvider"


### PR DESCRIPTION
## Describe your changes
- After ort 1.19.0, the histogram collector in onnxruntime static quantization calibration hits errors with Nan ("ValueError: supplied range of [nan, nan] is not finite"). There is no ETA for an investigation or fix for this issue so we will only test static quantization with MinMax calibration method.
- Remove config params for no-search configs that are set to defaults
- Use latest torch in cuda examples test since ort-gpu 1.19.0 is compatible with it now. (needs cudnn 9.x)

Some lint fixes for new ruff version.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
