### PR TITLE
CI: Use `bitsandbytes<0.44.0` for `llama2` example test

### DIFF
--- a/examples/llama2/requirements-pipeline.txt
+++ b/examples/llama2/requirements-pipeline.txt
@@ -3,4 +3,6 @@ azure-ai-ml
 azure-identity
 azure-keyvault-secrets
 azureml-fsspec
+# 0.44.0+ is not compatible with python <3.10
+bitsandbytes<0.44.0
 huggingface_hub


### PR DESCRIPTION
## Describe your changes
Latest version of bnb has changes with `zip(..., strict=True)` which is not compatible with python <3.10. We need to eventually move to python 3.10+ since 3.8 is old but it needs bigger changes to the ci infrastructure https://github.com/microsoft/Olive/pull/1369. 
Use a lower version in the test for now to unblock the CI.
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
