### PR TITLE
CI: Use PublishCodeCoverageResults@2

### DIFF
--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -77,6 +77,12 @@ jobs:
       failTaskOnFailedTests: true
     displayName: Upload pipeline run test results
 
+  # Code coverage requires
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk 7.0.x'
+    inputs:
+      version: 7.0.x
+
   - task: PublishCodeCoverageResults@2
     inputs:
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -80,6 +80,7 @@ jobs:
   - task: PublishCodeCoverageResults@2
     inputs:
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+    displayName: Publish code coverage results
 
   - script: git clean -dfX
     condition: always()

--- a/.azure_pipelines/job_templates/olive-test-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-template.yaml
@@ -77,9 +77,8 @@ jobs:
       failTaskOnFailedTests: true
     displayName: Upload pipeline run test results
 
-  - task: PublishCodeCoverageResults@1
+  - task: PublishCodeCoverageResults@2
     inputs:
-      codeCoverageTool: 'Cobertura'
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
 
   - script: git clean -dfX


### PR DESCRIPTION
## Describe your changes
PublishCodeCoverageResults@1 is deprecated and produces lots of warning in the run page.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
