### PR TITLE
GPTQ - Move `quantized_model` to CUDA device

### DIFF
--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -160,7 +160,8 @@ class GptqQuantizer(Pass):
         quantized_model: BaseGPTQForCausalLM = model_class(pytorch_model, False, quantize_config)
         
         # explicitly move quantized model to CUDA device to avoid the "Expected all tensors to be
-        # on the same device" error in auto-gptq
+        # on the same device" error in auto-gptq.
+        # see https://github.com/AutoGPTQ/AutoGPTQ/issues/729 
         quantized_model.to("cuda")
 
         fields_to_set = {

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -158,10 +158,9 @@ class GptqQuantizer(Pass):
         model_type = pytorch_model.config.model_type if hasattr(pytorch_model, "config") else ""
         model_class = GPTQ_CAUSAL_LM_MODEL_MAP.get(model_type, BaseGPTQForCausalLM)
         quantized_model: BaseGPTQForCausalLM = model_class(pytorch_model, False, quantize_config)
-        
         # explicitly move quantized model to CUDA device to avoid the "Expected all tensors to be
         # on the same device" error in auto-gptq.
-        # see https://github.com/AutoGPTQ/AutoGPTQ/issues/729 
+        # see https://github.com/AutoGPTQ/AutoGPTQ/issues/729
         quantized_model.to("cuda")
 
         fields_to_set = {

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -158,6 +158,10 @@ class GptqQuantizer(Pass):
         model_type = pytorch_model.config.model_type if hasattr(pytorch_model, "config") else ""
         model_class = GPTQ_CAUSAL_LM_MODEL_MAP.get(model_type, BaseGPTQForCausalLM)
         quantized_model: BaseGPTQForCausalLM = model_class(pytorch_model, False, quantize_config)
+        
+        # explicitly move quantized model to CUDA device to avoid the "Expected all tensors to be
+        # on the same device" error in auto-gptq
+        quantized_model.to("cuda")
 
         fields_to_set = {
             "outside_layer_modules": MODEL_OUTSIDE_LAYER_MODULES,


### PR DESCRIPTION
## Describe your changes
When using GPTQ the `quantized_model` must be moved to the CUDA device to avoid the "Expected all tensors to be on the same device" error in auto-gptq. See AutoGPTQ/AutoGPTQ#729


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [X] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

