### PR TITLE
SD: Make `CompVis/stable-diffusion-v1-4` the default model

### DIFF
--- a/examples/directml/stable_diffusion/README.md
+++ b/examples/directml/stable_diffusion/README.md
@@ -1,6 +1,6 @@
 # Stable Diffusion Optimization with DirectML <!-- omit in toc -->
 
-This sample shows how to optimize [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4), [Stable Diffusion v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5) or [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2) to run with ONNX Runtime and DirectML.
+This sample shows how to optimize [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4) or [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2) to run with ONNX Runtime and DirectML.
 
 Stable Diffusion comprises multiple PyTorch models tied together into a *pipeline*. This Olive sample will convert each PyTorch model to ONNX, and then run the converted ONNX models through the `OrtTransformersOptimization` pass. The transformer optimization pass performs several time-consuming graph transformations that make the models more efficient for inference at runtime. Output models are only guaranteed to be compatible with onnxruntime-directml 1.16.0 or newer.
 
@@ -45,8 +45,8 @@ The above command will enumerate the `config_<model_name>.json` files and optimi
 The stable diffusion models are large, and the optimization process is resource intensive. It is recommended to run optimization on a system with a minimum of 16GB of memory (preferably 32GB). Expect optimization to take several minutes (especially the U-Net model).
 
 Once the script successfully completes:
-- The optimized ONNX pipeline will be stored under `models/optimized/[model_id]` (for example `models/optimized/runwayml/stable-diffusion-v1-5`).
-- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/[model_id]` (for example `models/unoptimized/runwayml/stable-diffusion-v1-5`).
+- The optimized ONNX pipeline will be stored under `models/optimized/[model_id]` (for example `models/optimized/CompVis/stable-diffusion-v1-4`).
+- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/[model_id]` (for example `models/unoptimized/CompVis/stable-diffusion-v1-4`).
 
 Re-running the script with `--optimize` will delete the output models, but it will *not* delete the Olive cache. Subsequent runs will complete much faster since it will simply be copying previously optimized models; you may use the `--clean_cache` option to start from scratch (not typically used unless you are modifying the scripts, for example).
 
@@ -75,8 +75,7 @@ Inference will loop until the generated image passes the safety checker (otherwi
 
 Run `python stable_diffusion.py --help` for additional options. A few particularly relevant ones:
 - `--model_id <string>` : name of a stable diffusion model ID hosted by huggingface.co. This script has been tested with the following:
-  - `CompVis/stable-diffusion-v1-4`
-  - `runwayml/stable-diffusion-v1-5` (default)
+  - `CompVis/stable-diffusion-v1-4` (default)
   - `sayakpaul/sd-model-finetuned-lora-t4`
   - `stabilityai/stable-diffusion-2`
   - LoRA variants of the above base models may work as well. See [LoRA Models (Experimental)](#lora-models-experimental).
@@ -115,7 +114,7 @@ Olive merges the LoRA weights into the base model before conversion to ONNX (see
 - If you run into the following error while optimizing models, it is likely that your local HuggingFace cache has an incomplete copy of the stable diffusion model pipeline. Deleting `C:\users\<username>\.cache\huggingface` should resolve the issue by ensuring a fresh copy is downloaded.
 
   ```
-  OSError: Can't load tokenizer for 'C:\Users\<username>\.cache\huggingface\hub\models--runwayml--stable-diffusion-v1-5\snapshots\<sha>'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'C:\Users\<username>\.cache\huggingface\hub\models--runwayml--stable-diffusion-v1-5\snapshots\<sha>' is the correct path to a directory containing all relevant files for a CLIPTokenizer tokenizer.
+  OSError: Can't load tokenizer for 'C:\Users\<username>\.cache\huggingface\hub\models--CompVis--stable-diffusion-v1-4\snapshots\<sha>'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'C:\Users\<username>\.cache\huggingface\hub\models--CompVis--stable-diffusion-v1-4\snapshots\<sha>' is the correct path to a directory containing all relevant files for a CLIPTokenizer tokenizer.
   ```
 
 - Onnx conversion for unet terminates silently without any error message. This could be because your system ran out of disk space in the temp directory. You can add `--tempdir .` to the command line to use the current directory as the temp directory root. `.` can be replaced with any other directory with sufficient disk space and write permission.

--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -1,7 +1,7 @@
 # Stable Diffusion Optimization
 
 This folder contains sample use cases of Olive with ONNX Runtime and OpenVINO to optimize:
-- Stable Diffusion: [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4), [Stable Diffusion v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5), [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2)
+- Stable Diffusion: [Stable Diffusion v1-4](https://huggingface.co/CompVis/stable-diffusion-v1-4), [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2)
 - Stable Diffusion XL: [Stable Diffusion XL Base](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0), [Stable Diffusion XL Refiner](https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0)
 
 Stable Diffusion comprises multiple PyTorch models tied together into a *pipeline*.
@@ -77,7 +77,7 @@ The easiest way to optimize the pipeline is with the `stable_diffusion.py` and `
 
 **_Stable Diffusion_**
 ```bash
-# default model_id is "runwayml/stable-diffusion-v1-5"
+# default model_id is "CompVis/stable-diffusion-v1-4"
 python stable_diffusion.py --provider cuda --optimize
 ```
 
@@ -94,8 +94,8 @@ python stable_diffusion_xl.py --provider cuda --model_id stabilityai/stable-diff
 Otherwise, the vae models (vae-decoder for base and both vae-decoder and vae-encoder for refiner) will be in fp32 and all other sub-models will be in fp16 with fp32 input/output.
 
 Once the script successfully completes:
-- The optimized ONNX pipeline will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/runwayml/stable-diffusion-v1-5` or `models/optimized-cuda/stabilityai/stable-diffusion-xl-base-1.0`).
-- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/[model_id]` (for example `models/unoptimized/runwayml/stable-diffusion-v1-5` or `models/unoptimized/stabilityai/stable-diffusion-xl-base-1.0`).
+- The optimized ONNX pipeline will be stored under `models/optimized-cuda/[model_id]` (for example `models/optimized-cuda/CompVis/stable-diffusion-v1-4` or `models/optimized-cuda/stabilityai/stable-diffusion-xl-base-1.0`).
+- The unoptimized ONNX pipeline (models converted to ONNX, but not run through transformer optimization pass) will be stored under `models/unoptimized/[model_id]` (for example `models/unoptimized/CompVis/stable-diffusion-v1-4` or `models/unoptimized/stabilityai/stable-diffusion-xl-base-1.0`).
 
 Re-running the script with `--optimize` will delete the output models, but it will *not* delete the Olive cache. Subsequent runs will complete much faster since it will simply be copying previously optimized models; you may use the `--clean_cache` option to start from scratch (not typically used unless you are modifying the scripts, for example).
 
@@ -160,7 +160,7 @@ The above command will enumerate the `config_<model_name>.json` files and optimi
 The stable diffusion models are large, and the optimization process is resource intensive. It is recommended to run optimization on a system with a minimum of 16GB of memory (preferably 32GB). Expect optimization to take several minutes (especially the U-Net model).
 
 Once the script successfully completes:
-- The converted OpenVINO IR model will be stored under `models/optimized-openvino/[model_id]` (for example `models/optimized-openvino/runwayml/stable-diffusion-v1-5`).
+- The converted OpenVINO IR model will be stored under `models/optimized-openvino/[model_id]` (for example `models/optimized-openvino/CompVis/stable-diffusion-v1-4`).
 
 Re-running the script with `--optimize` will delete the output models, but it will *not* delete the Olive cache. Subsequent runs will complete much faster since it will simply be copying previously optimized models; you may use the `--clean_cache` option to start from scratch (not typically used unless you are modifying the scripts, for example).
 

--- a/examples/stable_diffusion/config_safety_checker.json
+++ b/examples/stable_diffusion/config_safety_checker.json
@@ -1,7 +1,7 @@
 {
     "input_model": {
         "type": "PyTorchModel",
-        "model_path": "runwayml/stable-diffusion-v1-5",
+        "model_path": "CompVis/stable-diffusion-v1-4",
         "model_loader": "safety_checker_load",
         "model_script": "user_script.py",
         "io_config": {

--- a/examples/stable_diffusion/config_text_encoder.json
+++ b/examples/stable_diffusion/config_text_encoder.json
@@ -1,7 +1,7 @@
 {
     "input_model": {
         "type": "PyTorchModel",
-        "model_path": "runwayml/stable-diffusion-v1-5",
+        "model_path": "CompVis/stable-diffusion-v1-4",
         "model_loader": "text_encoder_load",
         "model_script": "user_script.py",
         "io_config": {

--- a/examples/stable_diffusion/config_unet.json
+++ b/examples/stable_diffusion/config_unet.json
@@ -1,7 +1,7 @@
 {
     "input_model": {
         "type": "PyTorchModel",
-        "model_path": "runwayml/stable-diffusion-v1-5",
+        "model_path": "CompVis/stable-diffusion-v1-4",
         "model_loader": "unet_load",
         "model_script": "user_script.py",
         "io_config": {

--- a/examples/stable_diffusion/config_vae_decoder.json
+++ b/examples/stable_diffusion/config_vae_decoder.json
@@ -1,7 +1,7 @@
 {
     "input_model": {
         "type": "PyTorchModel",
-        "model_path": "runwayml/stable-diffusion-v1-5",
+        "model_path": "CompVis/stable-diffusion-v1-4",
         "model_loader": "vae_decoder_load",
         "model_script": "user_script.py",
         "io_config": {

--- a/examples/stable_diffusion/config_vae_encoder.json
+++ b/examples/stable_diffusion/config_vae_encoder.json
@@ -1,7 +1,7 @@
 {
     "input_model": {
         "type": "PyTorchModel",
-        "model_path": "runwayml/stable-diffusion-v1-5",
+        "model_path": "CompVis/stable-diffusion-v1-4",
         "model_loader": "vae_encoder_load",
         "model_script": "user_script.py",
         "io_config": {

--- a/examples/stable_diffusion/stable_diffusion.py
+++ b/examples/stable_diffusion/stable_diffusion.py
@@ -214,7 +214,7 @@ def optimize(
     shutil.rmtree(optimized_model_dir, ignore_errors=True)
 
     # The model_id and base_model_id are identical when optimizing a standard stable diffusion model like
-    # runwayml/stable-diffusion-v1-5. These variables are only different when optimizing a LoRA variant.
+    # CompVis/stable-diffusion-v1-4. These variables are only different when optimizing a LoRA variant.
     base_model_id = get_base_model_name(model_id)
 
     # Load the entire PyTorch pipeline to ensure all models and their configurations are downloaded and cached.
@@ -282,7 +282,7 @@ def optimize(
 def parse_common_args(raw_args):
     parser = argparse.ArgumentParser("Common arguments")
 
-    parser.add_argument("--model_id", default="runwayml/stable-diffusion-v1-5", type=str)
+    parser.add_argument("--model_id", default="CompVis/stable-diffusion-v1-4", type=str)
     parser.add_argument(
         "--provider", default="dml", type=str, choices=["dml", "cuda", "openvino"], help="Execution provider to use"
     )


### PR DESCRIPTION
## Describe your changes
`runwayml/stable-diffusion-v1-5` doesn't exist anymore. All references to this model is removed and `CompVis/stable-diffusion-v1-4` is made the default model.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
