### PR TITLE
Add support to quantize onnx models

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -48,6 +48,7 @@ def _get_hf_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     input_model = {
         "type": "HfModel",
         "model_path": model_path,
+        "generative": not args.non_generative,
         "load_kwargs": {
             "trust_remote_code": args.trust_remote_code,
             "attn_implementation": "eager",
@@ -60,7 +61,7 @@ def _get_hf_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     return input_model
 
 
-def _get_onnx_input_model(model_path: str) -> Dict:
+def _get_onnx_input_model(args: Namespace, model_path: str) -> Dict:
     """Get the input model config for ONNX model.
 
     Only supports local ONNX model file path.
@@ -69,6 +70,7 @@ def _get_onnx_input_model(model_path: str) -> Dict:
     model_config = {
         "type": "OnnxModel",
         "model_path": model_path,
+        "generative": not args.non_generative,
     }
 
     # additional processing for the model folder
@@ -107,6 +109,7 @@ def _get_pt_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     input_model_config = {
         "type": "PyTorchModel",
         "model_script": args.model_script,
+        "generative": not args.non_generative,
     }
 
     if args.script_dir:
@@ -223,7 +226,7 @@ def get_input_model_config(args: Namespace) -> Dict:
 
     # Check local onnx file/folder (user-provided model)
     if (model_path.is_file() and model_path.suffix == ".onnx") or any(model_path.glob("*.onnx")):
-        return _get_onnx_input_model(model_name_or_path)
+        return _get_onnx_input_model(args, model_name_or_path)
 
     # Check local HF model file (user-provided model)
     return _get_hf_input_model(args, model_name_or_path)
@@ -305,6 +308,7 @@ def add_input_model_options(
             "See https://microsoft.github.io/Olive/features/cli.html#input-model for more information"
         ),
     )
+    model_group.add_argument("--non-generative", action="store_false", help="Is non-generative model?")
     if enable_hf:
         model_group.add_argument(
             "--trust_remote_code", action="store_true", help="Trust remote code when loading a model."

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -179,7 +179,7 @@ class RunConfig(NestedConfig):
             raise ValueError("Invalid input model")
 
         input_model_config = values["input_model"].dict()
-        if input_model_config["type"].lower() != "hfmodel":
+        if input_model_config["type"].lower() not in ["hfmodel", "onnxmodel"]:
             return v
 
         if isinstance(v, DataConfig):

--- a/test/unit_test/cli/test_base.py
+++ b/test/unit_test/cli/test_base.py
@@ -15,6 +15,7 @@ from olive.cli.base import get_input_model_config
     (
         "model_name_or_path",
         "trust_remote_code",
+        "non_generative",
         "task",
         "model_script",
         "script_dir",
@@ -26,6 +27,7 @@ from olive.cli.base import get_input_model_config
         (
             None,  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             None,  # task
             "model.py",  # model_script
             "scripts",  # script_dir
@@ -36,12 +38,14 @@ from olive.cli.base import get_input_model_config
                 "script_dir": "scripts",
                 "model_loader": "_model_loader",
                 "dummy_inputs_func": "_dummy_inputs",
+                "generative": True,
             },
         ),
         # AML registry model test
         (
             "azureml://registries/my_registry/models/my_model/versions/1",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -49,6 +53,7 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
+                "generative": True,
                 "model_path": {
                     "type": "azureml_registry_model",
                     "registry_name": "my_registry",
@@ -65,6 +70,7 @@ from olive.cli.base import get_input_model_config
         (
             "https://huggingface.co/my_model/my_model",  # model_name_or_path
             True,  # trust_remote_code
+            True,  # non_generative
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -72,6 +78,7 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
+                "generative": False,
                 "model_path": "my_model/my_model",
                 "load_kwargs": {
                     "trust_remote_code": True,
@@ -83,6 +90,7 @@ from olive.cli.base import get_input_model_config
         (
             "azureml:my_model:1",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             None,  # task
             "model.py",  # model_script
             "scripts",  # script_dir
@@ -92,6 +100,7 @@ from olive.cli.base import get_input_model_config
                 "model_script": "model.py",
                 "script_dir": "scripts",
                 "io_config": "_io_config",
+                "generative": True,
                 "model_path": {"type": "azureml_model", "name": "my_model", "version": "1"},
             },
         ),
@@ -99,6 +108,7 @@ from olive.cli.base import get_input_model_config
         (
             "hf_model",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -106,6 +116,7 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
+                "generative": True,
                 "model_path": "hf_model",
                 "load_kwargs": {
                     "trust_remote_code": False,
@@ -117,6 +128,7 @@ from olive.cli.base import get_input_model_config
         (
             "model.pt",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             None,  # task
             "model.py",  # model_script
             None,  # script_dir
@@ -126,11 +138,13 @@ from olive.cli.base import get_input_model_config
                 "model_script": "model.py",
                 "io_config": "_io_config",
                 "model_path": "model.pt",
+                "generative": True,
             },
         ),
         (
             "model.pt",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             None,  # task
             "model.py",  # model_script
             None,  # script_dir
@@ -141,12 +155,14 @@ from olive.cli.base import get_input_model_config
                 "model_loader": "_model_loader",
                 "io_config": "_io_config",
                 "model_path": "model.pt",
+                "generative": True,
             },
         ),
         # Local onnx model test
         (
             "model.onnx",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             None,  # task
             None,  # model_script
             None,  # script_dir
@@ -154,12 +170,14 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "OnnxModel",
                 "model_path": "model.onnx",
+                "generative": True,
             },
         ),
         # Local hf model test
         (
             "hf",  # model_name_or_path
             False,  # trust_remote_code
+            False,  # non_generative
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -167,6 +185,7 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
+                "generative": True,
                 "model_path": "hf",
                 "load_kwargs": {
                     "trust_remote_code": False,
@@ -181,6 +200,7 @@ def test_get_input_model_config(
     MockUserModuleLoader,
     model_name_or_path,
     trust_remote_code,
+    non_generative,
     task,
     model_script,
     script_dir,
@@ -192,6 +212,7 @@ def test_get_input_model_config(
     args = SimpleNamespace(
         model_name_or_path=model_name_or_path,
         trust_remote_code=trust_remote_code,
+        non_generative=non_generative,
         task=task,
         model_script=model_script,
         script_dir=script_dir,

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -240,7 +240,7 @@ def test_cloud_cache_command(_, mock_container_client, test_set):
     mock_container_client().delete_blob.assert_called_once()
 
 
-@pytest.mark.parametrize("algorithm_names", [{"awq"}, {"awq", "gptq"}])
+@pytest.mark.parametrize("algorithm_names", [{"awq"}, {"awq", "gptq"}, {"bnb4"}, {"bnb4", "matmul4"}])
 @patch("olive.workflows.run")
 @patch("olive.cli.finetune.tempfile.TemporaryDirectory")
 @patch("huggingface_hub.repo_exists")


### PR DESCRIPTION
## Add support to quantize onnx models

Supported algorithms include bnb4, MatMul4, nvmo, dynamic onnx
and dynamic INC.

NOTE: Static quantization is not yet supported.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
