### PR TITLE
Set to use `dynamo=True` only with PyTorch 2.6 temporarily

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -202,7 +202,8 @@ class OnnxConversion(Pass):
             # The "legacy dynamo" is the torch.onnx_dynamo_export API
             legacy_dynamo_supported_version = version.parse("2.2.0").release
             # The new "dynamo" api is torch.onnx.export with dynamo=True
-            dynamo_supported_version = version.parse("2.5.0").release
+            # TODO(#1478): Change 2.6.0 back to 2.5.0 when dynamic_shapes are supported in Olive
+            dynamo_supported_version = version.parse("2.6.0").release
             if torch_version < legacy_dynamo_supported_version:
                 raise ImportError(
                     f"torch.onnx.dynamo_export is not available for torch version {torch_version}. "


### PR DESCRIPTION
## Describe your changes

For the Olive release, in the ONNX export pass, since when `dynamo=True` the dynamic_shapes argument is not provided properly, we temporarily change the check to require torch 2.6 to enable the new `dynamo=True` logic pass. This way when a user has torch 2.5 Olive will still use the old `dynamo_export` logic and function without errors.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link

- https://github.com/microsoft/Olive/issues/1478