### PR TITLE
GraphSurgeries: Add pass to olive_config.json, Resolve output_model_path

### DIFF
--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -12,6 +12,12 @@
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ]
         },
+        "GraphSurgeries": {
+            "module_path": "olive.passes.onnx.graph_surgeries.GraphSurgeries",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
         "ExtractAdapters": {
             "module_path": "olive.passes.onnx.extract_adapters.ExtractAdapters",
             "supported_providers": [ "*" ],

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -7,20 +7,20 @@
 
 import inspect
 import logging
+from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Type
 
 import numpy as np
 import onnx
 from onnx import ModelProto, TensorProto
 from onnx.helper import make_tensor
-from pathlib import Path
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
-from olive.passes import Pass
-from olive.passes.onnx.common import model_proto_to_olive_model, get_external_data_config
-from olive.passes.pass_config import PassConfigParam
 from olive.model.utils import resolve_onnx_path
+from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
+from olive.passes.pass_config import PassConfigParam
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Describe your changes
- Add pass to olive_config.json
- Resolve the output path, otherwise, it uses the original path which is a directory. We need to create a .onnx filename inside it. Came across a permissions issue on Windows with the directory path.
- Expose external data config like other onnx passes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
