### PR TITLE
Cleanup auto-opt options

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -127,15 +127,6 @@ class AutoOptCommand(BaseOliveCLICommand):
             ),
         )
         sub_parser.add_argument(
-            "--excluded_passes",
-            type=str,
-            nargs="*",
-            help=(
-                "List of passes to disable for optimization, if not specified, "
-                "auto-opt will disable ModelBuilder/OrtPerfTuning by default."
-            ),
-        )
-        sub_parser.add_argument(
             "--use_model_builder",
             action="store_true",
             help=(
@@ -173,10 +164,11 @@ class AutoOptCommand(BaseOliveCLICommand):
     def get_run_config(self, tempdir) -> Dict:
         config = deepcopy(TEMPLATE)
 
-        excluded_passes = self.args.excluded_passes or ["ModelBuilder", "OrtPerfTuning"]
+        excluded_passes = ["OrtPerfTuning"]
         if self.args.use_model_builder:
-            excluded_passes.remove("ModelBuilder")
             excluded_passes.append("OnnxConversion")
+        else:
+            excluded_passes.append("ModelBuilder")
 
         to_replace = [
             ("input_model", get_input_model_config(self.args)),

--- a/olive/cli/export_adapters.py
+++ b/olive/cli/export_adapters.py
@@ -6,7 +6,7 @@ import math
 from argparse import ArgumentParser
 from typing import TYPE_CHECKING, Tuple
 
-from olive.cli.base import BaseOliveCLICommand, add_logging_options
+from olive.cli.base import BaseOliveCLICommand
 from olive.common.utils import WeightsFileFormat, save_weights
 
 if TYPE_CHECKING:
@@ -73,7 +73,6 @@ class ExportAdaptersCommand(BaseOliveCLICommand):
             choices=["symmetric", "asymmetric"],
             help="Quantization mode for int4 quantization. Default is symmetric.",
         )
-        add_logging_options(sub_parser)
         sub_parser.set_defaults(func=ExportAdaptersCommand)
 
     def run(self):


### PR DESCRIPTION
## Describe your changes
Cleanup auto-opt options. 
No need to present excluded_passes option to the users. 
Disable session parameter tuning for this command.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
