### PR TITLE
Consolidate pass configs

### DIFF
--- a/olive/passes/__init__.py
+++ b/olive/passes/__init__.py
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.passes.olive_pass import AbstractPassConfig, FullPassConfig, Pass
-from olive.passes.pass_config import PassModuleConfig, PassParamDefault
+from olive.passes.olive_pass import FullPassConfig, Pass
+from olive.passes.pass_config import AbstractPassConfig, PassModuleConfig, PassParamDefault
 
 REGISTRY = Pass.registry
 

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -9,13 +9,19 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type, Union, get_args
 
-from olive.common.config_utils import NestedConfig, ParamCategory, validate_config, validate_lowercase
-from olive.common.pydantic_v1 import BaseModel, Field, ValidationError, create_model, validator
+from olive.common.config_utils import ParamCategory, validate_config
+from olive.common.pydantic_v1 import BaseModel, ValidationError, create_model
 from olive.common.user_module_loader import UserModuleLoader
 from olive.data.config import DataConfig
 from olive.hardware import DEFAULT_CPU_ACCELERATOR, AcceleratorSpec
 from olive.model import CompositeModelHandler, DistributedOnnxModelHandler, OliveModelHandler, ONNXModelHandler
-from olive.passes.pass_config import PassConfigBase, PassConfigParam, PassParamDefault, create_config_class
+from olive.passes.pass_config import (
+    AbstractPassConfig,
+    BasePassConfig,
+    PassConfigParam,
+    PassParamDefault,
+    create_config_class,
+)
 from olive.resource_path import ResourcePath
 from olive.strategy.search_parameter import (
     Categorical,
@@ -113,9 +119,9 @@ class Pass(ABC):
     def generate_search_space(
         cls,
         accelerator_spec: AcceleratorSpec,
-        config: Optional[Union[Dict[str, Any], PassConfigBase]] = None,
+        config: Optional[Union[Dict[str, Any], BasePassConfig]] = None,
         disable_search: Optional[bool] = False,
-    ) -> Tuple[Type[PassConfigBase], Dict[str, Any]]:
+    ) -> Tuple[Type[BasePassConfig], Dict[str, Any]]:
         """Generate search space for the pass."""
         assert accelerator_spec is not None, "Please specify the accelerator spec for the pass"
 
@@ -462,10 +468,10 @@ class Pass(ABC):
     @classmethod
     def _resolve_config(
         cls,
-        input_config: Union[Dict[str, Any], PassConfigBase],
+        input_config: Union[Dict[str, Any], BasePassConfig],
         default_config: Dict[str, PassConfigParam],
     ) -> Dict[str, Any]:
-        """Resolve config to PassConfigBase."""
+        """Resolve config to BasePassConfig."""
         config = input_config.dict()
         config = cls._resolve_defaults(config, default_config)
         if "user_script" in config:
@@ -484,25 +490,6 @@ class Pass(ABC):
         raise NotImplementedError
 
 
-class AbstractPassConfig(NestedConfig):
-    """Base class for pass configuration."""
-
-    type: str = Field(description="The type of the pass.")
-    config: Dict[str, Any] = Field(
-        None,
-        description=(
-            "The configuration of the pass. Values for required parameters must be provided. For optional parameters,"
-            " default values or searchable values (if available and search is not disabled) will be used if not"
-            " provided."
-        ),
-    )
-
-    @validator("type", pre=True)
-    def validate_type(cls, v):
-        return validate_lowercase(v)
-
-
-# TODO(jambayk): rename. We are using FullPassConfig since PassConfigBase already refers to inner config
 class FullPassConfig(AbstractPassConfig):
     """Configuration for a pass serialization.
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -19,8 +19,7 @@ from olive.engine import Engine, EngineConfig
 from olive.engine.packaging.packaging_config import PackagingConfig
 from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
 from olive.model import ModelConfig
-from olive.passes import AbstractPassConfig
-from olive.passes.pass_config import PassParamDefault
+from olive.passes.pass_config import AbstractPassConfig, PassParamDefault
 from olive.resource_path import AZUREML_RESOURCE_TYPES
 from olive.systems.system_config import SystemConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ select = [
 # NOTE: Refrain from growing the ignore list unless for exceptional cases.
 # Always include a comment to explain why.
 ignore = [
+  "A005", # Ignore modules using the same names as Python standard-library modules
   "B028", # FIXME: Add stacklevel to warnings
   "B905", # keep using less than Python 3.10. The strict is added in Python 3.10
   "D100", # Ignore missing docstring in public module


### PR DESCRIPTION
## Consolidate pass configs

Move AbstractPassConfig into pass_config.py and rename PassConfigBase to BasePassConfig.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
