### PR TITLE
Remove static key from quantize cli

### DIFF
--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -235,12 +235,12 @@ ALGORITHMS = {
         "onnx_model_defaults": {"implementation": "matmul4", "precision": "int4"},
         "description": "(OnnxModel) HQQ quantization using onnxruntime.",
     },
-    "static": {
-        "implementations": ["onnx_static", "inc_static"],
-        "hf_model_defaults": {"implementation": None, "precision": None},
-        "onnx_model_defaults": {"implementation": "onnx_static", "precision": "int8"},
-        "description": "(OnnxModel) Static quantization using onnxruntime.",
-    },
+    # "static": {
+    #     "implementations": ["onnx_static", "inc_static"],
+    #     "hf_model_defaults": {"implementation": None, "precision": None},
+    #     "onnx_model_defaults": {"implementation": "onnx_static", "precision": "int8"},
+    #     "description": "(OnnxModel) Static quantization using onnxruntime.",
+    # },
     "dynamic": {
         "implementations": ["onnx_dynamic", "inc_dynamic"],
         "hf_model_defaults": {"implementation": None, "precision": None},


### PR DESCRIPTION
## Describe your changes

`static` quantization is not supported by cli now. Removing `static` key from template. Otherwise, cli doc will have this option.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
