### PR TITLE
MatMulNBitsToQDQ: Pass to convert MatMulNBits contrib op to standard QDQ

### DIFF
--- a/docs/source/api/passes.rst
+++ b/docs/source/api/passes.rst
@@ -84,6 +84,18 @@ OnnxQuantization
 ----------------
 .. autoconfigclass:: olive.passes.OnnxQuantization
 
+.. _onnx_matmul4_quantizer:
+
+OnnxMatMul4Quantizer
+--------------------
+.. autoconfigclass:: olive.passes.OnnxMatMul4Quantizer
+
+.. _matmulnbits_to_qdq:
+
+MatMulNBitsToQDQ
+----------------
+.. autoconfigclass:: olive.passes.MatMulNBitsToQDQ
+
 .. _dynamic_to_fixed_shape:
 
 DynamicToFixedShape

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,6 @@ suppress_warnings = ["myst.xref_missing"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_static_path = ["_static"]
 html_css_files = [

--- a/examples/llama2/requirements-qlora.txt
+++ b/examples/llama2/requirements-qlora.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-accelerate
+# transformers>=4.33.2,<= 4.37.2 not compatible with latest accelerate
+accelerate<1.0.0
 bitsandbytes==0.43.3
 onnxruntime_genai
 peft

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -22,6 +22,7 @@
             "extra_dependencies": [ "inc" ]
         },
         "InsertBeamSearch": { "module_path": "olive.passes.onnx.insert_beam_search.InsertBeamSearch" },
+        "MatMulNBitsToQDQ": { "module_path": "olive.passes.onnx.mnb_to_qdq.MatMulNBitsToQDQ" },
         "MixedPrecisionOverrides": {
             "module_path": "olive.passes.onnx.mixed_precision_overrides.MixedPrecisionOverrides"
         },

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -176,7 +176,7 @@ class ExtractAdapters(Pass):
 
         # remove old dequantize nodes
         for node_name in nodes_to_remove:
-            dag.remove_node(node_name, check_no_consumers=True)
+            dag.remove_node(node_name)
 
         if config["make_inputs"]:
             if quant_modules and (config["dynamic_lora_r"] or config["optional_inputs"]):

--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -1,0 +1,307 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict
+
+import numpy as np
+import onnx
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import ONNXModelHandler
+from olive.model.utils import resolve_onnx_path
+from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
+from olive.passes.onnx.onnx_dag import OnnxDAG
+from olive.passes.pass_config import PassConfigParam
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+
+class MatMulNBitsToQDQ(Pass):
+    @classmethod
+    def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        return {
+            "use_transpose_op": PassConfigParam(
+                type_=bool,
+                # TODO(jambayk): decide whether to enable this by default or not
+                # False gives same output on arm Mac/Windows, but not on x64 Linux/Windows
+                default_value=True,
+                description=(
+                    "Whether to use a Transpose operator after the DequantizeLinear operator. If False, the weight"
+                    " initializer will be transposed instead."
+                ),
+            ),
+            **get_external_data_config(),
+        }
+
+    def _run_for_config(
+        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+    ) -> ONNXModelHandler:
+        output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
+
+        # create a dag from the model
+        dag = OnnxDAG.from_model_path(model.model_path)
+        # remove unnecessary identity nodes
+        dag.remove_identity_nodes()
+
+        num_modified = 0
+        for node_name in dag.get_node_names():
+            op_type = dag.get_node_op_type(node_name)
+            if op_type != "MatMulNBits":
+                continue
+
+            node_inputs = dag.get_node_inputs(node_name)
+            # only deal with the constant matmul case for now
+            if not all(dag.is_initializer(i_name) and not dag.is_input(i_name) for i_name in node_inputs[1:]):
+                continue
+
+            graph_idx = dag.get_graph_idx(node_name)
+
+            # original output proto
+            node_output = dag.get_node_outputs(node_name)[0]
+            is_model_output = dag.is_output(node_output)
+            node_output_proto = None
+            if dag.get_io(node_output).proto:
+                node_output_proto = dag.get_io(node_output).proto[-1]
+            node_attributes = dag.get_node_attributes(node_name)
+            K = node_attributes["K"]  # noqa: N806
+            N = node_attributes["N"]  # noqa: N806
+            block_size = node_attributes["block_size"]
+            num_k_blocks = math.ceil(K / block_size)
+
+            # only deal with 4 bits for now
+            if node_attributes["bits"] != 4:
+                continue
+
+            # we can only deal with trivial g_idx, dequantize linear does not support g_idx
+            if len(node_inputs) >= 5 and node_inputs[4]:
+                g_idx = dag.get_initializer_np_array(node_inputs[4])
+                trivial_g_idx = np.arange(K, dtype=np.int32) // block_size
+                if not np.array_equal(g_idx, trivial_g_idx):
+                    continue
+
+            # name for the DQ node
+            dq_name = self._get_new_node_name(dag, node_name, "DequantizeLinear")
+            # weight, scales, zeros
+            # (name, new_name, unpacked column size)
+            quant_inputs = [
+                (node_inputs[1], f"{dq_name}.qweight", K),
+                (node_inputs[2], f"{dq_name}.scales", num_k_blocks),
+            ]
+            if len(node_inputs) >= 4 and node_inputs[3]:
+                quant_inputs.append((node_inputs[3], f"{dq_name}.qzeros", num_k_blocks))
+            dq_inputs = []
+
+            for qi_name, new_qi_name, unpacked_col_size in quant_inputs:
+                dq_inputs.append(new_qi_name)
+
+                consumers = dag.get_consumers(qi_name)
+                if len(consumers) > 1 and not all(dag.get_node_op_type(c) == "MatMulNBits" for c in consumers):
+                    # if the initializer is used in multiple nodes, ensure that all of them are MatMulNBits
+                    # lets deal with this case later if it arises, could use a unique name if new_qi_name == qi_name
+                    continue
+
+                # get the np array
+                # weight: uint8, scales: float32, zeros: uint8
+                qi = dag.get_initializer_np_array(qi_name)
+                # reshape to 2D
+                qi = qi.reshape(N, -1)
+
+                # there are cases where unpack and repack is not needed: no transpose + no padding
+                # but will still do it for simplicity
+                if qi.dtype == np.uint8:
+                    qi = self._unpack_on_row(qi)
+                    # remove padding if any
+                    qi = qi[:, :unpacked_col_size]
+
+                if not config["use_transpose_op"]:
+                    # becomes K X N
+                    qi = qi.T
+
+                if qi.dtype == np.uint8:
+                    # pack in the format expected by onnx and create the tensor
+                    tensor = onnx.helper.make_tensor(
+                        new_qi_name, onnx.TensorProto.UINT4, qi.shape, self._pack_on_flat(qi).tobytes(), raw=True
+                    )
+                else:
+                    tensor = onnx.numpy_helper.from_array(qi, name=new_qi_name)
+
+                # add the initializer
+                dag.add_initializer(tensor, graph_idx)
+            # DQ default zp is 0 but MatMulNBits is 8, so we need to add a zero tensor with all 8s
+            if len(dq_inputs) == 2:
+                zp_name = f"{dq_name}.qzeros"
+                zp_tensor = onnx.helper.make_tensor(
+                    zp_name,
+                    onnx.TensorProto.UINT4,
+                    [N, num_k_blocks] if config["use_transpose_op"] else [num_k_blocks, N],
+                    self._pack_on_flat(np.zeros(N * num_k_blocks, dtype=np.uint8) + 8).tobytes(),
+                    raw=True,
+                )
+                dag.add_initializer(zp_tensor, graph_idx)
+                dq_inputs.append(zp_name)
+
+            # onnx dtype for the float tensors (scale, dequantized weight, matmul inputs+outputs)
+            float_elem_type = onnx.helper.np_dtype_to_tensor_dtype(dag.get_initializer_np_array(node_inputs[2]).dtype)
+
+            # new nodes and value infos to add to the graph
+            # ensure that the node names and output names are unique
+            # will add the new nodes, make consumers use the new output and remove the node
+            # if output is a model output, rename it back to the original name
+            new_nodes = []
+            new_value_infos = []
+
+            # DequantizeLinear
+            dq_name = self._get_new_node_name(dag, node_name, "DequantizeLinear")
+            dq_output = f"{dq_name}/output_0"
+            new_nodes.append(
+                onnx.helper.make_node(
+                    "DequantizeLinear",
+                    dq_inputs,
+                    [dq_output],
+                    name=dq_name,
+                    block_size=block_size,
+                    axis=1 if config["use_transpose_op"] else 0,
+                )
+            )
+            new_value_infos.append(
+                onnx.helper.make_tensor_value_info(
+                    dq_output, float_elem_type, shape=[N, K] if config["use_transpose_op"] else [K, N]
+                )
+            )
+
+            if config["use_transpose_op"]:
+                # Transpose
+                transpose_name = self._get_new_node_name(dag, node_name, "Transpose")
+                transpose_output = f"{transpose_name}/output_0"
+                new_nodes.append(
+                    onnx.helper.make_node(
+                        "Transpose", [dq_output], [transpose_output], name=transpose_name, perm=[1, 0]
+                    )
+                )
+                new_value_infos.append(
+                    onnx.helper.make_tensor_value_info(transpose_output, float_elem_type, shape=[K, N])
+                )
+                matmul_input = transpose_output
+            else:
+                matmul_input = dq_output
+
+            # MatMul
+            matmul_name = self._get_new_node_name(dag, node_name, "MatMul")
+            matmul_output = f"{matmul_name}/output_0"
+            new_nodes.append(
+                onnx.helper.make_node("MatMul", [node_inputs[0], matmul_input], [matmul_output], name=matmul_name)
+            )
+            if node_output_proto:
+                # the output shape is the same as the original MatMulNBits node
+                matmul_output_proto = onnx.ValueInfoProto()
+                matmul_output_proto.CopyFrom(node_output_proto)
+                matmul_output_proto.name = matmul_output
+                new_value_infos.append(matmul_output_proto)
+            final_name = matmul_name
+            final_output = matmul_output
+
+            if len(node_inputs) >= 5 and node_inputs[4]:
+                # Bias Add
+                # it has bias
+                bias_i_name = node_inputs[4]
+                new_bias_i_name = bias_i_name.replace("MatMulNBits", "MatMul")
+                bias_initiaizer = onnx.numpy_helper.from_array(
+                    dag.get_initializer_np_array(bias_i_name), name=new_bias_i_name
+                )
+                dag.add_initializer(bias_initiaizer, graph_idx)
+
+                bias_name = self._get_new_node_name(dag, node_name, "Add")
+                bias_output = f"{bias_name}/output_0"
+                new_nodes.append(
+                    onnx.helper.make_node("Add", [matmul_output, new_bias_i_name], [bias_output], name=bias_name)
+                )
+                if node_output_proto:
+                    # the output shape is the same as the original MatMulNBits node
+                    bias_output_proto = onnx.ValueInfoProto()
+                    bias_output_proto.CopyFrom(node_output_proto)
+                    bias_output_proto.name = bias_output
+                    new_value_infos.append(bias_output_proto)
+                final_name = bias_name
+                final_output = bias_output
+
+            for node in new_nodes:
+                dag.add_node(node, graph_idx)
+
+            # change the input of the consumers
+            for consumer in dag.get_consumers(node_name):
+                dag.replace_node_input(consumer, node_output, final_output)
+
+            # add the new value infos
+            for vi in new_value_infos:
+                dag.add_value_info(vi, graph_idx)
+
+            # remove the node
+            dag.remove_node(node_name)
+
+            # rename to original name if it is a model output
+            if is_model_output:
+                dag.rename_node_output(final_name, final_output, node_output)
+                dag.make_output(node_output)
+
+            num_modified += 1
+
+        dag.update()
+        logger.debug("Modified %d MatMulNBits nodes", num_modified)
+        # this might not work for all models but will just update the opset version to 21
+        # if there is an issue, try the logic in OnnxOpVersionConversion
+        dag.model.opset_import[0].version = max(21, dag.model.opset_import[0].version)
+
+        # save the model to the output path and return the model
+        return model_proto_to_olive_model(dag.model, output_model_path, config)
+
+    @staticmethod
+    def _get_new_node_name(dag: OnnxDAG, old_name: str, op_type: str):
+        """Get a new unique node name based on the old name and the new op type."""
+        new_name_base = None
+        for suffix in ["MatMulNBits", "MatMul_Q4"]:
+            if suffix in old_name:
+                new_name_base = old_name.replace(suffix, op_type)
+                break
+        if new_name_base is None:
+            new_name_base = f"{old_name}_{op_type}"
+
+        # will add an index if the name already exists
+        idx = 0
+        new_name = new_name_base
+        while dag.has_node(new_name):
+            new_name = f"{new_name_base}_{idx}"
+            idx += 1
+
+        return new_name
+
+    @staticmethod
+    def _unpack_on_row(tensor: "NDArray") -> "NDArray":
+        """Unpack uint8 into two uint4 (stored in uint8) column wise."""
+        # two uint4 packed into one uint8
+        # right 4 bits are the first uint4
+        shifts = np.array([0, 4])
+
+        # unpack the uint8
+        tensor = np.right_shift(tensor[:, :, None], shifts[None, None, :]).astype(np.uint8)
+        # mask out the first 4 bits
+        tensor &= 0xF
+        return tensor.reshape(tensor.shape[0], -1)
+
+    @staticmethod
+    def _pack_on_flat(tensor: "NDArray") -> "NDArray":
+        """Pack two uint4 into one uint8 on a flattened tensor."""
+        tensor = tensor.flatten()
+
+        if len(tensor) % 2:
+            tensor = np.pad(tensor, (0, 1), mode="constant")
+
+        # right 4 bits are the first uint4
+        return (tensor[0::2] & 0xF) | ((tensor[1::2] & 0xF) << 4)

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -240,7 +240,7 @@ def test_cloud_cache_command(_, mock_container_client, test_set):
     mock_container_client().delete_blob.assert_called_once()
 
 
-@pytest.mark.parametrize("algorithm_names", [{"awq"}, {"awq", "gptq"}, {"bnb4"}, {"bnb4", "matmul4"}])
+@pytest.mark.parametrize("algorithm_names", [{"awq"}, {"awq", "gptq"}, {"bnb4"}, {"bnb4", "int4_rtn"}])
 @patch("olive.workflows.run")
 @patch("olive.cli.finetune.tempfile.TemporaryDirectory")
 @patch("huggingface_hub.repo_exists")

--- a/test/unit_test/passes/onnx/test_mnb_to_qdq.py
+++ b/test/unit_test/passes/onnx/test_mnb_to_qdq.py
@@ -1,0 +1,86 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import numpy as np
+import onnx
+import onnxruntime
+import pytest
+import torch
+from packaging import version
+
+from olive.model import ONNXModelHandler
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.mnb_to_qdq import MatMulNBitsToQDQ
+
+
+@pytest.fixture(params=[True, False], ids=["symmetric", "asymmetric"], name="create_mnb_model")
+def create_mnb_model_fixture(request, tmp_path):
+    from onnxruntime.quantization.matmul_4bits_quantizer import MatMul4BitsQuantizer
+
+    block_size = 32
+    # odd, %32 != 0
+    in_dim = 33
+    # even, %32 == 0
+    hidden_dim = 64
+    out_dim = 32
+
+    class TestModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.f1 = torch.nn.Linear(in_dim, hidden_dim, bias=True)
+            self.f2 = torch.nn.Linear(hidden_dim, out_dim, bias=False)
+
+        def forward(self, x):
+            return self.f2(self.f1(x))
+
+    model = TestModel()
+
+    # base model
+    base_path = tmp_path / "base.onnx"
+    torch.onnx.export(
+        model,
+        torch.randn(1, 1, in_dim),
+        base_path,
+        input_names=["input"],
+        output_names=["output"],
+        dynamic_axes={"input": {0: "batch", 1: "seq"}, "output": {0: "batch", 1: "seq"}},
+    )
+
+    # quantized model
+    mnb_path = tmp_path / "mnb.onnx"
+    quant = MatMul4BitsQuantizer(onnx.load(base_path), block_size=block_size, is_symmetric=request.param)
+    quant.process()
+    onnx.save(quant.model.model, mnb_path)
+
+    return mnb_path, in_dim
+
+
+@pytest.mark.skipif(
+    version.parse(onnxruntime.__version__) < version.parse("1.20"),
+    reason="Int4 DQ is only supported in ORT >= 1.20",
+)
+@pytest.mark.parametrize("use_transpose_op", [True, False])
+def test_mnb_to_qdq(create_mnb_model, use_transpose_op, tmp_path):
+    mnb_path, in_dim = create_mnb_model
+    input_model = ONNXModelHandler(mnb_path)
+
+    # setup
+    p = create_pass_from_dict(MatMulNBitsToQDQ, {"use_transpose_op": use_transpose_op}, disable_search=True)
+    output_folder = tmp_path / "qdq-model"
+
+    # execute
+    qdq_model: ONNXModelHandler = p.run(input_model, output_folder)
+
+    # validate
+    original_session = onnxruntime.InferenceSession(str(mnb_path))
+    qdq_session = onnxruntime.InferenceSession(str(qdq_model.model_path))
+
+    input_data = {"input": np.random.randn(1, 1, in_dim).astype(np.float32)}
+    original_output = original_session.run(None, input_data)[0]
+    qdq_output = qdq_session.run(None, input_data)[0]
+    assert original_output.shape == qdq_output.shape
+    assert original_output.dtype == qdq_output.dtype
+    if use_transpose_op:
+        # Pre transposed DQ model does not match the expected output on x64
+        np.testing.assert_allclose(original_output, qdq_output, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
- Onnxruntime originally only support sub-4bit quantization using the `MatMulNBits` contrib operator. But int4/uint4 are now officially supported by onnx using the standard QDQ operators and is used by EPs such as DirectML and QNN.
- This pass converts a MatMulNBits node into a sequence of `DequantizeLinear`->`Transpose`(optional)->`MatMul` nodes. This way, existing quantization tools don't need to be modified to export in QDQ format.
- Updated the `quantize` CLI to use QDQ encoding by default. There is an option to use `MatMulNBits` if they pefer.

## Describe your changes

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
   New `MatMulNBitsToQDQ` pass to convert `MatMulNBits` to `DQ->MatMul`.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
