### PR TITLE
CI: Move default python 3.9

### DIFF
--- a/.azure_pipelines/job_templates/olive-build-doc-template.yaml
+++ b/.azure_pipelines/job_templates/olive-build-doc-template.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - template: olive-setup-template.yaml
       parameters:
-        python_version: '3.8'
+        python_version: '3.9'
         onnxruntime: 'onnxruntime'
         torch: 'torch'
 

--- a/.azure_pipelines/job_templates/olive-example-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-template.yaml
@@ -3,7 +3,7 @@
 parameters:
   name: ''
   pool: ''
-  python_version: '3.8'
+  python_version: '3.9'
   onnxruntime: 'onnxruntime'
   subfolder: 'local'
   torch: 'torch'

--- a/.azure_pipelines/job_templates/olive-setup-template.yaml
+++ b/.azure_pipelines/job_templates/olive-setup-template.yaml
@@ -1,5 +1,5 @@
 parameters:
-  python_version: '3.8'
+  python_version: '3.9'
   onnxruntime: 'onnxruntime'
   torch: torch
 

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -4,7 +4,7 @@ parameters:
   test_type: ''
   windows: False
   device: 'cpu'
-  python_version: '3.8'
+  python_version: '3.9'
   onnxruntime: 'onnxruntime'
   torch: 'torch'
   requirements_file: 'requirements-test.txt'

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -155,7 +155,7 @@ jobs:
     windows: 'False'
     test_type: 'multiple_ep'
     onnxruntime: onnxruntime
-    python_version: '3.8'
+    python_version: '3.9'
 
 # Not run since all test cases are skipped for Windows
 # # Multiple EP Windows testing

--- a/.azure_pipelines/package_publish.yaml
+++ b/.azure_pipelines/package_publish.yaml
@@ -6,7 +6,7 @@ pool:
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.8'
+    versionSpec: '3.9'
 
 - script: python -m pip install --upgrade pip setuptools wheel twine
   displayName: 'Install tools'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           # Version range or exact version of Python to use, using SemVer's version range syntax. Reads from .python-version if unset.
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install -r requirements-dev.txt

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,10 +28,10 @@ git checkout tags/v0.2.0
 To create a new conda environment and activate it, run the following command:
 
 ```bash
-conda create -n olive-env python=3.8
+conda create -n olive-env python=3.9
 conda activate olive-env
 ```
-You can replace `olive-env` with any name you want and `python=3.8` with the version of python you want to use.
+You can replace `olive-env` with any name you want and `python=3.9` with the version of python you want to use.
 
 Please refer to the [conda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) for more information on how to create and manage conda environments.
 

--- a/examples/bert/conda.yaml
+++ b/examples/bert/conda.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - datasets
       - evaluate

--- a/examples/bert/conda_gpu.yaml
+++ b/examples/bert/conda_gpu.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - datasets
       - evaluate

--- a/examples/llama2/conda_gpu.yaml
+++ b/examples/llama2/conda_gpu.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - accelerate
       - bitsandbytes

--- a/examples/llama2/notebook/llama2/conda.yaml
+++ b/examples/llama2/notebook/llama2/conda.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - accelerate
       - azure-keyvault-secrets

--- a/examples/open_llama/conda.yaml
+++ b/examples/open_llama/conda.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - datasets
       - optimum

--- a/examples/resnet/conda.yaml
+++ b/examples/resnet/conda.yaml
@@ -2,7 +2,7 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
+  - python=3.9.19
   - pip=20.2
   - pip:
       - onnxruntime

--- a/olive/cli/constants.py
+++ b/olive/cli/constants.py
@@ -7,7 +7,7 @@ CONDA_CONFIG = {
     "channels": ["defaults"],
     "dependencies": [
         "python=3.8.13",
-        "pip=22.3.1",
+        "pip=24.0",
         {
             "pip": [
                 "accelerate",

--- a/test/integ_test/aml_model_test/conda.yaml
+++ b/test/integ_test/aml_model_test/conda.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - azure-ai-ml
       - azure-identity

--- a/test/integ_test/evaluator/azureml_eval/conda.yaml
+++ b/test/integ_test/evaluator/azureml_eval/conda.yaml
@@ -2,8 +2,8 @@ name: project_environment
 channels:
   - defaults
 dependencies:
-  - python=3.8.13
-  - pip=22.3.1
+  - python=3.9.19
+  - pip=24.0
   - pip:
       - azureml-dataprep!=4.12.0
       - onnxruntime


### PR DESCRIPTION
## Describe your changes
- Python 3.8 has reached end of life and many dependencies are dropping support for it.
- transformers officially dropped support on main today but their latest version 4.46 already has incompatibilities causing our tests to break.
- Change the python version used in our tests to 3.9. 
- Olive core still supports but we should consider updating our minimum python version too.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
