### PR TITLE
Resolving objectives issue introduced with introduction of pass search

### DIFF
--- a/olive/search/samplers/random_sampler.py
+++ b/olive/search/samplers/random_sampler.py
@@ -29,8 +29,9 @@ class RandomSampler(SearchSampler):
         self,
         search_space: SearchSpace,
         config: Optional[Union[Dict[str, Any], ConfigBase]] = None,
+        objectives: Dict[str, Dict[str, Any]] = None,
     ):
-        super().__init__(search_space, config)
+        super().__init__(search_space, config, objectives)
 
         self._rng = Random(self.config.seed)
         self._search_points = [None] * len(self._search_space)

--- a/olive/search/samplers/sequential_sampler.py
+++ b/olive/search/samplers/sequential_sampler.py
@@ -25,8 +25,9 @@ class SequentialSampler(SearchSampler):
         self,
         search_space: SearchSpace,
         config: Optional[Union[Dict[str, Any], ConfigBase]] = None,
+        objectives: Dict[str, Dict[str, Any]] = None,
     ):
-        super().__init__(search_space, config)
+        super().__init__(search_space, config, objectives)
 
         self._index = 0
 

--- a/test/unit_test/search/samplers/test_tpe_sampler.py
+++ b/test/unit_test/search/samplers/test_tpe_sampler.py
@@ -21,9 +21,14 @@ class TestTPESampler:
                 ("PassD", Categorical(["a", "b", "c"])),
             ]
         )
+        objectives = {
+            "accuracy-accuracy_custom": {"goal": 0.75, "higher_is_better": True, "priority": 1},
+            "latency-avg": {"goal": 24, "higher_is_better": False, "priority": 2},
+            "latency-max": {"goal": 30, "higher_is_better": False, "priority": 3},
+        }
 
         config = {"seed": 101, "max_samples": 50}
-        sampler = TPESampler(search_space, config=config)
+        sampler = TPESampler(search_space, config, objectives)
 
         count = 0
         actual = []
@@ -159,9 +164,14 @@ class TestTPESampler:
                 ),
             ]
         )
+        objectives = {
+            "accuracy-accuracy_custom": {"goal": 0.75, "higher_is_better": True, "priority": 1},
+            "latency-avg": {"goal": 24, "higher_is_better": False, "priority": 2},
+            "latency-max": {"goal": 30, "higher_is_better": False, "priority": 3},
+        }
 
         config = {"seed": 101, "max_samples": 500}
-        sampler = TPESampler(search_space, config=config)
+        sampler = TPESampler(search_space, config, objectives)
 
         while not sampler.should_stop:
             sp = sampler.suggest()

--- a/test/unit_test/search/test_search_results.py
+++ b/test/unit_test/search/test_search_results.py
@@ -12,19 +12,21 @@ from olive.search.search_results import SearchResults
 
 class TestSearchResults:
     def test_empty(self):
-        results = SearchResults()
+        objectives = {
+            "accuracy-accuracy_custom": {"goal": 0.75, "higher_is_better": True, "priority": 1},
+            "latency-avg": {"goal": 24, "higher_is_better": False, "priority": 2},
+            "latency-max": {"goal": 30, "higher_is_better": False, "priority": 3},
+        }
+        results = SearchResults(objectives)
         results.sort()
 
         assert results._sorted_indices == []
         assert results.get_next_best_result(-1) == (None, None, None)
 
     def test_sort(self):
-        objectives2 = {
-            "accuracy-accuracy_custom": {"goal": 0.7220000147819519, "higher_is_better": True, "priority": 1},
-            "latency-avg": {"goal": 24.044427, "higher_is_better": False, "priority": 2},
-        }
-        objectives3 = {
-            **objectives2,
+        objectives = {
+            "accuracy-accuracy_custom": {"goal": 0.75, "higher_is_better": True, "priority": 1},
+            "latency-avg": {"goal": 24, "higher_is_better": False, "priority": 2},
             "latency-max": {"goal": 30, "higher_is_better": False, "priority": 3},
         }
 
@@ -62,14 +64,12 @@ class TestSearchResults:
 
         signals = [
             (
-                objectives2,
                 signal1,
                 ["model_id_1"],
             ),
             None,
             None,
             (
-                objectives2,
                 signal2,
                 ["model_id_2"],
             ),
@@ -77,13 +77,12 @@ class TestSearchResults:
             None,
             None,
             (
-                objectives3,
                 signal3,
                 ["model_id_3"],
             ),
         ]
 
-        results = SearchResults()
+        results = SearchResults(objectives)
         for i, signal in enumerate(signals):
             if signal:
                 results.record_feedback_signal(i, *signal)

--- a/test/unit_test/search/test_search_strategy.py
+++ b/test/unit_test/search/test_search_strategy.py
@@ -583,84 +583,37 @@ class TestSearchStrategy:
             [
                 (
                     "PassA",
-                    [
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.70,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 24.0, "higher_is_better": False, "priority": 2},
+                    {
+                        "accuracy-accuracy_custom": {
+                            "goal": 0.70,
+                            "higher_is_better": True,
+                            "priority": 1,
                         },
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.85,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 23.0, "higher_is_better": False, "priority": 2},
-                        },
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.80,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 25.0, "higher_is_better": False, "priority": 2},
-                        },
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.75,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 20.0, "higher_is_better": False, "priority": 2},
-                        },
-                    ],
+                        "latency-avg": {"goal": 24.0, "higher_is_better": False, "priority": 2},
+                    },
                 ),
                 (
                     "PassB",
-                    [
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.70,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 40.0, "higher_is_better": False, "priority": 2},
-                            "latency-max": {"goal": 64.0, "higher_is_better": False, "priority": 2},
+                    {
+                        "accuracy-accuracy_custom": {
+                            "goal": 0.80,
+                            "higher_is_better": True,
+                            "priority": 1,
                         },
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.80,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 45.0, "higher_is_better": False, "priority": 2},
-                            "latency-max": {"goal": 72.0, "higher_is_better": False, "priority": 2},
-                        },
-                    ],
+                        "latency-avg": {"goal": 45.0, "higher_is_better": False, "priority": 2},
+                        "latency-max": {"goal": 72.0, "higher_is_better": False, "priority": 2},
+                    },
                 ),
                 (
                     "PassC",
-                    [
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.89,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 16.0, "higher_is_better": False, "priority": 2},
+                    {
+                        "accuracy-accuracy_custom": {
+                            "goal": 0.90,
+                            "higher_is_better": True,
+                            "priority": 1,
                         },
-                        {
-                            "accuracy-accuracy_custom": {
-                                "goal": 0.92,
-                                "higher_is_better": True,
-                                "priority": 1,
-                            },
-                            "latency-avg": {"goal": 14.0, "higher_is_better": False, "priority": 2},
-                        },
-                    ],
+                        "latency-avg": {"goal": 14.0, "higher_is_better": False, "priority": 2},
+                    },
                 ),
             ]
         )


### PR DESCRIPTION
## Resolving objectives issue introduced with introduction of pass search

Olive allows multiple passes under the "passes" key in config where each entry can have dictate its own evaluator config i.e. the evaluation config to use for that specific pass. However, with pass search, this becomes an issue because each pass within the group can dictate conflicting objectives and goals. Circumventing the issue by collecting all the objectives across the group with the last one in the list winning if named the same. Also, handle the case where not all objectives are generated as part of the
post evaluation signal.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
