### PR TITLE
HfModel: Disable `use_exllama` by default for GPTQ models

### DIFF
--- a/test/unit_test/common/test_hf.py
+++ b/test/unit_test/common/test_hf.py
@@ -40,7 +40,8 @@ def test_load_model_from_task():
         ([ValueError("value error 1"), ValueError("value error 2")], ValueError, "value error 2"),
     ],
 )
-def test_load_model_from_task_exception_handling(exceptions, expected_exception, expected_message):
+@patch("olive.common.hf.utils.get_model_config")
+def test_load_model_from_task_exception_handling(_, exceptions, expected_exception, expected_message):
     with patch("transformers.pipelines.check_task") as mock_check_task:
         mocked_model_classes = []
         for exception in exceptions:


### PR DESCRIPTION
## Describe your changes
The default value for `use_exllama` in transformers is `True`. However, exllama model cannot be loaded on cpu (for model export) and doesn't have a backward pass implemented for finetuning. 
Since the main use for gptq quantized model in Olive is for export and finetuning, we should disable `use_exllama` by default. User can provide `use_exllama=True` as part of the loading args if they want to enable exllama for inference, etc.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
