### PR TITLE
Auto-opt: Add model split options, Fix logic

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -572,7 +572,7 @@ def add_accelerator_options(sub_parser, single_provider: bool = True):
         type=str,
         default="cpu",
         choices=["gpu", "cpu", "npu"],
-        help="Target device to run the model.",
+        help="Target device to run the model. Default is cpu.",
     )
 
     execution_providers = sorted(
@@ -585,7 +585,7 @@ def add_accelerator_options(sub_parser, single_provider: bool = True):
             type=str,
             default="CPUExecutionProvider",
             choices=execution_providers,
-            help="Execution provider to use for ONNX model.",
+            help="Execution provider to use for ONNX model. Default is CPUExecutionProvider.",
         )
     else:
         accelerator_group.add_argument(


### PR DESCRIPTION
- Add options for model splitting to the `auto-opt` cli. Only used for no-search mode since evaluating split model is undefined.
- Transformers optimizer pass config now correctly handles fp16 precision.
- MixedPrecision pass is removed since it is not relevant. We normally use the transformers optimizer pass with fp16 or OrtFloat32toFloat16 pass for fp16 conversion. 
- Dml EP does not require static shapes
- `mixed_precision_overrides` is optional and is applied before the quantization pass which uses it. It is not connected to the mixedprecision pass.

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
