### PR TITLE
fixed typo in finetuning doc

### DIFF
--- a/docs/source/how-to/cli/cli-finetune.md
+++ b/docs/source/how-to/cli/cli-finetune.md
@@ -49,7 +49,7 @@ olive finetune \
 You can download the model artifact using the Azure ML CLI:
 
 ```bash
-az ml job download --name {JOB_ID} --resource-group {RESOURCE_GROUP_NAME} --workspace-name {WORKSPACE_NAME} -all
+az ml job download --name {JOB_ID} --resource-group {RESOURCE_GROUP_NAME} --workspace-name {WORKSPACE_NAME} --all
 ```
 :::
 


### PR DESCRIPTION
Fixed typo in fine-tune (CLI) doc, which resolves #1531 
