### PR TITLE
Llama2: Use oasst data in `llama_qlora`

### DIFF
--- a/examples/llama2/README.md
+++ b/examples/llama2/README.md
@@ -180,15 +180,6 @@ Run the following command to execute the workflow:
 python llama2.py --qlora
 ```
 
-**Note:**
-Get access to the following resource on Hugging Face Hub:
-- [nampdn-ai/tiny-codes](https://huggingface.co/nampdn-ai/tiny-codes)
-
-Login to your Hugging Face account:
-```bash
-huggingface-cli login
-```
-
 ### Running Workflows on the Cloud
 
 You may notice that this workflow takes a long time to run, especially for QLoRA. Olive offers a feature that allows you to submit the workflow to the cloud, enabling it to run on the compute resources in your Azure Machine Learning workspace.

--- a/examples/llama2/llama2_qlora.json
+++ b/examples/llama2/llama2_qlora.json
@@ -14,20 +14,12 @@
         {
             "name": "train_data",
             "type": "HuggingfaceContainer",
-            "load_dataset_config": { "data_name": "nampdn-ai/tiny-codes", "split": "train[:4096]" },
-            "pre_process_data_config": {
-                "text_template": "### Language: {programming_language} \n### Question: {prompt} \n### Answer: {response}",
-                "max_seq_len": 1024
-            }
+            "load_dataset_config": { "data_name": "timdettmers/openassistant-guanaco", "split": "train[:4096]" }
         },
         {
             "name": "eval_data",
             "type": "HuggingfaceContainer",
-            "load_dataset_config": { "data_name": "nampdn-ai/tiny-codes", "split": "train[4096:4224]" },
-            "pre_process_data_config": {
-                "text_template": "### Language: {programming_language} \n### Question: {prompt} \n### Answer: {response}",
-                "max_seq_len": 1024
-            }
+            "load_dataset_config": { "data_name": "timdettmers/openassistant-guanaco", "split": "train[4096:4224]" }
         }
     ],
     "passes": {


### PR DESCRIPTION
## Describe your changes
- Change the example dataset from `nampdn-ai/tiny-codes` to `timdettmers/openassistant-guanaco` which was used in the original qlora paper. 
- tiny-codes is gated and requires permissions + login

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
