### PR TITLE
CLI: `generate-adapter` only accepts ONNX model

### DIFF
--- a/examples/llama2/llama2_multilora.ipynb
+++ b/examples/llama2/llama2_multilora.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Fine-tune Llama2 using QLoRA and Deploy Model with Multiple Adapters\n",
     "\n",
-    "In this tutorial, we will fine-tune a llama2 model using QLoRA, optimize it using ONNX Runtime tools, and extract the fine-tuned adapters from the model. \n",
+    "In this tutorial, we will fine-tune a llama2 model using QLoRA, convert it to ONNX, and extract the fine-tuned adapters from the model. \n",
     "The resulting model can be deployed with multiple adapters for different tasks."
    ]
   },
@@ -73,7 +73,8 @@
     "\n",
     "Olive provides a command line tools to run a lora/qlora fine-tuning workflow. This workflow includes the following steps:\n",
     "- `finetune`: Fine-tune a model using LoRA or QLoRA.\n",
-    "- `generate-adapter`: Export the fine-tuned model to ONNX, optimize it and extract the adapters as model inputs."
+    "- `capture-onnx-graph`: Convert the fine-tuned model to ONNX\n",
+    "- `generate-adapter`: Extract the adapters from the ONNX model as model inputs."
    ]
   },
   {
@@ -82,8 +83,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# run this cell to see the available options to finetune and generate-adapter commands\n",
+    "# run this cell to see the available options to finetune, capture-onnx-graph and generate-adapter commands\n",
     "!olive finetune --help\n",
+    "!olive capture-onnx-graph --help\n",
     "!olive generate-adapter --help"
    ]
   },
@@ -112,7 +114,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's generate the optimized onnx model with adapters as inputs. We can use the output of the previous step as input to this step."
+    "Export the model to onnx. We can use the output of the previous step as input to this step."
    ]
   },
   {
@@ -121,7 +123,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!olive generate-adapter -m models/tiny-codes/fine-tune --use_ort_genai -o models/tiny-codes/optimized"
+    "!olive capture-onnx-graph -m models/tiny-codes/fine-tune --torch_dtype float16 --use_ort_genai -o models/tiny-codes/onnx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, extract the adapters from the ONNX model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!olive generate-adapter -m models/tiny-codes/onnx -o models/tiny-codes/extracted"
    ]
   },
   {
@@ -129,8 +147,8 @@
    "metadata": {},
    "source": [
     "The output model files are can be found at:\n",
-    "- Model: `models/tiny-codes/optimized/model/model.onnx`\n",
-    "- Adapter weights: `models/tiny-codes/optimized/model/adapter_weights.onnx_adapter`"
+    "- Model: `models/tiny-codes/extracted/model/model.onnx`\n",
+    "- Adapter weights: `models/tiny-codes/extracted/model/adapter_weights.onnx_adapter`"
    ]
   },
   {
@@ -179,14 +197,14 @@
    "outputs": [],
    "source": [
     "base_model_name = \"meta-llama/llama-2-7b-hf\"\n",
-    "model_path = \"models/tiny-codes/optimized/model/model.onnx\"\n",
+    "model_path = \"models/tiny-codes/extracted/model/model.onnx\"\n",
     "adapters = {\n",
     "    \"guanaco\": {\n",
     "        \"weights\": \"models/exported/guanaco_qlora.onnx_adapter\",\n",
     "        \"template\": \"### Human: {prompt} ### Assistant:\"\n",
     "    },\n",
     "    \"tiny-codes\": {\n",
-    "        \"weights\": \"models/tiny-codes/optimized/model/adapter_weights.onnx_adapter\",\n",
+    "        \"weights\": \"models/tiny-codes/extracted/model/adapter_weights.onnx_adapter\",\n",
     "        \"template\": \"### Language: {prompt_0} \\n### Question: {prompt_1} \\n### Answer: \"\n",
     "    }\n",
     "}"

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -175,7 +175,7 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
             ("input_model", get_input_model_config(self.args)),
             ("output_dir", tempdir),
             ("log_severity_level", self.args.log_level),
-            ("systems", "local_system", "accelerators", 0, "device", "gpu" if is_fp16 else "cpu"),
+            (("systems", "local_system", "accelerators", 0, "device"), "gpu" if is_fp16 else "cpu"),
             (
                 ("systems", "local_system", "accelerators", 0, "execution_providers"),
                 [("CUDAExecutionProvider" if is_fp16 else "CPUExecutionProvider")],

--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -152,8 +152,7 @@ TEMPLATE = {
     "systems": {
         "local_system": {
             "type": "LocalSystem",
-            # will just use cuda ep now, only genai metadata is not agnostic to ep
-            # revisit once model builder supports lora adapters
+            # just a place holder, ep and device are not relevant for pytorch only workflow
             "accelerators": [{"device": "gpu", "execution_providers": ["CUDAExecutionProvider"]}],
         }
     },

--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -77,9 +77,6 @@ class FineTuneCommand(BaseOliveCLICommand):
             "--target_modules", type=str, help="The target modules for LoRA. If multiple, separate by comma."
         )
 
-        # TODO(jambayk): what about checkpoint_dir and resume from checkpoint support? clean checkpoint dir?
-        sub_parser.add_argument("--clean", action="store_true", help="Run in a clean cache directory")
-
         add_remote_options(sub_parser)
         add_logging_options(sub_parser)
         add_shared_cache_options(sub_parser)
@@ -122,7 +119,6 @@ class FineTuneCommand(BaseOliveCLICommand):
             ((*finetune_key, "training_args"), self.parse_training_args()),
             ((*finetune_key, "lora_r"), self.args.lora_r),
             ((*finetune_key, "lora_alpha"), self.args.lora_alpha),
-            (("clean_cache",), self.args.clean),
             ("output_dir", tempdir),
             ("log_severity_level", self.args.log_level),
         ]

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -27,7 +27,9 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
 
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
-        sub_parser = parser.add_parser("generate-adapter", help="Generate ONNX model with adapters as inputs")
+        sub_parser = parser.add_parser(
+            "generate-adapter", help="Generate ONNX model with adapters as inputs. Only accepts ONNX models."
+        )
 
         # Model options
         add_input_model_options(sub_parser, enable_onnx=True, default_output_path="optimized-model")

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -30,17 +30,8 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
         sub_parser = parser.add_parser("generate-adapter", help="Generate ONNX model with adapters as inputs")
 
         # Model options
-        add_input_model_options(
-            sub_parser, enable_hf=True, enable_hf_adapter=True, enable_onnx=True, default_output_path="optimized-model"
-        )
+        add_input_model_options(sub_parser, enable_onnx=True, default_output_path="optimized-model")
 
-        sub_parser.add_argument(
-            "--precision",
-            type=str,
-            default="float16",
-            choices=["float16", "float32"],
-            help="The precision of the optimized model and adapters.",
-        )
         sub_parser.add_argument(
             "--adapter_format",
             type=str,
@@ -48,12 +39,6 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
             choices=[el.value for el in WeightsFileFormat],
             help=f"Format to save the weights in. Default is {WeightsFileFormat.ONNX_ADAPTER}.",
         )
-
-        sub_parser.add_argument(
-            "--use_ort_genai", action="store_true", help="Use OnnxRuntie generate() API to run the model"
-        )
-
-        sub_parser.add_argument("--clean", action="store_true", help="Run in a clean cache directory")
 
         add_remote_options(sub_parser)
         add_logging_options(sub_parser)
@@ -74,16 +59,9 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
             save_output_model(run_config, self.args.output_path)
 
     def get_run_config(self, tempdir: str) -> Dict:
-        from olive.model import ModelConfig
-
         to_replace = [
             ("input_model", get_input_model_config(self.args)),
-            (("input_model", "adapter_path"), self.args.adapter_path),
-            (("passes", "o", "float16"), self.args.precision == "float16"),
             (("passes", "e", "save_format"), self.args.adapter_format),
-            # make the mapping of precisions better
-            (("passes", "m", "precision"), "fp16" if self.args.precision == "float16" else "fp32"),
-            (("clean_cache",), self.args.clean),
             ("output_dir", tempdir),
             ("log_severity_level", self.args.log_level),
         ]
@@ -94,49 +72,20 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
                 continue
             set_nested_dict_value(config, keys, value)
 
-        if not self.args.use_ort_genai:
-            del config["passes"]["m"]
-
         update_remote_options(config, self.args, "generate-adapter", tempdir)
         update_shared_cache_options(config, self.args)
-
-        input_model_config = ModelConfig.parse_obj(config["input_model"])
-        if input_model_config.type == "hfmodel" and input_model_config.config.get("adapter_path") is None:
-            raise ValueError("adapter_path is required for generate-adapter command")
-        if input_model_config.type == "onnxmodel":
-            del config["passes"]["c"], config["passes"]["o"]
-
         return config
 
 
 TEMPLATE = {
-    "input_model": {"type": "HfModel", "load_kwargs": {"attn_implementation": "eager"}},
+    "input_model": None,
     "systems": {
         "local_system": {
             "type": "LocalSystem",
-            # will just use cuda ep now, only genai metadata is not agnostic to ep
-            # revisit once model builder supports lora adapters
-            "accelerators": [{"device": "gpu", "execution_providers": ["CUDAExecutionProvider"]}],
+            "accelerators": [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}],
         }
     },
-    "passes": {
-        # TODO(jambayk): migrate to model builder once it supports lora adapters
-        # the models produced here are not fully optimized
-        "c": {
-            "type": "OnnxConversion",
-            "target_opset": 17,
-            "torch_dtype": "float32",
-            "save_metadata_for_token_generation": True,
-        },
-        "o": {
-            "type": "OrtTransformersOptimization",
-            "model_type": "gpt2",
-            "opt_level": 0,
-            "keep_io_types": False,
-        },
-        "e": {"type": "ExtractAdapters"},
-        "m": {"type": "ModelBuilder", "metadata_only": True},
-    },
+    "passes": {"e": {"type": "ExtractAdapters"}},
     "host": "local_system",
     "target": "local_system",
 }


### PR DESCRIPTION
## Describe your changes
- `generate-adapter` command only accepts ONNX model as input. The finetuned pytorch model must be converted to ONNX beforehand.
- Currently, only `capture-onnx-graph` path has been validated. Some checks and validations for `auto-opt` path are in progress.
- Update `capture-onnx-graph` to correctly handle genai metadata only mode and fp16 models.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
