### PR TITLE
MatMulNBitsToQDQ: Fix `nodes_to_exclude` access

### DIFF
--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -83,7 +83,7 @@ class MatMulNBitsToQDQ(Pass):
         int_elem_type = onnx.TensorProto.INT4 if config.use_int4 else onnx.TensorProto.UINT4
 
         # set of nodes to exclude from the conversion
-        nodes_to_exclude = set(config["nodes_to_exclude"] or [])
+        nodes_to_exclude = set(config.nodes_to_exclude or [])
 
         num_modified = 0
         for node_name in dag.get_node_names():


### PR DESCRIPTION
## Describe your changes
- #1613 was merged before #1567 so some code was still using the old dictionary logic.
- Not caught by CI since the unit tests jobs pin ort to 1.19.2 which skipped the tests.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes #1625 