### PR TITLE
[dynamo exporter] Fix a bug in dynamic_shapes related processing that makes regression on the benchmark

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -235,11 +235,11 @@ class OnnxConversion(Pass):
 
             dynamo_config.capture_scalar_outputs = True
             if isinstance(dummy_inputs, dict):
-                dummy_kwargs = the_input = dummy_inputs
+                dummy_kwargs = dummy_inputs
                 dummy_inputs = ()
             else:
                 dummy_kwargs = {}
-                dummy_inputs = the_input = tuple(dummy_inputs)
+                dummy_inputs = tuple(dummy_inputs)
 
             if torch_version < dynamo_supported_version:
                 onnx_program = torch.onnx.dynamo_export(
@@ -254,7 +254,7 @@ class OnnxConversion(Pass):
                 # dynamic_shapes has nested complexity, and it can't be validated multiple
                 # times like others, we validate it here.
                 io_config.dynamic_shapes, dummy_inputs, dummy_kwargs = _validate_dynamic_shapes(
-                    io_config.dynamic_shapes, the_input, pytorch_model
+                    io_config.dynamic_shapes, dummy_inputs, dummy_kwargs, pytorch_model
                 )
 
                 # there might be multiple files created during export, so we need to track the dir
@@ -590,7 +590,7 @@ class OnnxOpVersionConversion(Pass):
         return model_proto_to_olive_model(converted_model_proto, output_model_path, config)
 
 
-def _validate_dynamic_shapes(dynamic_shapes, dummy_inputs, model):
+def _validate_dynamic_shapes(dynamic_shapes, dummy_inputs, dummy_kwargs, model):
     """Validate dynamic_shapes.
 
     This function validates two things:
@@ -605,7 +605,7 @@ def _validate_dynamic_shapes(dynamic_shapes, dummy_inputs, model):
     :return: the validated dynamic_shapes
     """
     if not dynamic_shapes:
-        return dynamic_shapes
+        return dynamic_shapes, dummy_inputs, dummy_kwargs
 
     from torch.utils import _pytree
 
@@ -617,22 +617,24 @@ def _validate_dynamic_shapes(dynamic_shapes, dummy_inputs, model):
         {int(k): v for k, v in axes.items()} if isinstance(axes, dict) else axes for axes in flat_dynamic_shapes
     ]
 
-    # reconstruct the dynamic_shapes to the same tree structure as dummy_inputs
-    _, tree_structure = get_the_flattened_and_tree_spec(dummy_inputs, leave_is_str=False)
-    unflatten_dynamic_shapes = _pytree.tree_unflatten(new_dynamic_shapes, tree_structure)
+    # The input can only be either args or kwargs according to line 237.
+    if len(dummy_inputs) == 0:
+        # dummy_inputs is empty, so it must be kwargs
+        _, tree_structure = get_the_flattened_and_tree_spec(dummy_kwargs, leave_is_str=False)
+        unflatten_dynamic_shapes = _pytree.tree_unflatten(new_dynamic_shapes, tree_structure)
 
-    # NOTE: dynamic_shapes need to follow the same model.forward signature when it's referring to kwargs.
-    if isinstance(unflatten_dynamic_shapes, dict):
+        # NOTE: dynamic_shapes need to follow the same model.forward signature when it's referring to kwargs.
         param_order = list(inspect.signature(model.forward).parameters)
         # Sort io_config.dynamic_shapes based on this order
         unflatten_dynamic_shapes = collections.OrderedDict(
             sorted(unflatten_dynamic_shapes.items(), key=lambda item: param_order.index(item[0]))
         )
-        dummy_inputs = collections.OrderedDict(
-            sorted(dummy_inputs.items(), key=lambda item: param_order.index(item[0]))
+        dummy_kwargs = collections.OrderedDict(
+            sorted(dummy_kwargs.items(), key=lambda item: param_order.index(item[0]))
         )
-        # dummy_inputs is kwargs
-        return unflatten_dynamic_shapes, (), dummy_inputs
-    # If dynamic_shapes and dummy_inputs are both list/tuple, we don't need to do anything.
+        return unflatten_dynamic_shapes, dummy_inputs, dummy_kwargs
+    # If dynamic_shapes and dummy_inputs are both list/tuple, we don't need to sort.
     # dummy_inputs is args
-    return unflatten_dynamic_shapes, dummy_inputs, {}
+    _, tree_structure = get_the_flattened_and_tree_spec(dummy_inputs, leave_is_str=False)
+    unflatten_dynamic_shapes = _pytree.tree_unflatten(new_dynamic_shapes, tree_structure)
+    return unflatten_dynamic_shapes, dummy_inputs, dummy_kwargs


### PR DESCRIPTION
## Describe your changes

Sorry! Follow up #1639, found a bug from the benchmark that makes regression on static shapes.

When it was static shape (io_config.dynamic_shapes is None), `_validate_dynamic_shapes` returned only one value, which crashed the benchmark with static shapes.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
