### PR TITLE
Use concrete config classes instead of generic dictionary

### DIFF
--- a/olive/cache.py
+++ b/olive/cache.py
@@ -154,7 +154,9 @@ class OliveCache:
         self.update_shared_cache = cache_config.update_shared_cache
 
     @staticmethod
-    def get_run_json(pass_name: int, pass_config: dict, input_model_id: str, accelerator_spec: "AcceleratorSpec"):
+    def get_run_json(
+        pass_name: str, pass_config: Dict[str, Any], input_model_id: str, accelerator_spec: "AcceleratorSpec"
+    ) -> Dict[str, Any]:
         accelerator_spec = str(accelerator_spec) if accelerator_spec else None
         return {
             "input_model_id": input_model_id,

--- a/olive/passes/olive_pass.py
+++ b/olive/passes/olive_pass.py
@@ -58,7 +58,7 @@ class Pass(ABC):
     def __init__(
         self,
         accelerator_spec: AcceleratorSpec,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         host_device=None,
     ):
         """Initialize the pass.
@@ -66,30 +66,24 @@ class Pass(ABC):
         :param accelerator_spec: the accelerator spec for the pass.
         :type accelerator_spec: AcceleratorSpec
         :param config: the configuration representing search space.
-        :type config: Dict[str, Any]
+        :type config: Type[BasePassConfig]
         :param host_device: the host device for the pass.
         :type host_device: Optional[str]
         """
         assert accelerator_spec is not None, "Please specify the accelerator spec for the pass."
         assert config is not None, "Please specify the configuration for the pass."
 
-        # NOTE: The :disable_search argument isn't impactful here since the search isn't
-        # dependent on it. The same parameter in :generate_config is what decides
-        # how search points are handled. HEre, Using default values for each config
-        # parameter in the config class keeps it simple.
-        config_class, default_config = self.get_config_class(accelerator_spec, True)
-
+        self.config = config
         self.accelerator_spec = accelerator_spec
         self.host_device = host_device
 
-        self._config_class = config_class
-        self.config = config
-        self._user_module_loader = UserModuleLoader(self.config.get("user_script"), self.config.get("script_dir"))
+        if hasattr(self.config, "user_script") and hasattr(self.config, "script_dir"):
+            self._user_module_loader = UserModuleLoader(self.config.user_script, self.config.script_dir)
 
         # Params that are paths [(param_name, required)]
         self.path_params = [
             (param, param_config.required, param_config.category)
-            for param, param_config in default_config.items()
+            for param, param_config in self.default_config(accelerator_spec).items()
             if param_config.category in (ParamCategory.PATH, ParamCategory.DATA)
         ]
 
@@ -110,7 +104,7 @@ class Pass(ABC):
         accelerator_spec: AcceleratorSpec,
         config: Optional[Dict[str, Any]] = None,
         disable_search: Optional[bool] = False,
-    ) -> Tuple[Dict[str, Any], Dict[str, SearchParameter]]:
+    ) -> Tuple[Type[BasePassConfig], Dict[str, Any], Dict[str, SearchParameter]]:
         """Generate search space for the pass."""
         assert accelerator_spec is not None, "Please specify the accelerator spec for the pass"
         config = config or {}
@@ -125,7 +119,7 @@ class Pass(ABC):
         # Generate the search space by using both default value and default search value and user provided config
         config = validate_config(config, config_class)
         config = cls._resolve_config(config, default_config)
-        return cls._init_fixed_and_search_params(config, default_config)
+        return config_class, *cls._init_fixed_and_search_params(config, default_config)
 
     @classmethod
     def generate_config(
@@ -134,16 +128,16 @@ class Pass(ABC):
         config: Optional[Dict[str, Any]] = None,
         point: Optional[Dict[str, Any]] = None,
         disable_search: Optional[bool] = False,
-    ) -> Dict[str, Any]:
+    ) -> Type[BasePassConfig]:
         """Get the configuration for the pass at a specific point in the search space."""
         assert accelerator_spec is not None, "Please specify the accelerator spec for the pass"
 
         point = point or {}
-        fixed_values, search_params = cls.get_config_params(accelerator_spec, config, disable_search)
+        config_class, fixed_values, search_params = cls.get_config_params(accelerator_spec, config, disable_search)
         assert (
             set(point.keys()).intersection(set(search_params.keys())) == point.keys()
         ), "Search point is not in the search space."
-        return {**fixed_values, **search_params, **point}
+        return config_class.parse_obj({**fixed_values, **search_params, **point})
 
     @classmethod
     def _identify_search_values(
@@ -202,9 +196,8 @@ class Pass(ABC):
     @classmethod
     def validate_config(
         cls,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         accelerator_spec: AcceleratorSpec,
-        disable_search: Optional[bool] = False,
     ) -> bool:
         """Validate the input config for the pass."""
         return True
@@ -310,17 +303,13 @@ class Pass(ABC):
         output_model_attributes["additional_files"] = sorted(output_model_additional_files)
         output_model.model_attributes = output_model_attributes
 
-    def serialize_config(self, config: Dict[str, Any], check_object: bool = False) -> str:
-        """Serialize the configuration."""
-        return self._config_class(**config).to_json(check_object)
-
     def to_json(self, check_object: bool = False) -> Dict[str, Any]:
         """Convert the pass to json."""
         return {
             "type": self.__class__.__name__,
             "accelerator": self.accelerator_spec.to_json(),
             "host_device": self.host_device,
-            "config": self.serialize_config(self.config, check_object),
+            "config": self.config.to_json(check_object),
         }
 
     @classmethod
@@ -464,7 +453,7 @@ class Pass(ABC):
     @classmethod
     def _resolve_config(
         cls,
-        input_config: Union[Dict[str, Any], BasePassConfig],
+        input_config: Union[Dict[str, Any], Type[BasePassConfig]],
         default_config: Dict[str, PassConfigParam],
     ) -> Dict[str, Any]:
         """Resolve config to BasePassConfig."""
@@ -480,7 +469,7 @@ class Pass(ABC):
 
     @abstractmethod
     def _run_for_config(
-        self, model: OliveModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: OliveModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> OliveModelHandler:
         """Run the pass on the model with the given configuration."""
         raise NotImplementedError
@@ -502,6 +491,7 @@ class FullPassConfig(AbstractPassConfig):
 
         pass_cls = Pass.registry[self.type.lower()]
         accelerator_spec = AcceleratorSpec(**self.accelerator)  # pylint: disable=not-a-mapping
+        self.config = pass_cls.generate_config(accelerator_spec, self.config)
         return pass_cls(accelerator_spec, self.config, self.host_device)
 
 
@@ -518,5 +508,5 @@ def create_pass_from_dict(
     if accelerator_spec is None:
         accelerator_spec = DEFAULT_CPU_ACCELERATOR
 
-    config = pass_cls.generate_config(accelerator_spec, config, disable_search=disable_search)
+    config: Type[BasePassConfig] = pass_cls.generate_config(accelerator_spec, config, disable_search=disable_search)
     return pass_cls(accelerator_spec, config, host_device)

--- a/olive/passes/onnx/bnb_quantization.py
+++ b/olive/passes/onnx/bnb_quantization.py
@@ -5,7 +5,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List, Type
 
 import onnx
 from packaging import version
@@ -15,7 +15,7 @@ from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class OnnxBnb4Quantization(Pass):
         return config
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         from onnxruntime import __version__ as OrtVersion
 
@@ -60,8 +60,8 @@ class OnnxBnb4Quantization(Pass):
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
-        quant_type = config["quant_type"]
-        quantized_modules = config["quantized_modules"]
+        quant_type = config.quant_type
+        quantized_modules = config.quantized_modules
         if model.model_attributes:
             quantized_modules = quantized_modules or model.model_attributes.get("quantized_modules")
 
@@ -87,7 +87,7 @@ class OnnxBnb4Quantization(Pass):
         onnx_model = model.load_model()
 
         # get nodes to exclude from quantization
-        nodes_to_exclude = config["nodes_to_exclude"] or []
+        nodes_to_exclude = config.nodes_to_exclude or []
 
         # find all MatMul nodes in the graph
         matmul_nodes = self._find_matmul_nodes(onnx_model.graph)

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -5,13 +5,13 @@
 import logging
 import re
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import onnx
 
 from olive.model import ONNXModelHandler
 from olive.passes.onnx.onnx_dag import OnnxDAG
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.resource_path import LocalFile, LocalFolder
 
 logger = logging.getLogger(__name__)
@@ -139,7 +139,7 @@ def model_proto_to_file(
 def model_proto_to_olive_model(
     model_proto: onnx.ModelProto,
     output_model_path: Union[str, Path],
-    external_data_config: dict,
+    external_data_config: Union[Dict[str, Any], Type[BasePassConfig]],
     check_model: bool = False,
     external_initializers_file_name: Optional[str] = None,
     constant_inputs_file_name: Optional[str] = None,
@@ -163,6 +163,8 @@ def model_proto_to_olive_model(
         "size_threshold",
         "convert_attribute",
     ]
+    if not isinstance(external_data_config, dict):
+        external_data_config = external_data_config.dict()
     has_external_data = model_proto_to_file(
         model_proto, output_model_path, **{k: external_data_config[k] for k in config_keys if k in external_data_config}
     )

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -6,7 +6,7 @@ import logging
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Dict, Type
 
 import numpy as np
 import onnx
@@ -18,7 +18,7 @@ from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import LORA_NAME_PATTERNS, get_external_data_config, model_proto_to_olive_model
 from olive.passes.onnx.onnx_dag import OnnxDAG
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -74,7 +74,7 @@ class ExtractAdapters(Pass):
         return config
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
@@ -181,8 +181,8 @@ class ExtractAdapters(Pass):
         for node_name in nodes_to_remove:
             dag.remove_node(node_name)
 
-        if config["make_inputs"]:
-            if quant_modules and config["dynamic_lora_r"]:
+        if config.make_inputs:
+            if quant_modules and config.dynamic_lora_r:
                 # MatMulNBits has static K,N dimensions which are set as attributes
                 # No use case for DequantizeLinear with dynamic lora_r
                 logger.info("Quantized modules do not support dynamic_lora_r. Ignoring.")
@@ -196,15 +196,15 @@ class ExtractAdapters(Pass):
         dag.update()
 
         # save the weights
-        weights_path = save_weights(weights, Path(output_model_path).parent / "adapter_weights", config["save_format"])
+        weights_path = save_weights(weights, Path(output_model_path).parent / "adapter_weights", config.save_format)
 
         # save the model
         output_model = model_proto_to_olive_model(
             dag.model,
             output_model_path,
             config,
-            external_initializers_file_name=weights_path.name if not config["make_inputs"] else None,
-            constant_inputs_file_name=weights_path.name if config["make_inputs"] else None,
+            external_initializers_file_name=weights_path.name if not config.make_inputs else None,
+            constant_inputs_file_name=weights_path.name if config.make_inputs else None,
         )
         output_model.model_attributes = deepcopy(model.model_attributes) or {}
         # add adapter weights to the model attributes
@@ -214,7 +214,7 @@ class ExtractAdapters(Pass):
         additional_files.append(str(weights_path))
         # save information about the weights in the model attributes
         weights_info = {name: [list(value.shape), str(value.dtype)] for name, value in weights.items()}
-        if not config["make_inputs"]:
+        if not config.make_inputs:
             output_model.model_attributes["external_initializers"] = weights_info
         else:
             output_model.model_attributes["constant_inputs"] = weights_info
@@ -282,14 +282,16 @@ class ExtractAdapters(Pass):
         dag.add_initializer(new_initializer, dag.get_io(old_name).graph_idx)
 
     @classmethod
-    def _make_dynamic_optional(cls, dag: OnnxDAG, weights: Dict[str, "NDArray"], name: str, config: Dict[str, Any]):
+    def _make_dynamic_optional(
+        cls, dag: OnnxDAG, weights: Dict[str, "NDArray"], name: str, config: Type[BasePassConfig]
+    ):
         """Make the input dynamic and optional."""
         if "quant" in name:
             # dynamic shape not supported for quantized modules
             # cannot have empty tensor as default values, so create default initializers of the same shape
             # scales must be zero to make the dequantized weights zero
             # quant weight and zeros points also made zero to be clean and consistent
-            if config["optional_inputs"]:
+            if config.optional_inputs:
                 initializer_proto = onnx.numpy_helper.from_array(np.zeros_like(weights[name]), name)
                 dag.add_initializer(initializer_proto, 0, keep_input=True)
 
@@ -299,11 +301,11 @@ class ExtractAdapters(Pass):
         dim_idx = 1 if "lora_A" in name else 0
 
         # make the input dynamic
-        if config["dynamic_lora_r"]:
+        if config.dynamic_lora_r:
             dag.make_input_dim_dynamic(name, dim_idx, "lora_r")
 
         # create default initializer with the lora_r dimension set to 0
-        if config["optional_inputs"]:
+        if config.optional_inputs:
             shape = list(weights[name].shape)
             shape[dim_idx] = 0
             initializer_proto = onnx.numpy_helper.from_array(np.zeros(shape, dtype=weights[name].dtype), name)

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -3,14 +3,14 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List, Type
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 
 class OnnxFloatToFloat16(Pass):
@@ -47,7 +47,7 @@ class OnnxFloatToFloat16(Pass):
         return config
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         from onnxruntime.transformers.onnx_model import OnnxModel
 
@@ -56,9 +56,10 @@ class OnnxFloatToFloat16(Pass):
         # using the float16 converter from onnxruntime since it is regularly updated
         # and can handle large models (>2GB) as well as ort contrib ops
         ort_onnx_model = OnnxModel(model.load_model())
+        config_dict = config.dict()
         ort_onnx_model.convert_float_to_float16(
             **{
-                key: config[key]
+                key: config_dict[key]
                 for key in [
                     "min_positive_val",
                     "max_finite_val",

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -21,7 +21,7 @@ from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.onnx.onnx_dag import OnnxDAG
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -693,11 +693,11 @@ class GraphSurgeries(Pass):
         }
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
-        surgeries = config["surgeries"]
+        surgeries = config.surgeries
         onnx_model = model.load_model()
         for surgery in surgeries:
             logger.info("Applying surgery: %s", surgery)

--- a/olive/passes/onnx/io_datatype_converter.py
+++ b/olive/passes/onnx/io_datatype_converter.py
@@ -6,7 +6,7 @@ import logging
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Dict, Optional, Type
 
 import onnx
 
@@ -15,7 +15,7 @@ from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class OnnxIODataTypeConverter(Pass):
             )
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         from onnxruntime.transformers.onnx_model import OnnxModel
 
@@ -153,11 +153,11 @@ class OnnxIODataTypeConverter(Pass):
         self.create_io_mapping(ort_onnx_model.model.graph, i_map, o_map)
 
         pat = None
-        if config["name_pattern"]:
-            pat = re.compile(config["name_pattern"])
+        if config.name_pattern:
+            pat = re.compile(config.name_pattern)
 
-        source_dtype = config["source_dtype"]
-        target_dtype = config["target_dtype"]
+        source_dtype = config.source_dtype
+        target_dtype = config.target_dtype
 
         self._verify_elem_type(source_dtype)
         self._verify_elem_type(target_dtype)

--- a/olive/passes/onnx/mixed_precision_overrides.py
+++ b/olive/passes/onnx/mixed_precision_overrides.py
@@ -6,14 +6,14 @@
 import json
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Dict, Type, Union
 
 from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes.olive_pass import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_file
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = getLogger(__name__)
 
@@ -54,7 +54,7 @@ class MixedPrecisionOverrides(Pass):
     def _run_for_config(
         self,
         model: ONNXModelHandler,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         output_model_path: str,
     ) -> ONNXModelHandler:
         """Run for config.
@@ -84,10 +84,10 @@ class MixedPrecisionOverrides(Pass):
         from onnxruntime.quantization.onnx_model import ONNXModel
 
         overrides_content = {}
-        if isinstance(config["overrides_config"], dict):
-            overrides_content = config["overrides_config"]
-        elif isinstance(config["overrides_config"], str):
-            overrides_config_path = Path(config["overrides_config"])
+        if isinstance(config.overrides_config, dict):
+            overrides_content = config.overrides_config
+        elif isinstance(config.overrides_config, str):
+            overrides_config_path = Path(config.overrides_config)
             with overrides_config_path.open() as f:
                 overrides_content = json.load(f)
         else:
@@ -137,7 +137,7 @@ class MixedPrecisionOverrides(Pass):
         # If certain initializer tensor makes conflict, we do not convert it, but rather add it to conflict_data
         # which we analyze later
 
-        element_wise_binary_ops = config["element_wise_binary_ops"] or ["Add", "Sub", "Mul", "Div"]
+        element_wise_binary_ops = config.element_wise_binary_ops or ["Add", "Sub", "Mul", "Div"]
         for node in onnx_model.graph.node:
 
             if node.op_type in element_wise_binary_ops:
@@ -195,11 +195,11 @@ class MixedPrecisionOverrides(Pass):
         model_proto_to_file(
             onnx_model.model,
             output_model_path,
-            save_as_external_data=config["save_as_external_data"],
-            all_tensors_to_one_file=config["all_tensors_to_one_file"],
-            external_data_name=config["external_data_name"],
-            size_threshold=config["size_threshold"],
-            convert_attribute=config["convert_attribute"],
+            save_as_external_data=config.save_as_external_data,
+            all_tensors_to_one_file=config.all_tensors_to_one_file,
+            external_data_name=config.external_data_name,
+            size_threshold=config.size_threshold,
+            convert_attribute=config.convert_attribute,
         )
 
         overrides_jsonable = {

--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -5,7 +5,7 @@
 import logging
 import math
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Dict, Type
 
 import numpy as np
 import onnx
@@ -16,7 +16,7 @@ from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.onnx.onnx_dag import OnnxDAG
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -60,7 +60,7 @@ class MatMulNBitsToQDQ(Pass):
         }
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
@@ -70,9 +70,9 @@ class MatMulNBitsToQDQ(Pass):
         dag.remove_identity_nodes()
 
         # if matmulnbits zero point is the following, then the zero point is not needed in the DQ node
-        default_mnb_zp = 8 if config["use_int4"] else 0
-        int_np_dtype = np.int8 if config["use_int4"] else np.uint8
-        int_elem_type = onnx.TensorProto.INT4 if config["use_int4"] else onnx.TensorProto.UINT4
+        default_mnb_zp = 8 if config.use_int4 else 0
+        int_np_dtype = np.int8 if config.use_int4 else np.uint8
+        int_elem_type = onnx.TensorProto.INT4 if config.use_int4 else onnx.TensorProto.UINT4
 
         num_modified = 0
         for node_name in dag.get_node_names():
@@ -146,15 +146,15 @@ class MatMulNBitsToQDQ(Pass):
                     qi = qi.flatten()
 
                 # skip if is a no-op zero point
-                if not config["add_zero_point"] and new_qi_name.endswith(".qzeros") and np.all(qi == default_mnb_zp):
+                if not config.add_zero_point and new_qi_name.endswith(".qzeros") and np.all(qi == default_mnb_zp):
                     continue
 
-                if not config["use_transpose_op"]:
+                if not config.use_transpose_op:
                     # becomes K X N
                     qi = qi.T
 
                 if qi.dtype == np.uint8:
-                    if config["use_int4"]:
+                    if config.use_int4:
                         # no worries about making signed since the values only use 4 bits
                         qi = qi.astype(np.int8)
                         # subtract 8 to make it signed
@@ -178,11 +178,9 @@ class MatMulNBitsToQDQ(Pass):
                 dq_inputs.append(new_qi_name)
             # DQ default zp is 0 but MatMulNBits is 8, so we need to add a zero tensor with all 8s
             # no need to add for int4 if add_zero_point is False
-            if len(dq_inputs) == 2 and (config["add_zero_point"] or not config["use_int4"]):
+            if len(dq_inputs) == 2 and (config.add_zero_point or not config.use_int4):
                 zp_name = f"{dq_name}.qzeros"
-                zp_shape = (
-                    [N] if is_per_axis else ([N, num_k_blocks] if config["use_transpose_op"] else [num_k_blocks, N])
-                )
+                zp_shape = [N] if is_per_axis else ([N, num_k_blocks] if config.use_transpose_op else [num_k_blocks, N])
                 zp_tensor = onnx.helper.make_tensor(
                     zp_name,
                     int_elem_type,
@@ -216,16 +214,16 @@ class MatMulNBitsToQDQ(Pass):
                     block_size=None if is_per_axis else block_size,
                     # for some reason block_wise and per-axis appear to use swapped axis
                     # flip the axis if it is per-axis
-                    axis=(1 if config["use_transpose_op"] else 0) ^ (1 if is_per_axis else 0),
+                    axis=(1 if config.use_transpose_op else 0) ^ (1 if is_per_axis else 0),
                 )
             )
             new_value_infos.append(
                 onnx.helper.make_tensor_value_info(
-                    dq_output, float_elem_type, shape=[N, K] if config["use_transpose_op"] else [K, N]
+                    dq_output, float_elem_type, shape=[N, K] if config.use_transpose_op else [K, N]
                 )
             )
 
-            if config["use_transpose_op"]:
+            if config.use_transpose_op:
                 # Transpose
                 transpose_name = self._get_new_node_name(dag, node_name, "Transpose")
                 transpose_output = f"{transpose_name}/output_0"

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import Any, Dict, Union
+from typing import Dict, Type, Union
 
 from onnx import ModelProto
 
@@ -11,7 +11,7 @@ from olive.model import CompositeModelHandler, ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 
 class OptimumMerging(Pass):
@@ -43,7 +43,7 @@ class OptimumMerging(Pass):
         return config
 
     def _run_for_config(
-        self, model: CompositeModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: CompositeModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> Union[ONNXModelHandler, CompositeModelHandler]:
         import onnxruntime
 
@@ -65,7 +65,7 @@ class OptimumMerging(Pass):
             merged_model = merge_decoders(
                 model.model_components[0].model_path,
                 model.model_components[1].model_path,
-                strict=config["strict"],
+                strict=config.strict,
             )
         finally:
             ModelProto.ByteSize = prev_byte_size_func

--- a/olive/passes/onnx/peephole_optimizer.py
+++ b/olive/passes/onnx/peephole_optimizer.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict, Type
 
 import numpy as np
 import onnx
@@ -15,7 +15,7 @@ from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -259,7 +259,7 @@ class OnnxPeepholeOptimizer(Pass):
         return get_external_data_config()
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 

--- a/olive/passes/onnx/qnn/qnn_preprocess.py
+++ b/olive/passes/onnx/qnn/qnn_preprocess.py
@@ -5,14 +5,14 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict, Type
 
 from olive.hardware import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes.olive_pass import Pass
 from olive.passes.onnx.common import get_external_data_config
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ class QNNPreprocess(Pass):
     def _run_for_config(
         self,
         model: ONNXModelHandler,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         output_model_path: str,
     ) -> ONNXModelHandler:
         from onnxruntime import __version__ as OrtVersion
@@ -85,17 +85,17 @@ class QNNPreprocess(Pass):
             raise RuntimeError("QNNPreprocess only supports ONNXRuntime version 1.17.0 or later")
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
-        external_data_location = config["external_data_name"] or f"{Path(output_model_path).name}.data"
+        external_data_location = config.external_data_name or f"{Path(output_model_path).name}.data"
 
         # only 1.18.0 or later adds the following parameters
         extra_kwargs = {
-            "save_as_external_data": config["save_as_external_data"],
-            "all_tensors_to_one_file": config["all_tensors_to_one_file"],
-            "external_data_size_threshold": config["size_threshold"],
+            "save_as_external_data": config.save_as_external_data,
+            "all_tensors_to_one_file": config.all_tensors_to_one_file,
+            "external_data_size_threshold": config.size_threshold,
             "external_data_location": external_data_location,
-            "external_data_convert_attribute": config["convert_attribute"],
-            "inputs_to_make_channel_last": config["inputs_to_make_channel_last"],
-            "outputs_to_make_channel_last": config["outputs_to_make_channel_last"],
+            "external_data_convert_attribute": config.convert_attribute,
+            "inputs_to_make_channel_last": config.inputs_to_make_channel_last,
+            "outputs_to_make_channel_last": config.outputs_to_make_channel_last,
         }
         if version.parse(OrtVersion) < version.parse("1.18.0"):
             removed_config = [
@@ -114,7 +114,7 @@ class QNNPreprocess(Pass):
         modified = qnn_preprocess_model(
             model.model_path,
             output_model_path,
-            fuse_layernorm=config["fuse_layernorm"],
+            fuse_layernorm=config.fuse_layernorm,
             **extra_kwargs,
         )
         if not modified:

--- a/olive/passes/onnx/session_params_tuning.py
+++ b/olive/passes/onnx/session_params_tuning.py
@@ -7,7 +7,7 @@ import json
 import logging
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Type, Union
 
 import onnxruntime as ort
 
@@ -22,7 +22,7 @@ from olive.exception import EXCEPTIONS_TO_RAISE
 from olive.hardware.accelerator import AcceleratorLookup, AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.passes import Pass
-from olive.passes.pass_config import PassConfigParam, get_user_script_data_config
+from olive.passes.pass_config import BasePassConfig, PassConfigParam, get_user_script_data_config
 from olive.search.search_parameter import Categorical
 
 logger = logging.getLogger(__name__)
@@ -173,19 +173,15 @@ class OrtSessionParamsTuning(Pass):
     @classmethod
     def validate_config(
         cls,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         accelerator_spec: AcceleratorSpec,
-        disable_search: Optional[bool] = False,
     ) -> bool:
         """Validate the search point for the pass."""
-        if not super().validate_config(config, accelerator_spec, disable_search):
+        if not super().validate_config(config, accelerator_spec):
             return False
 
-        config_cls, _ = cls.get_config_class(accelerator_spec, disable_search)
-        config_cls.__config__.extra = Extra.allow
-        config = config_cls(**config)
-
         # Rename the search parameters with atomic/singular names for clarity
+        config.__class__.__config__.extra = Extra.allow
         config.execution_provider = config.providers_list
         config.provider_options = config.provider_options_list
         config.execution_mode = config.execution_mode_list
@@ -264,11 +260,11 @@ class OrtSessionParamsTuning(Pass):
         return True
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         # Rename the search parameters with atomic/singular names for clarity
-        self._config_class.__config__.extra = Extra.allow
-        config = self._config_class(**config)
+        config.__class__.__config__.extra = Extra.allow
+        config = config.copy()
         config.execution_provider = config.providers_list
         config.provider_options = config.provider_options_list
         config.execution_mode = config.execution_mode_list

--- a/olive/passes/onnx/split.py
+++ b/olive/passes/onnx/split.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Dict, Optional, Type
 
 import numpy as np
 import onnx
@@ -17,7 +17,7 @@ from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.onnx.onnx_dag import OnnxDAG
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class SplitModel(Pass):
         }
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> CompositeModelHandler:
         model_proto = model.load_model()
 

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -3,9 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
 
 import onnx
 
@@ -17,7 +16,7 @@ from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 if TYPE_CHECKING:
     from onnxruntime.transformers.onnx_model import OnnxModel
@@ -139,18 +138,14 @@ class OrtTransformersOptimization(Pass):
     @classmethod
     def validate_config(
         cls,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         accelerator_spec: AcceleratorSpec,
-        disable_search: Optional[bool] = False,
     ) -> bool:
-        if not super().validate_config(config, accelerator_spec, disable_search):
+        if not super().validate_config(config, accelerator_spec):
             return False
 
         from onnxruntime import __version__ as OrtVersion
         from packaging import version
-
-        config_cls, _ = cls.get_config_class(accelerator_spec, disable_search)
-        config = config_cls(**config)
 
         if config.float16:
             if accelerator_spec.execution_provider == "TensorrtExecutionProvider":
@@ -210,14 +205,14 @@ class OrtTransformersOptimization(Pass):
         run_config["optimization_options"] = fusion_options
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         from onnxruntime.transformers import optimizer as transformers_optimizer
 
-        num_kv_heads = config["num_key_value_heads"]
+        num_kv_heads = config.num_key_value_heads
 
         # start with a copy of the config
-        run_config = deepcopy(config)
+        run_config = config.dict()
         keys_to_remove = [
             "float16",
             "keep_io_types",
@@ -268,7 +263,7 @@ class OrtTransformersOptimization(Pass):
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
-        optimization_options = config["optimization_options"]
+        optimization_options = config.optimization_options
 
         if optimization_options:
             self._set_fusion_options(run_config)
@@ -296,22 +291,22 @@ class OrtTransformersOptimization(Pass):
 
         optimizer = transformers_optimizer.optimize_model(input=model.model_path, **run_config)
 
-        if config["float16"]:
+        if config.float16:
             optimizer.convert_float_to_float16(
-                keep_io_types=config["keep_io_types"],
-                op_block_list=config["force_fp32_ops"],
-                node_block_list=config["force_fp32_nodes"],
-                force_fp16_inputs=config["force_fp16_inputs"],
+                keep_io_types=config.keep_io_types,
+                op_block_list=config.force_fp32_ops,
+                node_block_list=config.force_fp32_nodes,
+                force_fp16_inputs=config.force_fp16_inputs,
             )
 
-            if config["use_gqa"]:
+            if config.use_gqa:
                 world_size = model.model_attributes.get("world_size", 1) if model.model_attributes is not None else 1
                 optimizer = self._replace_mha_with_gqa(optimizer, kv_num_heads=num_kv_heads, world_size=world_size)
                 optimizer.prune_graph()
                 # add allow_remove_graph_inputs to pass config
                 optimizer.update_graph(allow_remove_graph_inputs=True)
 
-        if config["input_int32"]:
+        if config.input_int32:
             optimizer.change_graph_inputs_to_int32()
 
         # Topologically sort the graph at the end since previous optimizations may have broken it

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -6,7 +6,7 @@ import logging
 import tempfile
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Dict, Type, Union
 
 import onnx
 
@@ -23,7 +23,7 @@ from olive.passes.onnx.common import (
     model_proto_to_file,
     model_proto_to_olive_model,
 )
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.resource_path import LocalFile
 from olive.search.search_parameter import Boolean, Categorical, Conditional
 
@@ -236,7 +236,7 @@ class VitisAIQuantization(Pass):
         }
 
     def _run_for_config(
-        self, model: ONNXModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
         if model_has_adapters(model.model_path):
             logger.info("Model has adapters which should not be quantized. Returning the model without quantization.")
@@ -248,12 +248,12 @@ class VitisAIQuantization(Pass):
         from olive.passes.onnx.vitis_ai.quant_utils import PowerOfTwoMethod
 
         # start with a copy of the config
-        run_config = deepcopy(config)
+        run_config = config.dict()
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
         # extra config
-        extra_options = deepcopy(config["extra_options"]) if config["extra_options"] else {}
+        extra_options = deepcopy(config.extra_options) if config.extra_options else {}
         # keys in extra_options that are already exposed
         intersection = set(extra_options.keys()).intersection(set(_exposed_extra_options_config.keys()))
         if intersection:
@@ -315,8 +315,8 @@ class VitisAIQuantization(Pass):
 
         # get the dataloader
         dataloader = None
-        if config["data_config"]:
-            data_config = validate_config(config["data_config"], DataConfig)
+        if config.data_config:
+            data_config = validate_config(config.data_config, DataConfig)
             dataloader = data_config.to_data_container().create_calibration_dataloader()
 
         execution_provider = self.accelerator_spec.execution_provider

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -115,7 +115,7 @@ class AbstractPassConfig(NestedConfig):
     """Base class for pass configuration."""
 
     type: str = Field(description="The type of the pass.")
-    config: Dict[str, Any] = Field(
+    config: Union[Dict[str, Any], Type[BasePassConfig]] = Field(
         None,
         description=(
             "The configuration of the pass. Values for required parameters must be provided. For optional parameters,"

--- a/olive/passes/pytorch/autoawq.py
+++ b/olive/passes/pytorch/autoawq.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 from copy import deepcopy
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, Union
 
 import torch
 from packaging import version
@@ -14,7 +14,7 @@ from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler
 from olive.passes import Pass
-from olive.passes.pass_config import PassConfigParam, get_user_script_data_config
+from olive.passes.pass_config import BasePassConfig, PassConfigParam, get_user_script_data_config
 from olive.passes.pytorch.common import inherit_hf_from_hf
 
 logger = logging.getLogger(__name__)
@@ -108,20 +108,22 @@ class AutoAWQQuantizer(Pass):
         }
 
     @torch.no_grad()
-    def _run_for_config(self, model: HfModelHandler, config: Dict[str, Any], output_model_path: str) -> HfModelHandler:
+    def _run_for_config(
+        self, model: HfModelHandler, config: Type[BasePassConfig], output_model_path: str
+    ) -> HfModelHandler:
         from awq import AutoAWQForCausalLM
 
         if not torch.cuda.is_available():
             raise ValueError("Please use GPU to run AWQ quantization.")
 
         data_kwargs = {}
-        if config["data_config"]:
+        if config.data_config:
             # set default values for data config
             data_kwargs.update(
                 {
-                    "calib_data": config["data_config"].load_dataset_params.get("data_name"),
-                    "split": config["data_config"].load_dataset_params.get("split"),
-                    "text_column": config["data_config"].pre_process_params.get("input_cols"),
+                    "calib_data": config.data_config.load_dataset_params.get("data_name"),
+                    "split": config.data_config.load_dataset_params.get("split"),
+                    "text_column": config.data_config.pre_process_params.get("input_cols"),
                 }
             )
 
@@ -145,14 +147,14 @@ class AutoAWQQuantizer(Pass):
         awq_model.quantize(
             tokenizer,
             quant_config={
-                "zero_point": config["zero_point"],
-                "q_group_size": config["q_group_size"],
-                "w_bit": config["w_bit"],
-                "version": config["version"],
-                "modules_to_not_convert": config["modules_to_not_convert"],
+                "zero_point": config.zero_point,
+                "q_group_size": config.q_group_size,
+                "w_bit": config.w_bit,
+                "version": config.version,
+                "modules_to_not_convert": config.modules_to_not_convert,
             },
-            duo_scaling=config["duo_scaling"],
-            export_compatible=config["export_compatible"],
+            duo_scaling=config.duo_scaling,
+            export_compatible=config.export_compatible,
             **data_kwargs,
         )
 

--- a/olive/passes/pytorch/capture_split_info.py
+++ b/olive/passes/pytorch/capture_split_info.py
@@ -6,7 +6,7 @@ import csv
 import logging
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Dict, Type, Union
 
 import numpy as np
 
@@ -15,7 +15,7 @@ from olive.common.utils import get_attr
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.passes import Pass
-from olive.passes.pass_config import ParamCategory, PassConfigParam
+from olive.passes.pass_config import BasePassConfig, ParamCategory, PassConfigParam
 
 logger = logging.getLogger(__name__)
 
@@ -65,15 +65,11 @@ class CaptureSplitInfo(Pass):
     @classmethod
     def validate_config(
         cls,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         accelerator_spec: AcceleratorSpec,
-        disable_search: Optional[bool] = False,
     ) -> bool:
-        if not super().validate_config(config, accelerator_spec, disable_search):
+        if not super().validate_config(config, accelerator_spec):
             return False
-
-        config_cls, _ = cls.get_config_class(accelerator_spec, disable_search)
-        config = config_cls(**config)
 
         if config.num_splits is None and config.cost_model is None:
             logger.info("One of num_splits or cost_model is required.")
@@ -90,12 +86,12 @@ class CaptureSplitInfo(Pass):
         return False
 
     def _run_for_config(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: Dict[str, Any], output_model_path: str
+        self, model: Union[HfModelHandler, PyTorchModelHandler], config: Type[BasePassConfig], output_model_path: str
     ) -> Union[HfModelHandler, PyTorchModelHandler]:
         split_assignments = None
-        if config["num_splits"]:
+        if config.num_splits:
             split_assignments = self.split_using_num_splits(model, config)
-        elif config["cost_model"]:
+        elif config.cost_model:
             split_assignments = self.split_using_cost_model(model, config)
         else:
             raise ValueError("One of num_splits or cost_model is required.")
@@ -109,12 +105,12 @@ class CaptureSplitInfo(Pass):
         return output_model
 
     def split_using_num_splits(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: Dict[str, Any]
+        self, model: Union[HfModelHandler, PyTorchModelHandler], config: Type[BasePassConfig]
     ) -> Dict[str, int]:
         # consider loading with meta device to avoid loading the weights
         loaded_model = model.load_model(cache_model=False)
 
-        block_to_split = config["block_to_split"]
+        block_to_split = config.block_to_split
         # check for None specifically since "" is a valid value
         if block_to_split is None and isinstance(model, HfModelHandler):
             model_wrapper = ModelWrapper.from_model(loaded_model)
@@ -127,21 +123,21 @@ class CaptureSplitInfo(Pass):
         block_members = [child_name for child_name, _ in block.named_children()]
 
         split_assignments = {}
-        for split_idx, split_members in enumerate(np.array_split(block_members, config["num_splits"])):
+        for split_idx, split_members in enumerate(np.array_split(block_members, config.num_splits)):
             for child_name in split_members:
                 split_assignments[f"{block_to_split}.{child_name}".lstrip(".")] = split_idx
 
         return split_assignments
 
     def split_using_cost_model(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: Dict[str, Any]
+        self, model: Union[HfModelHandler, PyTorchModelHandler], config: Type[BasePassConfig]
     ) -> Dict[str, int]:
         if self.accelerator_spec.memory is None:
             raise ValueError("Accelerator memory is required to split using cost model.")
 
         # will only care about the number of bytes for now
         module_to_cost = {}
-        with open(config["cost_model"]) as f:
+        with open(config.cost_model) as f:
             reader = csv.DictReader(f)
             for row in reader:
                 module_to_cost[row["module"]] = (int(row["num_params"]), int(row["num_bytes"]), int(row["num_flops"]))
@@ -149,12 +145,12 @@ class CaptureSplitInfo(Pass):
         loaded_model = model.load_model(cache_model=False)
 
         modules_to_exclude = set()
-        if config["exclude_embeds"] and isinstance(model, HfModelHandler):
+        if config.exclude_embeds and isinstance(model, HfModelHandler):
             model_wrapper = ModelWrapper.from_model(loaded_model)
             modules_to_exclude.update(model_wrapper.get_embeds()[1])
-        elif config["exclude_embeds"]:
+        elif config.exclude_embeds:
             modules_to_exclude.add("model.embed_tokens")
-        if config["exclude_lm_head"]:
+        if config.exclude_lm_head:
             modules_to_exclude.add("lm_head")
 
         split_assignments = {}

--- a/olive/passes/pytorch/merge_adapter_weights.py
+++ b/olive/passes/pytorch/merge_adapter_weights.py
@@ -4,14 +4,14 @@
 # --------------------------------------------------------------------------
 import logging
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Dict, Type
 
 import torch
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler
 from olive.passes import Pass
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,9 @@ class MergeAdapterWeights(Pass):
         return {}
 
     @torch.no_grad()
-    def _run_for_config(self, model: HfModelHandler, config: Dict[str, Any], output_model_path: str) -> HfModelHandler:
+    def _run_for_config(
+        self, model: HfModelHandler, config: Type[BasePassConfig], output_model_path: str
+    ) -> HfModelHandler:
         if not model.adapter_path:
             raise RuntimeError(
                 "No adapter path found in the model. Please check your input "

--- a/olive/passes/pytorch/slicegpt.py
+++ b/olive/passes/pytorch/slicegpt.py
@@ -6,7 +6,7 @@
 import json
 import logging
 import sys
-from typing import Any, Dict, Union
+from typing import Dict, Type, Union
 
 import torch
 from torch.utils.data import DataLoader, SubsetRandomSampler
@@ -19,6 +19,7 @@ from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.model.utils.path_utils import normalize_path_suffix
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
+from olive.passes.pass_config import BasePassConfig
 from olive.passes.pytorch.common import inherit_pytorch_from_hf
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ class SliceGPT(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: HfModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: HfModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> PyTorchModelHandler:
         if sys.version_info < (3, 10):
             raise ValueError("SliceGPT requires python3.10 or higher")
@@ -89,10 +90,6 @@ class SliceGPT(Pass):
         # Renaming variables to match their contextual use
         model_handler = model
         model = None
-
-        # convert config to pass config class
-        # this will validate the config and convert to the correct types
-        config = self._config_class(**config)
 
         model_adapter, _ = get_model_and_tokenizer(model_handler.model_name_or_path)
         model_handler.model = model_adapter.model

--- a/olive/passes/pytorch/sparsegpt.py
+++ b/olive/passes/pytorch/sparsegpt.py
@@ -7,7 +7,7 @@
 # https://arxiv.org/abs/2301.00774
 # -------------------------------------------------------------------------
 import logging
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Type, Union
 
 import torch
 
@@ -18,6 +18,7 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
+from olive.passes.pass_config import BasePassConfig
 from olive.passes.pytorch.common import inherit_hf_from_hf
 from olive.passes.pytorch.sparsegpt_utils import (
     SparseGPTModule,
@@ -92,22 +93,24 @@ class SparseGPT(Pass):
         }
 
     @torch.no_grad()
-    def _run_for_config(self, model: HfModelHandler, config: Dict[str, Any], output_model_path: str) -> HfModelHandler:
+    def _run_for_config(
+        self, model: HfModelHandler, config: Type[BasePassConfig], output_model_path: str
+    ) -> HfModelHandler:
         model_type = model.model_attributes["model_type"]
         if model_type not in supported_models:
             raise ValueError(f"Unsupported model type: {model_type}. Supported types: {supported_models}")
 
         # get sparsity mode and parameters
-        if isinstance(config["sparsity"], float):
-            assert 0 <= config["sparsity"] <= 1, "Sparsity must be in [0,1]."
-        elif isinstance(config["sparsity"], list):
-            assert len(config["sparsity"]) == 2, "Sparsity must be a float or a list of two integers."
-        mode = "unstructured" if isinstance(config["sparsity"], float) else "structured"
-        sparsity = config["sparsity"]
+        if isinstance(config.sparsity, float):
+            assert 0 <= config.sparsity <= 1, "Sparsity must be in [0,1]."
+        elif isinstance(config.sparsity, list):
+            assert len(config.sparsity) == 2, "Sparsity must be a float or a list of two integers."
+        mode = "unstructured" if isinstance(config.sparsity, float) else "structured"
+        sparsity = config.sparsity
         n, m = sparsity if mode == "structured" else [0, 0]
 
         # get device to use for computations
-        device = config["device"]
+        device = config.device
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
         logger.debug(
@@ -115,7 +118,7 @@ class SparseGPT(Pass):
         )
 
         # load_data
-        data_config = validate_config(config["data_config"], DataConfig)
+        data_config = validate_config(config.data_config, DataConfig)
         dataloader = data_config.to_data_container().create_dataloader()
         logger.debug("Data loaded. Number of batches: %d", len(dataloader))
 
@@ -138,8 +141,8 @@ class SparseGPT(Pass):
         outputs = torch.zeros_like(inputs)
 
         # prune layers
-        min_layer, max_layer = validate_min_max_layers(config["min_layer"], config["max_layer"], len(layers))
-        layer_name_filter = config["layer_name_filter"] or []
+        min_layer, max_layer = validate_min_max_layers(config.min_layer, config.max_layer, len(layers))
+        layer_name_filter = config.layer_name_filter or []
         if isinstance(layer_name_filter, str):
             layer_name_filter = [layer_name_filter]
         # loop over layers
@@ -181,7 +184,7 @@ class SparseGPT(Pass):
             losses = {}
             for name, sparse_gpt_module in sparge_gpt_modules.items():
                 loss = sparse_gpt_module.prune(
-                    mode, sparsity, n, m, blocksize=config["blocksize"], percdamp=config["percdamp"]
+                    mode, sparsity, n, m, blocksize=config.blocksize, percdamp=config.percdamp
                 )
                 losses[name] = loss
                 sparse_gpt_module.free()

--- a/olive/passes/pytorch/torch_trt_conversion.py
+++ b/olive/passes/pytorch/torch_trt_conversion.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Type, Union
 
 import torch
 
@@ -16,6 +16,7 @@ from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.passes import Pass
 from olive.passes.olive_pass import PassConfigParam
+from olive.passes.pass_config import BasePassConfig
 from olive.passes.pytorch.common import inherit_pytorch_from_hf
 from olive.passes.pytorch.sparsegpt_utils import get_layer_submodules, supported_models, validate_min_max_layers
 
@@ -65,11 +66,10 @@ class TorchTRTConversion(Pass):
     @classmethod
     def validate_config(
         cls,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         accelerator_spec: AcceleratorSpec,
-        disable_search: Optional[bool] = False,
     ) -> bool:
-        if not super().validate_config(config, accelerator_spec, disable_search):
+        if not super().validate_config(config, accelerator_spec):
             return False
 
         # since the run will leverage the host device to move the model to device,
@@ -81,7 +81,7 @@ class TorchTRTConversion(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: HfModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: HfModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> PyTorchModelHandler:
         from olive.passes.pytorch.trt_utils import compile_trt_model
 
@@ -94,7 +94,7 @@ class TorchTRTConversion(Pass):
         device = "cuda"
 
         # load_data
-        data_config = validate_config(config["data_config"], DataConfig)
+        data_config = validate_config(config.data_config, DataConfig)
         first_batch = data_config.to_data_container().get_first_batch()[0]
         first_batch = tensor_data_to_device(first_batch, device=device)
         batch_size = first_batch["input_ids"].shape[0]
@@ -105,7 +105,7 @@ class TorchTRTConversion(Pass):
         # move model to device
         pytorch_model.to(device=device)
         # convert model to fp16 if needed
-        if config["float16"]:
+        if config.float16:
             pytorch_model = pytorch_model.to(dtype=torch.float16)
         # disable cache
         use_cache = pytorch_model.config.use_cache
@@ -121,8 +121,8 @@ class TorchTRTConversion(Pass):
         layers = model_wrapper.get_layers(False)
 
         # get layer information
-        min_layer, max_layer = validate_min_max_layers(config["min_layer"], config["max_layer"], len(layers))
-        layer_name_filter = config["layer_name_filter"] or []
+        min_layer, max_layer = validate_min_max_layers(config.min_layer, config.max_layer, len(layers))
+        layer_name_filter = config.layer_name_filter or []
         if isinstance(layer_name_filter, str):
             layer_name_filter = [layer_name_filter]
         # layer information storage

--- a/olive/passes/qnn/context_binary_generator.py
+++ b/olive/passes/qnn/context_binary_generator.py
@@ -6,14 +6,14 @@
 import logging
 import platform
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Dict, Type, Union
 
 from olive.common.constants import OS
 from olive.constants import ModelFileFormat
 from olive.hardware import AcceleratorSpec
 from olive.model import QNNModelHandler, SNPEModelHandler
 from olive.passes.olive_pass import Pass
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.platform_sdk.qualcomm.runner import QNNSDKRunner
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class QNNContextBinaryGenerator(Pass):
     def _run_for_config(
         self,
         model: Union[QNNModelHandler, SNPEModelHandler],
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         output_model_path: str,
     ) -> QNNModelHandler:
         if platform.system() == OS.WINDOWS:
@@ -60,7 +60,7 @@ class QNNContextBinaryGenerator(Pass):
         main_cmd = "qnn-context-binary-generator"
         runner = QNNSDKRunner(use_dev_tools=True)
 
-        extra_args = config["extra_args"] or ""
+        extra_args = config.extra_args or ""
         model_arg = f"--model {model.model_path}"
 
         if model.model_file_format == ModelFileFormat.SNPE_DLC and "--dlc_path" not in extra_args:
@@ -77,7 +77,7 @@ class QNNContextBinaryGenerator(Pass):
         # TODO(trajep): find .so file in the same directory as the model
         output_model_path = Path(output_model_path).resolve()
 
-        binary_file = config["binary_file"]
+        binary_file = config.binary_file
         if not binary_file:
             binary_file = output_model_path.with_suffix(".serialized").name
 
@@ -86,7 +86,7 @@ class QNNContextBinaryGenerator(Pass):
         cmd_list = [
             main_cmd,
             model_arg,
-            f"--backend {config['backend']}",
+            f"--backend {config.backend}",
             f"--output_dir {output_model_path}",
             f"--binary_file {binary_file}" if binary_file else "",
             extra_args,
@@ -96,5 +96,5 @@ class QNNContextBinaryGenerator(Pass):
         return QNNModelHandler(
             output_model_full_path,
             model_file_format=ModelFileFormat.QNN_SERIALIZED_BIN,
-            model_attributes={"backend": config["backend"]},
+            model_attributes={"backend": config.backend},
         )

--- a/olive/passes/qnn/model_lib_generator.py
+++ b/olive/passes/qnn/model_lib_generator.py
@@ -6,14 +6,14 @@
 import logging
 import platform
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict, Type
 
 from olive.common.constants import OS
 from olive.constants import ModelFileFormat
 from olive.hardware import AcceleratorSpec
 from olive.model import QNNModelHandler
 from olive.passes.olive_pass import Pass
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.platform_sdk.qualcomm.runner import QNNSDKRunner
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class QNNModelLibGenerator(Pass):
     def _run_for_config(
         self,
         model: QNNModelHandler,
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         output_model_path: str,
     ) -> QNNModelHandler:
         main_cmd = "qnn-model-lib-generator"

--- a/olive/passes/snpe/conversion.py
+++ b/olive/passes/snpe/conversion.py
@@ -3,13 +3,13 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Union
+from typing import Callable, Dict, List, Type, Union
 
 from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler, SNPEModelHandler, TensorFlowModelHandler
 from olive.passes.olive_pass import Pass
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.platform_sdk.qualcomm.constants import InputLayout, InputType
 from olive.platform_sdk.qualcomm.snpe.tools.dev import get_dlc_io_config, to_dlc
 from olive.resource_path import LocalFile
@@ -95,12 +95,12 @@ class SNPEConversion(Pass):
     def _run_for_config(
         self,
         model: Union[ONNXModelHandler, TensorFlowModelHandler],
-        config: Dict[str, Any],
+        config: Type[BasePassConfig],
         output_model_path: str,
     ) -> SNPEModelHandler:
         if Path(output_model_path).suffix != ".dlc":
             output_model_path += ".dlc"
 
         to_dlc(model.model_path, model.framework, config, output_model_path)
-        io_config = get_dlc_io_config(output_model_path, config["input_names"], config["output_names"])
+        io_config = get_dlc_io_config(output_model_path, config.input_names, config.output_names)
         return SNPEModelHandler(model_path=LocalFile({"path": output_model_path}), **io_config)

--- a/olive/passes/snpe/quantization.py
+++ b/olive/passes/snpe/quantization.py
@@ -3,14 +3,14 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Type, Union
 
 from olive.common.config_utils import validate_config
 from olive.data.config import DataConfig
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import SNPEModelHandler
 from olive.passes.olive_pass import Pass
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.platform_sdk.qualcomm.snpe.tools.dev import quantize_dlc
 from olive.platform_sdk.qualcomm.utils.data_loader import FileListCommonDataLoader, FileListDataLoader
 from olive.resource_path import LocalFile
@@ -63,12 +63,12 @@ class SNPEQuantization(Pass):
         }
 
     def _run_for_config(
-        self, model: SNPEModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: SNPEModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> SNPEModelHandler:
         if Path(output_model_path).suffix != ".dlc":
             output_model_path += ".dlc"
 
-        data_config = validate_config(config["data_config"], DataConfig)
+        data_config = validate_config(config.data_config, DataConfig)
         dataloader = data_config.to_data_container().create_dataloader()
 
         # convert dataloader to FileListDataLoader if it is not already

--- a/olive/passes/snpe/snpe_to_onnx.py
+++ b/olive/passes/snpe/snpe_to_onnx.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import Any, Callable, Dict
+from typing import Callable, Dict, Type
 
 from olive.common.pydantic_v1 import validator
 from olive.hardware.accelerator import AcceleratorSpec
@@ -10,7 +10,7 @@ from olive.model import ONNXModelHandler, SNPEModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes.olive_pass import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
-from olive.passes.pass_config import PassConfigParam
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.platform_sdk.qualcomm.constants import SNPEDevice
 from olive.platform_sdk.qualcomm.snpe.tools.dev import dlc_to_onnx
 
@@ -51,14 +51,12 @@ class SNPEtoONNXConversion(Pass):
         }
 
     def _run_for_config(
-        self, model: SNPEModelHandler, config: Dict[str, Any], output_model_path: str
+        self, model: SNPEModelHandler, config: Type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
-        config = self._config_class(**config)
-
         output_model_path = resolve_onnx_path(output_model_path)
 
         # create a onnx model that wraps the dlc binary in a node
         onnx_model = dlc_to_onnx(model.model_path, config.dict(), **model.io_config)
 
         # save the model to the output path and return the model
-        return model_proto_to_olive_model(onnx_model, output_model_path, config.dict())
+        return model_proto_to_olive_model(onnx_model, output_model_path, config)

--- a/olive/systems/docker/docker_system.py
+++ b/olive/systems/docker/docker_system.py
@@ -361,8 +361,9 @@ class DockerSystem(OliveSystem):
     def _create_data_mounts_for_pass(self, container_root_path: Path, the_pass: "Pass"):
         mounts = {}
         mount_strs = []
+        config_dict = the_pass.config.dict()
         for param, _, category in the_pass.path_params:
-            param_val = the_pass.config.get(param)
+            param_val = config_dict.get(param)
             if category == ParamCategory.DATA and param_val:
                 mount = str(container_root_path / param)
                 mounts[param] = mount

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -2,7 +2,8 @@ accelerate
 azure-ai-ml
 azure-identity
 azure-storage-blob
-azureml-evaluate-mlflow>=0.0.60
+# azureml.evaluate.mlflow.hftransformers is deprecated in 0.0.66 and above
+azureml-evaluate-mlflow>=0.0.60, <0.0.66
 azureml-fsspec
 # Pin azureml-metrics[all] greater than 0.0.26 to avoid breaking change in azureml-evaluate-mlflow
 azureml-metrics[all]>=0.0.26

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -464,7 +464,7 @@ class TestOliveEvaluatorConfig:
     def test_valid_custom_type_validation(self, registry_get_mock, import_user_module_mock):
         registry_get_mock.return_value = MagicMock()
         OliveEvaluatorConfig.from_json({"type": "test_evaluator"})
-        registry_get_mock.called_once_with("test_evaluator")
+        registry_get_mock.assert_called_once_with("test_evaluator")
 
     @patch("olive.common.import_lib.import_user_module")
     @patch("olive.evaluator.registry.Registry.get")
@@ -474,4 +474,4 @@ class TestOliveEvaluatorConfig:
         with pytest.raises(ValidationError):
             OliveEvaluatorConfig.from_json({"type": "test_evaluator"})
 
-        registry_get_mock.called_once_with("test_evaluator")
+        registry_get_mock.assert_called_once_with("test_evaluator")

--- a/test/unit_test/passes/common/test_user_script.py
+++ b/test/unit_test/passes/common/test_user_script.py
@@ -10,4 +10,4 @@ class TestUserScriptConfig:
     def test_no_config(self):
         config = OrtSessionParamsTuning.generate_config(DEFAULT_CPU_ACCELERATOR, disable_search=True)
         assert config
-        assert OrtSessionParamsTuning.validate_config(config, DEFAULT_CPU_ACCELERATOR, disable_search=True)
+        assert OrtSessionParamsTuning.validate_config(config, DEFAULT_CPU_ACCELERATOR)

--- a/test/unit_test/passes/onnx/test_optimum_conversion.py
+++ b/test/unit_test/passes/onnx/test_optimum_conversion.py
@@ -86,13 +86,13 @@ def test_optimum_configs(config, is_valid, tmp_path):
     output_folder = tmp_path
 
     if not is_valid:
-        assert p.validate_config(config, None) is False
+        assert p.validate_config(p.config, None) is False
         with pytest.raises(
             ValueError,
             match="FP16 export is supported only when exporting on GPU. Please pass the option `--device cuda`.",
         ):
             p.run(input_model, output_folder)
     else:
-        assert p.validate_config(config, None)
+        assert p.validate_config(p.config, None) is True
         onnx_model = p.run(input_model, output_folder)
         assert Path(onnx_model.model_path).exists()

--- a/test/unit_test/passes/onnx/test_session_params_tuning.py
+++ b/test/unit_test/passes/onnx/test_session_params_tuning.py
@@ -69,14 +69,14 @@ def test_ort_session_params_tuning_with_customized_configs(mock_run, config):
     # assert
     if "providers_list" not in config:
         assert (
-            mock_run.call_args.args[1]["providers_list"] == "CPUExecutionProvider"
+            mock_run.call_args.args[1].providers_list == "CPUExecutionProvider"
         ), "providers_list is not set correctly as ['CPUExecutionProvider'] by default when user does not specify it"
     if "device" not in config:
         assert (
-            mock_run.call_args.args[1]["device"] == "cpu"
+            mock_run.call_args.args[1].device == "cpu"
         ), "device is not set correctly as cpu by default when user does not specify it"
     for k, v in config.items():
-        assert mock_run.call_args.args[1][k] == v, f"{k} is not set correctly as {v}"
+        assert getattr(mock_run.call_args.args[1], k) == v, f"{k} is not set correctly as {v}"
 
 
 @pytest.mark.parametrize(

--- a/test/unit_test/passes/onnx/test_transformer_optimization.py
+++ b/test/unit_test/passes/onnx/test_transformer_optimization.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------
 import logging
 import shutil
-from copy import deepcopy
 from test.unit_test.utils import ONNX_MODEL_PATH, get_onnx_model
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +22,7 @@ def test_fusion_options():
     config = {"model_type": "bart", "optimization_options": {"use_multi_head_attention": True}}
     config = OrtTransformersOptimization.generate_config(DEFAULT_CPU_ACCELERATOR, config, disable_search=True)
     transformer_optimization = OrtTransformersOptimization(DEFAULT_CPU_ACCELERATOR, config, True)
-    run_config = deepcopy(config)
+    run_config = config.dict()
     del (
         run_config["float16"],
         run_config["input_int32"],
@@ -76,7 +75,7 @@ def test_invalid_ep_config(use_gpu, fp16, accelerator_spec, mock_inferece_sessio
     config = {"model_type": "bert", "use_gpu": use_gpu, "float16": fp16}
     config = OrtTransformersOptimization.generate_config(accelerator_spec, config, disable_search=True)
     p = OrtTransformersOptimization(accelerator_spec, config, True)
-    is_pruned = not p.validate_config(config, accelerator_spec, disable_search=True)
+    is_pruned = not p.validate_config(config, accelerator_spec)
 
     if accelerator_spec.execution_provider == "CPUExecutionProvider":
         if fp16 and use_gpu:

--- a/test/unit_test/systems/python_environment/test_python_environment_system.py
+++ b/test/unit_test/systems/python_environment/test_python_environment_system.py
@@ -154,7 +154,6 @@ class TestPythonEnvironmentSystem:
         dummy_config = dummy_pass_config["config"]
         expected_pass_config = {"type": "DummyPass", "config": dummy_config}
         the_pass.to_json.return_value = dummy_pass_config
-        the_pass.serialize_config.return_value = dummy_config
 
         # mock return value
         mock_return_value = {"dummy_output_model_key": "dummy_output_model_value"}

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 import os
 from pathlib import Path
-from typing import Any, Dict, Tuple, Type, Union
+from typing import Type
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -236,14 +236,11 @@ def get_throughput_metric(*lat_subtype, user_config=None):
     )
 
 
-def get_onnxconversion_pass(
-    ignore_pass_config=True, target_opset=13
-) -> Union[Type[Pass], Tuple[Type[Pass], Dict[str, Any]]]:
+def get_onnxconversion_pass(target_opset=13) -> Type[Pass]:
     from olive.passes.onnx.conversion import OnnxConversion
 
     onnx_conversion_config = {"target_opset": target_opset}
-    p = create_pass_from_dict(OnnxConversion, onnx_conversion_config)
-    return p if ignore_pass_config else (p, p.to_json(check_object=True))
+    return create_pass_from_dict(OnnxConversion, onnx_conversion_config)
 
 
 def get_onnx_dynamic_quantization_pass(disable_search=False):


### PR DESCRIPTION
## Use concrete config classes instead of generic dictionary

* Pass now accepts a concrete BasePassConfig object instead of generic dict for config
* Pass._run_for_config similarly accepts a concrete BasePassConfig object
* Pass.generate_config returns a concrete BasePassConfig object
* Removed "disable_search" argument from Pass.validate_config
* Removed Pass.searialize_config. Use Pass.config.to_json or Pass.config.dict instead
* Removed Pass._config_class, Use Pass.config.__class__ instead
* Updated all passes and tests to use input config as an object of type BasePassConfig instead of generic dict

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
