### PR TITLE
Add cli output validation & improve cli logging

### DIFF
--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -12,8 +12,10 @@ from typing import ClassVar, Dict
 from olive.cli.base import (
     BaseOliveCLICommand,
     add_hf_model_options,
+    add_logging_options,
     add_remote_options,
     get_model_name_or_path,
+    get_output_model_number,
     is_remote_run,
     update_remote_option,
 )
@@ -34,6 +36,9 @@ class FineTuneCommand(BaseOliveCLICommand):
                 " inputs. Huggingface training arguments can be provided along with the defined options."
             ),
         )
+
+        add_logging_options(sub_parser)
+
         # TODO(jambayk): option to list/install required dependencies?
         sub_parser.add_argument(
             "--precision",
@@ -141,19 +146,21 @@ class FineTuneCommand(BaseOliveCLICommand):
         with tempfile.TemporaryDirectory() as tempdir:
             run_config = self.get_run_config(tempdir)
 
-            olive_run(run_config)
+            output = olive_run(run_config)
 
             if is_remote_run(self.args):
                 # TODO(jambayk): point user to datastore with outputs or download outputs
                 # both are not implemented yet
                 return
 
-            # need to improve the output structure of olive run
-            output_path = Path(self.args.output_path)
-            output_path.mkdir(parents=True, exist_ok=True)
-            hardlink_copy_dir(Path(tempdir) / "-".join(run_config["passes"].keys()) / "gpu-cuda_model", output_path)
-
-            logger.info("Model and adapters saved to %s", output_path.resolve())
+            if get_output_model_number(output) > 0:
+                # need to improve the output structure of olive run
+                output_path = Path(self.args.output_path)
+                output_path.mkdir(parents=True, exist_ok=True)
+                hardlink_copy_dir(Path(tempdir) / "-".join(run_config["passes"].keys()) / "gpu-cuda_model", output_path)
+                logger.info("Model and adapters saved to %s", output_path.resolve())
+            else:
+                logger.error("Failed to run fintune. Please set the log_level to 1 for more detailed logs.")
 
     def parse_training_args(self) -> Dict:
         if not self.unknown_args:
@@ -219,6 +226,7 @@ class FineTuneCommand(BaseOliveCLICommand):
             del config["passes"]["m"]
 
         update_remote_option(config, self.args, "finetune", tempdir)
+        config["log_severity_level"] = self.args.log_level
 
         return config
 

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -326,10 +326,7 @@ class Engine:
 
         try:
             if evaluate_input_model and not self.evaluator_config:
-                logger.debug(
-                    "evaluate_input_model is True but no evaluator provided in no-search mode. Skipping input model"
-                    " evaluation."
-                )
+                logger.debug("evaluate_input_model is True but no evaluator provided. Skipping input model evaluation.")
             elif evaluate_input_model:
                 results = self._evaluate_model(
                     input_model_config, input_model_id, self.evaluator_config, accelerator_spec

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -118,6 +118,10 @@
         "bnb": [ "bitsandbytes" ],
         "ort": [ "onnxruntime", "onnxruntime-directml", "onnxruntime-gpu", "onnxruntime-openvino", "numpy<2.0" ],
         "nvmo": [ "nvidia-modelopt~=0.11.0", "onnx-graphsurgeon" ],
-        "ort-genai": [ "onnxruntime-genai" ]
+        "ort-genai": [ "onnxruntime-genai" ],
+        "capture-onnx-graph": [ "onnxruntime-genai" ],
+        "cloud-cache": [ "azure-storage-blob" ],
+        "finetune": [ "onnxruntime-genai" ],
+        "tune-session-params": [ "psutil" ]
     }
 }

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import logging
 from pathlib import Path
 from typing import Dict, List, Union
 
@@ -24,8 +23,6 @@ from olive.passes import AbstractPassConfig
 from olive.passes.pass_config import PassParamDefault
 from olive.resource_path import AZUREML_RESOURCE_TYPES
 from olive.systems.system_config import SystemConfig
-
-logger = logging.getLogger(__name__)
 
 
 class RunPassConfig(AbstractPassConfig):
@@ -245,13 +242,6 @@ class RunConfig(NestedConfig):
         v = _resolve_system(v, values, "host")
         v = _resolve_system(v, values, "target")
         return _resolve_evaluator(v, values)
-
-    @validator("engine")
-    def validate_evaluate_input_model(cls, v):
-        if v.evaluate_input_model and v.evaluator is None:
-            logger.info("No evaluator is specified, skip to evaluate model")
-            v.evaluate_input_model = False
-        return v
 
     @validator("passes", pre=True, each_item=True)
     def validate_pass_host_evaluator(cls, v, values):


### PR DESCRIPTION
## Describe your changes

- Add huggingface model url support for cli model name: `https://huggingface.co/microsoft/Phi-3.5-MoE-instruct`
- Add log level configuration. The default value is 3 to avoid verbose logging. 
- Add export model number check for `capture-onnx`, `finetune` and `perf-tuning` cli. If there is no output model, will recommend user to change log level to get detailed logs.
- Add extras for `capture-onnx`, `finetune` and `perf-tuning` cli.
- Remove `validate_evaluate_input_model` as this is duplicated as [this check](https://github.com/microsoft/Olive/blob/main/olive/engine/engine.py#L328-L332). We want all logs controlled by logging.py

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
