### PR TITLE
Hf preprocess: filter empty text, default text-gen `padding_side=right`

### DIFF
--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -81,7 +81,7 @@ def huggingface_pre_process(
     def _tokenizer_and_align_labels(examples):
         tokenizer = get_tokenizer(model_name, trust_remote_code=trust_remote_code)
         tokenized_inputs = tokenizer(
-            *[examples[input_col] for input_col in input_cols],
+            *[examples[input_col] for input_col in input_cols if examples[input_col]],
             padding=kwargs.get("padding", True),
             truncation=kwargs.get("truncation", True),
             max_length=kwargs.get("max_length"),
@@ -136,7 +136,7 @@ def ner_huggingface_preprocess(
     def _tokenizer_and_align_labels(examples):
         tokenizer = get_tokenizer(model_name, trust_remote_code=trust_remote_code)
         tokenized_inputs = tokenizer(
-            *[examples[input_col] for input_col in input_cols],
+            *[examples[input_col] for input_col in input_cols if examples[input_col]],
             padding=kwargs.get("padding", True),
             truncation=kwargs.get("truncation", True),
             is_split_into_words=kwargs.get("is_split_into_words", True),

--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -43,6 +43,7 @@ class TextGenParams(ConfigBase):
     # might have to expose collator for dataloader to support dynamic padding of batches
     # if false, cannot guarantee all sequences are same length. data loader will have to handle this during collation
     pad_to_max_len: bool = True  # pad sequences to max_len, ignored for JOIN corpus strategy
+    padding_side: str = "right"  # pad to the right or left
     drop_short_sequences: bool = False  # drop sequences shorter than max_len. Mutually exclusive with pad_to_max_len
     use_attention_mask: bool = True  # add attention mask to each example
     # either use chat template or text
@@ -74,6 +75,12 @@ class TextGenParams(ConfigBase):
     random_retries: int = (
         10  # number of resamples to try before giving up when a sample is too short for RANDOM strategies
     )
+
+    @validator("padding_side", always=True)
+    def _check_padding_side(cls, v):
+        if v not in ["left", "right"]:
+            raise ValueError("padding_side must be either left or right")
+        return v
 
     @validator("drop_short_sequences", always=True)
     def _check_padding(cls, v, values):
@@ -168,6 +175,9 @@ def text_gen_pre_process(dataset, tokenizer, all_kwargs):
 
     args = validate_config(all_kwargs, TextGenParams, warn_unused_keys=True)
 
+    # set tokenizer padding side
+    tokenizer.padding_side = args.padding_side
+
     if isinstance(args.text_formatting_func, str):
         # load text_formatting_func
         args.text_formatting_func = args.get_user_module_loader().load_object(args.text_formatting_func)
@@ -186,7 +196,7 @@ def text_gen_pre_process(dataset, tokenizer, all_kwargs):
             )
         }
     )
-    text_list = dataset["text"]
+    text_list = [text for text in dataset["text"] if text]  # remove empty strings
     total_examples = len(text_list)  # total number of examples
 
     tokenized_inputs = {"input_ids": [], "labels": [], "attention_mask": []}


### PR DESCRIPTION
## Describe your changes
- filter out empty text during huggingface data preprocessing
- Set default padding side in text-gen data preprocessing to left. Previously, we just used the default padding side of the tokenizer which is left for llms like llama/phi. However, right padding is more useful since it is commonly used during finetuning + GQA operator also assumes right padding.
  - The padding side is only relevant for line-by-line strategy with padding enabled.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
