### PR TITLE
CI: Pin transformers<4.46.0

### DIFF
--- a/examples/bert/requirements.txt
+++ b/examples/bert/requirements.txt
@@ -8,4 +8,6 @@ optimum
 scikit-learn
 scipy
 tabulate
-transformers
+# 4.46.0 is broken https://github.com/huggingface/transformers/issues/34370
+# TODO(anyone): remove when the issue is fixed or CI migrates to python 3.9
+transformers<4.46.0

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -32,3 +32,6 @@ pytorch_lightning
 sentencepiece
 tabulate
 torchvision
+# 4.46.0 is broken https://github.com/huggingface/transformers/issues/34370
+# TODO(anyone): remove when the issue is fixed or CI migrates to python 3.9
+transformers<4.46.0


### PR DESCRIPTION
## Describe your changes
- 4.46.0 is not compatible with python 3.8 even though it officially supports the python version. 
- Pin the test requirements until the issue is fixed or we move our CI to python 3.9+

https://github.com/huggingface/transformers/issues/34370

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
