### PR TITLE
Restrict initialization of passes to what's called out in pass_flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ efficiently compose and tune integrated techniques for offering a ready-to-use E
 
 ## Installation
 We recommend installing Olive in a [virtual environment](https://docs.python.org/3/library/venv.html) or a
-[conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html). Olive is installed using
+[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html). Olive is installed using
 pip.
 
 Create a virtual/conda environment with the desired version of Python and activate it.

--- a/docs/source/getstarted/installation.md
+++ b/docs/source/getstarted/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 We recommend installing Olive in a [virtual environment](https://docs.python.org/3/library/venv.html) or a
-[conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html). Olive is installed using
+[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html). Olive is installed using
 pip.
 
 Create a virtual/conda environment with the desired version of Python and activate it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ conda activate olive-env
 ```
 You can replace `olive-env` with any name you want and `python=3.8` with the version of python you want to use.
 
-Please refer to the [conda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) for more information on how to create and manage conda environments.
+Please refer to the [conda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) for more information on how to create and manage conda environments.
 
 ### Virtual env
 To create a new virtual environment and activate it, run the following command:

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -212,7 +212,7 @@ def audio_classification_pre_process(
 
     # align labels with model configs
     model_config = get_model_config(model_name, trust_remote_code=trust_remote_code)
-    labels_to_filter = kwargs.get("labels_to_filter", None) or []
+    labels_to_filter = kwargs.get("labels_to_filter") or []
     dataset = dataset.filter(
         lambda x: x not in dataset.features["label"].str2int(labels_to_filter), input_columns=[label_col]
     )

--- a/olive/data/template.py
+++ b/olive/data/template.py
@@ -80,7 +80,7 @@ def huggingface_data_config_template(model_name, task, **kwargs) -> DataConfig:
                 }
     """
     for component_config_name in ["pre_process_data_config", "post_process_data_config"]:
-        component_config = kwargs.get(component_config_name, None) or {}
+        component_config = kwargs.get(component_config_name) or {}
         if isinstance(component_config, DataComponentConfig):
             component_config = component_config.dict()
         component_config["params"] = component_config.get("params") or {}

--- a/olive/engine/footprint.py
+++ b/olive/engine/footprint.py
@@ -78,7 +78,7 @@ class Footprint:
         self.objective_dict = objective_dict
 
     def record(self, foot_print_node: FootprintNode = None, **kwargs):
-        _model_id = kwargs.get("model_id", None)
+        _model_id = kwargs.get("model_id")
         if foot_print_node is not None:
             _model_id = foot_print_node.model_id
             self.nodes[_model_id] = foot_print_node


### PR DESCRIPTION
## Restrict initialization of passes to what's called out in pass_flows

Config can list any number of passes, but the ones that are actually run are the ones listed in pass_flows. This avoids the case where a pass may not be able to successfully be initialized which shouldn't matter because its not going to be run unless it is explicitly called out in the pass_flows.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
