### PR TITLE
Issue #1460: Don't run transformer optimizer pass when using MB

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -276,6 +276,10 @@ class AutoOptCommand(BaseOliveCLICommand):
             # JS EP doesn't support fp16
             del passes_config["fp16_to_fp32"]
 
+        if self.args.use_model_builder:
+            # Don't run optimizer when using model builder
+            del passes_config["transformer_optimizer"]
+
         for pass_name in list(passes_config.keys()):
             pass_run_config = passes_config[pass_name]
             pass_module_config = olive_config.get_pass_module_config(pass_run_config["type"])


### PR DESCRIPTION
## Issue #1460: Don't run transformer optimizer pass when using MB

The pass and MB aren't compatible.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes: #1460