### PR TITLE
Skip quantization that require calibration if model has adapters

### DIFF
--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -22,7 +22,7 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
-from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
+from olive.passes.onnx.common import get_external_data_config, model_has_adapters, model_proto_to_olive_model
 from olive.passes.pass_config import PassConfigParam
 from olive.strategy.search_parameter import Boolean, Categorical, Conditional
 
@@ -450,6 +450,10 @@ class IncQuantization(Pass):
     def _run_for_config(
         self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModelHandler:
+        if model_has_adapters(model.model_path):
+            logger.info("Model has adapters which should not be quantized. Returning the model without quantization.")
+            return model
+
         if "LOGLEVEL" not in os.environ:
             # set the log level for neural-compressor
             os.environ["LOGLEVEL"] = logging.getLevelName(logger.getEffectiveLevel())

--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -255,6 +255,10 @@ class MatMulNBitsToQDQ(Pass):
 
             num_modified += 1
 
+        if num_modified == 0:
+            logger.info("No MatMulNBits nodes found. Returning the original model.")
+            return model
+
         dag.update()
         logger.debug("Modified %d MatMulNBits nodes", num_modified)
         # this might not work for all models but will just update the opset version to 21

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -21,7 +21,12 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
-from olive.passes.onnx.common import get_external_data_config, model_proto_to_file, model_proto_to_olive_model
+from olive.passes.onnx.common import (
+    get_external_data_config,
+    model_has_adapters,
+    model_proto_to_file,
+    model_proto_to_olive_model,
+)
 from olive.passes.pass_config import PassConfigParam
 from olive.resource_path import LocalFile
 from olive.strategy.search_parameter import Boolean, Categorical, Conditional, ConditionalDefault
@@ -346,6 +351,10 @@ class OnnxQuantization(Pass):
     def _run_for_config(
         self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModelHandler:
+        if model_has_adapters(model.model_path):
+            logger.info("Model has adapters which should not be quantized. Returning the model without quantization.")
+            return model
+
         from onnxruntime import __version__ as OrtVersion
         from onnxruntime.quantization import QuantFormat, QuantType, quantize_dynamic, quantize_static
         from onnxruntime.quantization.calibrate import CalibrationMethod
@@ -706,6 +715,14 @@ class OnnxMatMul4Quantizer(Pass):
     def _run_for_config(
         self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModelHandler:
+        if model_has_adapters(model.model_path) and config["algorithm"] not in {None, "DEFAULT"}:
+            logger.info(
+                "Model has adapters which should only be quantized with algorithm=None or DEFAULT. Got %s. Returning"
+                " the model without quantization.",
+                config["algorithm"],
+            )
+            return model
+
         from onnxruntime import __version__ as OrtVersion
 
         if version.parse(OrtVersion) < version.parse("1.16.2"):

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -17,7 +17,12 @@ from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
-from olive.passes.onnx.common import get_external_data_config, model_proto_to_file, model_proto_to_olive_model
+from olive.passes.onnx.common import (
+    get_external_data_config,
+    model_has_adapters,
+    model_proto_to_file,
+    model_proto_to_olive_model,
+)
 from olive.passes.pass_config import PassConfigParam
 from olive.resource_path import LocalFile
 from olive.strategy.search_parameter import Boolean, Categorical, Conditional
@@ -235,6 +240,10 @@ class VitisAIQuantization(Pass):
     def _run_for_config(
         self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
     ) -> ONNXModelHandler:
+        if model_has_adapters(model.model_path):
+            logger.info("Model has adapters which should not be quantized. Returning the model without quantization.")
+            return model
+
         from onnxruntime.quantization.quant_utils import QuantFormat, QuantType
 
         from olive.passes.onnx.vitis_ai import quantize_static

--- a/test/unit_test/passes/onnx/test_common.py
+++ b/test/unit_test/passes/onnx/test_common.py
@@ -25,7 +25,7 @@ from olive.passes.onnx.common import model_proto_to_olive_model
         },
     ],
 )
-def test_onnx_conversion_pass(external_data_config, tmp_path):
+def test_model_proto_to_olive_model(external_data_config, tmp_path):
     model_proto = onnx.load(ONNX_MODEL_PATH)
     olive_model = model_proto_to_olive_model(model_proto, tmp_path / "test.onnx", external_data_config)
     assert olive_model, "Failed to save ONNX proto to Olive model"

--- a/test/unit_test/passes/onnx/test_extract_adapters.py
+++ b/test/unit_test/passes/onnx/test_extract_adapters.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
+from test.unit_test.utils import get_onnx_model
 
 import numpy as np
 import onnx
@@ -17,6 +18,7 @@ from transformers import AutoModelForCausalLM
 from olive.common.utils import WeightsFileFormat, find_submodules, load_weights
 from olive.model import HfModelHandler, ONNXModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.common import model_has_adapters
 from olive.passes.onnx.conversion import OnnxConversion
 from olive.passes.onnx.extract_adapters import ExtractAdapters
 from olive.passes.onnx.quantization import OnnxMatMul4Quantizer
@@ -111,6 +113,14 @@ def input_model_info_fixture(tmp_path_factory):
         },
         "adapter_path": adapters_path,
     }
+
+
+@pytest.mark.parametrize("model_type", [None, "float", "int4"])
+def test_model_has_adapters(tmp_path, input_model_info, model_type):
+    if model_type is None:
+        assert not model_has_adapters(get_onnx_model().model_path)
+    else:
+        assert model_has_adapters(input_model_info[model_type]["onnx_model"].model_path)
 
 
 @pytest.mark.parametrize("model_type", ["float", "qdq", "int4"])


### PR DESCRIPTION
## Describe your changes
If a model has unmerged adapters, we expect it to be used for MultiLoRA where the lora adapters can be switched. Quantization techniques that require calibration change the base weights as well as adapter weights together so we cannot just switch these quantized adapters. 

More work/research is needed to make a fully quantized model work with multi lora so we will skip any quantization that might break adapter switching.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
