### PR TITLE
ExtractAdapters: `dynamic_lora_r` and `optional_inputs`

### DIFF
--- a/olive/model/handler/onnx.py
+++ b/olive/model/handler/onnx.py
@@ -91,6 +91,21 @@ class ONNXModelHandler(OliveModelHandler, OnnxEpValidateMixin, OnnxGraphMixin): 
         model_path = super().model_path
         return get_additional_file_path(model_path, self.constant_inputs_file_name) if model_path else None
 
+    def change_model_path_to_dir(self) -> Path:
+        """Change the model path to the parent directory of the model file.
+
+        This is used when we want to store more files in the same directory as the model file.
+        :return: The parent directory of the model file.
+        """
+        model_path_resource = Path(self.get_resource("model_path"))
+        if model_path_resource.is_dir():
+            return model_path_resource
+
+        self.set_resource("model_path", model_path_resource.parent)
+        self.onnx_file_name = model_path_resource.name
+
+        return model_path_resource.parent
+
     def load_model(self, rank: int = None) -> ModelProto:
         return onnx.load(self.model_path)
 

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -232,9 +232,7 @@ class Pass(ABC):
         if not output_model_path.is_dir():
             if isinstance(output_model, ONNXModelHandler):
                 # change the "model_path" resource to the parent directory of the model file
-                output_model.set_resource("model_path", output_model_path.parent)
-                output_model.onnx_file_name = output_model_path.name
-                output_model_path = output_model_path.parent
+                output_model_path = output_model.change_model_path_to_dir()
             else:
                 logger.warning("Expecting the output model to be in a directory but found a file.")
                 return

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -117,10 +117,7 @@ class OnnxConversion(Pass):
 
         if isinstance(model, HfModelHandler) and config["save_metadata_for_token_generation"]:
             # output_model can only be an ONNXModelHandler
-            output_dir = Path(output_model.get_resource("model_path"))
-            if not output_dir.is_dir():
-                output_dir = str(output_dir.parent)
-                output_model.set_resource("model_path", output_dir)
+            output_dir = output_model.change_model_path_to_dir()
 
             output_model.model_attributes = model_attributes = output_model.model_attributes or {}
             model_attributes["additional_files"] = additional_files = model_attributes.get("additional_files", [])

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -203,7 +203,7 @@ class ExtractAdapters(Pass):
                     name=f"{weight_name}.split",
                     axis=0,
                 )
-                dag.add_node(split_node_proto, 0, overwrite_initializers=True)
+                dag.add_node(split_node_proto, 0, overwrite_input_initializers=True)
 
             # remove the original weights
             weights = packed_weights

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -63,6 +63,15 @@ class ExtractAdapters(Pass):
                     " float modules."
                 ),
             ),
+            "optional_inputs": PassConfigParam(
+                type_=bool,
+                default_value=True,
+                description=(
+                    "Create default initializers (empty tensor with lora_r dimension set to 0) for the adapter weights,"
+                    " if inputs not provided during inference. Only used if make_inputs is True. Valid only for float"
+                    " modules."
+                ),
+            ),
             "save_format": PassConfigParam(
                 type_=WeightsFileFormat,
                 default_value=WeightsFileFormat.NUMPY,
@@ -124,7 +133,7 @@ class ExtractAdapters(Pass):
                 elif dag.is_initializer(old_weight_name):
                     # weight is an float initializer
                     # create initializer with new weight name
-                    self._create_empty_initializer(dag, weights, old_weight_name, new_weight_name)
+                    self._externalize_initializer(dag, weights, old_weight_name, new_weight_name)
 
                     # change input to the new name
                     dag.replace_node_input(node_name, old_weight_name, new_weight_name)
@@ -141,7 +150,7 @@ class ExtractAdapters(Pass):
                     used_inputs = []
                     # create new initializers for the dequantize node
                     for old_input, new_input in zip(old_dequantize_node.inputs, new_quantized_names):
-                        self._create_empty_initializer(dag, weights, old_input, new_input)
+                        self._externalize_initializer(dag, weights, old_input, new_input)
                         used_inputs.append(new_input)
 
                     # create a new dequantize node
@@ -174,7 +183,7 @@ class ExtractAdapters(Pass):
                 # weight is Nbits quantized
                 # create empty initializers and change node inputs
                 for old_input, new_input in zip(dag.get_node_inputs(node_name)[1:], new_quantized_names):
-                    self._create_empty_initializer(dag, weights, old_input, new_input)
+                    self._externalize_initializer(dag, weights, old_input, new_input)
                     dag.replace_node_input(node_name, old_input, new_input)
 
                 # add the module to the quant modules
@@ -188,21 +197,14 @@ class ExtractAdapters(Pass):
             # create inputs for the weights
             for weight_name in weights:
                 dag.convert_initializer_to_input(weight_name)
-                if "quant" not in weight_name and config["dynamic_lora_r"]:
-                    dim_idx = 1 if "lora_A" in weight_name else 0
-                    dag.make_input_dim_dynamic(weight_name, dim_idx, "lora_r")
+                self._make_dynamic_optional(dag, weights, weight_name, config)
+
         elif config["make_inputs"] and config["pack_inputs"]:
             # what weights are packed together
             packed_weights, packings = self.pack_weights(weights, lora_modules, float_modules, quant_modules)
 
             # create inputs and split nodes for the packed weights
             for weight_name, to_pack in packings.items():
-                # shape
-                shape = packed_weights[weight_name].shape
-                if "quant" not in weight_name and config["dynamic_lora_r"]:
-                    dim_idx = 1 if "lora_A" in weight_name else 0
-                    shape[dim_idx] = "lora_r"
-
                 # input proto
                 input_proto = onnx.helper.make_tensor_value_info(
                     name=weight_name,
@@ -221,6 +223,9 @@ class ExtractAdapters(Pass):
                     axis=0,
                 )
                 dag.add_node(split_node_proto, 0, overwrite_input_initializers=True)
+
+                # make the inputs dynamic and optional
+                self._make_dynamic_optional(dag, packed_weights, weight_name, config)
 
             # remove the original weights
             weights = packed_weights
@@ -346,9 +351,10 @@ class ExtractAdapters(Pass):
         return new_initializer
 
     @classmethod
-    def _create_empty_initializer(cls, dag: OnnxDAG, weights: Dict[str, "NDArray"], old_name: str, new_name: str):
-        """Create an empty initializer with the same shape and type as the old initializer.
+    def _externalize_initializer(cls, dag: OnnxDAG, weights: Dict[str, "NDArray"], old_name: str, new_name: str):
+        """Create a new initializer with the same shape and type as the old initializer.
 
+        The initializer points to a dummy external location.
         Add the new initializer to the graph and store the weight in a dictionary.
 
         :param dag: OnnxDAG object
@@ -358,7 +364,7 @@ class ExtractAdapters(Pass):
         """
         assert dag.is_initializer(old_name), f"{old_name} is not an initializer"
 
-        old_proto = dag.get_io(old_name).proto
+        old_proto = dag.get_io(old_name).proto[-1]
 
         # store the weight in a dictionary
         weights[new_name] = onnx.numpy_helper.to_array(old_proto)
@@ -367,3 +373,23 @@ class ExtractAdapters(Pass):
         new_initializer = cls._copy_initializer(old_proto, new_name)
         # add the new initializer to the graph
         dag.add_initializer(new_initializer, dag.get_io(old_name).graph_idx)
+
+    @classmethod
+    def _make_dynamic_optional(cls, dag: OnnxDAG, weights: Dict[str, "NDArray"], name: str, config: Dict[str, Any]):
+        """Make the input dynamic and optional."""
+        if "quant" in name:
+            # dynamic shape and optional inputs not supported for quantized modules yet
+            return
+
+        dim_idx = 1 if "lora_A" in name else 0
+
+        # make the input dynamic
+        if config["dynamic_lora_r"]:
+            dag.make_input_dim_dynamic(name, dim_idx, "lora_r")
+
+        # create default initializer
+        if config["optional_inputs"]:
+            shape = list(weights[name].shape)
+            shape[dim_idx] = 0
+            initializer_proto = onnx.numpy_helper.from_array(np.zeros(shape, dtype=weights[name].dtype), name)
+            dag.add_initializer(initializer_proto, 0, keep_input=True)

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -55,6 +55,14 @@ class ExtractAdapters(Pass):
                     " is True."
                 ),
             ),
+            "dynamic_lora_r": PassConfigParam(
+                type_=bool,
+                default_value=True,
+                description=(
+                    "Whether the model uses dynamic shape for lora_r. Only used if make_inputs is True. Valid only for"
+                    " float modules."
+                ),
+            ),
             "save_format": PassConfigParam(
                 type_=WeightsFileFormat,
                 default_value=WeightsFileFormat.NUMPY,
@@ -180,12 +188,21 @@ class ExtractAdapters(Pass):
             # create inputs for the weights
             for weight_name in weights:
                 dag.convert_initializer_to_input(weight_name)
+                if "quant" not in weight_name and config["dynamic_lora_r"]:
+                    dim_idx = 1 if "lora_A" in weight_name else 0
+                    dag.make_input_dim_dynamic(weight_name, dim_idx, "lora_r")
         elif config["make_inputs"] and config["pack_inputs"]:
             # what weights are packed together
             packed_weights, packings = self.pack_weights(weights, lora_modules, float_modules, quant_modules)
 
             # create inputs and split nodes for the packed weights
             for weight_name, to_pack in packings.items():
+                # shape
+                shape = packed_weights[weight_name].shape
+                if "quant" not in weight_name and config["dynamic_lora_r"]:
+                    dim_idx = 1 if "lora_A" in weight_name else 0
+                    shape[dim_idx] = "lora_r"
+
                 # input proto
                 input_proto = onnx.helper.make_tensor_value_info(
                     name=weight_name,

--- a/olive/passes/onnx/onnx_dag.py
+++ b/olive/passes/onnx/onnx_dag.py
@@ -25,6 +25,24 @@ class SpecialInput(StrEnumBase):
 
     INPUT = "__input__"  # user input
     INITIALIZER = "__initializer__"  # constant initializer
+    INPUT_INITIALIZER = "__input_initializer__"  # input + initializer
+
+    @classmethod
+    def is_special_input(cls, value: str) -> bool:
+        try:
+            cls(value)
+            return True
+        except ValueError:
+            # check if value is a valid input name
+            return False
+
+    @classmethod
+    def is_input(cls, value: str) -> bool:
+        return value in {cls.INPUT, cls.INPUT_INITIALIZER}
+
+    @classmethod
+    def is_initializer(cls, value: str) -> bool:
+        return value in {cls.INITIALIZER, cls.INPUT_INITIALIZER}
 
 
 class SpecialOutput(StrEnumBase):
@@ -56,7 +74,7 @@ class OnnxIO(ConfigBase):
     graph_idx: int
     # reference to the protobuf object
     # can't be serialized to JSON, but we don't need it
-    proto: Union[ValueInfoProto, TensorProto] = None
+    proto: List[Union[ValueInfoProto, TensorProto]] = Field(default_factory=list)
 
 
 class OnnxDAG:
@@ -109,14 +127,24 @@ class OnnxDAG:
         :param graph_idx: index of the graph in the model.
         """
         for i in graph.input:
-            ios[i.name] = OnnxIO(proto=i, source=SpecialInput.INPUT, graph_idx=graph_idx)
+            ios[i.name] = OnnxIO(proto=[i], source=SpecialInput.INPUT, graph_idx=graph_idx)
         for o in graph.output:
-            ios[o.name] = OnnxIO(proto=o, destination=[SpecialOutput.OUTPUT], graph_idx=graph_idx)
+            ios[o.name] = OnnxIO(proto=[o], destination=[SpecialOutput.OUTPUT], graph_idx=graph_idx)
         for initializer in graph.initializer:
-            ios[initializer.name] = OnnxIO(proto=initializer, source=SpecialInput.INITIALIZER, graph_idx=graph_idx)
+            if initializer.name in ios:
+                # it can be both an input and an initializer
+                io = ios[initializer.name]
+                io.proto.append(initializer)
+                io.source = SpecialInput.INPUT_INITIALIZER
+            else:
+                ios[initializer.name] = OnnxIO(
+                    proto=[initializer],
+                    source=SpecialInput.INPUT_INITIALIZER,
+                    graph_idx=graph_idx,
+                )
         for vi in graph.value_info:
             if vi.name not in ios:
-                ios[vi.name] = OnnxIO(proto=vi, graph_idx=graph_idx)
+                ios[vi.name] = OnnxIO(proto=[vi], graph_idx=graph_idx)
         return ios
 
     @staticmethod
@@ -126,7 +154,7 @@ class OnnxDAG:
         ios: Dict[str, OnnxIO],
         connections: Dict[str, List[str]],
         graph_idx: int,
-        overwrite_initializers: bool = False,
+        overwrite_input_initializers: bool = False,
     ):
         """Process a node and populate the nodes and connections attributes.
 
@@ -135,8 +163,8 @@ class OnnxDAG:
         :param ios: dictionary to store the inputs, outputs, and initializers.
         :param connections: dictionary to store the connections between nodes.
         :param graph_idx: index of the graph in the model.
-        :param overwrite_initializers: whether to overwrite the initializers if a node output is already present
-            as an initializer. If False, it will raise an error.
+        :param overwrite_input_initializers: whether to overwrite the inputs and/or initializers if a node
+            output is already present as an one. If False, it will raise an error.
         """
         name = node_proto.name
         onnx_node = OnnxNode(
@@ -158,7 +186,7 @@ class OnnxDAG:
                 )
             ios[i].destination.append(name)
             parent = ios[i].source
-            if parent not in [SpecialInput.INPUT, SpecialInput.INITIALIZER]:
+            if not SpecialInput.is_special_input(parent):
                 connections[parent].append(name)
 
         for o in node_proto.output:
@@ -168,63 +196,90 @@ class OnnxDAG:
             if o not in ios:
                 ios[o] = OnnxIO(graph_idx=graph_idx)
             elif ios[o].source is not None and not (
-                overwrite_initializers and ios[o].source == SpecialInput.INITIALIZER
+                overwrite_input_initializers and SpecialInput.is_special_input(ios[o].source)
             ):
-                # if the output's original source is an initializer, we can overwrite it
+                # if the output's original source is an input/initializer, we can overwrite it
                 raise ValueError(f"Output {o} is already connected to another node.")
-            ios[o].source = name
+            ios[o] = OnnxIO(source=name, destination=ios[o].destination, graph_idx=graph_idx)
             for destination in ios[o].destination:
                 if destination != SpecialOutput.OUTPUT:
                     connections[name].append(destination)
 
-    def add_input(self, input_proto: ValueInfoProto, graph_idx: int):
+    def add_input(self, input_proto: ValueInfoProto, graph_idx: int, keep_initializer: bool = False):
         """Add an input to the graph.
 
         :param input_proto: ValueInfoProto of the input.
         :param graph_idx: index of the graph in the model.
+        :param keep_initializer: whether to keep the initializer if it exists with the same name.
         """
-        if input_proto.name in self.ios:
-            raise ValueError(f"Input {input_proto.name} already exists in the graph.")
+        self._add_special_input(input_proto, graph_idx, SpecialInput.INPUT, keep_initializer)
 
-        self.ios[input_proto.name] = OnnxIO(proto=input_proto, source=SpecialInput.INPUT, graph_idx=graph_idx)
-
-    def add_initializer(self, initializer: TensorProto, graph_idx: int):
+    def add_initializer(self, initializer: TensorProto, graph_idx: int, keep_input: bool = False):
         """Add an initializer to the graph.
 
         :param initializer: TensorProto of the initializer.
         :param graph_idx: index of the graph in the model.
+        :param keep_input: whether to keep the input if it exists with the same name.
         """
-        if initializer.name in self.ios:
-            raise ValueError(f"Initializer {initializer.name} already exists in the graph.")
+        self._add_special_input(initializer, graph_idx, SpecialInput.INITIALIZER, keep_input)
 
-        self.ios[initializer.name] = OnnxIO(proto=initializer, source=SpecialInput.INITIALIZER, graph_idx=graph_idx)
+    def _add_special_input(
+        self,
+        proto: Union[ValueInfoProto, TensorProto],
+        graph_idx: int,
+        i_type: SpecialInput,
+        keep_existing: bool = False,
+    ):
+        """Add a special input to the graph.
+
+        :param proto: ValueInfoProto or TensorProto of the input.
+        :param graph_idx: index of the graph in the model.
+        :param i_type: type of the special input.
+        :param keep_existing: whether to keep the existing input/initializer if it exists with the same name.
+        """
+        name = proto.name
+        proto_list = [proto]
+        other_type = SpecialInput.INITIALIZER
+        insert_idx = 0
+        if i_type == SpecialInput.INITIALIZER:
+            other_type = SpecialInput.INPUT
+            insert_idx = 1
+        if name in self.ios and not (keep_existing and self.ios[name].source == other_type):
+            raise ValueError(f"{i_type} {name} already exists in the graph.")
+        elif name in self.ios:
+            # keep the other type
+            proto_list.insert(insert_idx, self.ios[name].proto[0])
+
+        self.ios[name] = OnnxIO(proto=proto_list, source=i_type, graph_idx=graph_idx)
 
     def convert_initializer_to_input(self, initializer_name: str):
         """Convert an initializer to an input.
 
         :param initializer_name: name of the initializer to convert to an input.
         """
-        if not self.is_initializer(initializer_name):
+        io = self.ios[initializer_name]
+        if io.source != SpecialInput.INITIALIZER:
             raise ValueError(f"{initializer_name} is not an initializer.")
 
-        io = self.ios[initializer_name]
+        # update the ios
+        self.ios[initializer_name] = OnnxIO(
+            proto=[onnx.helper.make_tensor_value_info(initializer_name, io.proto[0].data_type, io.proto[0].dims)],
+            source=SpecialInput.INPUT,
+            destination=io.destination,
+            graph_idx=io.graph_idx,
+        )
 
-        old_proto = io.proto
-        new_proto = onnx.helper.make_tensor_value_info(initializer_name, old_proto.data_type, old_proto.dims)
-        io.source = SpecialInput.INPUT
-        io.proto = new_proto
-
-    def add_node(self, node_proto: NodeProto, graph_idx: int, overwrite_initializers: bool = False):
+    def add_node(self, node_proto: NodeProto, graph_idx: int, overwrite_input_initializers: bool = False):
         """Add a node to the graph.
 
         This adds the node to the `nodes` attribute and connects them using the `ios` attribute.
 
         :param node_proto: ONNX node.
         :param graph_idx: index of the graph in the model.
-        :param overwrite_initializers: whether to overwrite the initializers if a node output is already present
-            as an initializer. If false, it will raise an error.
+        :param overwrite_input_initializers: whether to overwrite the inputs and/or initializers if a node
+            output is already present as an one. If False, it will raise an error.
         """
-        self._process_node(node_proto, self.nodes, self.ios, self.connections, graph_idx, overwrite_initializers)
+        self._process_node(node_proto, self.nodes, self.ios, self.connections, graph_idx, overwrite_input_initializers)
 
     def remove_node(self, node_name: str, check_no_consumers: bool = False):
         """Remove a node from the graph.
@@ -281,11 +336,11 @@ class OnnxDAG:
 
                 # update the connections
                 old_parent = self.ios[old_input].source
-                if old_parent not in [SpecialInput.INPUT, SpecialInput.INITIALIZER]:
+                if SpecialInput.is_special_input(old_parent):
                     self.connections[old_parent].remove(node_name)
 
                 new_parent = self.ios[new_input].source
-                if new_parent not in [SpecialInput.INPUT, SpecialInput.INITIALIZER]:
+                if not SpecialInput.is_special_input(new_parent):
                     self.connections[new_parent].append(node_name)
 
                 num_updated += 1
@@ -346,7 +401,7 @@ class OnnxDAG:
         :param io_name: name of the input/output.
         :return: True if the input/output is a user input.
         """
-        return self.ios[io_name].source == SpecialInput.INPUT
+        return SpecialInput.is_input(self.ios[io_name].source)
 
     def is_initializer(self, io_name: str) -> bool:
         """Check if an input/output is an initializer.
@@ -354,7 +409,7 @@ class OnnxDAG:
         :param io_name: name of the input/output.
         :return: True if the input/output is an initializer.
         """
-        return self.ios[io_name].source == SpecialInput.INITIALIZER
+        return SpecialInput.is_initializer(self.ios[io_name].source)
 
     def is_output(self, io_name: str) -> bool:
         """Check if an input/output is an output.
@@ -378,7 +433,7 @@ class OnnxDAG:
         :param node_name: name of the node. It can also be an input or initializer.
         :return: list of names of nodes that consume one/more outputs of the node.
         """
-        if node_name in self.ios and self.ios[node_name].source in [SpecialInput.INPUT, SpecialInput.INITIALIZER]:
+        if node_name in self.ios and SpecialInput.is_special_input(self.ios[node_name].source):
             return list(self.ios[node_name].destination)
 
         return list(self.connections[node_name])
@@ -450,7 +505,7 @@ class OnnxDAG:
                     continue
                 if self.is_output(i):
                     # outputs are handled separately
-                    outputs.append(io.proto)
+                    outputs.append(io.proto[0])
                     continue
 
                 # inputs, initializers or intermediate connections
@@ -458,9 +513,9 @@ class OnnxDAG:
                     # no consumers, so don't add it to the graph proto
                     continue
                 if self.is_input(i):
-                    inputs.append(io.proto)
+                    inputs.append(io.proto[0])
                 elif self.is_initializer(i):
-                    initializers.append(io.proto)
+                    initializers.append(io.proto[-1])
 
             # update the graph proto
             graph.ClearField("node")

--- a/olive/passes/onnx/onnx_dag.py
+++ b/olive/passes/onnx/onnx_dag.py
@@ -139,7 +139,7 @@ class OnnxDAG:
             else:
                 ios[initializer.name] = OnnxIO(
                     proto=[initializer],
-                    source=SpecialInput.INPUT_INITIALIZER,
+                    source=SpecialInput.INITIALIZER,
                     graph_idx=graph_idx,
                 )
         for vi in graph.value_info:
@@ -200,7 +200,7 @@ class OnnxDAG:
             ):
                 # if the output's original source is an input/initializer, we can overwrite it
                 raise ValueError(f"Output {o} is already connected to another node.")
-            ios[o] = OnnxIO(source=name, destination=ios[o].destination, graph_idx=graph_idx)
+            ios[o].source = name
             for destination in ios[o].destination:
                 if destination != SpecialOutput.OUTPUT:
                     connections[name].append(destination)
@@ -367,7 +367,7 @@ class OnnxDAG:
 
                 # update the connections
                 old_parent = self.ios[old_input].source
-                if SpecialInput.is_special_input(old_parent):
+                if not SpecialInput.is_special_input(old_parent):
                     self.connections[old_parent].remove(node_name)
 
                 new_parent = self.ios[new_input].source
@@ -544,8 +544,10 @@ class OnnxDAG:
                     # no consumers, so don't add it to the graph proto
                     continue
                 if self.is_input(i):
+                    print(i, "is input")
                     inputs.append(io.proto[0])
                 elif self.is_initializer(i):
+                    print(i, "is initializer")
                     initializers.append(io.proto[-1])
 
             # update the graph proto

--- a/test/unit_test/passes/test_pass.py
+++ b/test/unit_test/passes/test_pass.py
@@ -95,12 +95,7 @@ def test_pass_model_attributes_additional_files(self, tmpdir):
         content = strm.read()
     assert content == "model_3_filepath_3"
 
-    def model_4_side_effect(arg):
-        return str(model_4_path) if arg == "model_path" else None
-
-    model_4 = MagicMock(spec=ONNXModelHandler)
-    model_4.get_resource = MagicMock(side_effect=model_4_side_effect)
-    model_4.model_attributes = {}
+    model_4 = ONNXModelHandler(model_path=str(model_4_path))
 
     # Output model's output path is a file rather than directory
     Pass._carry_forward_additional_files(model_3, model_4)  # pylint: disable=W0212


### PR DESCRIPTION
## Describe your changes
ONNXModelHandler:
- New `change_model_path_to_dir` method. Currently, there are two different places where this logic is implemented manually. In onnx conversion, it doesn't update the model_file_name which leads to warning when resolving the onnx model file path 

ExtractAdapter:
-  `dynamic_lora_r`: Option to make the dimension for LoRA r static or dynamic.
- `optional_inputs`: Onnx and ort allow the same name to be used for graph initializers and inputs. When this happens, the input behaves like an optional input where the initializer is used if the input is not provided. https://github.com/onnx/onnx/blob/main/docs/IR.md#nodes 
  Using this behavior, we can set the default initializer for the lora weights to be empty tensors with shapes `[in_dim, 0]` and `[0, out_dim]`. When the lora weights are not provided during session run, these initializers would be used which is equivalent to running the base model with no adapters. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
