### PR TITLE
CI: Use latest stable ort in unit tests

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -55,7 +55,7 @@ jobs:
   parameters:
     name: Linux_CPU_CI_Unit_Test
     pool: $(OLIVE_POOL_UBUNTU2004)
-    onnxruntime: onnxruntime==1.19.2
+    onnxruntime: onnxruntime
     test_type: 'unit_test'
 
 - template: job_templates/olive-test-linux-gpu-template.yaml
@@ -64,7 +64,7 @@ jobs:
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     test_type: 'unit_test'
     device: 'gpu'
-    onnxruntime: onnxruntime-gpu==1.19.2
+    onnxruntime: onnxruntime-gpu
     requirements_file: 'requirements-test-gpu.txt'
 
 # Windows unit tests
@@ -72,7 +72,7 @@ jobs:
   parameters:
     name: Windows_CPU_CI_Unit_Test
     pool: $(OLIVE_POOL_WIN2019)
-    onnxruntime: onnxruntime==1.19.2
+    onnxruntime: onnxruntime
     test_type: 'unit_test'
     windows: True
 


### PR DESCRIPTION
## Describe your changes
onnxruntime version was originally pinned due to incompatibilities with some pass dependencies. These tests were skipped with version check in #1554 but the CI yaml was not updated.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
