### PR TITLE
OnnxStaticQuantization: Remove `quant_preprocess=False` default for qnn ep

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -608,7 +608,6 @@ class OnnxStaticQuantization(OnnxQuantization):
             config["activation_type"].search_defaults = Categorical(["QInt8", "QUInt8", "QUInt16", "QInt16"])
             config["weight_type"].search_defaults = Categorical(["QInt8", "QUInt8", "QUInt16", "QInt16"])
             config["prepare_qnn_config"].default_value = True
-            config["quant_preprocess"].default_value = False
             # in QNN EP, the default value WeightSymmetric is None
             # but in base quantizer, the default value is True.
             config["WeightSymmetric"].default_value = None


### PR DESCRIPTION
## Describe your changes
`quant_preprocess` was originally set to `False` by default because I thought it might not be compatible with QNN EP. However, it is needed for most models for the quantization to work properly:
- The quantizer needs a shape inferred model to quantize some tensors.
- Model quality is bad if constants are not made into initializers (see #1552).

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
