### PR TITLE
ModelBuilder: Use `TRANSFORMERS_CACHE` as `cache_dir`

### DIFF
--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -7,10 +7,10 @@
 import copy
 import json
 import logging
-import os
-import tempfile
 from pathlib import Path
 from typing import Any, Dict, Union
+
+import transformers
 
 from olive.common.utils import IntEnumBase, StrEnumBase
 from olive.hardware.accelerator import AcceleratorSpec, Device
@@ -146,16 +146,6 @@ class ModelBuilder(Pass):
         else:
             target_execution_provider = "cpu"
 
-        # Select cache location based on priority
-        # HF_CACHE (HF >= v5) -> TRANSFORMERS_CACHE (HF < v5) -> local dir
-        cache_dir = os.environ.get("HF_HOME", None)
-        if not cache_dir:
-            cache_dir = os.environ.get("TRANSFORMERS_CACHE", None)
-        if not cache_dir:
-            # please do not clean up the cache dir as it contains huggingface model
-            # snapshots that can be reused for future runs
-            cache_dir = str(Path(tempfile.gettempdir()) / "hf_cache")
-
         extra_args = {"filename": str(output_model_filepath.name)}
         if metadata_only:
             extra_args["config_only"] = True
@@ -184,15 +174,26 @@ class ModelBuilder(Pass):
             if config[arg] is not None:
                 extra_args[arg] = "1" if config[arg] else "0"
 
-        create_model(
-            model_name=model_path,
-            input_path=input_path,
-            output_dir=str(output_model_filepath.parent),
-            precision=precision,
-            execution_provider=target_execution_provider,
-            cache_dir=cache_dir,
-            **extra_args,
-        )
+        try:
+            create_model(
+                model_name=model_path,
+                input_path=input_path,
+                output_dir=str(output_model_filepath.parent),
+                precision=precision,
+                execution_provider=target_execution_provider,
+                # model builder uses the cache_dir both as hf cache and also to store intermediate files
+                # not ideal, but we can't change this without changing the model builder
+                cache_dir=transformers.utils.TRANSFORMERS_CACHE,
+                **extra_args,
+            )
+        except Exception:
+            # if model building fails, clean up the intermediate files in the cache_dir
+            cache_dir = Path(transformers.utils.TRANSFORMERS_CACHE)
+            if cache_dir.is_dir():
+                for file in cache_dir.iterdir():
+                    if file.suffix == ".bin":
+                        file.unlink()
+            raise
 
         # Override default search options with ones from user config
         genai_config_filepath = str(output_model_filepath.parent / "genai_config.json")


### PR DESCRIPTION
## Describe your changes
We currently try to infer the transformers cache from environment variables but those are not set most of the time. `transformers.utils` has a variable which handles this logic internally so we can just use that instead. 

Also added some exception handling to remove the intermediate files that the model builder adds to the cache dir. Ideally, the transformers cache and intermediate cache should be dealt separately in order to not pollute the transformers cache.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
