### PR TITLE
auto-opt: `--use_ort_genai` option, fix fp16 transformers optimizer

### DIFF
--- a/examples/test/azureml/test_llama2.py
+++ b/examples/test/azureml/test_llama2.py
@@ -38,6 +38,9 @@ def test_llama2(search_algorithm, execution_order, system, cache_config, olive_j
     olive_config["passes"]["f"]["training_args"]["per_device_train_batch_size"] = 2
     olive_config["passes"]["f"]["training_args"]["per_device_eval_batch_size"] = 2
 
+    # don't know what version of ort might be in the container, set to numpy for backward compatibility
+    olive_config["passes"]["e"]["save_format"] = "numpy"
+
     # add shared cache config
     olive_config["cache_config"] = cache_config
 

--- a/examples/test/local/test_llama2.py
+++ b/examples/test/local/test_llama2.py
@@ -5,6 +5,7 @@
 import os
 
 import pytest
+from packaging import version
 
 from ..utils import assert_nodes, get_example_dir, patch_config
 
@@ -20,6 +21,8 @@ def setup():
 @pytest.mark.parametrize("system", ["local_system"])
 @pytest.mark.parametrize("olive_json", ["llama2_qlora.json"])
 def test_llama2(search_algorithm, execution_order, system, olive_json):
+    from onnxruntime import __version__ as ort_version
+
     from olive.workflows import run as olive_run
 
     olive_config = patch_config(olive_json, search_algorithm, execution_order, system)
@@ -33,6 +36,9 @@ def test_llama2(search_algorithm, execution_order, system, olive_json):
     olive_config["passes"]["f"]["training_args"]["logging_steps"] = 5
     olive_config["passes"]["f"]["training_args"]["per_device_train_batch_size"] = 2
     olive_config["passes"]["f"]["training_args"]["per_device_eval_batch_size"] = 2
+
+    if version.parse(ort_version) < version.parse("1.20"):
+        olive_config["passes"]["e"]["save_format"] = "numpy"
 
     footprint = olive_run(olive_config, tempdir=os.environ.get("OLIVE_TEMPDIR", None))
     assert_nodes(footprint)

--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -163,7 +163,7 @@ class AutoOptCommand(BaseOliveCLICommand):
         )
 
         sub_parser.add_argument(
-            "--use_ort_genai", action="store_true", help="Use OnnxRuntie generate() API to run the model"
+            "--use_ort_genai", action="store_true", help="Use OnnxRuntime generate() API to run the model"
         )
 
         add_search_options(sub_parser)

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -138,7 +138,7 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
         )
 
         sub_parser.add_argument(
-            "--use_ort_genai", action="store_true", help="Use OnnxRuntie generate() API to run the model"
+            "--use_ort_genai", action="store_true", help="Use OnnxRuntime generate() API to run the model"
         )
 
         # remote options

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -66,7 +66,7 @@ class ExtractAdapters(Pass):
             ),
             "save_format": PassConfigParam(
                 type_=WeightsFileFormat,
-                default_value=WeightsFileFormat.NUMPY,
+                default_value=WeightsFileFormat.ONNX_ADAPTER,
                 description="Format to save the weights in.",
             ),
         }


### PR DESCRIPTION
## Describe your changes
- Use ONNX adapter format as the default format
- Provide --use_ort_genai option to generate genai config via auto-opt CLI
- Correct the fp16 parameter in transformers optimizer config from `use_fp16` to `float16`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
