### PR TITLE
Expose accelerator memory and use in `CaptureSplitInfo`

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -146,8 +146,6 @@ class AutoOptCommand(BaseOliveCLICommand):
                 " the desired precision."
             ),
         )
-        # TODO(jambayk): Move this to device options
-        sub_parser.add_argument("--memory", type=int, help="Device memory in bytes to use for model splitting.")
 
         # MixedPrecisionOverrides options
         sub_parser.add_argument(
@@ -279,7 +277,6 @@ class AutoOptCommand(BaseOliveCLICommand):
         to_replace = [
             (("capture_split_info", "num_splits"), self.args.num_splits),
             (("capture_split_info", "cost_model"), self.args.cost_model),
-            (("capture_split_info", "max_memory"), self.args.memory),
             (("bnb4", "quant_type"), PRECISION_MAPPING["bnb4"].get(self.args.precision, self.args.precision)),
             (
                 ("dynamic_quant", "weight_type"),

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -15,6 +15,7 @@ import yaml
 from olive.cli.constants import CONDA_CONFIG
 from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import hardlink_copy_dir, hash_dict, hf_repo_exists, set_nested_dict_value, unescaped_str
+from olive.hardware.accelerator import AcceleratorSpec
 from olive.hardware.constants import DEVICE_TO_EXECUTION_PROVIDERS
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS, find_all_resources
 
@@ -598,6 +599,12 @@ def add_accelerator_options(sub_parser, single_provider: bool = True):
                 "If not provided, all available providers will be used."
             ),
         )
+    accelerator_group.add_argument(
+        "--memory",
+        type=AcceleratorSpec.str_to_int_memory,
+        default=None,
+        help="Memory limit for the accelerator in bytes. Default is None.",
+    )
 
     return accelerator_group
 
@@ -607,6 +614,7 @@ def update_accelerator_options(args, config, single_provider: bool = True):
     to_replace = [
         (("systems", "local_system", "accelerators", 0, "device"), args.device),
         (("systems", "local_system", "accelerators", 0, "execution_providers"), execution_providers),
+        (("systems", "local_system", "accelerators", 0, "memory"), args.memory),
     ]
     for k, v in to_replace:
         if v is not None:

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -893,7 +893,9 @@ class Engine:
             host_accelerators = self.host_config.config.accelerators
             if host_accelerators and host_accelerators[0].execution_providers:
                 host_accelerator_spec = AcceleratorSpec(
-                    host_accelerators[0].device, host_accelerators[0].execution_providers[0]
+                    host_accelerators[0].device,
+                    host_accelerators[0].execution_providers[0],
+                    memory=host_accelerators[0].memory,
                 )
             else:
                 host_accelerator_spec = None

--- a/olive/passes/pytorch/capture_split_info.py
+++ b/olive/passes/pytorch/capture_split_info.py
@@ -49,13 +49,6 @@ class CaptureSplitInfo(Pass):
                     " precision."
                 ),
             ),
-            # TODO(jambayk): Get this from the accelerator spec?
-            "max_memory": PassConfigParam(
-                type_=int,
-                description=(
-                    "Maximum memory in bytes that can be used by the model. Required if cost_model is provided."
-                ),
-            ),
             "exclude_embeds": PassConfigParam(
                 type_=bool,
                 default_value=False,
@@ -80,11 +73,15 @@ class CaptureSplitInfo(Pass):
             logger.info("One of num_splits or cost_model is required.")
             return False
 
-        if search_point.get("cost_model") is not None and search_point.get("max_memory") is None:
-            logger.info("max_memory is required if cost_model is provided.")
+        if search_point.get("cost_model") is not None and accelerator_spec.memory is None:
+            logger.info("Accelerator memory is required if cost_model is provided.")
             return False
 
         return True
+
+    @staticmethod
+    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+        return False
 
     def _run_for_config(
         self, model: Union[HfModelHandler, PyTorchModelHandler], config: Dict[str, Any], output_model_path: str
@@ -135,6 +132,9 @@ class CaptureSplitInfo(Pass):
     def split_using_cost_model(
         self, model: Union[HfModelHandler, PyTorchModelHandler], config: Dict[str, Any]
     ) -> Dict[str, int]:
+        if self.accelerator_spec.memory is None:
+            raise ValueError("Accelerator memory is required to split using cost model.")
+
         # will only care about the number of bytes for now
         module_to_bytes = {}
         with open(config["cost_model"]) as f:
@@ -168,7 +168,7 @@ class CaptureSplitInfo(Pass):
 
             # check if the next module can be added to the current split
             # if not, assign it to the next split
-            if split_bytes + num_bytes > config["max_memory"]:
+            if split_bytes + num_bytes > self.accelerator_spec.memory:
                 split_idx += 1
                 split_bytes = 0
 

--- a/olive/systems/accelerator_creator.py
+++ b/olive/systems/accelerator_creator.py
@@ -210,9 +210,9 @@ def create_accelerators(
                         "Ignore the CPUExecutionProvider for non-cpu device since cpu accelerator is also present."
                     )
                 else:
-                    accelerator_specs.append(AcceleratorSpec(device, ep))
+                    accelerator_specs.append(AcceleratorSpec(device, ep, memory=accelerator.memory))
         else:
-            accelerator_specs.append(AcceleratorSpec(device))
+            accelerator_specs.append(AcceleratorSpec(device, memory=accelerator.memory))
 
     assert accelerator_specs, (
         "No valid accelerator specified for target system. "

--- a/olive/systems/common.py
+++ b/olive/systems/common.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from olive.common.config_utils import CaseInsensitiveEnum, ConfigBase
-from olive.common.pydantic_v1 import validator
-from olive.hardware.accelerator import Device
+from olive.common.pydantic_v1 import Field, validator
+from olive.hardware.accelerator import AcceleratorSpec, Device
 
 
 class SystemType(CaseInsensitiveEnum):
@@ -19,14 +19,30 @@ class SystemType(CaseInsensitiveEnum):
 
 
 class AcceleratorConfig(ConfigBase):
-    device: Union[str, Device] = None
-    execution_providers: List[str] = None
+    device: Union[str, Device] = Field(None, description="Device to use for the accelerator")
+    execution_providers: List[str] = Field(
+        None, description="Execution providers for the accelerator. Each must end with ExecutionProvider"
+    )
+    memory: Union[int, str] = Field(
+        None, description="Memory size of accelerator in bytes. Can also be provided in string format like 1GB."
+    )
 
     @validator("execution_providers", always=True)
     def validate_device_and_execution_providers(cls, v, values):
-        if v is None and values.get("device") is None:
+        if not v and values.get("device") is None:
+            # checking for not v since v could be an empty list
             raise ValueError("Either device or execution_providers must be provided")
         return v
+
+    @validator("execution_providers", pre=True, each_item=True)
+    def validate_ep_suffix(cls, v):
+        if not v.endswith("ExecutionProvider"):
+            raise ValueError(f"Execution provider {v} should end with ExecutionProvider")
+        return v
+
+    @validator("memory", pre=True)
+    def validate_memory(cls, v):
+        return AcceleratorSpec.str_to_int_memory(v)
 
 
 class AzureMLDockerConfig(ConfigBase):

--- a/test/unit_test/hardware/test_accelerator.py
+++ b/test/unit_test/hardware/test_accelerator.py
@@ -118,6 +118,17 @@ def test_infer_accelerators_from_execution_provider(execution_providers_test):
             [("cpu", "CPUExecutionProvider")],
             ["CPUExecutionProvider"],
         ),
+        # LocalSystem with memory
+        (
+            {
+                "type": "LocalSystem",
+                "config": {
+                    "accelerators": [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"], "memory": 1234}]
+                },
+            },
+            [("cpu", "CPUExecutionProvider", 1234)],
+            ["CPUExecutionProvider"],
+        ),
     ],
 )
 @patch("onnxruntime.get_available_providers")
@@ -133,7 +144,11 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
         python_mock.start()
 
     expected_accelerator_specs = [
-        AcceleratorSpec(accelerator_type=acc_spec[0].lower(), execution_provider=acc_spec[1])
+        AcceleratorSpec(
+            accelerator_type=acc_spec[0].lower(),
+            execution_provider=acc_spec[1],
+            memory=acc_spec[2] if len(acc_spec) == 3 else None,
+        )
         for acc_spec in expected_acc_specs
     ]
 
@@ -151,10 +166,8 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             {"type": "LocalSystem"},
             [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}],
             [
-                (
-                    "There is no any accelerator specified. Inferred accelerators: "
-                    "[AcceleratorConfig(device='cpu', execution_providers=['CPUExecutionProvider'])]"
-                )
+                "There is no any accelerator specified. Inferred accelerators: "
+                "[AcceleratorConfig(device='cpu', execution_providers=['CPUExecutionProvider'], memory=None)]"
             ],
             ["AzureExecutionProvider", "CPUExecutionProvider"],
         ),
@@ -277,6 +290,25 @@ def test_create_accelerators(get_available_providers_mock, system_config, expect
             ["The following execution providers are not supported: 'ROCMExecutionProvider'"],
             ["CUDAExecutionProvider", "CPUExecutionProvider"],
         ),
+        (
+            # fill the EPs. memory is provided.
+            {"type": "LocalSystem", "config": {"accelerators": [{"device": "cpu", "memory": "10kB"}]}},
+            [
+                {
+                    "device": "cpu",
+                    "execution_providers": ["OpenVINOExecutionProvider", "CPUExecutionProvider"],
+                    "memory": 10000,
+                }
+            ],
+            [
+                "The following execution providers are filtered: DmlExecutionProvider.",
+                (
+                    "The accelerator execution providers is not specified for cpu. Use the inferred ones. "
+                    "['OpenVINOExecutionProvider', 'CPUExecutionProvider']"
+                ),
+            ],
+            ["OpenVINOExecutionProvider", "CPUExecutionProvider", "DmlExecutionProvider"],
+        ),
     ],
 )
 @patch("onnxruntime.get_available_providers")
@@ -308,6 +340,8 @@ def test_normalize_accelerators(
     for i, acc in enumerate(expected_accs):
         assert normalized_accs.config.accelerators[i].device == acc["device"]
         assert normalized_accs.config.accelerators[i].execution_providers == acc["execution_providers"]
+        if "memory" in acc:
+            assert normalized_accs.config.accelerators[i].memory == acc["memory"]
 
     if expected_logs:
         for log in expected_logs:
@@ -334,6 +368,13 @@ def test_normalize_accelerators(
             },
             ("npu", ["QNNExecutionProvider"]),
         ),
+        (
+            {
+                "type": "LocalSystem",
+                "config": {"accelerators": [{"execution_providers": ["QNNExecutionProvider"], "memory": "1gb"}]},
+            },
+            ("npu", ["QNNExecutionProvider"], 1e9),
+        ),
     ],
 )
 def test_normalize_accelerators_skip_ep_check(system_config, expected_acc):
@@ -341,6 +382,8 @@ def test_normalize_accelerators_skip_ep_check(system_config, expected_acc):
     normalized_accs = AcceleratorNormalizer(system_config, skip_supported_eps_check=True).normalize()
     assert normalized_accs.config.accelerators[0].device == expected_acc[0]
     assert normalized_accs.config.accelerators[0].execution_providers == expected_acc[1]
+    if len(expected_acc) == 3:
+        assert normalized_accs.config.accelerators[0].memory == expected_acc[2]
 
 
 @pytest.mark.parametrize(
@@ -459,12 +502,26 @@ def test_create_accelerator_with_error(
             },
             [("gpu", None)],
         ),
+        # LocalSystem with memory
+        (
+            {
+                "type": "LocalSystem",
+                "config": {
+                    "accelerators": [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"], "memory": 1234}]
+                },
+            },
+            [("cpu", "CPUExecutionProvider", 1234)],
+        ),
     ],
 )
 def test_create_accelerator_without_ep(system_config, expected_acc_specs):
     system_config = validate_config(system_config, SystemConfig)
     expected_accelerator_specs = [
-        AcceleratorSpec(accelerator_type=acc_spec[0].lower(), execution_provider=acc_spec[1])
+        AcceleratorSpec(
+            accelerator_type=acc_spec[0].lower(),
+            execution_provider=acc_spec[1],
+            memory=acc_spec[2] if len(acc_spec) == 3 else None,
+        )
         for acc_spec in expected_acc_specs
     ]
     accelerators = create_accelerators(system_config, skip_supported_eps_check=False, is_ep_required=False)
@@ -478,3 +535,5 @@ def test_accelerator_config():
     assert acc_cfg2.device is None
     with pytest.raises(ValueError, match="Either device or execution_providers must be provided"):
         _ = AcceleratorConfig.parse_obj({})
+    acc_cfg3 = AcceleratorConfig.parse_obj({"device": "cpu", "memory": "1MB"})
+    assert acc_cfg3.memory == 1e6

--- a/test/unit_test/systems/azureml/test_alias_system.py
+++ b/test/unit_test/systems/azureml/test_alias_system.py
@@ -11,7 +11,7 @@ from olive.systems.system_config import SystemConfig
                 {"device": "gpu", "execution_providers": ["CUDAExecutionProvider"]},
                 {"device": "cpu", "execution_providers": ["CPUExecutionProvider"]},
             ],
-            [{"device": "gpu", "execution_providers": ["CUDAExecutionProvider"]}],
+            [{"device": "gpu", "execution_providers": ["CUDAExecutionProvider"], "memory": None}],
         ),
         (
             [{"device": "cpu", "execution_providers": ["CPUExecutionProvider"]}],


### PR DESCRIPTION
## Describe your changes
- Expose `memory` in `AcceleratorSpec` and `AcceleratorConfig`.
- Removed the unused fields in accelerator spec to avoid confusion.
- CaptureSplitInfo pass now uses this field instead of a config parameter.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
