### PR TITLE
Delay pass creation until time to run

### DIFF
--- a/olive/passes/onnx/inc_quantization.py
+++ b/olive/passes/onnx/inc_quantization.py
@@ -251,8 +251,8 @@ _inc_woq_optional_config = {
 class IncQuantization(Pass):
     """Quantize ONNX model with Intel® Neural Compressor."""
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""
         return False
 

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -129,8 +129,8 @@ class ModelBuilder(Pass):
             return False
         return True
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         return False
 
     def _run_for_config(

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -19,8 +19,8 @@ class OptimumMerging(Pass):
 
     _accepts_composite_model = True
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""
         return False
 

--- a/olive/passes/onnx/session_params_tuning.py
+++ b/olive/passes/onnx/session_params_tuning.py
@@ -79,8 +79,8 @@ def get_thread_affinity_nums(affinity_str):
 class OrtSessionParamsTuning(Pass):
     """Optimize ONNX Runtime inference settings."""
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""
         return False
 

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -36,8 +36,8 @@ class OrtTransformersOptimization(Pass):
     # using a Linux machine which doesn't support onnxruntime-directml package.
     # It is enough for the pass to fail if `opt_level` > 0 and the host doesn't have the required packages.
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""
         from onnxruntime import __version__ as OrtVersion
         from packaging import version

--- a/olive/passes/onnx/vitis_ai_quantization.py
+++ b/olive/passes/onnx/vitis_ai_quantization.py
@@ -209,8 +209,8 @@ class VitisAIQuantization(Pass):
         super()._initialize()
         self.tmp_dir = tempfile.TemporaryDirectory(prefix="olive_vaiq_tmp")
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         """Override this method to return False by using the accelerator spec information."""
         return False
 

--- a/olive/passes/pytorch/capture_split_info.py
+++ b/olive/passes/pytorch/capture_split_info.py
@@ -77,8 +77,8 @@ class CaptureSplitInfo(Pass):
 
         return True
 
-    @staticmethod
-    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+    @classmethod
+    def is_accelerator_agnostic(cls, accelerator_spec: AcceleratorSpec) -> bool:
         return False
 
     def _run_for_config(

--- a/olive/systems/docker/runner.py
+++ b/olive/systems/docker/runner.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from olive.common.hf.login import huggingface_login
 from olive.logging import set_verbosity_from_env
 from olive.model import ModelConfig
-from olive.package_config import OlivePackageConfig
 from olive.passes.olive_pass import FullPassConfig
 
 logger = logging.getLogger("olive")
@@ -30,10 +29,6 @@ def runner_entry(config, output_path, output_name):
     model = ModelConfig.from_json(model_json).create_model()
 
     pass_config = config_json["pass"]
-
-    # Import the pass package configuration from the package_config
-    package_config = OlivePackageConfig.load_default_config()
-    package_config.import_pass_module(pass_config["type"])
 
     the_pass = FullPassConfig.from_json(pass_config).create_pass()
     output_model = the_pass.run(model, output_path)

--- a/olive/systems/isolated_ort/isolated_ort_system.py
+++ b/olive/systems/isolated_ort/isolated_ort_system.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
     from olive.hardware.accelerator import AcceleratorSpec
     from olive.model import ModelConfig, ONNXModelHandler
-    from olive.passes.olive_pass import Pass
+    from olive.passes.olive_pass import FullPassConfig
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class IsolatedORTSystem(OliveSystem):
 
     def run_pass(
         self,
-        the_pass: "Pass",
+        full_pass_config: "FullPassConfig",
         model_config: "ModelConfig",
         output_model_path: str,
     ) -> "ModelConfig":

--- a/olive/systems/local.py
+++ b/olive/systems/local.py
@@ -12,7 +12,7 @@ from olive.systems.olive_system import OliveSystem
 if TYPE_CHECKING:
     from olive.evaluator.metric_result import MetricResult
     from olive.evaluator.olive_evaluator import OliveEvaluator, OliveEvaluatorConfig
-    from olive.passes.olive_pass import Pass
+    from olive.passes.olive_pass import FullPassConfig, Pass
 
 
 class LocalSystem(OliveSystem):
@@ -20,11 +20,12 @@ class LocalSystem(OliveSystem):
 
     def run_pass(
         self,
-        the_pass: "Pass",
-        model_config: ModelConfig,
+        full_pass_config: "FullPassConfig",
+        model_config: "ModelConfig",
         output_model_path: str,
     ) -> ModelConfig:
         """Run the pass on the model."""
+        the_pass: Pass = full_pass_config.create_pass()
         model = model_config.create_model()
         output_model = the_pass.run(model, output_model_path)
         return ModelConfig.from_json(output_model.to_json())

--- a/olive/systems/olive_system.py
+++ b/olive/systems/olive_system.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
     from olive.hardware.accelerator import AcceleratorSpec
     from olive.model import ModelConfig
-    from olive.passes.olive_pass import Pass
+    from olive.passes.olive_pass import FullPassConfig
 
 
 logger = logging.getLogger(__name__)
@@ -41,8 +41,13 @@ class OliveSystem(ABC):
         self.hf_token = hf_token
 
     @abstractmethod
-    def run_pass(self, the_pass: "Pass", model_config: "ModelConfig", output_model_path: str) -> "ModelConfig":
-        """Run the pass on the model at a specific point in the search space."""
+    def run_pass(
+        self,
+        full_pass_config: "FullPassConfig",
+        model_config: "ModelConfig",
+        output_model_path: str,
+    ) -> "ModelConfig":
+        """Create and run the pass on the model."""
         raise NotImplementedError
 
     @abstractmethod

--- a/olive/systems/python_environment/python_environment_system.py
+++ b/olive/systems/python_environment/python_environment_system.py
@@ -23,7 +23,7 @@ from olive.systems.utils import create_new_environ, get_package_name_from_ep, ru
 if TYPE_CHECKING:
     from olive.evaluator.olive_evaluator import OliveEvaluatorConfig
     from olive.hardware.accelerator import AcceleratorSpec
-    from olive.passes.olive_pass import Pass
+    from olive.passes.olive_pass import FullPassConfig
 
 
 logger = logging.getLogger(__name__)
@@ -107,15 +107,14 @@ class PythonEnvironmentSystem(OliveSystem):
 
     def run_pass(
         self,
-        the_pass: "Pass",
-        model_config: ModelConfig,
+        full_pass_config: "FullPassConfig",
+        model_config: "ModelConfig",
         output_model_path: str,
-    ) -> ModelConfig:
+    ) -> "ModelConfig":
         """Run the pass on the model."""
-        pass_config = the_pass.to_json(check_object=True)
         config_jsons = {
             "model_config": model_config.to_json(check_object=True),
-            "pass_config": pass_config,
+            "pass_config": full_pass_config.to_json(check_object=True),
         }
         output_model_json = self._run_command(
             self.pass_runner_path,

--- a/test/integ_test/pass_runner/test_docker_system.py
+++ b/test/integ_test/pass_runner/test_docker_system.py
@@ -13,7 +13,7 @@ from olive.common.constants import OS
 from olive.hardware.accelerator import DEFAULT_CPU_ACCELERATOR
 from olive.logging import set_default_logger_severity
 from olive.model.config.model_config import ModelConfig
-from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.olive_pass import FullPassConfig
 from olive.passes.onnx.session_params_tuning import OrtSessionParamsTuning
 
 
@@ -33,8 +33,10 @@ def test_pass_runner(tmp_path):
     model_conf = ModelConfig.parse_obj({"type": "ONNXModel", "config": model_config})
 
     set_default_logger_severity(0)
-    p = create_pass_from_dict(OrtSessionParamsTuning, {}, True, DEFAULT_CPU_ACCELERATOR)
-    output_model = docker_target.run_pass(p, model_conf, tmp_path)
+    full_pass_config = FullPassConfig.from_run_pass_config(
+        {"type": OrtSessionParamsTuning.__name__}, DEFAULT_CPU_ACCELERATOR
+    )
+    output_model = docker_target.run_pass(full_pass_config, model_conf, tmp_path)
     result_eps = output_model.config["inference_settings"]["execution_provider"]
     assert result_eps == [DEFAULT_CPU_ACCELERATOR.execution_provider]
     assert output_model.config["model_path"] == model_config["model_path"]

--- a/test/unit_test/systems/test_local.py
+++ b/test/unit_test/systems/test_local.py
@@ -27,16 +27,19 @@ class TestLocalSystem:
 
     def test_run_pass(self):
         # setup
-        p = MagicMock()
-        p.run.return_value = PyTorchModelHandler("model_path")
-        olive_model = MagicMock()
+        full_pass_config = MagicMock()
+        model_config = MagicMock()
+        the_pass = MagicMock()
+
         output_model_path = "output_model_path"
+        full_pass_config.create_pass.return_value = the_pass
+        the_pass.run.return_value = PyTorchModelHandler("model_path")
 
         # execute
-        self.system.run_pass(p, olive_model, output_model_path)
+        self.system.run_pass(full_pass_config, model_config, output_model_path)
 
         # assert
-        p.run.assert_called_once_with(olive_model.create_model(), output_model_path)
+        the_pass.run.assert_called_once_with(model_config.create_model(), output_model_path)
 
     METRIC_TEST_CASE: ClassVar[List[Metric]] = [
         (partial(get_accuracy_metric, AccuracySubType.ACCURACY_SCORE)),


### PR DESCRIPTION
## Delay pass creation until time to run

Logic avoids instantiating a Pass unless it is to be run. To avoid instantiation, only FullPassConfig is passed around.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
