### PR TITLE
Conversion: Absorb lora scaling into lora_B weights

### DIFF
--- a/olive/common/hf/model_io.py
+++ b/olive/common/hf/model_io.py
@@ -7,7 +7,8 @@ from itertools import chain
 from typing import TYPE_CHECKING, Dict, Optional
 
 from olive.common.hf.mlflow import get_pretrained_name_or_path
-from olive.common.hf.utils import get_model_config, get_tokenizer, is_peft_model
+from olive.common.hf.peft import is_peft_model
+from olive.common.hf.utils import get_model_config, get_tokenizer
 
 logger = logging.getLogger(__name__)
 

--- a/olive/common/hf/peft.py
+++ b/olive/common/hf/peft.py
@@ -1,0 +1,105 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import importlib
+import logging
+from contextlib import contextmanager
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import torch
+from packaging import version
+
+from olive.common.utils import get_attr
+
+if TYPE_CHECKING:
+    from peft.tuners.lora import Linear as LoraLinear
+
+logger = logging.getLogger(__name__)
+
+
+def is_peft_model(model: torch.nn.Module) -> bool:
+    """Check if the model is a PeftModel."""
+    if importlib.util.find_spec("peft"):
+        from peft import PeftModel
+
+        return isinstance(model, PeftModel)
+    return False
+
+
+class ScaledLoraLinear(torch.nn.Module):
+    """A wrapper for the LoraLinear layer that pre-multiplies the lora_B weights by the scaling factor."""
+
+    def __init__(self, original: "LoraLinear"):
+        super().__init__()
+        active_adapter = original.active_adapter[0]
+        self.base_layer = original.base_layer
+        # using a deepcopy so that the name of node in exported model says lora_A instead of default
+        # should be okay since lora linears are small
+        self.lora_A = deepcopy(original.lora_A[active_adapter])
+        # copy the weights and scale them by the scaling factor
+        # don't want to modify the original weights
+        self.lora_B = deepcopy(original.lora_B[active_adapter])
+        self.lora_B.weight.data *= original.scaling[active_adapter]
+
+    def forward(self, x, *args, **kwargs):
+        previous_dtype = x.dtype
+
+        result = self.base_layer(x, *args, **kwargs)
+        x - x.to(self.lora_A.weight.dtype)
+        result += self.lora_B(self.lora_A(x))
+
+        return result.to(previous_dtype)
+
+
+@contextmanager
+def peft_export_context_manager(model: torch.nn.Module):
+    """Context manager for handling PeftModel models.
+
+    If the model is a PeftModel:
+        - Use the base model for exporting
+        - Replace all LoraLinear layers with ScaledLoraLinear layers so that the scaling factor is applied to
+          the weights beforehand and doesn't appear as a separate Mul node in the exported model.
+    """
+    if not is_peft_model(model):
+        yield model
+        return
+
+    # if pytorch_model is PeftModel, we need to get the base model
+    # otherwise, the model forward has signature (*args, **kwargs) and torch.onnx.export ignores the dummy_inputs
+    model = model.get_base_model()
+
+    from peft import __version__ as peft_version
+
+    if version.parse(peft_version) < version.parse("0.7.0"):
+        logger.warning(
+            "Model is a peft model but the peft version is not supported for exporting with fold_lora_scale!"
+            " Please use peft version 0.7.0 or higher."
+        )
+        yield model
+        return
+
+    from peft.tuners.lora import Linear as LoraLinear
+
+    original_linears = []
+    for name, module in model.named_modules():
+        if (
+            not isinstance(module, LoraLinear)
+            or len(module.active_adapters) != 1
+            or getattr(module, "use_dora", {}).get(module.active_adapters[0], False)
+        ):
+            continue
+
+        parent_name = ".".join(name.split(".")[:-1])
+        parent_module = get_attr(model, parent_name)
+        target_name = name.split(".")[-1]
+
+        scaled_linear = ScaledLoraLinear(module)
+        setattr(parent_module, target_name, scaled_linear)
+        original_linears.append((parent_module, target_name, module))
+    try:
+        yield model
+    finally:
+        for parent_module, target_name, linear in original_linears:
+            setattr(parent_module, target_name, linear)

--- a/olive/common/hf/utils.py
+++ b/olive/common/hf/utils.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import importlib
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
@@ -14,7 +13,6 @@ from olive.common.hf.mlflow import get_pretrained_name_or_path
 from olive.common.utils import hardlink_copy_file
 
 if TYPE_CHECKING:
-    import torch
     from transformers import PretrainedConfig, PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast
 
 logger = logging.getLogger(__name__)
@@ -213,12 +211,3 @@ def get_model_max_length(model_name_or_path: str, fail_on_not_found=False) -> in
             else:
                 logger.warning(not_found_msg)
                 return None
-
-
-def is_peft_model(model: "torch.nn.Module") -> bool:
-    """Check if the model is a PeftModel."""
-    if importlib.util.find_spec("peft"):
-        from peft import PeftModel
-
-        return isinstance(model, PeftModel)
-    return False

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -289,7 +289,7 @@ class ExtractAdapters(Pass):
         return [
             f".*[./]{key}[./]{name}[./]{matmul}$"
             for key in lora_modules
-            for name in ["default", "default_1"]
+            for name in ["default", "default_1", "lora_A", "lora_B"]
             for matmul in ["MatMul", "MatMul_Q4"]
         ]
 


### PR DESCRIPTION
## Describe your changes
LoRA has a scaling factor that is computed based on `lora_alpha` and `r`. These get multiplied with the output of the lora matmuls which results in an additional `Mul` node with the scaling float. However, this mul node is hard to keep track of during subsequent optimization steps (for example, it might get removed if scaling is 1). We also want to be able to use different sets of adapters which might not share the same scaling factor. 

To overcome this, we implement a context manager which finds all lora linear layers and wraps it with a custom module class that already has the scaling multiplied into the lora_B weights. This way, we can just ship the scaled weights.

Also moved other peft related model transformations into the context manager.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
