### PR TITLE
CLI: Use getattr on conditional args, Check handler type. Debug log in `get_attr`

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -62,7 +62,7 @@ def _get_hf_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
         input_model["task"] = args.task
     if getattr(args, "adapter_path", None):
         input_model["adapter_path"] = args.adapter_path
-    if getattr(args, "trust_remote_code", None):
+    if getattr(args, "trust_remote_code", None) is not None:
         input_model["load_kwargs"]["trust_remote_code"] = args.trust_remote_code
     return input_model
 

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -163,12 +163,18 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
     def get_run_config(self, tempdir: str) -> Dict:
         config = deepcopy(TEMPLATE)
 
+        input_model_config = get_input_model_config(self.args)
+        assert input_model_config["type"].lower() in {
+            "hfmodel",
+            "pytorchmodel",
+        }, "Only HfModel and PyTorchModel are supported in capture-onnx-graph command."
+
         # whether model is in fp16 (currently not supported by CPU EP)
         is_fp16 = (not self.args.use_model_builder and self.args.torch_dtype == "float16") or (
             self.args.use_model_builder and self.args.precision == "fp16"
         )
         to_replace = [
-            ("input_model", get_input_model_config(self.args)),
+            ("input_model", input_model_config),
             ("output_dir", tempdir),
             ("log_severity_level", self.args.log_level),
             (("systems", "local_system", "accelerators", 0, "device"), "gpu" if is_fp16 else "cpu"),

--- a/olive/cli/finetune.py
+++ b/olive/cli/finetune.py
@@ -109,9 +109,12 @@ class FineTuneCommand(BaseOliveCLICommand):
         return {k: v for k, v in vars(training_args).items() if k in arg_keys}
 
     def get_run_config(self, tempdir: str) -> Dict:
+        input_model_config = get_input_model_config(self.args)
+        assert input_model_config["type"].lower() == "hfmodel", "Only HfModel is supported in finetune command."
+
         finetune_key = ("passes", "f")
         to_replace = [
-            ("input_model", get_input_model_config(self.args)),
+            ("input_model", input_model_config),
             ((*finetune_key, "type"), self.args.method),
             ((*finetune_key, "torch_dtype"), self.args.torch_dtype),
             ((*finetune_key, "training_args"), self.parse_training_args()),

--- a/olive/cli/generate_adapter.py
+++ b/olive/cli/generate_adapter.py
@@ -59,8 +59,13 @@ class GenerateAdapterCommand(BaseOliveCLICommand):
             save_output_model(run_config, self.args.output_path)
 
     def get_run_config(self, tempdir: str) -> Dict:
+        input_model_config = get_input_model_config(self.args)
+        assert (
+            input_model_config["type"].lower() == "onnxmodel"
+        ), "Only ONNX models are supported in generate-adapter command."
+
         to_replace = [
-            ("input_model", get_input_model_config(self.args)),
+            ("input_model", input_model_config),
             (("passes", "e", "save_format"), self.args.adapter_format),
             ("output_dir", tempdir),
             ("log_severity_level", self.args.log_level),

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -37,7 +37,14 @@ class QuantizeCommand(BaseOliveCLICommand):
         )
 
         # model options
-        add_input_model_options(sub_parser, enable_hf=True, enable_pt=True, default_output_path="quantized-model")
+        add_input_model_options(
+            sub_parser,
+            enable_hf=True,
+            enable_hf_adapter=True,
+            enable_pt=True,
+            enable_onnx=True,
+            default_output_path="quantized-model",
+        )
 
         sub_parser.add_argument(
             "--algorithm",

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -292,7 +292,7 @@ def get_attr(module, attr, fail_on_not_found=False):
             if fail_on_not_found:
                 raise AttributeError(not_found_message) from e
             else:
-                logger.warning(not_found_message)
+                logger.debug(not_found_message)
                 return None
     return module
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -135,7 +135,7 @@ class RunConfig(NestedConfig):
             " no-search or auto-optimizer mode based on whether passes field is provided."
         ),
     )
-    passes: Dict[str, RunPassConfig] = Field(None, description="Pass configurations.")
+    passes: Dict[str, RunPassConfig] = Field(default_factory=dict, description="Pass configurations.")
     pass_flows: List[List[str]] = Field(
         None,
         description=(


### PR DESCRIPTION
## Describe your changes
CLI:
- For command arguments like `task`, `adapter_path`, and `trust_remote_code`, use `getattr` to avoid `AttributeError` in case the handler type is not supported. 
- Add assertions in the commands to ensure the expected model handler type is provided

utils:
- `get_attr` logs a debug message instead of a warning message. This util is used to find optional submodules so we should not log as warning.

workflow.run:
- default passes to an empty dict. Otherwise, some other code tries to use dict methods on None.
 
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
