### PR TITLE
SplitModel: Keep QDQ nodes together

### DIFF
--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -35,6 +35,6 @@ pytorch_lightning
 sentencepiece
 tabulate
 torchvision
-# 4.46.0 is broken https://github.com/huggingface/transformers/issues/34370
-# TODO(anyone): remove when the issue is fixed or CI migrates to python 3.9
-transformers<4.46.0
+# num_logits_to_keep is causing extra input.
+# TODO(anyone): Remove this once the issue is resolved
+transformers<4.45.0


### PR DESCRIPTION
## Describe your changes
Static quantized models have graphs of the pattern `input -> Q -> DQ -> op -> Q -> DQ -> ...`.  To be compatible with QNN Ep, the `DQ -> op -> Q` operators need stay in the same split.
SplitModel pass updated to handle this correctly:
- Q is assigned to the same split as the parent node.
- DQ is copied an assigned to the split of all child nodes.
- Some logic updates to generalize the assignment code.
 
## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
