### PR TITLE
ExtractAdapters: remove `pack_weights` option

### DIFF
--- a/docs/source/features/lora.md
+++ b/docs/source/features/lora.md
@@ -22,7 +22,7 @@ In addition, Olive provides a separate command to produce LoRA adapter for ORTâ€
 ```shell
 $ olive export-adapters [-h] [--adapter_path ADAPTER_PATH] \
                       [--output_path OUTPUT_PATH] [--dtype {float32,float16}] \
-                      [--pack_weights] [--quantize_int4] \
+                      [--quantize_int4] \
                       [--int4_block_size {16,32,64,128,256}] \
                       [--int4_quantization_mode {symmetric,asymmetric}]
 ```

--- a/olive/cli/export_adapters.py
+++ b/olive/cli/export_adapters.py
@@ -52,14 +52,6 @@ class ExportAdaptersCommand(BaseOliveCLICommand):
                 " quantization scales. Default is float32."
             ),
         )
-        sub_parser.add_argument(
-            "--pack_weights",
-            action="store_true",
-            help=(
-                "Whether to pack the weights. If True, the weights for each module type will be packed into a single"
-                " array."
-            ),
-        )
         # quantization options
         sub_parser.add_argument(
             "--quantize_int4",
@@ -124,13 +116,6 @@ class ExportAdaptersCommand(BaseOliveCLICommand):
                     # otherwise it's always 0 and not part of the node inputs
                     transformed_weights[new_name.replace(".weight", ".quant.zero_point")] = zero_point
                 quant_modules.add(new_name.replace(".weight", ".quant"))
-
-        if self.args.pack_weights:
-            from olive.passes.onnx.extract_adapters import ExtractAdapters
-
-            transformed_weights, _ = ExtractAdapters.pack_weights(
-                transformed_weights, lora_config.target_modules, float_modules, quant_modules
-            )
 
         output_path = save_weights(transformed_weights, self.args.output_path, self.args.save_format)
         print(f"Exported adapter weights to {output_path}")

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -390,8 +390,6 @@ class OnnxConversion(Pass):
         output_model_path = resolve_onnx_path(output_model_path)
         output_model = model_proto_to_olive_model(converted_onnx_model, output_model_path, config)
         output_model.model_attributes = model_attributes = deepcopy(model.model_attributes or {})
-        if is_peft_model(pytorch_model):
-            model_attributes["lora_modules"] = list(pytorch_model.peft_config["default"].target_modules)
         return output_model
 
     @staticmethod

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -389,7 +389,7 @@ class OnnxConversion(Pass):
         # save the model to the output path and return the model
         output_model_path = resolve_onnx_path(output_model_path)
         output_model = model_proto_to_olive_model(converted_onnx_model, output_model_path, config)
-        output_model.model_attributes = model_attributes = deepcopy(model.model_attributes or {})
+        output_model.model_attributes = deepcopy(model.model_attributes or {})
         return output_model
 
     @staticmethod


### PR DESCRIPTION
## Describe your changes
Remove the `pack_weights` option from the `ExtractAdapters` pass. It is not used and requires lora specific information (lora target modules) to do the packing. Also makes the logic unnecessarily complicated.
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
