### PR TITLE
LoRA: phi3 target_modules mapping, GPTQ/AWQ: keep original adapters

### DIFF
--- a/olive/common/hf/mappings.py
+++ b/olive/common/hf/mappings.py
@@ -86,3 +86,5 @@ MODEL_INSIDE_LAYER_MODULES = {
 }
 
 MODEL_LAYERS_BLOCK_NAME = {"phi3": "model.layers"}
+
+MODELS_TO_LORA_TARGET_MODULES_MAPPING = {"phi3": ["o_proj", "qkv_proj"]}

--- a/olive/model/config/model_config.py
+++ b/olive/model/config/model_config.py
@@ -87,7 +87,7 @@ class ModelConfig(NestedConfig):
         keys = ["model_path", "adapter_path", "model_script", "script_dir"]
         local_resource_paths = [Path(config[key]) for key in keys if config.get(key)]
 
-        additional_files = config.get("model_attributes", {}).get("additional_files", [])
+        additional_files = (config.get("model_attributes") or {}).get("additional_files") or []
         local_resource_paths.extend(Path(f) for f in additional_files)
         file_hashes = []
         for local_resource_path in local_resource_paths:

--- a/olive/passes/pytorch/autoawq.py
+++ b/olive/passes/pytorch/autoawq.py
@@ -4,12 +4,11 @@
 # --------------------------------------------------------------------------
 import logging
 from copy import deepcopy
-from pathlib import Path
 from typing import Any, Dict, Union
 
 import torch
 
-from olive.common.utils import StrEnumBase, copy_dir
+from olive.common.utils import StrEnumBase
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler, PyTorchModelHandler
@@ -128,18 +127,13 @@ class AutoAWQQuantizer(Pass):
             )
 
         adapter_path = None
-        # copy over adapter path if it exists
         if model.adapter_path:
             logger.info(
-                "Model has adapters but AWQ does not support adapters. Quantizing without adapters. Adapters"
-                " will be copied as is."
+                "Model has adapters but AWQ does not support adapters. Quantizing without adapters. The original"
+                " adapters will be used as is with the quantized base model."
             )
-            adapter_path = Path(output_model_path) / "adapter"
-            adapter_path.mkdir(parents=True, exist_ok=True)
-            copy_dir(model.adapter_path, adapter_path, dirs_exist_ok=True)
-
-            output_model_path = str(Path(output_model_path) / "model")
-            # TODO(jambayk): should we update the base_model_name_or_path in the adapter_config json?
+            # TODO(jambayk): should we copy the adapter? what about non-local adapters?
+            adapter_path = model.adapter_path
 
         # autoawq load the model with fp16 by default and they did not expose the interface to change it
         awq_model = AutoAWQForCausalLM.from_pretrained(

--- a/olive/passes/pytorch/autoawq.py
+++ b/olive/passes/pytorch/autoawq.py
@@ -136,7 +136,7 @@ class AutoAWQQuantizer(Pass):
             )
             adapter_path = Path(output_model_path) / "adapter"
             adapter_path.mkdir(parents=True, exist_ok=True)
-            copy_dir(model.adapter_path, adapter_path)
+            copy_dir(model.adapter_path, adapter_path, dirs_exist_ok=True)
 
             output_model_path = str(Path(output_model_path) / "model")
             # TODO(jambayk): should we update the base_model_name_or_path in the adapter_config json?

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -136,7 +136,7 @@ class GptqQuantizer(Pass):
             )
             adapter_path = Path(output_model_path) / "adapter"
             adapter_path.mkdir(parents=True, exist_ok=True)
-            copy_dir(model.adapter_path, adapter_path)
+            copy_dir(model.adapter_path, adapter_path, dirs_exist_ok=True)
 
             output_model_path = str(Path(output_model_path) / "model")
             # TODO(jambayk): should we update the base_model_name_or_path in the adapter_config json?

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -13,7 +13,6 @@ import torch
 
 from olive.common.config_utils import validate_config
 from olive.common.hf.mappings import MODEL_INSIDE_LAYER_MODULES, MODEL_LAYERS_BLOCK_NAME, MODEL_OUTSIDE_LAYER_MODULES
-from olive.common.utils import copy_dir
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler, PyTorchModelHandler
@@ -131,15 +130,11 @@ class GptqQuantizer(Pass):
         adapter_path = None
         if isinstance(model, HfModelHandler) and model.adapter_path:
             logger.info(
-                "Model has adapters but GPTQ does not support adapters. Quantizing without adapters. Adapters"
-                " will be copied as is."
+                "Model has adapters but GPTQ does not support adapters. Quantizing without adapters. The original"
+                " adapters will be used as is with the quantized base model."
             )
-            adapter_path = Path(output_model_path) / "adapter"
-            adapter_path.mkdir(parents=True, exist_ok=True)
-            copy_dir(model.adapter_path, adapter_path, dirs_exist_ok=True)
-
-            output_model_path = str(Path(output_model_path) / "model")
-            # TODO(jambayk): should we update the base_model_name_or_path in the adapter_config json?
+            # TODO(jambayk): should we copy the adapter? what about non-local adapters?
+            adapter_path = model.adapter_path
 
             # create a new input model with the adapter path removed
             model.model = None


### PR DESCRIPTION
## Describe your changes
**LoRA**
- `phi3` is not in the `peft` model type mapping https://github.com/huggingface/peft/blob/431c0e2d5ca56fa512dc4c96876c4145bb538f62/src/peft/utils/constants.py#L85 so user needs to provide the `target_modules` manually. 
- Added mapping for the additional model types.

**GPTQ/AWQ**
- Use the original adapter path if present instead of copying the adapter to the new output directory
- This way it is general and can support non-local adapters as well. In the cache, it doesn't matter if the one of the resources points to an existing resource as long as we don't modify the resource contents.

adapter copy fix for gptq and awq passes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
