### PR TITLE
MatMulNBitsToQDQ: Support `INT4` elem type, per-axis quantization

### DIFF
--- a/olive/common/hf/quant.py
+++ b/olive/common/hf/quant.py
@@ -175,8 +175,6 @@ class QuantLinear4bit(torch.nn.Module):
         self.in_features = in_features
         self.out_features = out_features
 
-        assert group_size >= 16, "group_size must >= 16"
-        assert math.log2(group_size).is_integer(), "group_size must be a power of 2"
         self.group_size = group_size
 
         # only support 4 bits for now

--- a/test/unit_test/passes/onnx/test_mnb_to_qdq.py
+++ b/test/unit_test/passes/onnx/test_mnb_to_qdq.py
@@ -30,9 +30,11 @@ def create_mnb_model_fixture(request, tmp_path):
             super().__init__()
             self.f1 = torch.nn.Linear(in_dim, hidden_dim, bias=True)
             self.f2 = torch.nn.Linear(hidden_dim, out_dim, bias=False)
+            # equivalent to per-axis quantization
+            self.f3 = torch.nn.Linear(out_dim, out_dim, bias=False)
 
         def forward(self, x):
-            return self.f2(self.f1(x))
+            return self.f3(self.f2(self.f1(x)))
 
     model = TestModel()
 
@@ -53,7 +55,7 @@ def create_mnb_model_fixture(request, tmp_path):
     quant.process()
     onnx.save(quant.model.model, mnb_path)
 
-    return mnb_path, in_dim
+    return mnb_path, in_dim, request.param
 
 
 @pytest.mark.skipif(
@@ -61,17 +63,23 @@ def create_mnb_model_fixture(request, tmp_path):
     reason="Int4 DQ is only supported in ORT >= 1.20",
 )
 @pytest.mark.parametrize("use_transpose_op", [True, False])
+@pytest.mark.parametrize("use_int4", [True, False])
+@pytest.mark.parametrize("add_zero_point", [True, False])
 @pytest.mark.parametrize("execution_provider", ["CPUExecutionProvider", "CUDAExecutionProvider"])
-def test_mnb_to_qdq(create_mnb_model, execution_provider, use_transpose_op, tmp_path):
+def test_mnb_to_qdq(create_mnb_model, execution_provider, add_zero_point, use_int4, use_transpose_op, tmp_path):
     available_providers = onnxruntime.get_available_providers()
     if execution_provider not in available_providers:
         pytest.skip(f"{execution_provider} is not available on this system {available_providers}")
 
-    mnb_path, in_dim = create_mnb_model
+    mnb_path, in_dim, is_symmetric = create_mnb_model
     input_model = ONNXModelHandler(mnb_path)
 
     # setup
-    p = create_pass_from_dict(MatMulNBitsToQDQ, {"use_transpose_op": use_transpose_op}, disable_search=True)
+    p = create_pass_from_dict(
+        MatMulNBitsToQDQ,
+        {"use_transpose_op": use_transpose_op, "use_int4": use_int4, "add_zero_point": add_zero_point},
+        disable_search=True,
+    )
     output_folder = tmp_path / "qdq-model"
 
     # execute
@@ -80,8 +88,14 @@ def test_mnb_to_qdq(create_mnb_model, execution_provider, use_transpose_op, tmp_
     # validate
     original_session = onnxruntime.InferenceSession(str(mnb_path), providers=[execution_provider])
     original_session.disable_fallback()
-    qdq_session = onnxruntime.InferenceSession(str(qdq_model.model_path), providers=[execution_provider])
-    qdq_session.disable_fallback()
+    if is_symmetric and use_int4 and not add_zero_point and use_transpose_op:
+        # there seems to be a bug in ORT graph optimization which changes the int4 DQ to uint8 DQ
+        with pytest.raises(Exception, match="uint8"):
+            onnxruntime.InferenceSession(str(qdq_model.model_path), providers=[execution_provider])
+        return
+    else:
+        qdq_session = onnxruntime.InferenceSession(str(qdq_model.model_path), providers=[execution_provider])
+        qdq_session.disable_fallback()
 
     input_data = {"input": np.random.randn(1, 1, in_dim).astype(np.float32)}
     original_output = original_session.run(None, input_data)[0]


### PR DESCRIPTION
## Describe your changes
- `use_int4` parameter added to use `INT4` elem type instead of `UINT4`. Quantized data is converted to int4 by first casting from uint8 to int8 and then subtracting 8.
- We expect INT4 to only be used for symmetric quantized models but it appears to work fine for assymetric quantized models so there is no restriction on it.
- `add_zero_point` parameter to force adding zero points to the DQ node even though they are all zeros.
- If the number of K-blocks is 1, we assume it to be per-axis quantization and create the DQ node as such:
  - no `block_size` attribute
  - scales and zero points are 1-D
  - `axis` is opposite that of block-wise quantization

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
