### PR TITLE
Add SpinQuant pass

### DIFF
--- a/docs/source/how-to/configure-workflows/pass/quantization-pytorch.md
+++ b/docs/source/how-to/configure-workflows/pass/quantization-pytorch.md
@@ -40,12 +40,26 @@ Please refer to [AutoAWQQuantizer](awq_quantizer) for more details about the pas
 ## QuaRot
 `QuaRot` is a technique that rotates the weights of a model to make them more conducive to quantization. It is based on the [QuaRot paper](https://arxiv.org/abs/2305.14314) but only performs offline weight rotation. Can be followed by a pass such as GPTQ to quantize the rotated model weights.
 
-This pass only supports HuggingFace transformer PyTorch models. Please refer to [QuaRot](quarot) for more details on the types of transformers models supported.
+This pass only supports HuggingFace transformer PyTorch models.
 
 ### Example Configuration
 ```json
 {
     "type": "QuaRot",
     "rotate_mode": "hadamard"
+}
+```
+
+## SpinQuant
+`SpinQuant` is a technique simlar to QuaRot that rotates the weights of a model to make them more conducive to quantization. The rotation weights are trained on a calibration dataset to improve activation quantization quality. It is based on the [SpinQuant paper](https://arxiv.org/pdf/2405.16406) but only performs offline weight rotation. Can be followed by a pass such as GPTQ to quantize the rotated model weights.
+
+This pass only supports HuggingFace transformer PyTorch models.
+
+### Example Configuration
+```json
+{
+    "type": "SpinQuant",
+    "rotate_mode": "hadamard",
+    "a_bits": 8
 }
 ```

--- a/docs/source/reference/pass.rst
+++ b/docs/source/reference/pass.rst
@@ -240,6 +240,12 @@ QuaRot
 ------
 .. autoconfigclass:: olive.passes.QuaRot
 
+.. _spinquant:
+
+SpinQuant
+---------
+.. autoconfigclass:: olive.passes.SpinQuant
+
 .. _gptq_quantizer:
 
 GptqQuantizer

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -297,6 +297,12 @@
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ]
         },
+        "SpinQuant": {
+            "module_path": "olive.passes.pytorch.rotate.SpinQuant",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
         "SliceGPT": {
             "module_path": "olive.passes.pytorch.slicegpt.SliceGPT",
             "supported_providers": [ "*" ],

--- a/olive/passes/pytorch/sgdg.py
+++ b/olive/passes/pytorch/sgdg.py
@@ -1,0 +1,190 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+# Based on https://github.com/JunLi-Galios/Optimization-on-Stiefel-Manifold-via-Cayley-Transform
+import random
+
+import torch
+from torch.optim.optimizer import Optimizer, required
+
+# ruff: noqa: N802,N806
+
+
+def norm(v, dim=1):
+    assert len(v.size()) == 2
+    return v.norm(p=2, dim=dim, keepdim=True)
+
+
+def unit(v, dim=1, eps=1e-8):
+    vnorm = norm(v, dim)
+    return v / vnorm.add(eps), vnorm
+
+
+def qr_retraction(tan_vec):  # tan_vec, p-by-n, p <= n
+    tan_vec.t_()
+    q, r = torch.linalg.qr(tan_vec)  # pylint: disable=not-callable
+    d = torch.diag(r, 0)
+    ph = d.sign()
+    q *= ph.expand_as(q)
+    q.t_()
+
+    return q
+
+
+def matrix_norm_one(W):
+    out = torch.abs(W)
+    out = torch.sum(out, dim=0)
+    return torch.max(out)
+
+
+def Cayley_loop(X, W, tan_vec, t):
+    Y = X + t * tan_vec
+    for _ in range(5):
+        Y = X + t * torch.matmul(W, 0.5 * (X + Y))
+
+    return Y.t()
+
+
+episilon = 1e-8
+
+
+class SGDG(Optimizer):
+    r"""Cayley-SGD-G optimizer.
+
+        This optimizer updates variables with two different routines
+        based on the boolean variable 'stiefel'.
+
+        If stiefel is True, the variables will be updated by SGD-G proposed
+        as decorrelated weight matrix.
+
+        If stiefel is False, the variables will be updated by SGD.
+        This routine was taken from https://github.com/pytorch/pytorch/blob/master/torch/optim/sgd.py.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+
+        -- common parameters
+        lr (float): learning rate
+        momentum (float, optional): momentum factor (default: 0)
+        stiefel (bool, optional): whether to use SGD-G (default: False)
+
+        -- parameters in case stiefel is False
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        dampening (float, optional): dampening for momentum (default: 0)
+        nesterov (bool, optional): enables Nesterov momentum (default: False)
+
+        -- parameters in case stiefel is True
+        omega (float, optional): orthogonality regularization factor (default: 0)
+        grad_clip (float, optional): threshold for gradient norm clipping (default: None)
+
+    """
+
+    def __init__(
+        self,
+        params,
+        lr=required,
+        momentum=0,
+        dampening=0,
+        weight_decay=0,
+        nesterov=False,
+        stiefel=False,
+        omega=0,
+        grad_clip=None,
+    ):
+        defaults = {
+            "lr": lr,
+            "momentum": momentum,
+            "dampening": dampening,
+            "weight_decay": weight_decay,
+            "nesterov": nesterov,
+            "stiefel": stiefel,
+            "omega": omega,
+            "grad_clip": grad_clip,
+        }
+        if nesterov and (momentum <= 0 or dampening != 0):
+            raise ValueError("Nesterov momentum requires a momentum and zero dampening")
+        super().__init__(params, defaults)
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault("nesterov", False)
+
+    def step(self, closure=None):
+        """Perform a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            momentum = group["momentum"]
+            stiefel = group["stiefel"]
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+
+                unity, _ = unit(p.data.view(p.size()[0], -1))
+                if stiefel and unity.size()[0] <= unity.size()[1]:
+
+                    weight_decay = group["weight_decay"]
+                    dampening = group["dampening"]
+                    nesterov = group["nesterov"]
+
+                    rand_num = random.randint(1, 101)
+                    if rand_num == 1:
+                        unity = qr_retraction(unity)
+
+                    g = p.grad.data.view(p.size()[0], -1)
+
+                    lr = group["lr"]
+
+                    param_state = self.state[p]
+                    if "momentum_buffer" not in param_state:
+                        param_state["momentum_buffer"] = torch.zeros(g.t().size())
+                        if p.is_cuda:
+                            param_state["momentum_buffer"] = param_state["momentum_buffer"].cuda()
+
+                    V = param_state["momentum_buffer"]
+                    V = momentum * V - g.t()
+                    MX = torch.mm(V, unity)
+                    XMX = torch.mm(unity, MX)
+                    XXMX = torch.mm(unity.t(), XMX)
+                    W_hat = MX - 0.5 * XXMX
+                    W = W_hat - W_hat.t()
+                    t = 0.5 * 2 / (matrix_norm_one(W) + episilon)
+                    alpha = min(t, lr)
+
+                    p_new = Cayley_loop(unity.t(), W, V, alpha)
+                    V_new = torch.mm(W, unity.t())  # n-by-p
+                    #                     check_identity(p_new.t())
+                    p.data.copy_(p_new.view(p.size()))
+                    V.copy_(V_new)
+
+                else:
+                    d_p = p.grad.data
+                    if weight_decay != 0:
+                        d_p.add_(weight_decay, p.data)
+                    if momentum != 0:
+                        param_state = self.state[p]
+                        if "momentum_buffer" not in param_state:
+                            buf = param_state["momentum_buffer"] = d_p.clone()
+                        else:
+                            buf = param_state["momentum_buffer"]
+                            buf.mul_(momentum).add_(1 - dampening, d_p)
+                        if nesterov:
+                            d_p = d_p.add(momentum, buf)
+                        else:
+                            d_p = buf
+
+                    p.data.add_(-group["lr"], d_p)
+
+        return loss

--- a/olive/passes/pytorch/train_utils.py
+++ b/olive/passes/pytorch/train_utils.py
@@ -1,0 +1,232 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import dataclasses
+import logging
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import transformers
+
+from olive.common.config_utils import NestedConfig
+from olive.common.pydantic_v1 import Field, validator
+from olive.common.utils import cleanup_memory
+from olive.data.config import DataConfig
+from olive.model import HfModelHandler
+from olive.model.config.hf_config import HfLoadKwargs
+
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    import torch
+    from transformers import PreTrainedModel
+
+
+# creating a Config class since transformers.TrainingArguments is a dataclass
+# pydantic handles dataclasses differently and causes issues with validation
+# this also allows us to handle and validate extra_args better
+class BaseHFTrainingArguments(NestedConfig):
+    """Training arguments for transformers.Trainer."""
+
+    _nested_field_name = "extra_args"
+
+    gradient_checkpointing: bool = Field(True, description="Use gradient checkpointing. Recommended.")
+    report_to: Union[str, List[str]] = Field(
+        "none", description="The list of integrations to report the results and logs to."
+    )
+    output_dir: str = Field(None, description="The output dir for logs and checkpoints. If None, will use a temp dir.")
+    deepspeed: Union[bool, str, Dict] = Field(
+        None,
+        description=(
+            "Use [Deepspeed](https://github.com/microsoft/deepspeed). If True, will use default deepspeed config. Else,"
+            " it is a path to a deepspeed config file or a dict with deepspeed config."
+        ),
+    )
+    extra_args: Dict[str, Any] = Field(
+        None,
+        description=(
+            "Extra arguments to pass to the trainer. Values can be provided directly to this field as a dict or as"
+            " keyword arguments to the config. See transformers.TrainingArguments for more details on the available"
+            " arguments."
+        ),
+    )
+
+    @validator("extra_args", pre=True, always=True)
+    def validate_extra_args(cls, v):
+        if v is None:
+            v = {}
+        # make sure extra args are fields of transformers.Trainer
+        training_args_fields = {f.name for f in dataclasses.fields(transformers.TrainingArguments) if f.init}
+        for k in list(v):  # need a copy of the keys since we are mutating the dict
+            if k not in training_args_fields:
+                logger.warning("Extra arg %s is not a field of transformers.TrainingArguments. Ignoring.", k)
+                del v[k]
+        return v
+
+    def create_training_args(self) -> transformers.TrainingArguments:
+        args = self.dict()
+        if not args["output_dir"]:
+            raise ValueError("output_dir must be provided.")
+        if args["deepspeed"] is True:
+            args["deepspeed"] = deepcopy(DEFAULT_DEEPSPEED_CONFIG)
+        elif args["deepspeed"] is False:
+            del args["deepspeed"]
+        extra_args = args.pop("extra_args")
+        return transformers.TrainingArguments(**args, **extra_args)
+
+
+def load_hf_base_model(
+    model_handler: HfModelHandler,
+    torch_dtype: Optional["torch.dtype"] = None,
+    device_map: Optional[Union[int, str, Dict]] = None,
+    **kwargs,
+) -> "PreTrainedModel":
+    """Load a base PyTorch model.
+
+    :param model_handler: The input model handler.
+    :param torch_dtype: The torch dtype to load the model with.
+    :param device_map: The device map to load the model with.
+    :param kwargs: Additional arguments to update load_kwargs with.
+    :return: The new loaded pytorch model
+    """
+    # model cannot have it's own adapter
+    if model_handler.adapter_path:
+        raise ValueError("Model already has an adapter. Please provide a model without an adapter.")
+
+    # don't want the original loaded model
+    # also frees gpu memory if original model is on gpu
+    model_handler.model = None
+    cleanup_memory()
+
+    # create copy of the input model, will modify this model
+    # also resets adapter_path
+    new_model_handler = deepcopy(model_handler)
+
+    # load model, reset load_kwargs and adapter_path
+    load_kwargs = new_model_handler.load_kwargs.dict() if new_model_handler.load_kwargs else {}
+    load_kwargs.update(
+        {
+            "torch_dtype": torch_dtype,
+            "device_map": device_map,
+        }
+    )
+    # overwrite load_kwargs with kwargs
+    load_kwargs.update(kwargs)
+    new_model_handler.load_kwargs = HfLoadKwargs(**load_kwargs)
+
+    return new_model_handler.load_model(cache_model=False)
+
+
+def prepare_model_for_finetuning(model: "PreTrainedModel", training_args: BaseHFTrainingArguments):
+    """Prepare the model for fine-tuning.
+
+    Freeze base model's layers and prepare model for gradient checkpointing if necessary.
+    Similar to peft.prepare_model_for_kbit_training but no casting to fp32 and gradient checkpointing is
+    also supported for non-quantized models.
+
+    :param model: The Hugging Face PyTorch model to prepare for fine-tuning.
+    :param training_args: The training arguments for the model.
+    """
+    for param in model.parameters():
+        # freeze base model's layers
+        param.requires_grad = False
+
+    if training_args.gradient_checkpointing and not model.supports_gradient_checkpointing:
+        logger.warning(
+            "gradient_checkpointing is True, but model does not support gradient checkpointing! Setting"
+            " gradient_checkpoing to False"
+        )
+        training_args.gradient_checkpointing = False
+    elif training_args.gradient_checkpointing:
+        # For backward compatibility
+        if hasattr(model, "enable_input_require_grads"):
+            model.enable_input_require_grads()
+        else:
+
+            def make_inputs_require_grad(module_, input_, output_):
+                output_.requires_grad_(True)
+
+            model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+        # enable gradient checkpointing for memory efficiency
+        model.gradient_checkpointing_enable()
+
+    logger.debug("The number of trainable parameters in the original model: %s", count_trainable_parameters(model))
+
+
+def count_trainable_parameters(model) -> str:
+    """Count and return the number of trainable parameters in a model."""
+    trainable_params = 0
+    all_param = 0
+    for param in model.parameters():
+        all_param += param.numel()
+        if param.requires_grad:
+            trainable_params += param.numel()
+    return (
+        f"trainable params: {trainable_params} || all params: {all_param} "
+        f"|| trainable%: {100 * trainable_params / all_param:.2f}"
+    )
+
+
+def get_training_dataset(data_config: DataConfig):
+    """Get the training dataset from the data config."""
+    from datasets import Dataset
+
+    def data_generator(dataset):
+        # not iterating over dataset directly since we only require loaded dataset to have __len__ and __getitem__
+        for idx in range(len(dataset)):  # pylint: disable=consider-using-enumerate
+            example = dataset[idx]
+            if isinstance(example, tuple):
+                # if example = {**example[0], "labels": example[1]}, the attention_mask is not the same
+                # for some reason, so yield a new dict
+                yield {**example[0], "labels": example[1]}
+            else:
+                yield example
+
+    # each sample is an (input_dict, target) tuple
+    data_container = data_config.to_data_container()
+    dataset = data_container.pre_process(data_container.load_dataset())
+    dataset = Dataset.from_generator(data_generator, gen_kwargs={"dataset": dataset})
+    dataset.set_format("torch")
+
+    return dataset
+
+
+DEFAULT_DEEPSPEED_CONFIG = {
+    "zero_optimization": {
+        "stage": 3,
+        "allgather_partitions": True,
+        "allgather_bucket_size": 5e8,
+        "overlap_comm": True,
+        "reduce_scatter": True,
+        "reduce_bucket_size": "auto",
+        "contiguous_gradients": True,
+        "stage3_prefetch_bucket_size": "auto",
+        "stage3_param_persistence_threshold": "auto",
+        "sub_group_size": 1e9,
+        "stage3_max_live_parameters": 1e9,
+        "stage3_max_reuse_distance": 1e9,
+        "stage3_gather_16bit_weights_on_model_save": "auto",
+        "offload_param": {
+            "device": "cpu",
+        },
+        "offload_optimizer": {
+            "device": "cpu",
+        },
+    },
+    "fp16": {
+        "enabled": "auto",
+        "loss_scale": 0,
+        "loss_scale_window": 1000,
+        "initial_scale_power": 16,
+        "hysteresis": 2,
+        "min_loss_scale": 1,
+    },
+    "bf16": {"enabled": "auto"},
+    "train_micro_batch_size_per_gpu": "auto",
+    "train_batch_size": "auto",
+    "gradient_accumulation_steps": "auto",
+    "gradient_clipping": "auto",
+}

--- a/test/unit_test/passes/pytorch/test_rotate.py
+++ b/test/unit_test/passes/pytorch/test_rotate.py
@@ -2,19 +2,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from unittest.mock import patch
+
 import pytest
 import torch
 
+from olive.data.template import huggingface_data_config_template
 from olive.model import HfModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
-from olive.passes.pytorch.rotate import QuaRot
+from olive.passes.pytorch.rotate import QuaRot, SpinQuant
 
 
-@pytest.mark.parametrize(
-    "model_path", ["katuni4ka/tiny-random-phi3", "hf-internal-testing/tiny-random-LlamaForCausalLM"]
-)
-@pytest.mark.parametrize("rotate_mode", ["hadamard", "random"])
-def test_quarot(tmp_path, model_path, rotate_mode):
+def common_test_rotate(rotate_pass, tmp_path, model_path, rotate_mode, atol, **config_kwargs):
     input_model = HfModelHandler(model_path=model_path)
     if input_model.get_hf_model_type() == "llama":
         # this checkpoint has an invalid generation config that cannot be saved
@@ -25,7 +24,7 @@ def test_quarot(tmp_path, model_path, rotate_mode):
         input_model.get_hf_tokenizer().save_pretrained(model_path)
         input_model = HfModelHandler(model_path=model_path)
 
-    p = create_pass_from_dict(QuaRot, {"rotate_mode": rotate_mode}, disable_search=True)
+    p = create_pass_from_dict(rotate_pass, {"rotate_mode": rotate_mode, **config_kwargs}, disable_search=True)
 
     output_path = str(tmp_path / "output")
     output_model = p.run(input_model, output_path)
@@ -41,4 +40,51 @@ def test_quarot(tmp_path, model_path, rotate_mode):
     with torch.no_grad():
         original_output = original_model(i)
         rotated_output = rotated_model(i)
-        assert torch.allclose(original_output.logits, rotated_output.logits, atol=1e-5)
+        assert torch.allclose(original_output.logits, rotated_output.logits, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "model_path", ["katuni4ka/tiny-random-phi3", "hf-internal-testing/tiny-random-LlamaForCausalLM"]
+)
+@pytest.mark.parametrize("rotate_mode", ["hadamard", "random"])
+def test_quarot(tmp_path, model_path, rotate_mode):
+    common_test_rotate(QuaRot, tmp_path, model_path, rotate_mode, 1e-5)
+
+
+def get_patched_data_config(model_name_or_path, trust_remote_code):
+    return huggingface_data_config_template(
+        model_name=model_name_or_path,
+        task="text-generation",
+        load_dataset_config={
+            "data_name": "wikitext",
+            "subset": "wikitext-2-raw-v1",
+            "split": "train",
+            "trust_remote_code": trust_remote_code,
+        },
+        pre_process_data_config={
+            "add_special_tokens": False,
+            "max_seq_len": 10,
+            "max_samples": 8,
+            "trust_remote_code": trust_remote_code,
+        },
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires a GPU")
+@pytest.mark.parametrize(
+    "model_path", ["katuni4ka/tiny-random-phi3", "hf-internal-testing/tiny-random-LlamaForCausalLM"]
+)
+@pytest.mark.parametrize("rotate_mode", ["hadamard", "random"])
+@patch("olive.passes.pytorch.rotate.SpinQuant.get_train_data_config", side_effect=get_patched_data_config)
+def test_spinquant(_, tmp_path, model_path, rotate_mode):
+    common_test_rotate(
+        SpinQuant,
+        tmp_path,
+        model_path,
+        rotate_mode,
+        # training updates the rotation matrix so the outputs are slightly different
+        5e-3,
+        # not all gpus support bf16
+        # gradient checkpointing doesn't work on v100 CI agent
+        training_args={"bf16": False, "gradient_checkpointing": False},
+    )


### PR DESCRIPTION
## Describe your changes
Add a new pass do weight rotation using SpinQuant. 
- Similar to QuaRot, this pass also only performs offline weight rotation.
- The concept is similar to QuaRot but the rotation weights are trained on a calibration dataset to improve activation quantization quality. 
- Only per_token and per_tensor activation quantization are supported. Groupwise quatization is not supported yet since we don't expect it to be used in subsequent QDQ models.
- Common training utils have been abstracted from the lora passes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
