### PR TITLE
CI: Use open_llama model in llama2 test

### DIFF
--- a/examples/test/local/test_llama2.py
+++ b/examples/test/local/test_llama2.py
@@ -6,8 +6,6 @@ import os
 
 import pytest
 
-from olive.common.hf.login import huggingface_login
-
 from ..utils import assert_nodes, get_example_dir, patch_config
 
 
@@ -24,10 +22,11 @@ def setup():
 def test_llama2(search_algorithm, execution_order, system, olive_json):
     from olive.workflows import run as olive_run
 
-    hf_token = os.environ.get("HF_TOKEN")
-    huggingface_login(hf_token)
-
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
+
+    # replace meta-llama with open-llama version of the model
+    # doesn't require login
+    olive_config["input_model"]["model_path"] = "openlm-research/open_llama_7b_v2"
 
     # reduce qlora steps for faster test
     olive_config["passes"]["f"]["training_args"]["max_steps"] = 5


### PR DESCRIPTION
## Describe your changes
Use `openlm-research/open_llama_7b_v2` instead of `meta-llama/Llama-2-7b-hf` since the meta-llama model is gated and requires login. We don't have login secrets on fork builds but still want to test this example. 
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
