### PR TITLE
Move module class variables from implementation to olive_config.json

### DIFF
--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -30,21 +30,24 @@
             "supported_providers": [ "CPUExecutionProvider" ],
             "supported_accelerators": [ "cpu" ],
             "supported_precisions": [ "int4", "int8" ],
-            "extra_dependencies": [ "inc" ]
+            "extra_dependencies": [ "inc" ],
+            "run_on_target": true
         },
         "IncQuantization": {
             "module_path": "olive.passes.onnx.inc_quantization.IncQuantization",
             "supported_providers": [ "CPUExecutionProvider" ],
             "supported_accelerators": [ "cpu" ],
             "supported_precisions": [ "int4", "int8" ],
-            "extra_dependencies": [ "inc" ]
+            "extra_dependencies": [ "inc" ],
+            "run_on_target": true
         },
         "IncStaticQuantization": {
             "module_path": "olive.passes.onnx.inc_quantization.IncStaticQuantization",
             "supported_providers": [ "CPUExecutionProvider" ],
             "supported_accelerators": [ "cpu" ],
             "supported_precisions": [ "int4", "int8" ],
-            "extra_dependencies": [ "inc" ]
+            "extra_dependencies": [ "inc" ],
+            "run_on_target": true
         },
         "InsertBeamSearch": {
             "module_path": "olive.passes.onnx.insert_beam_search.InsertBeamSearch",
@@ -143,7 +146,8 @@
             "supported_providers": [ "*" ],
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ],
-            "extra_dependencies": [ "optimum" ]
+            "extra_dependencies": [ "optimum" ],
+            "run_on_target": true
         },
         "OrtMixedPrecision": {
             "module_path": "olive.passes.onnx.mixed_precision.OrtMixedPrecision",
@@ -156,7 +160,8 @@
             "supported_providers": [ "*" ],
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ],
-            "module_dependencies": [ "psutil" ]
+            "module_dependencies": [ "psutil" ],
+            "run_on_target": true
         },
         "OrtTransformersOptimization": {
             "module_path": "olive.passes.onnx.transformer_optimization.OrtTransformersOptimization",
@@ -174,7 +179,8 @@
             "module_path": "olive.passes.onnx.vitis_ai_quantization.VitisAIQuantization",
             "supported_providers": [ "VitisAIExecutionProvider" ],
             "supported_accelerators": [ "npu" ],
-            "supported_precisions": [ "int8" ]
+            "supported_precisions": [ "int8" ],
+            "run_on_target": true
         },
         "VitisQDQQuantizer": {
             "module_path": "olive.passes.onnx.vitis_ai.quantizer.VitisQDQQuantizer",

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -43,9 +43,6 @@ class Pass(ABC):
     # composite model will be processed individually.
     _accepts_composite_model: bool = False
 
-    # Flag indicate whether the pass need to be run in target instead of host
-    run_on_target: bool = False
-
     @classmethod
     def __init_subclass__(cls, **kwargs) -> None:
         """Register the Pass."""

--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -251,8 +251,6 @@ _inc_woq_optional_config = {
 class IncQuantization(Pass):
     """Quantize ONNX model with Intel® Neural Compressor."""
 
-    run_on_target = True
-
     @staticmethod
     def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -18,7 +18,6 @@ class OptimumMerging(Pass):
     """Merges a decoder_model with its decoder_with_past_model via the Optimum library."""
 
     _accepts_composite_model = True
-    run_on_target = True
 
     @staticmethod
     def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:

--- a/olive/passes/onnx/session_params_tuning.py
+++ b/olive/passes/onnx/session_params_tuning.py
@@ -79,8 +79,6 @@ def get_thread_affinity_nums(affinity_str):
 class OrtSessionParamsTuning(Pass):
     """Optimize ONNX Runtime inference settings."""
 
-    run_on_target = True
-
     @staticmethod
     def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -205,8 +205,6 @@ class VitisAIQuantization(Pass):
     We can search for best parameters for vai_q_onnx quantization at same time.
     """
 
-    run_on_target = True
-
     def _initialize(self):
         super()._initialize()
         self.tmp_dir = tempfile.TemporaryDirectory(prefix="olive_vaiq_tmp")

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -169,6 +169,14 @@ class PassModuleConfig(ConfigBase):
     module_dependencies: List[str] = Field(default_factory=list)
     extra_dependencies: List[str] = Field(default_factory=list)
 
+    # Flag indicate whether the pass need to be run in target instead of host
+    run_on_target: bool = False
+
+    def set_class_variables(self, cls):
+        attrs = {"supported_providers", "supported_accelerators", "supported_precisions", "run_on_target"}
+        for attr in attrs:
+            setattr(cls, attr, getattr(self, attr))
+
     @validator("module_path", pre=True)
     def validate_module_path(cls, v):
         if not v:

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -74,7 +74,7 @@ class RunEngineConfig(EngineConfig):
     ort_py_log_severity_level: int = 3
     log_to_file: bool = False
 
-    def create_engine(self, azureml_client_config, workflow_id):
+    def create_engine(self, olive_config, azureml_client_config, workflow_id):
         config = self.dict(include=EngineConfig.__fields__.keys())
         if self.cache_config:
             cache_config = validate_config(self.cache_config, CacheConfig)
@@ -86,7 +86,11 @@ class RunEngineConfig(EngineConfig):
                 enable_shared_cache=self.enable_shared_cache,
             )
         return Engine(
-            **config, cache_config=cache_config, azureml_client_config=azureml_client_config, workflow_id=workflow_id
+            **config,
+            olive_config=olive_config,
+            cache_config=cache_config,
+            azureml_client_config=azureml_client_config,
+            workflow_id=workflow_id,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ select = [
 # NOTE: Refrain from growing the ignore list unless for exceptional cases.
 # Always include a comment to explain why.
 ignore = [
+  "A005", # Ignore modules using the same names as Python standard-library modules
   "B028", # FIXME: Add stacklevel to warnings
   "B905", # keep using less than Python 3.10. The strict is added in Python 3.10
   "D100", # Ignore missing docstring in public module


### PR DESCRIPTION
## Move module class variables from implementation to olive_config.json

This prevents loading the module pre-emptively even when it isn't intended to be used. Also, after module gets imported, set the variable back on the class so rest of the implementation doesn't get impacted.

TODO: Pass::run_on_target should be removed but code paths in tests circumvent loading the olive package config. Follow up change to implement pass search will fix the issue.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
