### PR TITLE
Fix provider option handling in Olive commands

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -120,6 +120,7 @@ class AutoOptCommand(BaseOliveCLICommand):
         sub_parser.add_argument(
             "--precision",
             type=str,
+            default="fp32",
             choices=["fp16", "fp32", "int4", "int8"],
             help=(
                 "The output precision of the optimized model. If not specified, "

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -588,12 +588,10 @@ def update_accelerator_options(args, config, single_provider: bool = True):
         (("systems", "local_system", "accelerators", 0, "device"), args.device),
     ]
 
-    args.providers_list = args.providers_list or []
-    for idx, provider in enumerate(args.providers_list):
-        if not provider.endswith("ExecutionProvider"):
-            args.providers_list[idx] = f"{provider}ExecutionProvider"
-
     execution_providers = [args.provider] if single_provider else args.providers_list
+    for idx, provider in enumerate(execution_providers):
+        if not provider.endswith("ExecutionProvider"):
+            execution_providers[idx] = f"{provider}ExecutionProvider"
     to_replace.append((("systems", "local_system", "accelerators", 0, "execution_providers"), execution_providers))
 
     for k, v in to_replace:


### PR DESCRIPTION
## Describe your changes
Fix provider option handling.
Use fp32 as default target precision in auto-opt command.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
