### PR TITLE
Engine: Improve output structure, CLI: Configurable model options, Separate `finetune`+`generate-adapter`

### DIFF
--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -357,10 +357,6 @@ will be used.
 
 - `clean_run_cache: [Boolean]` This decides whether to clean the run cache of the pass before running the pass. This is `false` by default.
 
-- `output_name: str` In no-search mode (i.e., `search_strategy` is `null`), if `output_name` is provided, the output model of the pass will be
-saved to the engine's `output_dir` with the prefix of `output_name`. For the final pass, if the engine's `output_name` is provided, it will override
-the `output_name` of the pass.
-
 Please refer to [Configuring Pass](../tutorials/configure_pass.rst) for more details on `type`, `disable_search` and `config`.
 
 Please also find the detailed options from following table for each pass:

--- a/examples/directml/llm/config_llm.json
+++ b/examples/directml/llm/config_llm.json
@@ -97,6 +97,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "",
     "output_dir": "footprints"
 }

--- a/examples/directml/llm/llm.py
+++ b/examples/directml/llm/llm.py
@@ -160,7 +160,6 @@ def optimize(
         "cuda": ["CUDAExecutionProvider"],
     }[device]
 
-    olive_config["output_name"] = model_name
     olive_config["passes"]["optimize"]["hidden_size"] = config.hidden_size
     olive_config["passes"]["optimize"]["num_heads"] = config.num_heads
     olive_config["passes"]["optimize"]["num_key_value_heads"] = config.num_key_value_heads
@@ -224,7 +223,7 @@ def optimize(
 
     olive_run(olive_config)
 
-    footprints_file_path = Path(__file__).resolve().parent / "footprints" / f"{model_name}_gpu-{device}_footprints.json"
+    footprints_file_path = Path(__file__).resolve().parent / "footprints" / "footprints.json"
     with footprints_file_path.open("r") as footprint_file:
         footprints = json.load(footprint_file)
 

--- a/examples/directml/stable_diffusion_xl/config_text_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder.json
@@ -118,6 +118,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "text_encoder",
-    "output_dir": "footprints"
+    "output_dir": "footprints/text_encoder"
 }

--- a/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
+++ b/examples/directml/stable_diffusion_xl/config_text_encoder_2.json
@@ -158,6 +158,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "text_encoder_2",
-    "output_dir": "footprints"
+    "output_dir": "footprints/text_encoder_2"
 }

--- a/examples/directml/stable_diffusion_xl/config_unet.json
+++ b/examples/directml/stable_diffusion_xl/config_unet.json
@@ -102,6 +102,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "unet",
-    "output_dir": "footprints"
+    "output_dir": "footprints/unet"
 }

--- a/examples/directml/stable_diffusion_xl/config_vae_decoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_decoder.json
@@ -114,6 +114,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "vae_decoder",
-    "output_dir": "footprints"
+    "output_dir": "footprints/vae_decoder"
 }

--- a/examples/directml/stable_diffusion_xl/config_vae_encoder.json
+++ b/examples/directml/stable_diffusion_xl/config_vae_encoder.json
@@ -93,6 +93,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "vae_encoder",
-    "output_dir": "footprints"
+    "output_dir": "footprints/vae_encoder"
 }

--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -366,9 +366,7 @@ def optimize(
 
         olive_run(olive_config)
 
-        footprints_file_path = (
-            Path(__file__).resolve().parent / "footprints" / f"{submodel_name}_gpu-{provider}_footprints.json"
-        )
+        footprints_file_path = Path(__file__).resolve().parent / "footprints" / "footprints.json"
         with footprints_file_path.open("r") as footprint_file:
             footprints = json.load(footprint_file)
 

--- a/examples/inception/inception_config.json
+++ b/examples/inception/inception_config.json
@@ -73,6 +73,5 @@
     "host": "local_system",
     "evaluator": "common_evaluator",
     "cache_dir": "cache",
-    "output_dir": "outputs",
-    "output_name": "snpe_quantized"
+    "output_dir": "outputs"
 }

--- a/examples/llama2/llama2_multilora.ipynb
+++ b/examples/llama2/llama2_multilora.ipynb
@@ -64,10 +64,9 @@
    "source": [
     "## Workflow\n",
     "\n",
-    "Olive provides a command line tool to run a lora/qlora fine-tuning workflow.\n",
-    "\n",
-    "It performs the optimization pipeline:\n",
-    "- GPU, FP16: *Pytorch Model -> Fine-tuned Pytorch Model -> Onnx Model -> Transformers Optimized Onnx Model fp16 -> Extract Adapters*"
+    "Olive provides a command line tools to run a lora/qlora fine-tuning workflow. This workflow includes the following steps:\n",
+    "- `finetune`: Fine-tune a model using LoRA or QLoRA.\n",
+    "- `generate-adapter`: Export the fine-tuned model to ONNX, optimize it and extract the adapters as model inputs."
    ]
   },
   {
@@ -76,15 +75,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# run this cell to see the available options to finetune command\n",
-    "!olive finetune --help"
+    "# run this cell to see the available options to finetune and generate-adapter commands\n",
+    "!olive finetune --help\n",
+    "!olive generate-adapter --help"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us now fine tune the llama2 model using QLoRA on [nampdn-ai/tiny-codes](https://huggingface.co/datasets/nampdn-ai/tiny-codes) to generate python code given a langauge and prompt."
+    "First, fine tune the llama2 model using QLoRA on [nampdn-ai/tiny-codes](https://huggingface.co/datasets/nampdn-ai/tiny-codes) to generate python code given a langauge and prompt."
    ]
   },
   {
@@ -97,8 +97,24 @@
     "    -m meta-llama/Llama-2-7b-hf -d nampdn-ai/tiny-codes \\\n",
     "    --train_split \"train[:4096]\" --eval_split \"train[4096:4224]\" \\\n",
     "    --text_template \"### Language: {programming_language} \\n### Question: {prompt} \\n### Answer: {response}\" \\\n",
-    "    --per_device_train_batch_size 16 --per_device_eval_batch_size 16 --max_steps 150 --logging_steps 50 \\\n",
-    "    -o models/tiny-codes --use_ort_genai"
+    "    --per_device_train_batch_size 16 --per_device_eval_batch_size 16 --max_steps 15 --logging_steps 5 \\\n",
+    "    -o models/tiny-codes/fine-tune"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's generate the optimized onnx model with adapters as inputs. We can use the output of the previous step as input to this step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!olive generate-adapter -m models/tiny-codes/fine-tune --use_ort_genai -o models/tiny-codes/optimized"
    ]
   },
   {
@@ -106,8 +122,8 @@
    "metadata": {},
    "source": [
     "The output model files are can be found at:\n",
-    "- Model: `models/tiny-codes/model.onnx`\n",
-    "- Adapter weights: `models/tiny-codes/adapter_weights.npz`"
+    "- Model: `models/tiny-codes/optimized/model/model.onnx`\n",
+    "- Adapter weights: `models/tiny-codes/optimized/model/adapter_weights.npz`"
    ]
   },
   {
@@ -156,14 +172,14 @@
    "outputs": [],
    "source": [
     "base_model_name = \"meta-llama/llama-2-7b-hf\"\n",
-    "model_path = \"models/tiny-codes/model.onnx\"\n",
+    "model_path = \"models/tiny-codes/optimized/model/model.onnx\"\n",
     "adapters = {\n",
     "    \"guanaco\": {\n",
     "        \"weights\": \"models/exported/guanaco_qlora.npz\",\n",
     "        \"template\": \"### Human: {prompt} ### Assistant:\"\n",
     "    },\n",
     "    \"tiny-codes\": {\n",
-    "        \"weights\": \"models/tiny-codes/adapter_weights.npz\",\n",
+    "        \"weights\": \"models/tiny-codes/optimized/model/adapter_weights.npz\",\n",
     "        \"template\": \"### Language: {prompt_0} \\n### Question: {prompt_1} \\n### Answer: \"\n",
     "    }\n",
     "}"

--- a/examples/llama2/llama2_multilora.ipynb
+++ b/examples/llama2/llama2_multilora.ipynb
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, fine tune the llama2 model using QLoRA on [nampdn-ai/tiny-codes](https://huggingface.co/datasets/nampdn-ai/tiny-codes) to generate python code given a langauge and prompt."
+    "First, fine tune the llama2 model using QLoRA on [nampdn-ai/tiny-codes](https://huggingface.co/datasets/nampdn-ai/tiny-codes) to generate python code given a language and prompt."
    ]
   },
   {

--- a/examples/llama2/llama2_template.json
+++ b/examples/llama2/llama2_template.json
@@ -118,6 +118,7 @@
         "gptq_quant_int4": { "type": "GptqQuantizer", "data_config": "wikitext2_train" }
     },
     "evaluator": "merged_evaluator",
+    "evaluate_input_model": false,
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",

--- a/examples/mistral/mistral_fp16_optimize.json
+++ b/examples/mistral/mistral_fp16_optimize.json
@@ -50,6 +50,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_dir": "models",
-    "output_name": "mistral_fp16"
+    "output_dir": "models/mistral_fp16"
 }

--- a/examples/mistral/mistral_int4_optimize.json
+++ b/examples/mistral/mistral_int4_optimize.json
@@ -63,6 +63,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_dir": "models",
-    "output_name": "mistral_int4"
+    "output_dir": "models/mistral_int4"
 }

--- a/examples/open_llama/open_llama_arc.json
+++ b/examples/open_llama/open_llama_arc.json
@@ -58,7 +58,6 @@
     },
     "evaluator": "common_evaluator",
     "cache_dir": "cache",
-    "output_name": "ollama",
     "target": "azure_arc",
     "host": "aml",
     "output_dir": "models/open_llama_arc"

--- a/examples/open_llama/open_llama_config.json
+++ b/examples/open_llama/open_llama_config.json
@@ -39,7 +39,6 @@
     },
     "evaluator": "common_evaluator",
     "cache_dir": "cache",
-    "output_name": "ollama",
     "host": "local_system",
     "target": "local_system",
     "output_dir": "models/open_llama"

--- a/examples/open_llama/open_llama_inc_woq.json
+++ b/examples/open_llama/open_llama_inc_woq.json
@@ -54,6 +54,5 @@
     },
     "evaluator": "common_evaluator",
     "cache_dir": "cache",
-    "output_name": "ollama",
     "output_dir": "models/open_llama_inc_woq"
 }

--- a/examples/phi2/phi2_optimize_template.json
+++ b/examples/phi2/phi2_optimize_template.json
@@ -148,7 +148,6 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "phi2",
     "output_dir": "phi2",
     "clean_cache": false,
     "log_severity_level": 0,

--- a/examples/phi3/.gitignore
+++ b/examples/phi3/.gitignore
@@ -1,3 +1,1 @@
-phi3_cpu*.json
-phi3_gpu*.json
-phi3_quarot.json
+phi3_run_*.json

--- a/examples/phi3/README.md
+++ b/examples/phi3/README.md
@@ -72,7 +72,7 @@ If you have an Olive configuration file, you can also run the olive command for 
 olive run [--config CONFIGURATION_FILE]
 
 # Examples
-olive run --config phi3_mobile_int4.json
+olive run --config phi3_run_mobile_int4.json
 ```
 
 We also introduce QuaRot, a new Quantization scheme based on Rotations, which is able to quantize LLMs end-to-end.

--- a/examples/phi3/phi3_vision.py
+++ b/examples/phi3/phi3_vision.py
@@ -42,9 +42,11 @@ def get_args(raw_args):
         default="int4",
         choices=["int4", "fp16"],
         help=(
-            "Precision of optimized model. "
-            "int4: run quantization on the model, which is able to run on CPU and CUDA."
-            "fp16: no quantization, only run on CUDA.",
+            (
+                "Precision of optimized model. "
+                "int4: run quantization on the model, which is able to run on CPU and CUDA."
+                "fp16: no quantization, only run on CUDA."
+            ),
         ),
     )
     parser.add_argument(
@@ -60,7 +62,7 @@ def get_args(raw_args):
     parser.add_argument(
         "--output_dir",
         type=str,
-        default="cache/phi3-vision-128k-instruct",
+        default="models/phi3-vision-128k-instruct",
         required=False,
         help="Path to folder to store ONNX model and additional files (e.g. GenAI config, external data files, etc.)",
     )
@@ -126,7 +128,7 @@ def main(raw_args=None):
         generate(args.optimized_model_path)
         return
 
-    input_model_path = output_dir / "phi3-vision-128k-instruct" / "pytorch"
+    input_model_path = output_dir / "pytorch"
     if not is_model_ready(input_model_path):
         print(f"Model not found from {input_model_path}, preparing the model...")
         # prepare the input model
@@ -180,7 +182,7 @@ def main(raw_args=None):
     to_remove_folders = [
         Path(args.output_dir).resolve() / "vision",
         Path(args.output_dir).resolve() / "text",
-        Path(args.output_dir).resolve() / "text-embedding",
+        Path(args.output_dir).resolve() / "text_embedding",
     ]
     for folder in to_remove_folders:
         shutil.rmtree(folder, ignore_errors=True)

--- a/examples/phi3/vision/scripts/prepare_phi3_vision_for_olive.sh
+++ b/examples/phi3/vision/scripts/prepare_phi3_vision_for_olive.sh
@@ -8,7 +8,7 @@ then
     echo "Usage: prepare_phi3_vision_for_olive.sh <output_dir>"
     exit 1
 else
-    base_output_dir="$1"/phi3-vision-128k-instruct
+    base_output_dir="$1"
     pytorch_output_dir="$base_output_dir"/pytorch
 fi
 

--- a/examples/stable_diffusion/config_safety_checker.json
+++ b/examples/stable_diffusion/config_safety_checker.json
@@ -95,6 +95,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "safety_checker",
-    "output_dir": "footprints"
+    "output_dir": "footprints/safety_checker"
 }

--- a/examples/stable_diffusion/config_text_encoder.json
+++ b/examples/stable_diffusion/config_text_encoder.json
@@ -92,6 +92,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "text_encoder",
-    "output_dir": "footprints"
+    "output_dir": "footprints/text_encoder"
 }

--- a/examples/stable_diffusion/config_unet.json
+++ b/examples/stable_diffusion/config_unet.json
@@ -107,6 +107,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "unet",
-    "output_dir": "footprints"
+    "output_dir": "footprints/unet"
 }

--- a/examples/stable_diffusion/config_vae_decoder.json
+++ b/examples/stable_diffusion/config_vae_decoder.json
@@ -92,6 +92,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "vae_decoder",
-    "output_dir": "footprints"
+    "output_dir": "footprints/vae_decoder"
 }

--- a/examples/stable_diffusion/config_vae_encoder.json
+++ b/examples/stable_diffusion/config_vae_encoder.json
@@ -92,6 +92,5 @@
     "host": "local_system",
     "target": "local_system",
     "cache_dir": "cache",
-    "output_name": "vae_encoder",
-    "output_dir": "footprints"
+    "output_dir": "footprints/vae_encoder"
 }

--- a/examples/stable_diffusion/sd_utils/ort.py
+++ b/examples/stable_diffusion/sd_utils/ort.py
@@ -53,9 +53,7 @@ def validate_ort_version(provider: str):
 
 
 def save_optimized_onnx_submodel(submodel_name, provider, model_info):
-    footprints_file_path = (
-        Path(__file__).resolve().parents[1] / "footprints" / f"{submodel_name}_gpu-{provider}_footprints.json"
-    )
+    footprints_file_path = Path(__file__).resolve().parents[1] / "footprints" / submodel_name / "footprints.json"
     with footprints_file_path.open("r") as footprint_file:
         footprints = json.load(footprint_file)
 

--- a/examples/test/local/test_whisper.py
+++ b/examples/test/local/test_whisper.py
@@ -24,7 +24,7 @@ def setup():
     # prepare configs
     from prepare_whisper_configs import main as prepare_whisper_configs
 
-    prepare_whisper_configs(["--package_model"])
+    prepare_whisper_configs(["--package_model", "--log_level", "0"])
 
     yield
     sys.path.remove(example_dir)

--- a/examples/vgg/vgg_config.json
+++ b/examples/vgg/vgg_config.json
@@ -19,15 +19,9 @@
             "type": "SNPEConversion",
             "input_names": [ "data" ],
             "input_shapes": [ [ 1, 3, 224, 224 ] ],
-            "output_names": [ "vgg0_dense2_fwd" ],
-            "output_name": "vgg_snpe"
+            "output_names": [ "vgg0_dense2_fwd" ]
         },
-        "snpe_quantization": {
-            "type": "SNPEQuantization",
-            "enable_htp": true,
-            "data_config": "raw_data",
-            "output_name": "vgg_snpe_quantized"
-        }
+        "snpe_quantization": { "type": "SNPEQuantization", "enable_htp": true, "data_config": "raw_data" }
     },
     "log_severity_level": 0,
     "clean_cache": true,

--- a/examples/whisper/prepare_whisper_configs.py
+++ b/examples/whisper/prepare_whisper_configs.py
@@ -87,6 +87,12 @@ def get_args(raw_args):
             " increase this value to 1e-5 or 1e-4. Default: 1e-6"
         ),
     )
+    parser.add_argument(
+        "--log_level",
+        type=int,
+        default=3,
+        help="Olive log level. Default: 3 (ERROR)",
+    )
     return parser.parse_args(raw_args)
 
 
@@ -112,6 +118,9 @@ def main(raw_args=None):
     with open("whisper_template.json") as f:
         template_json = json.load(f)
     model_name = args.model_name
+
+    # set log_level
+    template_json["log_severity_level"] = args.log_level
 
     # update model paths
     for model_component in template_json["input_model"]["model_components"]:
@@ -149,7 +158,7 @@ def main(raw_args=None):
         config = deepcopy(template_json)
 
         # set output name
-        config["output_name"] = f"whisper_{device}_{precision}"
+        config["output_dir"] = f"models/whisper_{device}_{precision}"
         # add packaging config
         if args.package_model:
             config["packaging_config"] = {"type": "Zipfile", "name": f"whisper_{device}_{precision}"}

--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -13,7 +13,6 @@ import onnxruntime as ort
 from prepare_whisper_configs import download_audio_test_data
 
 from olive.evaluator.olive_evaluator import OnnxEvaluator
-from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModelHandler
 
 sys.path.append(str(Path(__file__).parent / "code"))
@@ -78,15 +77,11 @@ def main(raw_args=None):
     # get device and ep
     device = config["systems"]["local_system"]["accelerators"][0]["device"]
     ep = config["systems"]["local_system"]["accelerators"][0]["execution_providers"][0]
-    accelerator_spec = AcceleratorSpec(accelerator_type=device, execution_provider=ep)
 
     # load output model json
-    output_model_json_path = Path(config["output_dir"])
-    output_model_json = {}
-    for model_json in output_model_json_path.glob(f"**/{config['output_name']}_{accelerator_spec}_model.json"):
-        with model_json.open() as f:
-            output_model_json = json.load(f)
-        break
+    output_model_json_path = Path(config["output_dir"]) / "output_model" / "model_config.json"
+    with output_model_json_path.open() as f:
+        output_model_json = json.load(f)
 
     # load output model onnx
     olive_model = ONNXModelHandler(**output_model_json["config"])

--- a/examples/whisper/whisper_template.json
+++ b/examples/whisper/whisper_template.json
@@ -84,13 +84,12 @@
             "target_opset": 17
         }
     },
-    "log_severity_level": 0,
+    "log_severity_level": "<place_holder>",
     "host": "local_system",
     "target": "local_system",
     "evaluator": "common_evaluator",
     "evaluate_input_model": false,
     "clean_cache": false,
     "cache_dir": "cache",
-    "output_dir": "models",
-    "output_name": "<place_holder>"
+    "output_dir": "models/<place_holder>"
 }

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -163,16 +163,16 @@ class OliveCache:
         if resource_path is None:
             return None
 
-        if resource_path.is_local_resource_or_string_name():
-            return resource_path.get_path()
-        else:
-            return self.download_resource(resource_path).get_path()
+        return self.get_local_path_or_download(resource_path).get_path()
 
-    def download_resource(self, resource_path: ResourcePath):
-        """Return the path to a non-local resource.
+    def get_local_path_or_download(self, resource_path: ResourcePath):
+        """Return the path to a local instance of the resource path.
 
-        Non-local resources are stored in the non_local_resources subdirectory of the cache.
+        Non-local resources are downloaded and stored in the non_local_resources subdirectory of the cache.
         """
+        if resource_path.is_local_resource_or_string_name():
+            return resource_path
+
         # choose left 8 characters of hash as resource path hash to reduce the risk of length too long
         resource_path_hash = hash_dict(resource_path.to_json())[:8]
         resource_path_json = self.dirs.resources / f"{resource_path_hash}.json"
@@ -230,8 +230,8 @@ class OliveCache:
         self,
         model_number: str,
         output_dir: Union[str, Path] = None,
-        output_name: Union[str, Path] = None,
         overwrite: bool = False,
+        only_cache_files: bool = True,
     ) -> Optional[Dict]:
         """Save a model from the cache to a given path."""
         # This function should probably be outside of the cache module
@@ -241,7 +241,6 @@ class OliveCache:
         model_number = model_number.split("_")[0]
         output_dir = Path(output_dir) if output_dir else Path.cwd()
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_name = output_name if output_name else "model"
 
         model_jsons = list(self.dirs.models.glob(f"{model_number}_*.json"))
         assert len(model_jsons) == 1, f"No model found for {model_number}"
@@ -257,31 +256,46 @@ class OliveCache:
         model_config: ModelConfig = ModelConfig.from_json(model_json)
         resource_paths = model_config.get_resource_paths()
         for resource_name, resource_path in resource_paths.items():
-            if not resource_path or resource_path.is_string_name():
-                # Nothing to do if the path is empty or a string name
+            if (
+                not resource_path
+                or resource_path.is_string_name()
+                or (only_cache_files and not resource_path.get_path().startswith(str(self.cache_dir)))
+            ):
+                # Nothing to do if the path is empty or a string name or if we only want to cache local files
                 continue
-            # get cached resource path if not local or string name
-            if not resource_path.is_local_resource():
-                local_resource_path = self.download_resource(resource_path)
-            else:
-                local_resource_path = resource_path
-            # if there are multiple resource paths, we will save them to a subdirectory of output_dir/output_name
-            if len(resource_paths) > 1:
-                save_dir = (output_dir / output_name).with_suffix("")
-                save_name = resource_name.replace("_path", "")
-            else:
-                save_dir = output_dir
-                save_name = output_name
+
+            # get the path in the cache
+            local_resource_path = self.get_local_path_or_download(resource_path)
+
+            # check if path is from non-local resource cache
+            local_resource_str = local_resource_path.get_path()
+            resource_dir_str = str(self.dirs.resources)
+            if only_cache_files and local_resource_str.startswith(resource_dir_str):
+                # get the original resource path from the cache
+                # resource_path could be "/cache/resources/1234/mlflow_model_folder"
+                # load the json file "/cache/resources/1234.json" to get the original resource path
+                resource_path_json = (
+                    self.dirs.resources / f"{Path(local_resource_str.replace(resource_dir_str, '')).parts[1]}.json"
+                )
+                with resource_path_json.open("r") as f:
+                    resource_json = json.load(f)
+                    if create_resource_path(resource_json["dest"]) == local_resource_path:
+                        # make sure it is the full resource and not a member of the resource
+                        model_json["config"][resource_name] = resource_json["source"]
+                        continue
 
             # save resource to output directory
-            model_json["config"][resource_name] = local_resource_path.save_to_dir(save_dir, save_name, overwrite)
+            model_json["config"][resource_name] = local_resource_path.save_to_dir(
+                output_dir, resource_name.replace("_path", ""), overwrite
+            )
 
-        # Copy "additional files" to the output folder
+        # Copy "additional files" to the model folder
+        # we only have additional files for onnx models so saving to "model" is safe
         model_attributes = model_json["config"].get("model_attributes") or {}
         additional_files = model_attributes.get("additional_files", [])
 
         for i, src_filepath in enumerate(additional_files):
-            dst_filepath = Path(output_dir) / output_name / Path(src_filepath).name
+            dst_filepath = output_dir / "model" / Path(src_filepath).name
             additional_files[i] = str(dst_filepath)
 
             if not dst_filepath.exists():
@@ -291,7 +305,7 @@ class OliveCache:
             model_json["config"]["model_attributes"]["additional_files"] = additional_files
 
         # save model json
-        with (output_dir / f"{output_name}.json").open("w") as f:
+        with (output_dir / "model_config.json").open("w") as f:
             json.dump(model_json, f, indent=4)
 
         return model_json

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -392,35 +392,37 @@ def update_remote_option(config: Dict, args: Namespace, cli_action: str, tempdir
 def save_output_model(config: Dict, output_model_dir: Union[str, Path]):
     """Save the output model to the output_model_dir.
 
-    This assumes single passflow with a single accelerator = single output model.
+    This assumes a single accelerator workflow.
     """
     run_output_path = Path(config["output_dir"]) / "output_model"
-    if not run_output_path.exists():
+    if not any(run_output_path.rglob("model_config.json")):
+        # there must be an run_output_path with at least one model_config.json
         print("Command failed. Please set the log_level to 1 for more detailed logs.")
         return
 
     output_model_dir = Path(output_model_dir).resolve()
 
+    # hardlink/copy the output model to the output_model_dir
     hardlink_copy_dir(run_output_path, output_model_dir)
 
     # need to update the local path in the model_config.json
     # should the path be relative or absolute? relative makes it easy to move the output
     # around but the path needs to be updated when the model config is used
-    model_config_path = output_model_dir / "model_config.json"
-    with model_config_path.open("r") as f:
-        model_config = json.load(f)
+    for model_config_file in output_model_dir.rglob("model_config.json"):
+        with model_config_file.open("r") as f:
+            model_config = json.load(f)
 
-    all_resources = find_all_resources(model_config)
-    for resource_key, resource_path in all_resources.items():
-        resource_path_str = resource_path.get_path()
-        if resource_path_str.startswith(str(run_output_path)):
-            set_nested_dict_value(
-                model_config,
-                resource_key,
-                resource_path_str.replace(str(run_output_path), str(output_model_dir)),
-            )
+        all_resources = find_all_resources(model_config)
+        for resource_key, resource_path in all_resources.items():
+            resource_path_str = resource_path.get_path()
+            if resource_path_str.startswith(str(run_output_path)):
+                set_nested_dict_value(
+                    model_config,
+                    resource_key,
+                    resource_path_str.replace(str(run_output_path), str(output_model_dir)),
+                )
 
-    with model_config_path.open("w") as f:
-        json.dump(model_config, f, indent=4)
+        with model_config_file.open("w") as f:
+            json.dump(model_config, f, indent=4)
 
     print(f"Command succeeded. Output model saved to {output_model_dir}")

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -261,10 +261,12 @@ def add_model_options(
     enable_hf_adapter: bool = False,
     enable_pt: bool = False,
     enable_onnx: bool = False,
+    default_output_path: Optional[str] = None,
 ):
     """Add model options to the sub_parser.
 
     Use enable_hf, enable_hf_adapter, enable_pt, enable_onnx to enable the corresponding model options.
+    If default_output_path is None, it is required to provide the output_path.
     """
     assert any([enable_hf, enable_hf_adapter, enable_pt, enable_onnx]), "At least one model option should be enabled."
 
@@ -316,6 +318,26 @@ def add_model_options(
             type=str,
             help="The directory containing the model script file.",
         )
+
+    model_group.add_argument(
+        "-o",
+        "--output_path",
+        type=output_path_type,
+        required=default_output_path is None,
+        default=default_output_path,
+        help="Path to save the command output.",
+    )
+
+
+def output_path_type(path: str) -> str:
+    """Resolve the output path and mkdir if it doesn't exist."""
+    path = Path(path).resolve()
+
+    if path.exists():
+        assert path.is_dir(), f"{path} is not a directory."
+
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def is_remote_run(args: Namespace) -> bool:

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -44,7 +44,7 @@ def _get_hf_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     args.task is optional.
     args.adapter_path might not be present.
     """
-    print(f"Loading HuggingFace model from: {model_path}")
+    print(f"Loading HuggingFace model from {model_path}")
     input_model = {
         "type": "HfModel",
         "model_path": model_path,
@@ -65,7 +65,7 @@ def _get_onnx_input_model(model_path: str) -> Dict:
 
     Only supports local ONNX model file path.
     """
-    print(f"Loading ONNX model from: {model_path}")
+    print(f"Loading ONNX model from {model_path}")
     return {
         "type": "OnnxModel",
         "model_path": model_path,
@@ -95,7 +95,7 @@ def _get_pt_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
         input_model_config["script_dir"] = args.script_dir
 
     if model_path:
-        print("Loading PyTorch model from:", model_path)
+        print("Loading PyTorch model from", model_path)
         input_model_config["model_path"] = model_path
 
     if user_module_loader.has_function("_model_loader"):
@@ -151,6 +151,7 @@ def get_input_model_config(args: Namespace) -> Dict:
             assert model_config["type"].lower() == "hfmodel", "Only HfModel supports adapter_path."
             model_config["config"]["adapter_path"] = adapter_path
 
+        print(f"Loaded previous command output of type {model_config['type']} from {model_name_or_path}")
         return model_config
 
     # Check AzureML model

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -2,14 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
-# ruff: noqa: T201
-
-import shutil
 import tempfile
 from argparse import ArgumentParser
 from copy import deepcopy
-from pathlib import Path
 from typing import ClassVar, Dict
 
 from olive.cli.base import (
@@ -18,12 +13,11 @@ from olive.cli.base import (
     add_model_options,
     add_remote_options,
     get_input_model_config,
-    get_output_model_number,
     is_remote_run,
-    update_model_config,
+    save_output_model,
     update_remote_option,
 )
-from olive.common.utils import IntEnumBase, hardlink_copy_dir, set_nested_dict_value, set_tempdir
+from olive.common.utils import IntEnumBase, set_nested_dict_value, set_tempdir
 
 
 class ModelBuilderAccuracyLevel(IntEnumBase):
@@ -40,7 +34,7 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
     def register_subcommand(parser: ArgumentParser):
         sub_parser = parser.add_parser(
             "capture-onnx-graph",
-            help=("Capture ONNX graph using PyTorch Exporter or Model Builder from the Huggingface model."),
+            help="Capture ONNX graph using PyTorch Exporter or Model Builder from the Huggingface model.",
         )
 
         add_logging_options(sub_parser)
@@ -166,28 +160,12 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
         with tempfile.TemporaryDirectory() as tempdir:
             run_config = self.get_run_config(tempdir)
 
-            output = olive_run(run_config)
+            olive_run(run_config)
 
             if is_remote_run(self.args):
-                # TODO(jambayk): point user to datastore with outputs or download outputs
-                # both are not implemented yet
                 return
 
-            if get_output_model_number(output) > 0:
-                output_path = Path(self.args.output_path)
-                output_path.mkdir(parents=True, exist_ok=True)
-                pass_name = "m" if self.args.use_model_builder else "c"
-                device_name = "gpu-cuda_model" if self.args.device == "gpu" else "cpu-cpu_model"
-                source_path = Path(tempdir) / pass_name / device_name
-                if source_path.is_dir():
-                    hardlink_copy_dir(source_path, output_path)
-                else:
-                    shutil.move(str(source_path.with_suffix(".onnx")), output_path)
-
-                update_model_config(source_path.with_suffix(".json"), output_path)
-                print(f"ONNX Model is saved to {output_path.resolve()}")
-            else:
-                print("Failed to run capture-onnx-graph. Please set the log_level to 1 for more detailed logs.")
+            save_output_model(run_config, self.args.output_path)
 
     def get_run_config(self, tempdir: str) -> Dict:
         config = deepcopy(TEMPLATE)

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -17,7 +17,7 @@ from olive.cli.base import (
     save_output_model,
     update_remote_option,
 )
-from olive.common.utils import IntEnumBase, set_nested_dict_value, set_tempdir
+from olive.common.utils import IntEnumBase, set_nested_dict_value
 
 
 class ModelBuilderAccuracyLevel(IntEnumBase):
@@ -40,7 +40,9 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
         add_logging_options(sub_parser)
 
         # model options
-        add_model_options(sub_parser, enable_hf=True, enable_hf_adapter=True, enable_pt=True)
+        add_model_options(
+            sub_parser, enable_hf=True, enable_hf_adapter=True, enable_pt=True, default_output_path="onnx-model"
+        )
 
         sub_parser.add_argument(
             "--device",
@@ -53,11 +55,6 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
                 "If 'cpu' is selected, the execution_providers will be set to CPUExecutionProvider."
                 "For PyTorch Exporter, the device is used to cast the model to before capturing the ONNX graph."
             ),
-        )
-
-        sub_parser.add_argument("-o", "--output_path", type=str, default="onnx-model", help="Output path")
-        sub_parser.add_argument(
-            "--tempdir", default=None, type=str, help="Root directory for tempfile directories and files"
         )
 
         # PyTorch Exporter options
@@ -155,9 +152,7 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
     def run(self):
         from olive.workflows import run as olive_run
 
-        set_tempdir(self.args.output_path)
-
-        with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory(prefix="olive-cli-tmp-", dir=self.args.output_path) as tempdir:
             run_config = self.get_run_config(tempdir)
 
             olive_run(run_config)

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -40,7 +40,7 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
         add_logging_options(sub_parser)
 
         # model options
-        add_model_options(sub_parser)
+        add_model_options(sub_parser, enable_hf=True, enable_hf_adapter=True, enable_pt=True)
 
         sub_parser.add_argument(
             "--device",
@@ -169,9 +169,9 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
 
     def get_run_config(self, tempdir: str) -> Dict:
         config = deepcopy(TEMPLATE)
-        config["input_model"] = get_input_model_config(self.args)
 
         to_replace = [
+            ("input_model", get_input_model_config(self.args)),
             ("output_dir", tempdir),
             ("log_severity_level", self.args.log_level),
             (("systems", "local_system", "accelerators", 0, "device"), self.args.device),

--- a/olive/cli/export_adapters.py
+++ b/olive/cli/export_adapters.py
@@ -2,9 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
-# ruff: noqa: T201
-
 import math
 from argparse import ArgumentParser
 from typing import TYPE_CHECKING, Tuple

--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -36,7 +36,7 @@ class FineTuneCommand(BaseOliveCLICommand):
         add_logging_options(sub_parser)
 
         # Model options
-        add_model_options(sub_parser)
+        add_model_options(sub_parser, enable_hf=True)
 
         sub_parser.add_argument(
             "--torch_dtype",
@@ -157,6 +157,7 @@ class FineTuneCommand(BaseOliveCLICommand):
         preprocess_key = ("data_configs", 0, "pre_process_data_config")
         finetune_key = ("passes", "f")
         to_replace = [
+            ("input_model", get_input_model_config(self.args)),
             ((*load_key, "data_name"), self.args.data_name),
             ((*load_key, "split"), self.args.train_split),
             (
@@ -178,7 +179,6 @@ class FineTuneCommand(BaseOliveCLICommand):
             to_replace.append(((*finetune_key, "target_modules"), self.args.target_modules.split(",")))
 
         config = deepcopy(TEMPLATE)
-        config["input_model"] = get_input_model_config(self.args)
 
         for keys, value in to_replace:
             if value is None:

--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -17,7 +17,7 @@ from olive.cli.base import (
     save_output_model,
     update_remote_option,
 )
-from olive.common.utils import set_nested_dict_value, set_tempdir, unescaped_str
+from olive.common.utils import set_nested_dict_value, unescaped_str
 
 
 class FineTuneCommand(BaseOliveCLICommand):
@@ -36,7 +36,7 @@ class FineTuneCommand(BaseOliveCLICommand):
         add_logging_options(sub_parser)
 
         # Model options
-        add_model_options(sub_parser, enable_hf=True)
+        add_model_options(sub_parser, enable_hf=True, default_output_path="finetuned-adapter")
 
         sub_parser.add_argument(
             "--torch_dtype",
@@ -109,11 +109,6 @@ class FineTuneCommand(BaseOliveCLICommand):
             "--target_modules", type=str, help="The target modules for LoRA. If multiple, separate by comma."
         )
 
-        # directory options
-        sub_parser.add_argument("-o", "--output_path", type=str, default="finetuned-adapter", help="Output path")
-        sub_parser.add_argument(
-            "--tempdir", default=None, type=str, help="Root directory for tempfile directories and files"
-        )
         # TODO(jambayk): what about checkpoint_dir and resume from checkpoint support? clean checkpoint dir?
         sub_parser.add_argument("--clean", action="store_true", help="Run in a clean cache directory")
 
@@ -125,9 +120,7 @@ class FineTuneCommand(BaseOliveCLICommand):
     def run(self):
         from olive.workflows import run as olive_run
 
-        set_tempdir(self.args.tempdir)
-
-        with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory(prefix="olive-cli-tmp-", dir=self.args.output_path) as tempdir:
             run_config = self.get_run_config(tempdir)
 
             olive_run(run_config)

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -40,7 +40,7 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
         )
 
         # Model options
-        add_model_options(sub_parser, adapter=True)
+        add_model_options(sub_parser, enable_hf=True, enable_hf_adapter=True)
 
         sub_parser.add_argument(
             "--use_ort_genai", action="store_true", help="Use OnnxRuntie generate() API to run the model"
@@ -75,6 +75,8 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
             save_output_model(run_config, self.args.output_path)
 
     def get_run_config(self, tempdir: str) -> Dict:
+        from olive.model import ModelConfig
+
         to_replace = [
             ("input_model", get_input_model_config(self.args)),
             (("input_model", "adapter_path"), self.args.adapter_path),
@@ -98,6 +100,10 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
 
         update_remote_option(config, self.args, "generate-adapter", tempdir)
         config["log_severity_level"] = self.args.log_level
+
+        input_model_config = ModelConfig.parse_obj(config["input_model"])
+        if input_model_config.config.get("adapter_path") is None:
+            raise ValueError("adapter_path is required for generate-adapter command")
 
         return config
 

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -1,0 +1,135 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import tempfile
+from argparse import ArgumentParser
+from copy import deepcopy
+from typing import ClassVar, Dict
+
+from olive.cli.base import (
+    BaseOliveCLICommand,
+    add_logging_options,
+    add_model_options,
+    add_remote_options,
+    get_input_model_config,
+    is_remote_run,
+    save_output_model,
+    update_remote_option,
+)
+from olive.common.utils import set_nested_dict_value, set_tempdir
+
+
+class GenerateAdapterCommand(BaseOliveCLICommand):
+    allow_unknown_args: ClassVar[bool] = True
+
+    @staticmethod
+    def register_subcommand(parser: ArgumentParser):
+        sub_parser = parser.add_parser(
+            "generate-adapter", help="Convert and optimize the model for ONNX Runtime with adapters as inputs"
+        )
+
+        add_logging_options(sub_parser)
+
+        sub_parser.add_argument(
+            "--precision",
+            type=str,
+            default="float16",
+            choices=["float16", "float32"],
+            help="The precision of the optimized model and adapters.",
+        )
+
+        # Model options
+        add_model_options(sub_parser, adapter=True)
+
+        sub_parser.add_argument(
+            "--use_ort_genai", action="store_true", help="Use OnnxRuntie generate() API to run the model"
+        )
+
+        # directory options
+        sub_parser.add_argument("-o", "--output_path", type=str, default="optimized-model", help="Output path")
+        sub_parser.add_argument(
+            "--tempdir", default=None, type=str, help="Root directory for tempfile directories and files"
+        )
+        # TODO(jambayk): what about checkpoint_dir and resume from checkpoint support? clean checkpoint dir?
+        sub_parser.add_argument("--clean", action="store_true", help="Run in a clean cache directory")
+
+        # remote options
+        add_remote_options(sub_parser)
+
+        sub_parser.set_defaults(func=GenerateAdapterCommand)
+
+    def run(self):
+        from olive.workflows import run as olive_run
+
+        set_tempdir(self.args.tempdir)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            run_config = self.get_run_config(tempdir)
+
+            olive_run(run_config)
+
+            if is_remote_run(self.args):
+                return
+
+            save_output_model(run_config, self.args.output_path)
+
+    def get_run_config(self, tempdir: str) -> Dict:
+        to_replace = [
+            ("input_model", get_input_model_config(self.args)),
+            (("input_model", "adapter_path"), self.args.adapter_path),
+            (("passes", "o", "float16"), self.args.precision == "float16"),
+            # make the mapping of precisions better
+            (("passes", "m", "precision"), "fp16" if self.args.precision == "float16" else "fp32"),
+            (("clean_cache",), self.args.clean),
+            ("output_dir", tempdir),
+        ]
+        if self.args.trust_remote_code:
+            to_replace.append((("input_model", "load_kwargs", "trust_remote_code"), True))
+
+        config = deepcopy(TEMPLATE)
+        for keys, value in to_replace:
+            if value is None:
+                continue
+            set_nested_dict_value(config, keys, value)
+
+        if not self.args.use_ort_genai:
+            del config["passes"]["m"]
+
+        update_remote_option(config, self.args, "generate-adapter", tempdir)
+        config["log_severity_level"] = self.args.log_level
+
+        return config
+
+
+TEMPLATE = {
+    "input_model": {"type": "HfModel", "load_kwargs": {"attn_implementation": "eager"}},
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            # will just use cuda ep now, only genai metadata is not agnostic to ep
+            # revisit once model builder supports lora adapters
+            "accelerators": [{"device": "gpu", "execution_providers": ["CUDAExecutionProvider"]}],
+        }
+    },
+    "passes": {
+        # TODO(jambayk): migrate to model builder once it supports lora adapters
+        # the models produced here are not fully optimized
+        "c": {
+            "type": "OnnxConversion",
+            "target_opset": 17,
+            "torch_dtype": "float32",
+            "save_metadata_for_token_generation": True,
+        },
+        "o": {
+            "type": "OrtTransformersOptimization",
+            "model_type": "gpt2",
+            "opt_level": 0,
+            "keep_io_types": False,
+        },
+        "e": {"type": "ExtractAdapters"},
+        "m": {"type": "ModelBuilder", "metadata_only": True},
+    },
+    "host": "local_system",
+    "target": "local_system",
+}

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -17,7 +17,7 @@ from olive.cli.base import (
     save_output_model,
     update_remote_option,
 )
-from olive.common.utils import set_nested_dict_value, set_tempdir
+from olive.common.utils import set_nested_dict_value
 
 
 class GenerateAdapterCommand(BaseOliveCLICommand):
@@ -40,18 +40,12 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
         )
 
         # Model options
-        add_model_options(sub_parser, enable_hf=True, enable_hf_adapter=True)
+        add_model_options(sub_parser, enable_hf=True, enable_hf_adapter=True, default_output_path="optimized-model")
 
         sub_parser.add_argument(
             "--use_ort_genai", action="store_true", help="Use OnnxRuntie generate() API to run the model"
         )
 
-        # directory options
-        sub_parser.add_argument("-o", "--output_path", type=str, default="optimized-model", help="Output path")
-        sub_parser.add_argument(
-            "--tempdir", default=None, type=str, help="Root directory for tempfile directories and files"
-        )
-        # TODO(jambayk): what about checkpoint_dir and resume from checkpoint support? clean checkpoint dir?
         sub_parser.add_argument("--clean", action="store_true", help="Run in a clean cache directory")
 
         # remote options
@@ -62,9 +56,7 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
     def run(self):
         from olive.workflows import run as olive_run
 
-        set_tempdir(self.args.tempdir)
-
-        with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory(prefix="olive-cli-tmp-", dir=self.args.output_path) as tempdir:
             run_config = self.get_run_config(tempdir)
 
             olive_run(run_config)

--- a/olive/cli/launcher.py
+++ b/olive/cli/launcher.py
@@ -27,6 +27,7 @@ def get_cli_parser(called_as_console_script: bool = True) -> ArgumentParser:
     commands_parser = parser.add_subparsers()
 
     # Register commands
+    # TODO(jambayk): Consider adding a common tempdir option to all commands
     # NOTE: The order of the commands is to organize the documentation better.
     WorkflowRunCommand.register_subcommand(commands_parser)
     CaptureOnnxGraphCommand.register_subcommand(commands_parser)

--- a/olive/cli/launcher.py
+++ b/olive/cli/launcher.py
@@ -27,14 +27,14 @@ def get_cli_parser(called_as_console_script: bool = True) -> ArgumentParser:
     commands_parser = parser.add_subparsers()
 
     # Register commands
-    CaptureOnnxGraphCommand.register_subcommand(commands_parser)
     WorkflowRunCommand.register_subcommand(commands_parser)
+    CaptureOnnxGraphCommand.register_subcommand(commands_parser)
     FineTuneCommand.register_subcommand(commands_parser)
     GenerateAdapterCommand.register_subcommand(commands_parser)
     ExportAdaptersCommand.register_subcommand(commands_parser)
+    PerfTuningCommand.register_subcommand(commands_parser)
     ConfigureQualcommSDKCommand.register_subcommand(commands_parser)
     ManageAMLComputeCommand.register_subcommand(commands_parser)
-    PerfTuningCommand.register_subcommand(commands_parser)
     CloudCacheCommand.register_subcommand(commands_parser)
 
     return parser

--- a/olive/cli/launcher.py
+++ b/olive/cli/launcher.py
@@ -11,6 +11,7 @@ from olive.cli.cloud_cache import CloudCacheCommand
 from olive.cli.configure_qualcomm_sdk import ConfigureQualcommSDKCommand
 from olive.cli.export_adapters import ExportAdaptersCommand
 from olive.cli.finetune import FineTuneCommand
+from olive.cli.generate_adapter import GenerateAdapterCommand
 from olive.cli.manage_aml_compute import ManageAMLComputeCommand
 from olive.cli.perf_tuning import PerfTuningCommand
 from olive.cli.run import WorkflowRunCommand
@@ -29,6 +30,7 @@ def get_cli_parser(called_as_console_script: bool = True) -> ArgumentParser:
     CaptureOnnxGraphCommand.register_subcommand(commands_parser)
     WorkflowRunCommand.register_subcommand(commands_parser)
     FineTuneCommand.register_subcommand(commands_parser)
+    GenerateAdapterCommand.register_subcommand(commands_parser)
     ExportAdaptersCommand.register_subcommand(commands_parser)
     ConfigureQualcommSDKCommand.register_subcommand(commands_parser)
     ManageAMLComputeCommand.register_subcommand(commands_parser)

--- a/olive/cli/launcher.py
+++ b/olive/cli/launcher.py
@@ -27,6 +27,7 @@ def get_cli_parser(called_as_console_script: bool = True) -> ArgumentParser:
     commands_parser = parser.add_subparsers()
 
     # Register commands
+    # NOTE: The order of the commands is to organize the documentation better.
     WorkflowRunCommand.register_subcommand(commands_parser)
     CaptureOnnxGraphCommand.register_subcommand(commands_parser)
     FineTuneCommand.register_subcommand(commands_parser)

--- a/olive/cli/manage_aml_compute.py
+++ b/olive/cli/manage_aml_compute.py
@@ -2,9 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
-# ruff: noqa: T201
-
 import logging
 from argparse import ArgumentParser
 from pathlib import Path

--- a/olive/cli/perf_tuning.py
+++ b/olive/cli/perf_tuning.py
@@ -41,7 +41,7 @@ class PerfTuningCommand(BaseOliveCLICommand):
         add_logging_options(sub_parser)
 
         # model options
-        add_model_options(sub_parser)
+        add_model_options(sub_parser, enable_onnx=True)
 
         # dataset options
         dataset_group = sub_parser.add_argument_group(

--- a/olive/cli/perf_tuning.py
+++ b/olive/cli/perf_tuning.py
@@ -264,14 +264,13 @@ class PerfTuningCommand(BaseOliveCLICommand):
         self.refine_args()
 
         template_config = PerfTuningCommand.perf_tuning_template()
-        template_config["input_model"] = get_input_model_config(self.args)
-        print(f"input_model: {template_config['input_model']}")
 
         perf_tuning_key = ("passes", "perf_tuning")
         system_device_key = ("systems", "local_system", "accelerators", 0, "device")
 
         data_configs = [self._get_data_config(template_config)]
         to_replace = [
+            ("input_model", get_input_model_config(self.args)),
             ("data_configs", data_configs),
             (perf_tuning_key, self._update_pass_config(template_config["passes"]["perf_tuning"])),
             (system_device_key, self.args.device),

--- a/olive/cli/perf_tuning.py
+++ b/olive/cli/perf_tuning.py
@@ -2,9 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
-# ruff: noqa: T201
-
 import json
 import tempfile
 from argparse import ArgumentParser
@@ -21,13 +18,11 @@ from olive.cli.base import (
     add_model_options,
     add_remote_options,
     get_input_model_config,
-    get_output_model_number,
     is_remote_run,
     update_remote_option,
 )
 from olive.common.utils import set_nested_dict_value, set_tempdir
 from olive.data.config import DataConfig
-from olive.workflows import run as olive_run
 
 
 class PerfTuningCommand(BaseOliveCLICommand):
@@ -276,6 +271,8 @@ class PerfTuningCommand(BaseOliveCLICommand):
                 self.args.providers_list[idx] = f"{provider}ExecutionProvider"
 
     def get_run_config(self, tempdir) -> Dict:
+        self.refine_args()
+
         template_config = PerfTuningCommand.perf_tuning_template()
         template_config["input_model"] = get_input_model_config(self.args)
         print(f"input_model: {template_config['input_model']}")
@@ -285,10 +282,11 @@ class PerfTuningCommand(BaseOliveCLICommand):
 
         data_configs = [self._get_data_config(template_config)]
         to_replace = [
-            (("data_configs"), data_configs),
+            ("data_configs", data_configs),
             (perf_tuning_key, self._update_pass_config(template_config["passes"]["perf_tuning"])),
             (system_device_key, self.args.device),
             ((*perf_tuning_key, "data_config"), data_configs[0].name),
+            ("output_dir", tempdir),
         ]
 
         if self.args.providers_list:
@@ -307,29 +305,26 @@ class PerfTuningCommand(BaseOliveCLICommand):
         return config
 
     def run(self):
-        self.refine_args()
+        from olive.workflows import run as olive_run
+
         set_tempdir(self.args.tempdir)
+
         with tempfile.TemporaryDirectory() as tempdir:
             run_config = self.get_run_config(tempdir)
-            run_config["output_dir"] = tempdir
             output = olive_run(run_config)
 
             if is_remote_run(self.args):
-                # TODO(jambayk): point user to datastore with outputs or download outputs
-                # both are not implemented yet
                 return
 
-            if get_output_model_number(output) > 0:
-                # need to improve the output structure of olive run
-                output_path = Path(self.args.output_path)
-                output_path.mkdir(parents=True, exist_ok=True)
-                for provider in self.args.providers_list:
-                    provider_key = provider.replace("ExecutionProvider", "").lower()
-                    infer_setting_output_path = output_path / f"{self.args.device}-{provider_key}.json"
-                    rls_json_path = Path(tempdir) / "perf_tuning" / f"{self.args.device}-{provider_key}_model.json"
-                    with rls_json_path.open() as f:
-                        infer_settings = json.load(f)["config"]["inference_settings"]
-                        json.dump(infer_settings, infer_setting_output_path.open("w"), indent=4)
-                print(f"Inference session parameters are saved to {output_path.resolve()}")
-            else:
-                print("Failed to run tune-session-params. Please set the log_level to 1 for more detailed logs.")
+            output_path = Path(self.args.output_path).resolve()
+            output_path.mkdir(parents=True, exist_ok=True)
+            for key, value in output.items():
+                if len(value.nodes) < 1:
+                    print(f"Tuning for {key} failed. Please set the log_level to 1 for more detailed logs.")
+                    continue
+
+                infer_setting_output_path = output_path / f"{key}.json"
+                infer_settings = value.get_model_inference_config(value.get_output_model_id())
+                with infer_setting_output_path.open("w") as f:
+                    json.dump(infer_settings, f, indent=4)
+            print(f"Inference session parameters are saved to {output_path}.")

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -182,9 +182,12 @@ class Footprint:
         with open(file_path) as f:
             return cls.from_json(f.read())
 
+    def get_output_model_id(self):
+        # TODO(anyone): Make this more robust by ensuring there is only one pass flow and one output model
+        return next(reversed(self.nodes.keys()))
+
     def get_output_model_path(self):
-        model_id = next(reversed(self.nodes.keys()))
-        return self.get_model_path(model_id)
+        return self.get_model_path(self.get_output_model_id())
 
     def get_model_config(self, model_id):
         model_config = self.nodes[model_id].model_config

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -259,7 +259,7 @@ class Pass(ABC):
             # like for perf-tuning pass
             output_model_additional_files.add(str(output_filepath))
 
-        output_model_attributes["additional_files"] = list(output_model_additional_files)
+        output_model_attributes["additional_files"] = sorted(output_model_additional_files)
         output_model.model_attributes = output_model_attributes
 
     def serialize_config(self, config: Dict[str, Any], check_object: bool = False) -> str:

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -217,7 +217,7 @@ class ModelBuilder(Pass):
                 str(output_model_filepath.parent / "genai_config.json"),
             ]
         else:
-            model_attributes["additional_files"] = list(
+            model_attributes["additional_files"] = sorted(
                 set(additional_files)
                 # all files in the output directory except the model and model.data files
                 | {str(fp) for fp in output_model_filepath.parent.iterdir()}

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -65,19 +65,11 @@ class RunPassConfig(AbstractPassConfig):
             " related to this pass type will be cleaned."
         ),
     )
-    output_name: str = Field(
-        None,
-        description=(
-            "Prefix of the name of the output of this pass in the output directory. Only used when the workflow is run"
-            " in no-search mode. If not provided, only the output of the last pass will be saved."
-        ),
-    )
 
 
 class RunEngineConfig(EngineConfig):
     evaluate_input_model: bool = True
     output_dir: Union[Path, str] = None
-    output_name: str = None
     packaging_config: Union[PackagingConfig, List[PackagingConfig]] = None
     cloud_cache_config: Union[bool, CloudCacheConfig] = False
     log_severity_level: int = 1

--- a/olive/workflows/run/run.py
+++ b/olive/workflows/run/run.py
@@ -252,7 +252,6 @@ def run_engine(package_config: OlivePackageConfig, run_config: RunConfig):
                     host=host,
                     evaluator_config=pass_config.evaluator,
                     clean_run_cache=pass_config.clean_run_cache,
-                    output_name=pass_config.output_name,
                 )
             engine.set_pass_flows(pass_flows)
 
@@ -263,7 +262,6 @@ def run_engine(package_config: OlivePackageConfig, run_config: RunConfig):
                 accelerator_spec,
                 run_config.engine.packaging_config,
                 run_config.engine.output_dir,
-                run_config.engine.output_name,
                 run_config.engine.evaluate_input_model,
                 run_config.engine.log_to_file,
                 run_config.engine.log_severity_level,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,3 +195,4 @@ classmethod-decorators = ["classmethod", "olive.common.pydantic_v1.validator", "
 "test/**" = ["INP001"]
 "scripts/**" = ["INP001"]
 "examples/directml/llm/chat_app/**" = ["TID252", "UP006", "T201"]
+"olive/cli/**" = ["T201"]

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from olive.cli.launcher import main as cli_main
-from olive.engine.footprint import Footprint
 
 
 @pytest.mark.parametrize("console_script", [True, False])
@@ -103,9 +102,8 @@ def test_configure_qualcomm_sdk_command(mock_configure):
 
 @patch("olive.workflows.run")
 @patch("olive.cli.finetune.tempfile.TemporaryDirectory")
-@patch("olive.cli.finetune.update_model_config")
-@patch("huggingface_hub.repo_exists")
-def test_finetune_command(mock_repo_exists, mock_update_model_config, mock_tempdir, mock_run, tmp_path):
+@patch("huggingface_hub.repo_exists", return_value=True)
+def test_finetune_command(_, mock_tempdir, mock_run, tmp_path):
     # some directories
     tmpdir = tmp_path / "tmpdir"
     tmpdir.mkdir()
@@ -114,19 +112,18 @@ def test_finetune_command(mock_repo_exists, mock_update_model_config, mock_tempd
 
     # setup
     mock_tempdir.return_value = tmpdir.resolve()
-    mock_repo_exists.return_value = True
-    mock_run.return_value = {"output_dir": Footprint(nodes={"dummy_output": "dummy_output"})}
-    workflow_output_dir = tmpdir / "f-c-o-e" / "gpu-cuda_model"
+    workflow_output_dir = tmpdir / "output_model"
     workflow_output_dir.mkdir(parents=True)
-    dummy_output = workflow_output_dir / "dummy_output"
+    dummy_output = workflow_output_dir / "model_config.json"
     with open(dummy_output, "w") as f:
-        f.write("dummy_output")
+        json.dump({"dummy": "output"}, f)
 
     # setup
+    model_id = "dummy-model-id"
     command_args = [
         "finetune",
         "-m",
-        "dummy_model",
+        model_id,
         "-d",
         "dummy_dataset",
         "--text_field",
@@ -139,16 +136,56 @@ def test_finetune_command(mock_repo_exists, mock_update_model_config, mock_tempd
     cli_main(command_args)
 
     config = mock_run.call_args[0][0]
-    assert config["input_model"]["model_path"] == "dummy_model"
+    assert config["input_model"]["model_path"] == model_id
     assert {el.name for el in output_dir.iterdir()} == {dummy_output.name}
 
 
-@patch("olive.cli.perf_tuning.olive_run")
-@patch("olive.cli.perf_tuning.tempfile.TemporaryDirectory")
-@patch("olive.common.ort_inference.get_ort_inference_session")
-@patch("huggingface_hub.repo_exists")
-@pytest.mark.parametrize("data_config_path", ["", "dummy_data_config_path.json"])
-def test_perf_tuning_command(mock_repo_exists, mock_ort_infer_sess, mock_tempdir, mock_run, data_config_path, tmp_path):
+def test_perf_tuning_command(tmp_path):
+    from test.unit_test.utils import ONNX_MODEL_PATH
+
+    # some directories
+    output_dir = tmp_path / "output_dir"
+
+    # setup
+    data_config = {
+        "name": "test_data_config_for_tuning",
+        "type": "DummyDataContainer",
+        "load_dataset_config": {"input_shapes": [(1, 1)], "input_names": ["input"]},
+    }
+    data_config_path = str(tmp_path / "data_config.json")
+    with open(data_config_path, "w") as f:
+        json.dump(data_config, f)
+
+    # setup
+    command_args = [
+        "tune-session-params",
+        "-m",
+        str(ONNX_MODEL_PATH),
+        "--data_config_path",
+        data_config_path,
+        "--output_path",
+        str(output_dir),
+        "--providers_list",
+        "CPUExecutionProvider",
+    ]
+
+    # execute
+    # run in subprocess to avoid affecting other tests
+    out = subprocess.run(["olive", *command_args], check=True, capture_output=True)
+
+    # assert
+    assert f"Inference session parameters are saved to {output_dir}" in out.stdout.decode("utf-8")
+    with open(output_dir / "cpu-cpu.json") as f:
+        infer_settings = json.load(f)
+        assert infer_settings["execution_provider"] == ["CPUExecutionProvider"]
+        assert infer_settings.keys() >= {"provider_options", "session_options"}
+
+
+@patch("olive.workflows.run")
+@patch("olive.cli.capture_onnx.tempfile.TemporaryDirectory")
+@patch("huggingface_hub.repo_exists", return_value=True)
+@pytest.mark.parametrize("use_model_builder", [True, False])
+def test_capture_onnx_command(_, mock_tempdir, mock_run, use_model_builder, tmp_path):
     # some directories
     tmpdir = tmp_path / "tmpdir"
     tmpdir.mkdir()
@@ -156,54 +193,14 @@ def test_perf_tuning_command(mock_repo_exists, mock_ort_infer_sess, mock_tempdir
     output_dir = tmp_path / "output_dir"
 
     # setup
-    data_config = {
-        "name": "dummy_data",
-        "type": "TransformersTokenDummyDataContainer",
-        "load_dataset_config": {"model_name": "microsoft/phi-2"},
-    }
-    if data_config_path:
-        data_config_path = str(tmpdir / data_config_path)
-        with open(data_config_path, "w") as f:
-            json.dump(data_config, f)
     mock_tempdir.return_value = tmpdir.resolve()
-    mock_repo_exists.return_value = True
-    workflow_output_dir = tmpdir / "perf_tuning" / "gpu-cuda-model"
+    workflow_output_dir = tmpdir / "output_model"
     workflow_output_dir.mkdir(parents=True)
-    dummy_output = workflow_output_dir / "dummy_output"
+    dummy_output = workflow_output_dir / "model_config.json"
     with open(dummy_output, "w") as f:
-        f.write("dummy_output")
+        json.dump({"config": {"inference_settings": {"dummy-key": "dummy-value"}}}, f)
 
-    # setup
-    command_args = [
-        "tune-session-params",
-        "-m",
-        "dummy_model",
-        "--data_config_path",
-        data_config_path,
-        "--hf_model_name",
-        "Intel/bert-base-uncased-mrpc",
-        "--output_path",
-        str(output_dir),
-    ]
-
-    # execute
-    cli_main(command_args)
-
-    config = mock_run.call_args[0][0]
-    assert config["input_model"]["model_path"] == "dummy_model"
-    assert config["data_configs"][0].name == config["passes"]["perf_tuning"]["data_config"]
-
-
-@patch("olive.workflows.run")
-@patch("olive.cli.capture_onnx.tempfile.TemporaryDirectory")
-@pytest.mark.parametrize("use_model_builder", [True, False])
-def test_capture_onnx_command(mock_tempdir, mock_run, use_model_builder, tmp_path):
-    # setup
-    mock_tempdir.return_value = tmp_path.resolve()
-    output_dir = tmp_path / "output_dir"
-    model_id = "microsoft/phi-2"
-
-    # setup
+    model_id = "dummy-model-id"
     command_args = [
         "capture-onnx-graph",
         "-m",
@@ -221,11 +218,13 @@ def test_capture_onnx_command(mock_tempdir, mock_run, use_model_builder, tmp_pat
     config = mock_run.call_args[0][0]
     assert config["input_model"]["model_path"] == model_id
     assert "m" in config["passes"] if use_model_builder else "c" in config["passes"]
+    assert {el.name for el in output_dir.iterdir()} == {dummy_output.name}
 
 
 @pytest.mark.parametrize("test_set", [(None, "successfully"), (MagicMock(name="blob1"), "failed")])
 @patch("azure.storage.blob.ContainerClient")
-def test_cloud_cache_command(mock_container_client, test_set):
+@patch("olive.cli.cloud_cache.get_credentials", return_value="dummy-credentials")
+def test_cloud_cache_command(_, mock_container_client, test_set):
     # setup
     command_args = [
         "cloud-cache",
@@ -246,7 +245,9 @@ def test_cloud_cache_command(mock_container_client, test_set):
 
     # assert
     assert (test_set[1] in message for message in log.output), "Expected log message not found."
-    mock_container_client.assert_called_once()
+    mock_container_client.assert_called_once_with(
+        account_url="https://account.blob.core.windows.net", container_name="container", credential="dummy-credentials"
+    )
     mock_container_client().delete_blob.assert_called_once()
 
 

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -311,12 +311,13 @@ class TestEngine:
         assert output_node.model_config == onnx_model_config
         assert expected_metrics == output_node.metrics.value
 
-        model_json_path = output_dir / "output_model" / "model_config.json"
+        output_model_dir = output_dir / "output_model"
+        model_json_path = output_model_dir / "model_config.json"
         assert model_json_path.is_file()
         with model_json_path.open() as f:
             assert json.load(f) == expected_saved_model_config.to_json()
 
-        result_json_path = output_dir / "output_model_metrics.json"
+        result_json_path = output_model_dir / "metrics.json"
         assert result_json_path.is_file()
         with result_json_path.open() as f:
             assert json.load(f) == expected_metrics.__root__

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -99,8 +99,8 @@ def create_onnx_model_with_dynamic_axis(onnx_model_path, batch_size=1):
     )
 
 
-def get_onnx_model_config():
-    return ModelConfig.parse_obj({"type": "ONNXModel", "config": {"model_path": str(ONNX_MODEL_PATH)}})
+def get_onnx_model_config(model_path=None):
+    return ModelConfig.parse_obj({"type": "ONNXModel", "config": {"model_path": str(model_path or ONNX_MODEL_PATH)}})
 
 
 def get_composite_onnx_model_config():


### PR DESCRIPTION
## Describe your changes
**Engine**:
- Improve the output folder structure of a workflow run. The current structure was meant for multiple-ep, multiple-passflow worfklows but that is not the common usage for olive.
- Unnecessary nesting for accelerator spec and pass flows is removed for single ep, single passflow scenario.
- `output_name` is removed from both pass config and engine config.
  - The behavior of `output_name` is arbitrary. User can get the output in a specific folder by directly providing the `output_dir` like `parent-dir/specific-dir`.
  - `output_name` was allowed for pass config to save intermediate models. But this can be achieved by providing multiple pass flows like `[[A, B], [A, B, C]]`. This is cleaner than the former.
- Refer to `Engine.run` for more details on the new output structure.

**CLI**:
- `add_model_options` is made configurable so that only the desired model type related options are added.
- `save_output_model` uses the new engine output directory structure to copy the output model into the final output directory.
- `finetune` command separated into `finetune` and `generate-adapter` commands. These commands can be chained as shown in the llama2 multilora notebook.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
