### PR TITLE
Update olive_config and auto-opt to use precision, providers and accelerators

### DIFF
--- a/olive/hardware/constants.py
+++ b/olive/hardware/constants.py
@@ -20,8 +20,8 @@ PROVIDER_PACKAGE_MAPPING = {
 }
 
 DEVICE_TO_EXECUTION_PROVIDERS = {
-    "cpu": ["OpenVINOExecutionProvider"],
-    "gpu": [
+    "cpu": {"CPUExecutionProvider", "OpenVINOExecutionProvider"},
+    "gpu": {
         "DmlExecutionProvider",
         "CUDAExecutionProvider",
         "ROCMExecutionProvider",
@@ -29,6 +29,6 @@ DEVICE_TO_EXECUTION_PROVIDERS = {
         "TensorrtExecutionProvider",
         "OpenVINOExecutionProvider",
         "JsExecutionProvider",
-    ],
-    "npu": ["QNNExecutionProvider"],
+    },
+    "npu": {"DmlExecutionProvider", "QNNExecutionProvider", "VitisAIExecutionProvider", "OpenVINOExecutionProvider"},
 }

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -1,108 +1,344 @@
 {
     "passes": {
         "AppendPrePostProcessingOps": {
-            "module_path": "olive.passes.onnx.append_pre_post_processing_ops.AppendPrePostProcessingOps"
+            "module_path": "olive.passes.onnx.append_pre_post_processing_ops.AppendPrePostProcessingOps",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
         },
-        "DynamicToFixedShape": { "module_path": "olive.passes.onnx.dynamic_to_fixed_shape.DynamicToFixedShape" },
-        "ExtractAdapters": { "module_path": "olive.passes.onnx.extract_adapters.ExtractAdapters" },
+        "DynamicToFixedShape": {
+            "module_path": "olive.passes.onnx.dynamic_to_fixed_shape.DynamicToFixedShape",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "ExtractAdapters": {
+            "module_path": "olive.passes.onnx.extract_adapters.ExtractAdapters",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
         "ModelBuilder": {
             "module_path": "olive.passes.onnx.model_builder.ModelBuilder",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "int4", "int8", "fp16", "fp32" ],
             "extra_dependencies": [ "ort-genai" ]
         },
         "IncDynamicQuantization": {
             "module_path": "olive.passes.onnx.inc_quantization.IncDynamicQuantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int4", "int8" ],
             "extra_dependencies": [ "inc" ]
         },
         "IncQuantization": {
             "module_path": "olive.passes.onnx.inc_quantization.IncQuantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int4", "int8" ],
             "extra_dependencies": [ "inc" ]
         },
         "IncStaticQuantization": {
             "module_path": "olive.passes.onnx.inc_quantization.IncStaticQuantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int4", "int8" ],
             "extra_dependencies": [ "inc" ]
         },
-        "InsertBeamSearch": { "module_path": "olive.passes.onnx.insert_beam_search.InsertBeamSearch" },
-        "MatMulNBitsToQDQ": { "module_path": "olive.passes.onnx.mnb_to_qdq.MatMulNBitsToQDQ" },
-        "MixedPrecisionOverrides": {
-            "module_path": "olive.passes.onnx.mixed_precision_overrides.MixedPrecisionOverrides"
+        "InsertBeamSearch": {
+            "module_path": "olive.passes.onnx.insert_beam_search.InsertBeamSearch",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
         },
-        "MoEExpertsDistributor": { "module_path": "olive.passes.onnx.moe_experts_distributor.MoEExpertsDistributor" },
-        "OnnxBnb4Quantization": { "module_path": "olive.passes.onnx.bnb_quantization.OnnxBnb4Quantization" },
-        "OnnxConversion": { "module_path": "olive.passes.onnx.conversion.OnnxConversion" },
-        "OnnxDynamicQuantization": { "module_path": "olive.passes.onnx.quantization.OnnxDynamicQuantization" },
-        "OnnxFloatToFloat16": { "module_path": "olive.passes.onnx.float16_conversion.OnnxFloatToFloat16" },
-        "OnnxIOFloat16ToFloat32": { "module_path": "olive.passes.onnx.float32_conversion.OnnxIOFloat16ToFloat32" },
-        "OnnxMatMul4Quantizer": { "module_path": "olive.passes.onnx.quantization.OnnxMatMul4Quantizer" },
-        "OnnxModelOptimizer": { "module_path": "olive.passes.onnx.model_optimizer.OnnxModelOptimizer" },
-        "OnnxOpVersionConversion": { "module_path": "olive.passes.onnx.conversion.OnnxOpVersionConversion" },
-        "OnnxQuantization": { "module_path": "olive.passes.onnx.quantization.OnnxQuantization" },
-        "OnnxStaticQuantization": { "module_path": "olive.passes.onnx.quantization.OnnxStaticQuantization" },
+        "MatMulNBitsToQDQ": {
+            "module_path": "olive.passes.onnx.mnb_to_qdq.MatMulNBitsToQDQ",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "MixedPrecisionOverrides": {
+            "module_path": "olive.passes.onnx.mixed_precision_overrides.MixedPrecisionOverrides",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "MoEExpertsDistributor": {
+            "module_path": "olive.passes.onnx.moe_experts_distributor.MoEExpertsDistributor",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "OnnxBnb4Quantization": {
+            "module_path": "olive.passes.onnx.bnb_quantization.OnnxBnb4Quantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "fp4", "nf4" ]
+        },
+        "OnnxConversion": {
+            "module_path": "olive.passes.onnx.conversion.OnnxConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "OnnxDynamicQuantization": {
+            "module_path": "olive.passes.onnx.quantization.OnnxDynamicQuantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int8", "uint8" ]
+        },
+        "OnnxFloatToFloat16": {
+            "module_path": "olive.passes.onnx.float16_conversion.OnnxFloatToFloat16",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "fp16" ]
+        },
+        "OnnxIOFloat16ToFloat32": {
+            "module_path": "olive.passes.onnx.float32_conversion.OnnxIOFloat16ToFloat32",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "fp32" ]
+        },
+        "OnnxMatMul4Quantizer": {
+            "module_path": "olive.passes.onnx.quantization.OnnxMatMul4Quantizer",
+            "supported_providers": [ "CPUExecutionProvider", "CUDAExecutionProvider" ],
+            "supported_accelerators": [ "cpu", "gpu" ],
+            "supported_precisions": [ "int4" ]
+        },
+        "OnnxModelOptimizer": {
+            "module_path": "olive.passes.onnx.model_optimizer.OnnxModelOptimizer",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "OnnxOpVersionConversion": {
+            "module_path": "olive.passes.onnx.conversion.OnnxOpVersionConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "OnnxQuantization": {
+            "module_path": "olive.passes.onnx.quantization.OnnxQuantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int8" ]
+        },
+        "OnnxStaticQuantization": {
+            "module_path": "olive.passes.onnx.quantization.OnnxStaticQuantization",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int8", "int16", "uint8", "uint16" ]
+        },
         "OptimumConversion": {
             "module_path": "olive.passes.onnx.optimum_conversion.OptimumConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
             "extra_dependencies": [ "optimum" ]
         },
         "OptimumMerging": {
             "module_path": "olive.passes.onnx.optimum_merging.OptimumMerging",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
             "extra_dependencies": [ "optimum" ]
         },
-        "OrtMixedPrecision": { "module_path": "olive.passes.onnx.mixed_precision.OrtMixedPrecision" },
+        "OrtMixedPrecision": {
+            "module_path": "olive.passes.onnx.mixed_precision.OrtMixedPrecision",
+            "supported_providers": [ "CUDAExecutionProvider", "DmlExecutionProvider" ],
+            "supported_accelerators": [ "gpu", "npu" ],
+            "supported_precisions": [ "fp16" ]
+        },
         "OrtSessionParamsTuning": {
             "module_path": "olive.passes.onnx.session_params_tuning.OrtSessionParamsTuning",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
             "module_dependencies": [ "psutil" ]
         },
         "OrtTransformersOptimization": {
-            "module_path": "olive.passes.onnx.transformer_optimization.OrtTransformersOptimization"
+            "module_path": "olive.passes.onnx.transformer_optimization.OrtTransformersOptimization",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
         },
-        "QNNPreprocess": { "module_path": "olive.passes.onnx.qnn.qnn_preprocess.QNNPreprocess" },
-        "VitisAIQuantization": { "module_path": "olive.passes.onnx.vitis_ai_quantization.VitisAIQuantization" },
-        "VitisQDQQuantizer": { "module_path": "olive.passes.onnx.vitis_ai.quantizer.VitisQDQQuantizer" },
-        "VitisQOpQuantizer": { "module_path": "olive.passes.onnx.vitis_ai.quantizer.VitisQOpQuantizer" },
-        "quantize_static": { "module_path": "olive.passes.onnx.vitis_ai.quantize.quantize_static" },
-        "PowerOfTwoMethod": { "module_path": "olive.passes.onnx.vitis_ai.quant_utils.PowerOfTwoMethod" },
-        "SplitModel": { "module_path": "olive.passes.onnx.split.SplitModel" },
+        "QNNPreprocess": {
+            "module_path": "olive.passes.onnx.qnn.qnn_preprocess.QNNPreprocess",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "VitisAIQuantization": {
+            "module_path": "olive.passes.onnx.vitis_ai_quantization.VitisAIQuantization",
+            "supported_providers": [ "VitisAIExecutionProvider" ],
+            "supported_accelerators": [ "npu" ],
+            "supported_precisions": [ "int8" ]
+        },
+        "VitisQDQQuantizer": {
+            "module_path": "olive.passes.onnx.vitis_ai.quantizer.VitisQDQQuantizer",
+            "supported_providers": [ "VitisAIExecutionProvider" ],
+            "supported_accelerators": [ "npu" ],
+            "supported_precisions": [ "int8" ]
+        },
+        "VitisQOpQuantizer": {
+            "module_path": "olive.passes.onnx.vitis_ai.quantizer.VitisQOpQuantizer",
+            "supported_providers": [ "VitisAIExecutionProvider" ],
+            "supported_accelerators": [ "npu" ],
+            "supported_precisions": [ "int8" ]
+        },
+        "PowerOfTwoMethod": {
+            "module_path": "olive.passes.onnx.vitis_ai.quant_utils.PowerOfTwoMethod",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "SplitModel": {
+            "module_path": "olive.passes.onnx.split.SplitModel",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
         "OpenVINOConversion": {
             "module_path": "olive.passes.openvino.conversion.OpenVINOConversion",
+            "supported_providers": [ "OpenVINOExecutionProvider" ],
+            "supported_accelerators": [ "cpu", "gpu", "npu" ],
+            "supported_precisions": [ "*" ],
             "extra_dependencies": [ "openvino" ]
         },
         "OpenVINOQuantization": {
             "module_path": "olive.passes.openvino.quantization.OpenVINOQuantization",
+            "supported_providers": [ "OpenVINOExecutionProvider" ],
+            "supported_accelerators": [ "cpu", "gpu", "npu" ],
+            "supported_precisions": [ "*" ],
             "extra_dependencies": [ "openvino" ]
         },
         "AutoAWQQuantizer": {
             "module_path": "olive.passes.pytorch.autoawq.AutoAWQQuantizer",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int4", "int8", "int16", "uint4", "uint8", "uint16" ],
             "module_dependencies": [ "autoawq" ]
         },
         "GptqQuantizer": {
             "module_path": "olive.passes.pytorch.gptq.GptqQuantizer",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int4", "int8", "int16", "uint4", "uint8", "uint16" ],
             "module_dependencies": [ "auto-gptq", "optimum" ]
         },
-        "CaptureSplitInfo": { "module_path": "olive.passes.pytorch.capture_split_info.CaptureSplitInfo" },
-        "MergeAdapterWeights": { "module_path": "olive.passes.pytorch.merge_adapter_weights.MergeAdapterWeights" },
-        "LoftQ": { "module_path": "olive.passes.pytorch.lora.LoftQ" },
-        "LoRA": { "module_path": "olive.passes.pytorch.lora.LoRA", "extra_dependencies": [ "lora" ] },
-        "PyTorchTensorParallel": { "module_path": "olive.passes.pytorch.tensor_parallel.PyTorchTensorParallel" },
-        "QLoRA": { "module_path": "olive.passes.pytorch.lora.QLoRA", "extra_dependencies": [ "bnb", "lora" ] },
+        "CaptureSplitInfo": {
+            "module_path": "olive.passes.pytorch.capture_split_info.CaptureSplitInfo",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "MergeAdapterWeights": {
+            "module_path": "olive.passes.pytorch.merge_adapter_weights.MergeAdapterWeights",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "LoftQ": {
+            "module_path": "olive.passes.pytorch.lora.LoftQ",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "LoRA": {
+            "module_path": "olive.passes.pytorch.lora.LoRA",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
+            "extra_dependencies": [ "lora" ]
+        },
+        "PyTorchTensorParallel": {
+            "module_path": "olive.passes.pytorch.tensor_parallel.PyTorchTensorParallel",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "QLoRA": {
+            "module_path": "olive.passes.pytorch.lora.QLoRA",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
+            "extra_dependencies": [ "bnb", "lora" ]
+        },
         "QuantizationAwareTraining": {
             "module_path": "olive.passes.pytorch.quantization_aware_training.QuantizationAwareTraining",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
             "module_dependencies": [ "pytorch-lightning" ]
         },
-        "SparseGPT": { "module_path": "olive.passes.pytorch.sparsegpt.SparseGPT" },
-        "SliceGPT": { "module_path": "olive.passes.pytorch.slicegpt.SliceGPT" },
-        "QuaRot": { "module_path": "olive.passes.pytorch.quarot.QuaRot", "extra_dependencies": [ "flash-attn" ] },
+        "SparseGPT": {
+            "module_path": "olive.passes.pytorch.sparsegpt.SparseGPT",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "SliceGPT": {
+            "module_path": "olive.passes.pytorch.slicegpt.SliceGPT",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "QuaRot": {
+            "module_path": "olive.passes.pytorch.quarot.QuaRot",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int4", "int8", "int16", "uint4", "uint8", "uint16" ],
+            "extra_dependencies": [ "flash-attn" ]
+        },
         "TorchTRTConversion": {
             "module_path": "olive.passes.pytorch.torch_trt_conversion.TorchTRTConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
             "extra_dependencies": [ "torch-tensorrt" ]
         },
-        "QNNConversion": { "module_path": "olive.passes.qnn.conversion.QNNConversion" },
-        "QNNModelLibGenerator": { "module_path": "olive.passes.qnn.model_lib_generator.QNNModelLibGenerator" },
-        "QNNContextBinaryGenerator": {
-            "module_path": "olive.passes.qnn.context_binary_generator.QNNContextBinaryGenerator"
+        "QNNConversion": {
+            "module_path": "olive.passes.qnn.conversion.QNNConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
         },
-        "SNPEConversion": { "module_path": "olive.passes.snpe.conversion.SNPEConversion" },
-        "SNPEQuantization": { "module_path": "olive.passes.snpe.quantization.SNPEQuantization" },
-        "SNPEtoONNXConversion": { "module_path": "olive.passes.snpe.snpe_to_onnx.SNPEtoONNXConversion" },
+        "QNNModelLibGenerator": {
+            "module_path": "olive.passes.qnn.model_lib_generator.QNNModelLibGenerator",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "QNNContextBinaryGenerator": {
+            "module_path": "olive.passes.qnn.context_binary_generator.QNNContextBinaryGenerator",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "SNPEConversion": {
+            "module_path": "olive.passes.snpe.conversion.SNPEConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "SNPEQuantization": {
+            "module_path": "olive.passes.snpe.quantization.SNPEQuantization",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
+        "SNPEtoONNXConversion": {
+            "module_path": "olive.passes.snpe.snpe_to_onnx.SNPEtoONNXConversion",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
         "NVModelOptQuantization": {
             "module_path": "olive.passes.onnx.nvmo_quantization.NVModelOptQuantization",
+            "supported_providers": [ "CUDAExecutionProvider" ],
+            "supported_accelerators": [ "gpu" ],
+            "supported_precisions": [ "int4", "int8", "fp8" ],
             "extra_dependencies": [ "nvmo" ]
         }
     },

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -3,11 +3,13 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Type, Union
+from typing import Callable, ClassVar, Dict, List, Optional, Set, Type, Union
 
 from olive.common.config_utils import ConfigBase, ConfigParam, ParamCategory, validate_object
 from olive.common.pydantic_v1 import Field, create_model, validator
 from olive.common.utils import StrEnumBase
+from olive.hardware.accelerator import Device
+from olive.hardware.constants import DEVICE_TO_EXECUTION_PROVIDERS
 from olive.resource_path import validate_resource_path
 from olive.strategy.search_parameter import SearchParameter, SpecialParamValue, json_to_search_parameter
 
@@ -139,7 +141,31 @@ def create_config_class(
 
 
 class PassModuleConfig(ConfigBase):
+    class Precision(StrEnumBase):
+        INT4 = "int4"
+        INT8 = "int8"
+        INT16 = "int16"
+        INT32 = "int32"
+        UINT4 = "uint4"
+        UINT8 = "uint8"
+        UINT16 = "uint16"
+        UINT32 = "uint32"
+        FP4 = "fp4"
+        FP8 = "fp8"
+        FP16 = "fp16"
+        FP32 = "fp32"
+        NF4 = "nf4"
+
+    ACCELERATORS: ClassVar[Set[str]] = {v.value for v in Device}
+    PRECISIONS: ClassVar[Set[str]] = {v.value for v in Precision}
+    EXECUTION_PROVIDERS: ClassVar[Set[str]] = {
+        provider for provider_list in DEVICE_TO_EXECUTION_PROVIDERS.values() for provider in provider_list
+    }
+
     module_path: str
+    supported_providers: Set[str] = Field(default_factory=set)
+    supported_accelerators: Set[str] = Field(default_factory=set)
+    supported_precisions: Set[str] = Field(default_factory=set)
     module_dependencies: List[str] = Field(default_factory=list)
     extra_dependencies: List[str] = Field(default_factory=list)
 
@@ -147,4 +173,43 @@ class PassModuleConfig(ConfigBase):
     def validate_module_path(cls, v):
         if not v:
             raise ValueError("module_path cannot be empty or None")
+        return v
+
+    @validator("supported_providers", pre=True)
+    def validate_supported_providers(cls, v, values):
+        v = v or []
+        if v == ["*"]:
+            v = PassModuleConfig.EXECUTION_PROVIDERS
+        return v
+
+    @validator("supported_providers", pre=True, each_item=True)
+    def validate_supported_provider(cls, v, values):
+        if v not in PassModuleConfig.EXECUTION_PROVIDERS:
+            raise ValueError(f"Invalid provider: {v}")
+        return v
+
+    @validator("supported_accelerators", pre=True)
+    def validate_supported_accelerators(cls, v, values):
+        v = v or []
+        if v == ["*"]:
+            v = PassModuleConfig.ACCELERATORS
+        return v
+
+    @validator("supported_accelerators", pre=True, each_item=True)
+    def validate_supported_accelerator(cls, v, values):
+        if v not in PassModuleConfig.ACCELERATORS:
+            raise ValueError(f"Invalid accelerator: {v}")
+        return v
+
+    @validator("supported_precisions", pre=True)
+    def validate_supported_precisions(cls, v, values):
+        v = v or []
+        if v == ["*"]:
+            v = PassModuleConfig.PRECISIONS
+        return v
+
+    @validator("supported_precisions", pre=True, each_item=True)
+    def validate_supported_precision(cls, v, values):
+        if v not in PassModuleConfig.PRECISIONS:
+            raise ValueError(f"Invalid precision: {v}")
         return v

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -25,7 +25,7 @@ from olive.systems.system_config import SystemConfig
         (["OpenVINOExecutionProvider"], None),
         (["CUDAExecutionProvider"], ["gpu"]),
         (["CPUExecutionProvider", "CUDAExecutionProvider"], ["gpu"]),
-        (["DmlExecutionProvider", "CUDAExecutionProvider"], ["gpu"]),
+        (["DmlExecutionProvider", "CUDAExecutionProvider"], None),
         (["QNNExecutionProvider", "CUDAExecutionProvider"], ["npu", "gpu"]),
     ],
 )


### PR DESCRIPTION
## Update olive_config and auto-opt to use precision, providers and accelerators

* Implement providers, accelerators and precisions for pass in olive_config.json.
  Each pass module config now also requires listing supported providers, accelerators
  and precisions.
* Update auto-opt cli to use a pre-defined order of passes when search is disabled.
  The list of passes is selected based on the user's choice of precision for
  the output model.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
