### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Windows specific files should retain windows line-endings
+*.ps1 text eol=crlf
+
+# make sure .sh retains Unix line endings, even when checked out on windows.
+*.sh text eol=lf


### PR DESCRIPTION
## Describe your changes
Add a .gitattributes file with `* text=auto` so that file endings are automatically handled by git and overrides the user settings.

Otherwise, if a user hasn't set `git config core.autocrlf` a file saved on Windows uses CRLF endings. This shows up as the whole file being changed.  https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
