### PR TITLE
Fix graph vertex ordering during topological ordering

### DIFF
--- a/olive/strategy/utils.py
+++ b/olive/strategy/utils.py
@@ -54,7 +54,11 @@ class DirectedGraph:
         visited = set()
         order = []
 
-        for v in self.vertices:
+        # Since the dependee vertex is inserted in front, iterate the vertices in
+        # reverse order to retain the relative order of vertices in the graph.
+        # Without it the graph vertices are reversed even in cases where no
+        # dependency exist.
+        for v in reversed(self.vertices):
             if v not in visited:
                 self._topological_sort_util(v, visited, order)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ select = [
 # NOTE: Refrain from growing the ignore list unless for exceptional cases.
 # Always include a comment to explain why.
 ignore = [
+  "A005", # Ignore modules using the same names as Python standard-library modules
   "B028", # FIXME: Add stacklevel to warnings
   "B905", # keep using less than Python 3.10. The strict is added in Python 3.10
   "D100", # Ignore missing docstring in public module


### PR DESCRIPTION
## Fix graph vertex ordering during topological ordering

Previous implementation returned vertices in reverse order even when there are no dependencies in the graph. Iterate the vertices in reverse order so input order can be retained.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
