### PR TITLE
`auto-opt`: Add model splitting options, Update no-search rules

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -98,6 +98,14 @@ class AutoOptCommand(BaseOliveCLICommand):
                 "when the model is supported by model builder"
             ),
         )
+        sub_parser.add_argument(
+            "--use_qdq_encoding",
+            action="store_true",
+            help=(
+                "Whether to use QDQ encoding for quantized operators instead of ONNXRuntime contrib operators like"
+                " MatMulNBits"
+            ),
+        )
 
         # DynamicToFixedShape options
         sub_parser.add_argument(
@@ -120,6 +128,21 @@ class AutoOptCommand(BaseOliveCLICommand):
                 "Required only when using QNNExecutionProvider."
             ),
         )
+
+        # Split options
+        split_group = sub_parser.add_mutually_exclusive_group(required=False)
+        split_group.add_argument(
+            "--num-splits",
+            type=int,
+            help="Number of splits to use for model splitting. Input model must be an HfModel.",
+        )
+        split_group.add_argument(
+            "--cost-model",
+            type=str,
+            help="Path to the cost model file to use for model splitting. Mutually exclusive with num-splits.",
+        )
+        # TODO(jambayk): Move this to device options
+        sub_parser.add_argument("--device-memory", type=int, help="Device memory in bytes to use for model splitting.")
 
         # MixedPrecisionOverrides options
         sub_parser.add_argument(
@@ -249,6 +272,9 @@ class AutoOptCommand(BaseOliveCLICommand):
         )
 
         to_replace = [
+            (("capture_split_info", "num_splits"), self.args.num_splits),
+            (("capture_split_info", "cost_model"), self.args.cost_model),
+            (("capture_split_info", "max_memory"), self.args.device_memory),
             (("bnb4", "quant_type"), PRECISION_MAPPING["bnb4"].get(self.args.precision, self.args.precision)),
             (
                 ("dynamic_quant", "weight_type"),
@@ -258,7 +284,7 @@ class AutoOptCommand(BaseOliveCLICommand):
                 ("model_builder", "precision"),
                 PRECISION_MAPPING["model_builder"].get(self.args.precision, self.args.precision),
             ),
-            (("model_builder", "metadata_only"), config["input_model"]["type"].lower() == "onnxmodel"),
+            (("transformer_optimizer", "use_fp16"), self.args.precision == "fp16"),
             (("to_fixed_shape", "dim_param"), self.args.dynamic_to_fixed_shape_dim_param),
             (("to_fixed_shape", "dim_value"), self.args.dynamic_to_fixed_shape_dim_value),
             (("mixed_precision_overrides", "overrides_config"), mixed_precision_overrides_config),
@@ -267,19 +293,43 @@ class AutoOptCommand(BaseOliveCLICommand):
             if value is not None:
                 set_nested_dict_value(passes_config, keys, value)
 
-        del passes_config["conversion" if self.args.use_model_builder else "model_builder"]
-        if (self.args.provider != "QNNExecutionProvider") or self.args.use_model_builder:
+        passes_to_remove = set()
+        if config["input_model"]["type"].lower() == "onnxmodel":
+            # remove passes that only operate on PyTorch/Hf models
+            passes_to_remove.update(["capture_split_info", "conversion", "model_builder", "split_model"])
+        else:
+            # only one graph capture pass is used
+            passes_to_remove.add("conversion" if self.args.use_model_builder else "model_builder")
+
+        # optional split passes
+        if self.args.num_splits is None and self.args.cost_model is None:
+            passes_to_remove.update(["capture_split_info", "split_model"])
+        if self.args.cost_model is not None and self.args.device_memory is None:
+            raise ValueError("device_memory is required if cost_model is provided.")
+
+        if self.args.provider != "QNNExecutionProvider" or self.args.use_model_builder:
             # Use the DynamicToFixedShape pass only for QNNExecutionProvider
             # becase QNN doesn't support dynamic shaped inputs
-            del passes_config["to_fixed_shape"]
-        elif self.args.provider != "JsExecutionProvider":
-            # JS EP doesn't support fp16
-            del passes_config["fp16_to_fp32"]
+            passes_to_remove.add("to_fixed_shape")
+
+        if self.args.provider != "JsExecutionProvider":
+            # JS EP doesn't support fp16 io
+            passes_to_remove.add("fp16_to_fp32")
 
         if self.args.use_model_builder:
-            # Don't run optimizer when using model builder
-            del passes_config["transformer_optimizer"]
+            # Don't run optimizers when using model builder
+            passes_to_remove.add("transformer_optimizer")
+            passes_to_remove.add("optimizer")
 
+        if mixed_precision_overrides_config is None:
+            # Remove mixed_precision_overrides pass if not required
+            passes_to_remove.add("mixed_precision_overrides")
+
+        if not self.args.use_qdq_encoding:
+            # Remove QDQ encoding pass if not required
+            passes_to_remove.add("mnb_to_qdq")
+
+        # remove passes that are incompatible with the selected precision, provider, or device
         for pass_name in list(passes_config.keys()):
             pass_run_config = passes_config[pass_name]
             pass_module_config = olive_config.get_pass_module_config(pass_run_config["type"])
@@ -288,7 +338,10 @@ class AutoOptCommand(BaseOliveCLICommand):
                 or (self.args.provider not in pass_module_config.supported_providers)
                 or (self.args.device not in pass_module_config.supported_accelerators)
             ):
-                del passes_config[pass_name]
+                passes_to_remove.add(pass_name)
+
+        for pass_name in passes_to_remove:
+            del passes_config[pass_name]
 
         if "to_fixed_shape" in passes_config and not (
             self.args.dynamic_to_fixed_shape_dim_param and self.args.dynamic_to_fixed_shape_dim_value
@@ -298,7 +351,12 @@ class AutoOptCommand(BaseOliveCLICommand):
                 "when using QNNExecutionProvider."
             )
 
-        if ("conversion" not in passes_config) and ("model_builder" not in passes_config):
+        # check that there is at least one capture pass for non-onnx models
+        if (
+            (config["input_model"]["type"].lower() != "onnxmodel")
+            and ("conversion" not in passes_config)
+            and ("model_builder" not in passes_config)
+        ):
             raise ValueError("Cannot export an onnx model with combination of provided options.")
 
         return passes_config
@@ -340,19 +398,33 @@ TEMPLATE = {
     },
     "passes": OrderedDict(
         [
+            # pytorch related passes
+            ("capture_split_info", {"type": "CaptureSplitInfo"}),
+            # always convert in float32 since float16 doesn't work for all models
             ("conversion", {"type": "OnnxConversion"}),
-            ("model_builder", {"type": "ModelBuilder", "precision": "fp32", "metadata_only": False}),
-            ("transformer_optimizer", {"type": "OrtTransformersOptimization"}),
+            ("model_builder", {"type": "ModelBuilder", "precision": "fp32"}),
+            # model optimization passes
+            # use transformer optimizer for fp16 conversion too
+            # opt_level set to 0 to avoid graph transformations done by onnxruntime inference sessions
+            # that are incompatible with later passes. opt_level > 0 is optional and cane be done during session creation
+            (
+                "transformer_optimizer",
+                {"type": "OrtTransformersOptimization", "opt_level": 0, "use_fp16": False, "keep_io_types": False},
+            ),
             ("optimizer", {"type": "OnnxModelOptimizer"}),
+            # change io types to fp32
             ("fp16_to_fp32", {"type": "OnnxIOFloat16ToFloat32"}),
+            # qnn preparation passes
+            ("to_fixed_shape", {"type": "DynamicToFixedShape", "dim_param": None, "dim_value": None}),
             ("qnn_preprocess", {"type": "QNNPreprocess"}),
+            ("mixed_precision_overrides", {"type": "MixedPrecisionOverrides", "overrides_config": None}),
+            # quantization passes
             ("dynamic_quant", {"type": "OnnxQuantization", "weight_type": "QInt8"}),
             ("matmul4", {"type": "OnnxMatMul4Quantizer"}),
             ("bnb4", {"type": "OnnxBnb4Quantization", "quant_type": "nf4"}),
-            ("to_fixed_shape", {"type": "DynamicToFixedShape", "dim_param": None, "dim_value": None}),
-            ("mixed_precision_overrides", {"type": "MixedPrecisionOverrides", "overrides_config": None}),
-            ("mixed_precision", {"type": "OrtMixedPrecision"}),
+            # post processing passes
             ("mnb_to_qdq", {"type": "MatMulNBitsToQDQ"}),
+            ("split_model", {"type": "SplitModel"}),
             ("extract_adapters", {"type": "ExtractAdapters"}),
         ]
     ),
@@ -363,6 +435,7 @@ TEMPLATE = {
 }
 
 PRECISION_MAPPING = {
+    "capture_split_info": {},
     "conversion": {},
     "model_builder": {},
     "transformer_optimizer": {},
@@ -376,5 +449,6 @@ PRECISION_MAPPING = {
     "mixed_precision_overrides": {},
     "mixed_precision": {},
     "mnb_to_qdq": {},
+    "split_model": {},
     "extract_adapters": {},
 }

--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -139,7 +139,12 @@ class AutoOptCommand(BaseOliveCLICommand):
         split_group.add_argument(
             "--cost-model",
             type=str,
-            help="Path to the cost model file to use for model splitting. Mutually exclusive with num-splits.",
+            help=(
+                "Path to the cost model csv file to use for model splitting. Mutually exclusive with num-splits. Must"
+                " be a csv with headers `module,num_params,num_bytes` where each row corresponds to the name or a"
+                " module (with no children), the number of parameters, and the number of bytes the module uses when in"
+                " the desired precision."
+            ),
         )
         # TODO(jambayk): Move this to device options
         sub_parser.add_argument("--device-memory", type=int, help="Device memory in bytes to use for model splitting.")

--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -418,7 +418,7 @@ TEMPLATE = {
             # pytorch related passes
             ("capture_split_info", {"type": "CaptureSplitInfo"}),
             # always convert in float32 since float16 doesn't work for all models
-            ("conversion", {"type": "OnnxConversion"}),
+            ("conversion", {"type": "OnnxConversion", "torch_dtype": "float32"}),
             ("model_builder", {"type": "ModelBuilder", "precision": "fp32"}),
             # model optimization passes
             # use transformer optimizer for fp16 conversion too

--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -327,7 +327,7 @@ class AutoOptCommand(BaseOliveCLICommand):
             # will re-enable it if needed in the future
             passes_to_remove.update(["transformer_optimizer", "optimizer"])
 
-        if self.args.provider != "JsExecutionProvider":
+        if self.args.provider not in {"JsExecutionProvider", "WebGpuExecutionProvider"}:
             # JS EP doesn't support fp16 io
             passes_to_remove.add("fp16_to_fp32")
 

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -572,7 +572,7 @@ def add_accelerator_options(sub_parser, single_provider: bool = True):
         type=str,
         default="cpu",
         choices=["gpu", "cpu", "npu"],
-        help="Target device to run the model.",
+        help="Target device to run the model. Default is cpu.",
     )
 
     execution_providers = sorted(
@@ -585,7 +585,7 @@ def add_accelerator_options(sub_parser, single_provider: bool = True):
             type=str,
             default="CPUExecutionProvider",
             choices=execution_providers,
-            help="Execution provider to use for ONNX model.",
+            help="Execution provider to use for ONNX model. Default is CPUExecutionProvider.",
         )
     else:
         accelerator_group.add_argument(

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -165,8 +165,8 @@
         },
         "QNNPreprocess": {
             "module_path": "olive.passes.onnx.qnn.qnn_preprocess.QNNPreprocess",
-            "supported_providers": [ "*" ],
-            "supported_accelerators": [ "*" ],
+            "supported_providers": [ "QNNExecutionProvider" ],
+            "supported_accelerators": [ "npu"],
             "supported_precisions": [ "*" ]
         },
         "VitisAIQuantization": {

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -102,7 +102,7 @@
         },
         "OnnxMatMul4Quantizer": {
             "module_path": "olive.passes.onnx.quantization.OnnxMatMul4Quantizer",
-            "supported_providers": [ "CPUExecutionProvider", "CUDAExecutionProvider" ],
+            "supported_providers": [ "CPUExecutionProvider", "CUDAExecutionProvider", "DmlExecutionProvider" ],
             "supported_accelerators": [ "cpu", "gpu" ],
             "supported_precisions": [ "int4" ]
         },
@@ -166,7 +166,7 @@
         "QNNPreprocess": {
             "module_path": "olive.passes.onnx.qnn.qnn_preprocess.QNNPreprocess",
             "supported_providers": [ "QNNExecutionProvider" ],
-            "supported_accelerators": [ "npu"],
+            "supported_accelerators": [ "npu" ],
             "supported_precisions": [ "*" ]
         },
         "VitisAIQuantization": {

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -186,7 +186,6 @@ class ExtractAdapters(Pass):
                 # MatMulNBits has static K,N dimensions which are set as attributes
                 # No use case for DequantizeLinear with dynamic lora_r
                 logger.info("Quantized modules do not support dynamic_lora_r. Ignoring.")
-                logger.debug("Quantized modules: %s", quant_modules)
 
             # create inputs for the weights
             for weight_name in weights:

--- a/olive/passes/pytorch/capture_split_info.py
+++ b/olive/passes/pytorch/capture_split_info.py
@@ -44,9 +44,9 @@ class CaptureSplitInfo(Pass):
                 category=ParamCategory.PATH,
                 description=(
                     "Path to the cost model csv file. One of num_splits or cost_model is required. Must be a csv with"
-                    " headers `module,num_bytes` where module is the name modules (with no children) in the model and"
-                    " num_bytes is the int number of bytes the module uses when in the desired precision. Any other"
-                    " column is not used."
+                    " headers `module,num_params,num_bytes` where each row corresponds to the name or a module (with no"
+                    " children), the number of parameters, and the number of bytes the module uses when in the desired"
+                    " precision."
                 ),
             ),
             # TODO(jambayk): Get this from the accelerator spec?


### PR DESCRIPTION
## Describe your changes
- Add new options to enable model splitting in `auto-opt` command. Only used for no-search model since model evaluation for split model is undefined.

Some other rule changes:
- Add `--use_qdq_encoding` option to make this optional
- Remove pytorch and model splitting passes when input model is onnx model
- Remove optimizer and matmul4 passes when model builder is used since the model is already optimized and in the expected precision
- Keep/remove passes that are only needed for specific EPs.
- Onnx conversion is always in fp32 since fp16 conversion doesn't work for all models. We instead use the transformers optimizer pass to do the conversion to fp16 afterwards.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes #1464