### PR TITLE
CLI: Don't allow unknown args, `-a` alias for `--adapter_path`

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -5,7 +5,7 @@
 import tempfile
 from argparse import ArgumentParser
 from copy import deepcopy
-from typing import ClassVar, Dict, List
+from typing import Dict, List
 
 from olive.cli.base import (
     BaseOliveCLICommand,
@@ -67,7 +67,6 @@ TEMPLATE = {
 
 
 class AutoOptCommand(BaseOliveCLICommand):
-    allow_unknown_args: ClassVar[bool] = True
 
     @staticmethod
     def register_subcommand(parser: ArgumentParser):

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -312,6 +312,7 @@ def add_input_model_options(
     if enable_hf_adapter:
         assert enable_hf, "enable_hf must be True when enable_hf_adapter is True."
         model_group.add_argument(
+            "-a",
             "--adapter_path",
             type=str,
             help="Path to the adapters weights saved after peft fine-tuning. Local folder or huggingface id.",

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -5,7 +5,7 @@
 import tempfile
 from argparse import ArgumentParser
 from copy import deepcopy
-from typing import ClassVar, Dict
+from typing import Dict
 
 from olive.cli.base import (
     BaseOliveCLICommand,
@@ -30,8 +30,6 @@ class ModelBuilderAccuracyLevel(IntEnumBase):
 
 
 class CaptureOnnxGraphCommand(BaseOliveCLICommand):
-    allow_unknown_args: ClassVar[bool] = True
-
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         sub_parser = parser.add_parser(

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -5,7 +5,7 @@
 import tempfile
 from argparse import ArgumentParser
 from copy import deepcopy
-from typing import ClassVar, Dict
+from typing import Dict
 
 from olive.cli.base import (
     BaseOliveCLICommand,
@@ -23,8 +23,6 @@ from olive.common.utils import WeightsFileFormat, set_nested_dict_value
 
 
 class GenerateAdapterCommand(BaseOliveCLICommand):
-    allow_unknown_args: ClassVar[bool] = True
-
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         sub_parser = parser.add_parser(

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -66,6 +66,20 @@ def test_legacy_call(deprecated_module):
     )
 
 
+def test_unknown_args():
+    # setup
+    command_args = ["olive", "run", "--config", "config.json", "--unknown-arg", "-u"]
+
+    # execute and assert
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        subprocess.run(command_args, check=True, capture_output=True)
+
+    error_message = exc_info.value.stderr.decode("utf-8")
+    assert "Unknown arguments:" in error_message
+    assert "--unknown-arg" in error_message
+    assert "-u" in error_message
+
+
 @pytest.mark.parametrize("packages", [True, False])
 @pytest.mark.parametrize("setup", [True, False])
 @pytest.mark.parametrize("tempdir", [None, "tempdir"])


### PR DESCRIPTION
## Describe your changes
- Unknown args are only allowed in finetune command to handle additional training args. These should not be allowed in other commands so that they fail with unknown args instead of ignoring them.
- Add `-a` alias for `--adapter_path`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
