### PR TITLE
OnnxModelOptimizer: Rename to OnnxPeepholeOptimizer, handle failed shape inference

### DIFF
--- a/docs/source/api/passes.rst
+++ b/docs/source/api/passes.rst
@@ -18,11 +18,11 @@ OnnxOpVersionConversion
 -----------------------
 .. autoconfigclass:: olive.passes.OnnxOpVersionConversion
 
-.. _onnx_model_optimizer:
+.. _onnx_peephole_optimizer:
 
-OnnxModelOptimizer
-------------------
-.. autoconfigclass:: olive.passes.OnnxModelOptimizer
+OnnxPeepholeOptimizer
+---------------------
+.. autoconfigclass:: olive.passes.OnnxPeepholeOptimizer
 
 .. _ort_transformers_optimization:
 

--- a/docs/source/features/passes/onnx.md
+++ b/docs/source/features/passes/onnx.md
@@ -5,17 +5,17 @@
 Olive provides multiple transformations and optimizations based on various ONNX to improve model performance.
 
 ## Model Optimizer
-`OnnxModelOptimizer` optimizes an ONNX model by fusing nodes. Fusing nodes involves merging multiple nodes in a model into a single node to
+`OnnxPeepholeOptimizer` optimizes an ONNX model by fusing nodes. Fusing nodes involves merging multiple nodes in a model into a single node to
 reduce the computational cost and improve the performance of the model. The optimization process involves analyzing the structure of the ONNX model and identifying nodes that can be fused.
 
-Also, inserts a `Cast` operation for cases where `ArgMax` input isn't supported on the device. For example, on GPU inferencing, TensorProto.INT64 isn't supported so a `Cast` operator inserted to cast the inputs to TensorProto.INT32.
+Also, inserts a `Cast` operation for cases where `ArgMax` input. For example, before ONNXRuntime 1.20, TensorProto.INT64 isn't supported on CPU or CUDA EP so a `Cast` operator inserted to cast the inputs to TensorProto.INT32.
 
-Please refer to [OnnxModelOptimizer](onnx_model_optimizer) for more details about the pass and its config parameters.
+Please refer to [OnnxPeepholeOptimizer](onnx_peephole_optimizer) for more details about the pass and its config parameters.
 
 ### Example Configuration
 ```json
 {
-    "type": "OnnxModelOptimizer"
+    "type": "OnnxPeepholeOptimizer"
 }
 ```
 

--- a/docs/source/overview/options.md
+++ b/docs/source/overview/options.md
@@ -361,7 +361,7 @@ Please also find the detailed options from following table for each pass:
 | [OnnxConversion](onnx_conversion) | Convert a PyTorch model to ONNX model |
 | [OnnxOpVersionConversion](onnx_op_version_conversion) | Convert a Onnx model to target op version |
 | [ModelBuilder](model_builder) | Convert a generative PyTorch model to ONNX model using [ONNX Runtime Generative AI](https://github.com/microsoft/onnxruntime-genai) module |
-| [OnnxModelOptimizer](onnx_model_optimizer) | Optimize ONNX model by fusing nodes. |
+| [OnnxPeepholeOptimizer](onnx_peephole_optimizer) | Optimize ONNX model by fusing nodes. |
 | [OnnxTransformersOptimization](onnx_transformers_optimization) | Optimize transformer based models in scenarios where ONNX Runtime does not apply the optimization at load time. It is based on onnxruntime.transformers.optimizer. |
 | [OrtSessionParamsTuning](ort_session_params_tuning) | Optimize ONNX Runtime inference settings. |
 | [OnnxDynamicQuantization](onnx_dynamic_quantization) | ONNX Dynamic Quantization Pass. |

--- a/examples/bert/bert_qat_customized_train_loop_cpu.json
+++ b/examples/bert/bert_qat_customized_train_loop_cpu.json
@@ -36,7 +36,7 @@
             "training_loop_func": "training_loop_func"
         },
         "conversion": { "type": "OnnxConversion", "target_opset": 17 },
-        "model_optimizer": { "type": "ONNXModelOptimizer" },
+        "peephole_optimizer": { "type": "OnnxPeepholeOptimizer" },
         "transformers_optimization": { "type": "OrtTransformersOptimization" },
         "session_params_tuning": { "type": "OrtSessionParamsTuning" }
     },

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -106,8 +106,8 @@
             "supported_accelerators": [ "cpu", "gpu" ],
             "supported_precisions": [ "int4" ]
         },
-        "OnnxModelOptimizer": {
-            "module_path": "olive.passes.onnx.model_optimizer.OnnxModelOptimizer",
+        "OnnxPeepholeOptimizer": {
+            "module_path": "olive.passes.onnx.peephole_optimizer.OnnxPeepholeOptimizer",
             "supported_providers": [ "*" ],
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ]

--- a/olive/passes/onnx/peephole_optimizer.py
+++ b/olive/passes/onnx/peephole_optimizer.py
@@ -10,7 +10,7 @@ import numpy as np
 import onnx
 from google.protobuf.message import Message
 
-from olive.hardware.accelerator import AcceleratorSpec, Device
+from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
@@ -20,50 +20,60 @@ from olive.passes.pass_config import PassConfigParam
 logger = logging.getLogger(__name__)
 
 
+# TODO(anyone): Move from onnxruntime.transformers.onnx_model.OnnxModel to OnnxDAG
+# or reimplement logic using onnx-rewriter
+# no need to create a new instance of OnnxModel for each optimization
 class ModelOptimizer:
     def __init__(self, source_model_path):
         self.source_model_path = str(source_model_path)
-        self.prepare()
-
-    def prepare(self):
-        from onnxruntime.transformers.onnx_model import OnnxModel as TransformersOnnxModel
-
         self.model = onnx.load(self.source_model_path)
-        self.onnx_model = TransformersOnnxModel(self.model)
-        self.graph = self.onnx_model.graph()
-
-        self.node_name2module = {}
-
-        for node_idx, node in enumerate(self.graph.node):
-            if node.name == "":
-                node.name = str(node.op_type) + str(node_idx)
-            self.node_name2module[node.name] = [node, node_idx]
-
-    def optimize(self):
-        self.fuse_transpose_qat()
 
     def fuse_transpose_qat(self):
-        for module in self.node_name2module.values():
+        # DequantizeLinear -> Transpose = Dequantize Linear with transposed initializer
+        # Might need to check if this is performant for EPs like DML
+        # Very limited use case, assumes a lot of things about the model
+        # probably better to remove this or create a more general solution
+        from onnxruntime.transformers.onnx_model import OnnxModel as TransformersOnnxModel
+
+        onnx_model = TransformersOnnxModel(self.model)
+        graph = onnx_model.graph()
+
+        node_name2module = {}
+        for node_idx, node in enumerate(graph.node):
+            if node.name == "":
+                node.name = str(node.op_type) + str(node_idx)
+            node_name2module[node.name] = [node, node_idx]
+
+        num_changed = 0
+        for module in node_name2module.values():
             node = module[0]
             node_index = module[1]
             if node.op_type == "Transpose" and "DequantizeLinear" in node.input[0]:
                 dequant_node_name = node.input[0][:-9]
                 new_dequant_node_output = node.output[0]
-                dequant_node = self.node_name2module[dequant_node_name][0]
-                x_node = self.node_name2module[dequant_node.input[0][:-9]][0]
-                x_scale_node = self.node_name2module[dequant_node.input[1][:-9]][0]
-                x_zero_point_node = self.node_name2module[dequant_node.input[2][:-9]][0]
+                dequant_node = node_name2module[dequant_node_name][0]
+                x_node = node_name2module[dequant_node.input[0][:-9]][0]
+                x_scale_node = node_name2module[dequant_node.input[1][:-9]][0]
+                x_zero_point_node = node_name2module[dequant_node.input[2][:-9]][0]
 
-                x_val = self.onnx_model.get_constant_value(dequant_node.input[0])
+                x_val = onnx_model.get_constant_value(dequant_node.input[0])
                 new_x_val = np.transpose(x_val, axes=(1, 0))
-                x_scale_val = self.onnx_model.get_constant_value(dequant_node.input[1])
-                x_zero_point_val = self.onnx_model.get_constant_value(dequant_node.input[2])
+                x_scale_val = onnx_model.get_constant_value(dequant_node.input[1])
+                x_zero_point_val = onnx_model.get_constant_value(dequant_node.input[2])
 
-                self.remove_nodes(self.graph, [node, dequant_node, x_node, x_scale_node, x_zero_point_node])
+                self.remove_nodes(graph, [node, dequant_node, x_node, x_scale_node, x_zero_point_node])
                 new_dequant, x, x_scale, x_zero_point = self.create_dequantizelinear_node(
                     new_x_val, x_scale_val, x_zero_point_val, new_dequant_node_output, node_index
                 )
-                self.add_nodes(self.graph, [new_dequant, x, x_scale, x_zero_point], node_index)
+                self.add_nodes(graph, [new_dequant, x, x_scale, x_zero_point], node_index)
+                num_changed += 1
+
+        if num_changed > 0:
+            logger.debug(
+                "Converted %d Transpose -> DequantizeLinear to DequantizeLinear with transposed initializer",
+                num_changed,
+            )
+            onnx_model.topological_sort()
 
     def create_dequantizelinear_node(self, x_val, x_scale_val, x_zero_point_val, outputs, node_name_suffix):
         x_tensor = onnx.helper.make_tensor(
@@ -146,29 +156,32 @@ class ModelOptimizer:
             suffix += 1
 
     def patch_unsupported_argmax_operator(self):
-        # ArgMax supports limited input types on GPU. To patch, add a Cast operator ahead of ArgMax
-        # so the model is usuable for inferencing.
+        # ORT<1.20 doesn't support int64 input for ArgMax operator on CPU EP.
+        # CUDA EP also falls back to CPU EP for non float inputs.
+        # Add a cast node to convert int64 input to int32.
         from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
         from onnxruntime.transformers.onnx_model import OnnxModel as TransformersOnnxModel
 
         o_model = TransformersOnnxModel(self.model)
         o_model.topological_sort()  # Prerequisite for SymbolicShapeInference to succeed
 
-        s_model = TransformersOnnxModel(
-            SymbolicShapeInference.infer_shapes(
-                o_model.model,
-                auto_merge=True,
-                guess_output_rank=True,
-                # verbose=1,
+        try:
+            s_model = TransformersOnnxModel(
+                SymbolicShapeInference.infer_shapes(o_model.model, auto_merge=True, guess_output_rank=True)
             )
-        )
+        except Exception as e:
+            logger.debug("Shape inference failed. Will try to continue without it. Error: %s", e)
+            s_model = o_model
 
         o_nodes_by_name = {n.name: n for n in o_model.nodes()}
         s_value_info_by_name = {v.name: v for v in s_model.model.graph.value_info}
         s_value_info_by_name.update({n.name: n for n in s_model.model.graph.input})
 
+        num_changed = 0
         for s_argmax_node in s_model.get_nodes_by_op_type("ArgMax"):
-            s_value_info = s_value_info_by_name[s_argmax_node.input[0]]
+            if (s_value_info := s_value_info_by_name.get(s_argmax_node.input[0])) is None:
+                # there is no value info for the input, so we can't determine the type
+                continue
             if s_value_info.type.tensor_type.HasField("elem_type") and (
                 s_value_info.type.tensor_type.elem_type == onnx.TensorProto.INT64
             ):
@@ -185,9 +198,11 @@ class ModelOptimizer:
                 o_model.add_node(cast_node)
                 o_nodes_by_name[cast_node_name] = cast_node
 
-                logger.debug("ModelOptimization: inserted node %s", cast_node.name)
+                num_changed += 1
 
-        self.model = o_model.model  # pylint: disable=attribute-defined-outside-init
+        if num_changed > 0:
+            logger.debug("Patched %d ArgMax operators with Cast operators", num_changed)
+            o_model.topological_sort()
 
     def fuse_reshape_operations(self):
         # Remove unnecessary Reshape operator. Consecutive Reshape operators with latter's input being "[-1]"
@@ -199,6 +214,8 @@ class ModelOptimizer:
         o_consumers = o_model.input_name_to_nodes()
 
         expected_constant_value = np.array([-1])
+
+        num_changed = 0
         for o_reshape_node in o_model.get_nodes_by_op_type("Reshape"):
             input_node_0 = o_producers.get(o_reshape_node.input[0])
 
@@ -209,14 +226,14 @@ class ModelOptimizer:
             if previous_is_reshape and current_flattens and only_consumer:
                 o_reshape_node.input[0] = input_node_0.input[0]
                 input_node_0.input.remove(input_node_0.input[0])
+                num_changed += 1
 
-                logger.debug("ModelOptimization: removed node %s", input_node_0.name)
+        if num_changed > 0:
+            logger.debug("Fused %d redundant Reshape operators", num_changed)
+            o_model.prune_graph()
 
-        o_model.prune_graph()
-        self.model = o_model.model  # pylint: disable=attribute-defined-outside-init
 
-
-class OnnxModelOptimizer(Pass):
+class OnnxPeepholeOptimizer(Pass):
     """Optimize ONNX model by fusing nodes."""
 
     @classmethod
@@ -229,13 +246,10 @@ class OnnxModelOptimizer(Pass):
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
         # optimize model
-        model_optimizer = ModelOptimizer(model.model_path)
-        model_optimizer.optimize()
-
-        if self.accelerator_spec.accelerator_type == Device.GPU:
-            model_optimizer.patch_unsupported_argmax_operator()
-
-        model_optimizer.fuse_reshape_operations()
+        peephole_optimizer = ModelOptimizer(model.model_path)
+        peephole_optimizer.fuse_transpose_qat()
+        peephole_optimizer.patch_unsupported_argmax_operator()
+        peephole_optimizer.fuse_reshape_operations()
 
         # save the model to the output path and return the model
-        return model_proto_to_olive_model(model_optimizer.model, output_model_path, config)
+        return model_proto_to_olive_model(peephole_optimizer.model, output_model_path, config)


### PR DESCRIPTION
## Describe your changes
OnnxModelOptimizer:
- Rename pass to `OnnxPeepholeOptimizer`
- Cleaned up the logic to separate the different optimizer steps inside it.
- Added a comment to migrate this Pass to OnnxDAG or onnx-rewriter eventually since these are all node pattern matching and replacement steps
- Handle failed shape inference in argmax patch step. There is nothing we can do if the shape inference fails. Try to make do with the original model and skip nodes if there is no elem type info.

auto-opt:
- Fix a bug where the workflow config provided to `_get_passes_config` did not have the input model information
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
