### PR TITLE
Validate pass config before instantiating the pass

### DIFF
--- a/olive/cache.py
+++ b/olive/cache.py
@@ -11,7 +11,7 @@ import shutil
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from olive.common.config_utils import ConfigBase, convert_configs_to_dicts, validate_config
 from olive.common.constants import DEFAULT_CACHE_DIR, DEFAULT_WORKFLOW_ID
@@ -274,7 +274,11 @@ class OliveCache:
             logger.exception("Failed to cache olive config")
 
     def get_output_model_id(
-        self, pass_name: int, pass_config: dict, input_model_id: str, accelerator_spec: "AcceleratorSpec" = None
+        self,
+        pass_name: str,
+        pass_config: Dict[str, Any],
+        input_model_id: str,
+        accelerator_spec: "AcceleratorSpec" = None,
     ):
         run_json = self.get_run_json(pass_name, pass_config, input_model_id, accelerator_spec)
         return hash_dict(run_json)[:8]

--- a/olive/package_config.py
+++ b/olive/package_config.py
@@ -5,11 +5,14 @@
 import functools
 import importlib
 from pathlib import Path
-from typing import Dict, List
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Type
 
 from olive.common.config_utils import ConfigBase
-from olive.common.pydantic_v1 import validator
+from olive.common.pydantic_v1 import Field, validator
 from olive.passes import PassModuleConfig
+
+if TYPE_CHECKING:
+    from olive.passes.olive_pass import Pass
 
 
 class OlivePackageConfig(ConfigBase):
@@ -18,8 +21,10 @@ class OlivePackageConfig(ConfigBase):
     passes key is case-insensitive and stored in lowercase.
     """
 
-    passes: Dict[str, PassModuleConfig]
-    extra_dependencies: Dict[str, List[str]]
+    passes: Dict[str, PassModuleConfig] = Field(default_factory=dict)
+    extra_dependencies: Dict[str, List[str]] = Field(default_factory=dict)
+
+    _pass_modules: ClassVar[Dict[str, Type["Pass"]]] = {}
 
     @validator("passes")
     def validate_passes(cls, values):
@@ -36,12 +41,13 @@ class OlivePackageConfig(ConfigBase):
         return OlivePackageConfig.parse_file(OlivePackageConfig.get_default_config_path())
 
     def import_pass_module(self, pass_type: str):
-        pass_module_config = self.get_pass_module_config(pass_type)
-        module_path, module_name = pass_module_config.module_path.rsplit(".", 1)
-        module = importlib.import_module(module_path, module_name)
-        cls = getattr(module, module_name)
-        pass_module_config.set_class_variables(cls)
-        return cls
+        if pass_type not in self._pass_modules:
+            pass_module_config = self.get_pass_module_config(pass_type)
+            module_path, module_name = pass_module_config.module_path.rsplit(".", 1)
+            module = importlib.import_module(module_path, module_name)
+            self._pass_modules[pass_type] = cls = getattr(module, module_name)
+            pass_module_config.set_class_variables(cls)
+        return self._pass_modules[pass_type]
 
     def get_pass_module_config(self, pass_type: str) -> PassModuleConfig:
         if "." in pass_type:

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -92,24 +92,6 @@ def get_user_script_data_config(
 DEFAULT_SET = set(PassParamDefault)
 
 
-class AbstractPassConfig(NestedConfig):
-    """Base class for pass configuration."""
-
-    type: str = Field(description="The type of the pass.")
-    config: Dict[str, Any] = Field(
-        None,
-        description=(
-            "The configuration of the pass. Values for required parameters must be provided. For optional parameters,"
-            " default values or searchable values (if available and search is not disabled) will be used if not"
-            " provided."
-        ),
-    )
-
-    @validator("type", pre=True)
-    def validate_type(cls, v):
-        return validate_lowercase(v)
-
-
 class BasePassConfig(ConfigBase):
 
     @validator("*", pre=True)
@@ -127,6 +109,24 @@ class BasePassConfig(ConfigBase):
         if isinstance(v, dict) and v.get("olive_parameter_type") == "SearchParameter":
             return json_to_search_parameter(v)
         return v
+
+
+class AbstractPassConfig(NestedConfig):
+    """Base class for pass configuration."""
+
+    type: str = Field(description="The type of the pass.")
+    config: Dict[str, Any] = Field(
+        None,
+        description=(
+            "The configuration of the pass. Values for required parameters must be provided. For optional parameters,"
+            " default values or searchable values (if available and search is not disabled) will be used if not"
+            " provided."
+        ),
+    )
+
+    @validator("type", pre=True)
+    def validate_type(cls, v):
+        return validate_lowercase(v)
 
 
 def create_config_class(

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 
@@ -67,12 +67,19 @@ class TorchTRTConversion(Pass):
             ),
         }
 
-    def validate_search_point(
-        self, search_point: Dict[str, Any], accelerator_spec: AcceleratorSpec, with_fixed_value: bool = False
+    @classmethod
+    def validate_config(
+        cls,
+        config: Dict[str, Any],
+        accelerator_spec: AcceleratorSpec,
+        disable_search: Optional[bool] = False,
     ) -> bool:
+        if not super().validate_config(config, accelerator_spec, disable_search):
+            return False
+
         # since the run will leverage the host device to move the model to device,
         # we need to check if the host device is GPU
-        if self.host_device != Device.GPU:
+        if accelerator_spec.accelerator_type != Device.GPU:
             logger.info("TorchTRTConversion only supports GPU.")
             return False
         return True

--- a/olive/systems/azureml/aml_system.py
+++ b/olive/systems/azureml/aml_system.py
@@ -248,16 +248,12 @@ class AzureMLSystem(OliveSystem):
         the_pass: "Pass",
         model_config: ModelConfig,
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> ModelConfig:
-        """Run the pass on the model at a specific point in the search space."""
+        """Run the pass on the model."""
         ml_client = self.azureml_client_config.create_client()
 
         # serialize pass
-        point = point or {}
-        config = the_pass.config_at_search_point(point)
         pass_config = the_pass.to_json(check_object=True)
-        pass_config["config"].update(the_pass.serialize_config(config, check_object=True))
 
         with tempfile.TemporaryDirectory() as tempdir:
             pipeline_job = self._create_pipeline_for_pass(tempdir, model_config.to_json(check_object=True), pass_config)

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -108,11 +108,10 @@ class DockerSystem(OliveSystem):
         the_pass: "Pass",
         model_config: "ModelConfig",
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> "ModelConfig":
-        """Run the pass on the model at a specific point in the search space."""
+        """Run the pass on the model."""
         with tempfile.TemporaryDirectory() as tempdir:
-            return self._run_pass_container(Path(tempdir), the_pass, model_config, output_model_path, point)
+            return self._run_pass_container(Path(tempdir), the_pass, model_config, output_model_path)
 
     def _run_pass_container(
         self,
@@ -120,13 +119,8 @@ class DockerSystem(OliveSystem):
         the_pass: "Pass",
         model_config: "ModelConfig",
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> "ModelConfig":
-        point = point or {}
-        config = the_pass.config_at_search_point(point)
-
         pass_config = the_pass.to_json(check_object=True)
-        pass_config["config"].update(the_pass.serialize_config(config, check_object=True))
 
         volumes_list = []
         runner_output_path = "runner_output"

--- a/olive/systems/isolated_ort/isolated_ort_system.py
+++ b/olive/systems/isolated_ort/isolated_ort_system.py
@@ -8,7 +8,7 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -66,9 +66,8 @@ class IsolatedORTSystem(OliveSystem):
         the_pass: "Pass",
         model_config: "ModelConfig",
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> "ModelConfig":
-        """Run the pass on the model at a specific point in the search space."""
+        """Run the pass on the model."""
         logger.warning("IsolatedORTSystem does not support running passes.")
         raise NotImplementedError
 

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, List
 
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import ModelConfig
@@ -23,11 +23,10 @@ class LocalSystem(OliveSystem):
         the_pass: "Pass",
         model_config: ModelConfig,
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> ModelConfig:
-        """Run the pass on the model at a specific point in the search space."""
+        """Run the pass on the model."""
         model = model_config.create_model()
-        output_model = the_pass.run(model, output_model_path, point)
+        output_model = the_pass.run(model, output_model_path)
         return ModelConfig.from_json(output_model.to_json())
 
     def evaluate_model(

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from olive.common.config_utils import validate_config
 from olive.systems.common import AcceleratorConfig, SystemType
@@ -46,7 +46,6 @@ class OliveSystem(ABC):
         the_pass: "Pass",
         model_config: "ModelConfig",
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> "ModelConfig":
         """Run the pass on the model at a specific point in the search space."""
         raise NotImplementedError

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -9,7 +9,7 @@ import platform
 import shutil
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from olive.common.constants import OS
 from olive.common.utils import run_subprocess
@@ -110,13 +110,9 @@ class PythonEnvironmentSystem(OliveSystem):
         the_pass: "Pass",
         model_config: ModelConfig,
         output_model_path: str,
-        point: Optional[Dict[str, Any]] = None,
     ) -> ModelConfig:
-        """Run the pass on the model at a specific point in the search space."""
-        point = point or {}
-        config = the_pass.config_at_search_point(point)
+        """Run the pass on the model."""
         pass_config = the_pass.to_json(check_object=True)
-        pass_config["config"].update(the_pass.serialize_config(config, check_object=True))
         config_jsons = {
             "model_config": model_config.to_json(check_object=True),
             "pass_config": pass_config,

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -270,6 +270,10 @@ class RunConfig(NestedConfig):
             )
         return v
 
+    @validator("pass_flows", pre=True)
+    def validate_pass_flows(cls, v, values):
+        return v or []
+
     @validator("workflow_host", pre=True)
     def validate_workflow_host(cls, v, values):
         if v is None:

--- a/test/unit_test/engine/test_engine.py
+++ b/test/unit_test/engine/test_engine.py
@@ -62,10 +62,10 @@ class TestEngine:
         engine.register(OnnxConversion, host=system, evaluator_config=evaluator_config)
 
         # assert
-        assert name in engine.pass_config
-        assert engine.pass_config[name]["type"] == OnnxConversion
-        assert engine.pass_config[name]["host"] == system
-        assert engine.pass_config[name]["evaluator"] == evaluator_config
+        assert name in engine.pass_run_configs
+        assert engine.pass_run_configs[name]["type"] == OnnxConversion.__name__
+        assert engine.pass_run_configs[name]["host"] == system
+        assert engine.pass_run_configs[name]["evaluator"] == evaluator_config
 
     def test_register_no_search(self, tmpdir):
         # setup
@@ -82,7 +82,7 @@ class TestEngine:
         engine.register(OnnxDynamicQuantization)
 
         # assert
-        assert "OnnxDynamicQuantization" in engine.pass_config
+        assert "OnnxDynamicQuantization" in engine.pass_run_configs
 
     def test_default_engine_run(self, tmpdir):
         # setup
@@ -169,11 +169,7 @@ class TestEngine:
 
         # execute
         output_dir = Path(tmp_path)
-        actual_res = engine.run(
-            model_config,
-            [DEFAULT_CPU_ACCELERATOR],
-            output_dir=output_dir,
-        )
+        actual_res = engine.run(model_config, [DEFAULT_CPU_ACCELERATOR], output_dir=output_dir)
         actual_res = actual_res[DEFAULT_CPU_ACCELERATOR]
 
         # make sure the input model always be in engine.footprints

--- a/test/unit_test/passes/common/test_user_script.py
+++ b/test/unit_test/passes/common/test_user_script.py
@@ -9,5 +9,5 @@ from olive.passes.onnx.session_params_tuning import OrtSessionParamsTuning
 class TestUserScriptConfig:
     def test_no_config(self):
         config = {}
-        config = OrtSessionParamsTuning.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, True)
+        config = OrtSessionParamsTuning.generate_config(DEFAULT_CPU_ACCELERATOR, config, True)
         assert config

--- a/test/unit_test/passes/onnx/test_bnb_quantization.py
+++ b/test/unit_test/passes/onnx/test_bnb_quantization.py
@@ -78,9 +78,9 @@ def test_validate_quant_type(pass_config, model_attributes, expected_error, tmp_
     p = create_pass_from_dict(OnnxBnb4Quantization, pass_config, disable_search=True)
     if expected_error:
         with pytest.raises(expected_error):
-            p.run(input_model, str(tmp_path / "model.onnx"), None)
+            p.run(input_model, str(tmp_path / "model.onnx"))
     else:
-        p.run(input_model, str(tmp_path / "model.onnx"), None)
+        p.run(input_model, str(tmp_path / "model.onnx"))
 
 
 @pytest.mark.parametrize(("model_generator", "expected_count"), [(get_onnx_matmul_model, 1), (get_onnx_gemm_model, 0)])
@@ -117,5 +117,5 @@ def count_matmulbnb4_nodes(model: onnx.ModelProto):
 def test_quantized_modules(tmp_path, model_generator, quantized_modules, expected_count):
     input_model = model_generator(str(tmp_path / "model.onnx"))
     p = create_pass_from_dict(OnnxBnb4Quantization, {"quant_type": "nf4", "quantized_modules": quantized_modules})
-    output_model = p.run(input_model, (tmp_path / "output_model.onnx"), None)
+    output_model = p.run(input_model, (tmp_path / "output_model.onnx"))
     assert count_matmulbnb4_nodes(output_model.load_model()) == expected_count

--- a/test/unit_test/passes/onnx/test_optimum_conversion.py
+++ b/test/unit_test/passes/onnx/test_optimum_conversion.py
@@ -86,13 +86,13 @@ def test_optimum_configs(config, is_valid, tmp_path):
     output_folder = tmp_path
 
     if not is_valid:
-        assert p.validate_search_point(config, None) is False
+        assert p.validate_config(config, None) is False
         with pytest.raises(
             ValueError,
             match="FP16 export is supported only when exporting on GPU. Please pass the option `--device cuda`.",
         ):
             p.run(input_model, output_folder)
     else:
-        assert p.validate_search_point(config, None)
+        assert p.validate_config(config, None)
         onnx_model = p.run(input_model, output_folder)
         assert Path(onnx_model.model_path).exists()

--- a/test/unit_test/passes/onnx/test_transformer_optimization.py
+++ b/test/unit_test/passes/onnx/test_transformer_optimization.py
@@ -21,7 +21,7 @@ from olive.passes.onnx.transformer_optimization import OrtTransformersOptimizati
 
 def test_fusion_options():
     config = {"model_type": "bart", "optimization_options": {"use_multi_head_attention": True}}
-    config = OrtTransformersOptimization.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, True)
+    config = OrtTransformersOptimization.generate_config(DEFAULT_CPU_ACCELERATOR, config, disable_search=True)
     transformer_optimization = OrtTransformersOptimization(DEFAULT_CPU_ACCELERATOR, config, True)
     run_config = deepcopy(config)
     del (
@@ -47,7 +47,7 @@ def test_ort_transformer_optimization_pass(tmp_path):
     input_model = get_onnx_model()
     config = {"model_type": "bert"}
 
-    config = OrtTransformersOptimization.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, disable_search=True)
+    config = OrtTransformersOptimization.generate_config(DEFAULT_CPU_ACCELERATOR, config, disable_search=True)
     p = OrtTransformersOptimization(DEFAULT_CPU_ACCELERATOR, config, True)
     output_folder = str(tmp_path / "onnx")
 
@@ -71,9 +71,9 @@ def test_invalid_ep_config(use_gpu, fp16, accelerator_spec, mock_inferece_sessio
 
     input_model = get_onnx_model()
     config = {"model_type": "bert", "use_gpu": use_gpu, "float16": fp16}
-    config = OrtTransformersOptimization.generate_search_space(accelerator_spec, config, disable_search=True)
+    config = OrtTransformersOptimization.generate_config(accelerator_spec, config, disable_search=True)
     p = OrtTransformersOptimization(accelerator_spec, config, True)
-    is_pruned = not p.validate_search_point(config, accelerator_spec)
+    is_pruned = not p.validate_config(config, accelerator_spec, disable_search=True)
 
     if accelerator_spec.execution_provider == "CPUExecutionProvider":
         if fp16 and use_gpu:
@@ -140,7 +140,7 @@ def test_transformer_optimization_invalid_model_type(tmp_path):
     input_model = get_onnx_model()
     config = {"model_type": None}
 
-    config = OrtTransformersOptimization.generate_search_space(DEFAULT_CPU_ACCELERATOR, config, disable_search=True)
+    config = OrtTransformersOptimization.generate_config(DEFAULT_CPU_ACCELERATOR, config, disable_search=True)
     p = OrtTransformersOptimization(DEFAULT_CPU_ACCELERATOR, config, True)
     output_folder = str(tmp_path / "onnx")
 
@@ -158,7 +158,7 @@ def test_optimization_with_provider(mock_proto_to_model, mock_optimize_model, tm
     config = {"model_type": "bert", "use_gpu": True}
 
     dml_ep = AcceleratorSpec(accelerator_type=Device.GPU, execution_provider="DmlExecutionProvider")
-    config = OrtTransformersOptimization.generate_search_space(dml_ep, config, disable_search=True)
+    config = OrtTransformersOptimization.generate_config(dml_ep, config, disable_search=True)
     p = OrtTransformersOptimization(dml_ep, config, True)
     output_folder = str(tmp_path / "onnx")
 

--- a/test/unit_test/passes/test_pass_serialization.py
+++ b/test/unit_test/passes/test_pass_serialization.py
@@ -11,8 +11,8 @@ from olive.passes.onnx.conversion import OnnxConversion
 
 @pytest.mark.parametrize("host_device", [None, "cpu", "gpu"])
 def test_pass_serialization(host_device):
-    onnx_conversion_config = {}
-    config = OnnxConversion.generate_search_space(DEFAULT_CPU_ACCELERATOR, onnx_conversion_config)
+    config = {}
+    config = OnnxConversion.generate_config(DEFAULT_CPU_ACCELERATOR, config)
     onnx_conversion = OnnxConversion(DEFAULT_CPU_ACCELERATOR, config, host_device=host_device)
     json = onnx_conversion.to_json(True)
 

--- a/test/unit_test/systems/docker/test_docker_system.py
+++ b/test/unit_test/systems/docker/test_docker_system.py
@@ -277,8 +277,6 @@ class TestDockerSystem:
 
         p = create_pass_from_dict(OrtSessionParamsTuning, {}, disable_search=True)
         pass_config = p.to_json(check_object=True)
-        config = p.config_at_search_point({})
-        pass_config["config"].update(p.serialize_config(config, check_object=True))
 
         onnx_model = get_onnx_model_config()
 

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -151,13 +151,10 @@ class TestPythonEnvironmentSystem:
                 "dummy_param_2": "dummy_param_2_value",
             },
         }
-        full_config = {
-            "dummy_param_1": "dummy_param_1_value",
-            "dummy_param_2": "dummy_param_2_value2",
-        }
-        expected_pass_config = {"type": "DummyPass", "config": full_config}
+        dummy_config = dummy_pass_config["config"]
+        expected_pass_config = {"type": "DummyPass", "config": dummy_config}
         the_pass.to_json.return_value = dummy_pass_config
-        the_pass.serialize_config.return_value = full_config
+        the_pass.serialize_config.return_value = dummy_config
 
         # mock return value
         mock_return_value = {"dummy_output_model_key": "dummy_output_model_value"}
@@ -233,9 +230,8 @@ class TestPythonEnvironmentSystem:
 
         # create pass_config.json
         the_pass = get_onnxconversion_pass()
-        config = the_pass.config_at_search_point({})
         pass_config = the_pass.to_json(check_object=True)
-        pass_config["config"].update(the_pass.serialize_config(config, check_object=True))
+
         with (tmp_path / "pass_config.json").open("w") as f:
             json.dump(pass_config, f)
 

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -36,7 +36,7 @@ class TestLocalSystem:
         self.system.run_pass(p, olive_model, output_model_path)
 
         # assert
-        p.run.assert_called_once_with(olive_model.create_model(), output_model_path, None)
+        p.run.assert_called_once_with(olive_model.create_model(), output_model_path)
 
     METRIC_TEST_CASE: ClassVar[List[Metric]] = [
         (partial(get_accuracy_metric, AccuracySubType.ACCURACY_SCORE)),

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -240,11 +240,7 @@ def get_onnxconversion_pass(ignore_pass_config=True, target_opset=13):
 
     onnx_conversion_config = {"target_opset": target_opset}
     p = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
-    if ignore_pass_config:
-        return p
-    pass_config = p.config_at_search_point({})
-    pass_config = p.serialize_config(pass_config)
-    return p, pass_config
+    return p if ignore_pass_config else (p, p.to_json(check_object=True)["config"])
 
 
 def get_onnx_dynamic_quantization_pass(disable_search=False):


### PR DESCRIPTION
## Validate pass config before instantiating the pass

* Use of search point should be limited to engine logic only. Rest of the Olive implementation should receive a validated configuration to use.
* Validation is for complete configuration and not merely for a search point.
* Fixed a few issues related to use of BasePassConfig vs. FullPassConfig.
* Add local caching to OlivePackageConfig for loaded modules.
* Renamed a few variables in engine logic to be explicit about use of pass config vs. pass run config.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
