### PR TITLE
GptqQuantizer: Option to save in hf format

### DIFF
--- a/examples/llama2/README.md
+++ b/examples/llama2/README.md
@@ -91,7 +91,6 @@ This workflow quantizes the Llama2 model using [GPTQ](https://arxiv.org/abs/2210
 
 - This workflow is only supported for GPU and need GPU to run.
 - GPTQ quantization can be enabled by passing `--use_gptq` flag to the script.
-- You must be logged in to HuggingFace using `huggingface-cli login` to download the dataset or update `token` field in the config file with your HuggingFace token.
 
 Requirements file: [requirements-gptq.txt](requirements-gptq.txt)
 
@@ -179,6 +178,15 @@ Run the following command to execute the workflow:
 
 ```bash
 python llama2.py --qlora
+```
+
+**Note:**
+Get access to the following resource on Hugging Face Hub:
+- [nampdn-ai/tiny-codes](https://huggingface.co/nampdn-ai/tiny-codes)
+
+Login to your Hugging Face account:
+```bash
+huggingface-cli login
 ```
 
 ### Running Workflows on the Cloud

--- a/examples/opt_125m/README.md
+++ b/examples/opt_125m/README.md
@@ -1,16 +1,22 @@
 # AutoAwq in Onnxruntime
-Sample use case of Olive to optimize facebook/opt_125m model using AutoAwq which produces a quantized model that can be converted and run in Onnxruntime.
+Sample use case of Olive to optimize facebook/opt_125m model using AutoAwq/AutoGPTQ which produces a quantized model that can be converted and run in Onnxruntime.
 
 ## Optimization Workflows
 Performs optimization pipeline:
 - *Pytorch Model -> AutoAwqQuantization -> Pytorch Model*
 - *Pytorch Model -> AutoAwqQuantization -> Onnx Model -> Transformers Optimized*
+- *Pytorch Model -> AutoGPTQQuantization -> Pytorch Model*
+- *Pytorch Model -> AutoGPTQQuantization -> Onnx Model -> Transformers Optimized*
 
 ## Prerequisite
 
 Before running this script, you need to install the required python packages from the requirements.txt file.
 ```bash
-pip install -r requirements.txt
+# awq
+pip install -r requirements-awq.txt
+
+# gptq
+pip install -r requirements-gptq.txt
 ```
 
 Also, please ensure you already installed olive-ai. Please refer to the [installation guide](https://github.com/microsoft/Olive?tab=readme-ov-file#installation) for more information.
@@ -23,6 +29,12 @@ Olive already simplifies the optimization process by providing a single json con
 # only run awq
 python -m olive.workflows.run --config awq.json
 
-# run awq, export onnx, and optimize onnx
+# run awq, export to onnx, and optimize onnx
 python -m olive.workflows.run --config awq_onnx.json
+
+# only run gptq
+python -m olive.workflows.run --config gptq.json
+
+# run gptq, export to onnx, and optimize onnx
+python -m olive.workflows.run --config gptq_onnx.json
 ```

--- a/examples/opt_125m/awq.json
+++ b/examples/opt_125m/awq.json
@@ -10,5 +10,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_dir": "models/opt_125m"
+    "output_dir": "models/awq"
 }

--- a/examples/opt_125m/gptq.json
+++ b/examples/opt_125m/gptq.json
@@ -1,0 +1,22 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "facebook/opt-125m" },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "CUDAExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "wikitext2_train",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": { "add_special_tokens": false, "max_samples": 128 }
+        }
+    ],
+    "passes": { "gptq_quant_int4": { "type": "GptqQuantizer", "data_config": "wikitext2_train" } },
+    "host": "local_system",
+    "target": "local_system",
+    "cache_dir": "cache",
+    "output_dir": "models/gptq"
+}

--- a/examples/opt_125m/gptq_onnx.json
+++ b/examples/opt_125m/gptq_onnx.json
@@ -6,8 +6,20 @@
             "accelerators": [ { "device": "gpu", "execution_providers": [ "CUDAExecutionProvider" ] } ]
         }
     },
+    "data_configs": [
+        {
+            "name": "wikitext2_train",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": { "add_special_tokens": false, "max_samples": 128 }
+        }
+    ],
     "passes": {
-        "4bit_awq_quantizer": { "type": "AutoAWQQuantizer", "pack_model_for_onnx_conversion": true },
+        "gptq_quant_int4": {
+            "type": "GptqQuantizer",
+            "data_config": "wikitext2_train",
+            "pack_model_for_onnx_conversion": true
+        },
         "conversion_merged": { "type": "OnnxConversion", "device": "cuda", "torch_dtype": "float32" },
         "transformers_optimization_fp16": {
             "type": "OrtTransformersOptimization",
@@ -20,5 +32,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_dir": "models/awq_onnx"
+    "output_dir": "models/gptq_onnx"
 }

--- a/examples/opt_125m/requirements-awq.txt
+++ b/examples/opt_125m/requirements-awq.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+autoawq

--- a/examples/opt_125m/requirements-gptq.txt
+++ b/examples/opt_125m/requirements-gptq.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+auto-gptq

--- a/examples/opt_125m/requirements.txt
+++ b/examples/opt_125m/requirements.txt
@@ -1,4 +1,3 @@
-autoawq
 optimum
 # version mismatch between torch in autoawq and transformers
 transformers==4.41.2

--- a/examples/phi3/README.md
+++ b/examples/phi3/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 
 If you target GPU, pls install onnxruntime and onnxruntime-genai gpu packages.
 
-
+<!-- TODO(anyone): Remove this when genai doesn't require login -->
 ### For optimizing model from Hugging Face
 if you have not logged in Hugging Face account,
 - Install Hugging Face CLI and login your Hugging Face account for model access
@@ -50,7 +50,7 @@ python phi3.py --target mobile --inference --prompt "Write a story starting with
 # Fine-tune the model with lora method, optimize the model for cuda target and inference with ONNX Runtime Generate() API
 python phi3.py --target cuda --finetune_method lora --inference --prompt "Write a story starting with once upon a time" --max_length 200
 
-# Fine-tune, quantize and optimize the model
+# Fine-tune, quantize using AWQ and optimize the model for cpu target
 python phi3.py --target cpu --precision int4 --finetune_method lora --awq
 ```
 
@@ -85,6 +85,11 @@ To run the workflow,
 ```bash
 python phi3.py --quarot
 ```
+
+### Get access to fine-tuning dataset
+Get access to the following resources on Hugging Face Hub:
+- [nampdn-ai/tiny-codes](https://huggingface.co/nampdn-ai/tiny-codes)
+
 
 ## More Inference Examples
 - [Android chat APP with Phi-3 and ONNX Runtime Mobile](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/mobile/examples/phi-3/android)

--- a/examples/phi3/phi3_template.json
+++ b/examples/phi3/phi3_template.json
@@ -45,8 +45,8 @@
                 "per_device_eval_batch_size": 1,
                 "gradient_accumulation_steps": 4,
                 "gradient_checkpointing": false,
-                "max_steps": 15,
-                "logging_steps": 5,
+                "max_steps": 150,
+                "logging_steps": 50,
                 "max_grad_norm": 0.3
             }
         },
@@ -59,8 +59,8 @@
                 "per_device_eval_batch_size": 1,
                 "gradient_accumulation_steps": 4,
                 "gradient_checkpointing": false,
-                "max_steps": 15,
-                "logging_steps": 5,
+                "max_steps": 150,
+                "logging_steps": 50,
                 "group_by_length": true,
                 "max_grad_norm": 0.3
             }

--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import codecs
 import logging
 import tempfile
 from argparse import ArgumentParser
@@ -18,7 +17,7 @@ from olive.cli.base import (
     is_remote_run,
     update_remote_option,
 )
-from olive.common.utils import hardlink_copy_dir, set_nested_dict_value, set_tempdir
+from olive.common.utils import hardlink_copy_dir, set_nested_dict_value, set_tempdir, unescaped_str
 
 logger = logging.getLogger(__name__)
 
@@ -270,7 +269,3 @@ AZUREML_SYSTEM_TEMPLATE = {
     "accelerators": [{"device": "GPU", "execution_providers": ["CUDAExecutionProvider"]}],
     "aml_docker_config": {"base_image": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04"},
 }
-
-
-def unescaped_str(arg_str):
-    return codecs.decode(arg_str, "unicode_escape")

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import codecs
 import hashlib
 import inspect
 import io
@@ -556,3 +557,8 @@ def load_weights(path: Union[str, Path], file_format: Optional[WeightsFileFormat
                 weights[key] = f.get_tensor(key)
 
     return weights
+
+
+def unescaped_str(arg_str):
+    """Decode strings without escaping."""
+    return codecs.decode(arg_str, "unicode_escape")

--- a/olive/passes/pytorch/autoawq.py
+++ b/olive/passes/pytorch/autoawq.py
@@ -109,9 +109,9 @@ class AutoAWQQuantizer(Pass):
                 type_=bool,
                 default_value=False,
                 description=(
-                    "Whether to pack the model for ONNX conversion. If True, the model will be saved as a PyTorch"
-                    " model. If False, the model will be saved as a HF model with quantized weights. Default value is"
-                    " False."
+                    "Whether to pack the model for ONNX conversion. If True, the model will be saved as a PyTorch model"
+                    " with custom quantized linears. If False, the model will be saved as a HF model with quantized"
+                    " weights. Default value is False."
                 ),
             ),
         }
@@ -189,9 +189,9 @@ class AutoAWQQuantizer(Pass):
         awq_model.save_quantized(output_model_path)
 
         # return HfModelHandler with updated model path
-        new_load_kwargs = deepcopy(model.load_kwargs.dict())
+        new_load_kwargs = deepcopy(model.load_kwargs.dict()) if model.load_kwargs else {}
         # model is saved in safetensors format so need to enable safetensors load
-        if model.load_kwargs.extra_args and new_load_kwargs["extra_args"].get("use_safetensors") is False:
+        if new_load_kwargs.get("extra_args", {}).get("use_safetensors") is False:
             new_load_kwargs["extra_args"]["use_safetensors"] = True
         return inherit_hf_from_hf(model, output_model_path, load_kwargs=new_load_kwargs)
 

--- a/olive/passes/pytorch/autoawq.py
+++ b/olive/passes/pytorch/autoawq.py
@@ -191,7 +191,7 @@ class AutoAWQQuantizer(Pass):
         # return HfModelHandler with updated model path
         new_load_kwargs = deepcopy(model.load_kwargs.dict()) if model.load_kwargs else {}
         # model is saved in safetensors format so need to enable safetensors load
-        if new_load_kwargs.get("extra_args", {}).get("use_safetensors") is False:
+        if new_load_kwargs.get("extra_args") and new_load_kwargs["extra_args"].get("use_safetensors") is False:
             new_load_kwargs["extra_args"]["use_safetensors"] = True
         return inherit_hf_from_hf(model, output_model_path, load_kwargs=new_load_kwargs)
 

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -225,6 +225,6 @@ class GptqQuantizer(Pass):
         # return HfModelHandler with updated model path
         new_load_kwargs = deepcopy(model.load_kwargs.dict()) if model.load_kwargs else {}
         # model is saved in safetensors format so need to enable safetensors load
-        if new_load_kwargs.get("extra_args", {}).get("use_safetensors") is False:
+        if new_load_kwargs.get("extra_args") and new_load_kwargs["extra_args"].get("use_safetensors") is False:
             new_load_kwargs["extra_args"]["use_safetensors"] = True
         return inherit_hf_from_hf(model, output_model_path, load_kwargs=new_load_kwargs)

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -2,7 +2,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 import logging
+from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import torch
@@ -14,7 +17,7 @@ from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.model.utils.path_utils import normalize_path_suffix
 from olive.passes import Pass
 from olive.passes.pass_config import PassConfigParam, get_user_script_data_config
-from olive.passes.pytorch.common import inherit_pytorch_from_hf, inherit_pytorch_from_pytorch
+from olive.passes.pytorch.common import inherit_hf_from_hf, inherit_pytorch_from_hf, inherit_pytorch_from_pytorch
 
 logger = logging.getLogger(__name__)
 
@@ -100,12 +103,22 @@ class GptqQuantizer(Pass):
                     Data config for quantization. Default value is None.
                 """,
             ),
+            "pack_model_for_onnx_conversion": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description=(
+                    "Whether to pack the model for ONNX conversion. If True, the model will be saved as a PyTorch model"
+                    " with custom quantized layers. If False, the model will be saved in the same format as the input"
+                    " model."
+                ),
+            ),
         }
 
     @torch.no_grad()
     def _run_for_config(
         self, model: Union[HfModelHandler, PyTorchModelHandler], config: Dict[str, Any], output_model_path: str
     ) -> PyTorchModelHandler:
+        # pylint: disable=protected-access
         from auto_gptq import BaseQuantizeConfig
         from auto_gptq.modeling import BaseGPTQForCausalLM
         from auto_gptq.modeling.auto import GPTQ_CAUSAL_LM_MODEL_MAP
@@ -115,7 +128,7 @@ class GptqQuantizer(Pass):
         if not torch.cuda.is_available():
             raise ValueError("Please use GPU to run gptq quantization.")
         elif self.host_device != Device.GPU:
-            logger.warning(
+            logger.debug(
                 "GPTQ quantization requires GPU but the host device is %s, will ignore the host device",
                 self.host_device,
             )
@@ -146,6 +159,8 @@ class GptqQuantizer(Pass):
             true_sequential=config["true_sequential"],
             desc_act=config["desc_act"],
             sym=config["sym"],
+            # this is so that the weight gets saved as "model.safetensors"
+            model_file_base_name="model",
         )
 
         def get_onnx_quant_linear(*args, **kwargs):
@@ -168,25 +183,48 @@ class GptqQuantizer(Pass):
 
         import auto_gptq
 
-        original = auto_gptq.modeling._utils.dynamically_import_QuantLinear  # pylint: disable=protected-access
+        original = auto_gptq.modeling._utils.dynamically_import_QuantLinear
+
+        quantizer = get_onnx_quant_linear if config["pack_model_for_onnx_conversion"] else original
         try:
             # Replace QuantLinear in autogptq with QuantLinear for quant linear layer packing
-            auto_gptq.modeling._utils.dynamically_import_QuantLinear = (  # pylint: disable=protected-access
-                get_onnx_quant_linear
-            )
+            auto_gptq.modeling._utils.dynamically_import_QuantLinear = quantizer
 
             # Autogpq quantize_model currently only support cuda device. It accepts model on cpu but
             # will move each block(layer) to cuda before quantization and move back to cpu when finished.
             quantized_model.quantize(dataset)
         finally:
-            auto_gptq.modeling._utils.dynamically_import_QuantLinear = original  # pylint: disable=protected-access
+            auto_gptq.modeling._utils.dynamically_import_QuantLinear = original
 
-        quantized_model = quantized_model.model
+        if config["pack_model_for_onnx_conversion"] or isinstance(model, PyTorchModelHandler):
 
-        output_model_path = normalize_path_suffix(output_model_path, "model.pt")
-        torch.save(quantized_model, output_model_path)
+            quantized_model = quantized_model.model
 
-        if isinstance(model, HfModelHandler):
-            return inherit_pytorch_from_hf(model, output_model_path)
+            output_model_path = normalize_path_suffix(output_model_path, "model.pt")
+            torch.save(quantized_model, output_model_path)
 
-        return inherit_pytorch_from_pytorch(model, output_model_path)
+            if isinstance(model, HfModelHandler):
+                return inherit_pytorch_from_hf(model, output_model_path)
+
+            return inherit_pytorch_from_pytorch(model, output_model_path)
+
+        # save quantized model and metadata
+        model.save_metadata(output_model_path)
+        quantized_model.save_quantized(output_model_path)
+
+        # need to disable exllama to be able to load on cpu
+        # should we do this using load kwargs? It works but transformers prints a warning
+        config_json_path = Path(output_model_path) / "config.json"
+        with open(config_json_path, encoding="utf-8") as f:
+            model_config = json.load(f)
+
+        model_config["quantization_config"]["use_exllama"] = False
+        with open(config_json_path, "w", encoding="utf-8") as f:
+            json.dump(model_config, f, indent=2)
+
+        # return HfModelHandler with updated model path
+        new_load_kwargs = deepcopy(model.load_kwargs.dict()) if model.load_kwargs else {}
+        # model is saved in safetensors format so need to enable safetensors load
+        if new_load_kwargs.get("extra_args", {}).get("use_safetensors") is False:
+            new_load_kwargs["extra_args"]["use_safetensors"] = True
+        return inherit_hf_from_hf(model, output_model_path, load_kwargs=new_load_kwargs)

--- a/olive/passes/pytorch/merge_adapter_weights.py
+++ b/olive/passes/pytorch/merge_adapter_weights.py
@@ -32,9 +32,11 @@ class MergeAdapterWeights(Pass):
                 "model type or remove `MergeAdapterWeights` from passes configs"
             )
 
-        load_kwargs = model.load_kwargs
-        new_load_kwargs = deepcopy(load_kwargs.dict())
-        if load_kwargs.quantization_method == "bitsandbytes" and load_kwargs.quantization_config["load_in_4bit"]:
+        new_load_kwargs = deepcopy(model.load_kwargs.dict()) if model.load_kwargs else {}
+        if (
+            new_load_kwargs.get("quantization_method") == "bitsandbytes"
+            and new_load_kwargs["quantization_config"]["load_in_4bit"]
+        ):
             logger.debug(
                 "Merging adapter weights for Bitsandbytes 4bit quantized model is not supported. The quantization"
                 " config is removed from the load kwargs."

--- a/test/unit_test/passes/pytorch/test_autoawq.py
+++ b/test/unit_test/passes/pytorch/test_autoawq.py
@@ -28,10 +28,10 @@ def test_awq(pack_model_for_onnx_conversion, tmp_path: Path):
         disable_search=True,
         accelerator_spec=AcceleratorSpec(accelerator_type=Device.GPU, execution_provider="CUDAExecutionProvider"),
     )
-    gptq_out_folder = str(tmp_path / "gptq")
+    awq_out_folder = str(tmp_path / "awq")
 
     # execute
-    out = p.run(input_model, gptq_out_folder)
+    out = p.run(input_model, awq_out_folder)
 
     # assert
     if pack_model_for_onnx_conversion:

--- a/test/unit_test/passes/pytorch/test_gptq.py
+++ b/test/unit_test/passes/pytorch/test_gptq.py
@@ -9,7 +9,7 @@ import torch
 
 from olive.data.config import DataComponentConfig, DataConfig
 from olive.hardware.accelerator import AcceleratorSpec, Device
-from olive.model import HfModelHandler
+from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.pytorch.gptq import GptqQuantizer
 
@@ -18,7 +18,8 @@ from olive.passes.pytorch.gptq import GptqQuantizer
     not torch.cuda.is_available(),
     reason="gptq requires GPU.",
 )
-def test_gptq_default(tmp_path: Path):
+@pytest.mark.parametrize("pack_model_for_onnx_conversion", [True, False])
+def test_gptq_default(pack_model_for_onnx_conversion, tmp_path: Path):
     # setup
     input_model = HfModelHandler(model_path="facebook/opt-125m")
     config = {
@@ -37,6 +38,7 @@ def test_gptq_default(tmp_path: Path):
             pre_process_data_config=DataComponentConfig(type="skip_pre_process"),
             post_process_data_config=DataComponentConfig(type="skip_post_process"),
         ),
+        "pack_model_for_onnx_conversion": pack_model_for_onnx_conversion,
     }
     p = create_pass_from_dict(
         GptqQuantizer,
@@ -48,4 +50,13 @@ def test_gptq_default(tmp_path: Path):
 
     # execute
     out = p.run(input_model, gptq_out_folder)
-    assert out is not None
+
+    # assert
+    if pack_model_for_onnx_conversion:
+        assert isinstance(out, PyTorchModelHandler)
+    else:
+        assert isinstance(out, HfModelHandler)
+
+    from transformers import OPTForCausalLM
+
+    assert isinstance(out.load_model(), OPTForCausalLM)


### PR DESCRIPTION
## Describe your changes
Follow up to #1337 
- GptqQuantizer now supports saving hf input model in hf model format.
- Fix for bugs related to `load_kwargs` that were introduced when dealing with `use_safetensors` in the previous PR. 
- Improvements to the readmes and example script.
- GPTQ option not added to phi3 example since the model type is not natively supported by auto-gptq and I was not able to make it work with config values for the model details. Will need further investigation if this support is needed.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
