### PR TITLE
Make certain gptq options customizable via model specific mapping

### DIFF
--- a/olive/common/hf/mappings.py
+++ b/olive/common/hf/mappings.py
@@ -70,3 +70,18 @@ MODEL_TYPE_MAPPING = {
     "llama": "gpt2",
     "roberta": "bert",
 }
+
+MODEL_OUTSIDE_LAYER_MODULES = {
+    "phi3": ["model.embed_tokens", "embed_dropout", "model.norm"],
+}
+
+MODEL_INSIDE_LAYER_MODULES = {
+    "phi3": [
+        ["self_attn.qkv_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_up_proj"],
+        ["mlp.down_proj"],
+    ]
+}
+
+MODEL_LAYERS_BLOCK_NAME = {"phi3": "model.layers"}


### PR DESCRIPTION
## Make certain gptq options customizable via model specific mapping

This is to avoid hardcoding these paramters in config files for models that aren't (like phi3) yet officially supported by auto-gptq.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ x Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
