### PR TITLE
CI: Use venv in docker

### DIFF
--- a/.azure_pipelines/dockerfiles/linux-cpu.dockerfile
+++ b/.azure_pipelines/dockerfiles/linux-cpu.dockerfile
@@ -21,5 +21,5 @@ COPY . /olive
 WORKDIR /olive
 RUN python -m venv olive-venv
 RUN . olive-venv/bin/activate && \
-    python -m pip install --upgrade setuptools && \
-    python -m pip install -e .
+    pip install --upgrade setuptools && \
+    pip install -e .

--- a/.azure_pipelines/dockerfiles/linux-cpu.dockerfile
+++ b/.azure_pipelines/dockerfiles/linux-cpu.dockerfile
@@ -19,4 +19,7 @@ RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 
 COPY . /olive
 WORKDIR /olive
-RUN pip install -e .
+RUN python -m venv olive-venv
+RUN . olive-venv/bin/activate && \
+    python -m pip install --upgrade setuptools && \
+    python -m pip install -e .

--- a/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
+++ b/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
@@ -41,5 +41,5 @@ COPY . /olive
 WORKDIR /olive
 RUN python -m venv olive-venv
 RUN . olive-venv/bin/activate && \
-    python -m pip install --upgrade setuptools && \
-    python -m pip install -e .
+    pip install --upgrade setuptools && \
+    pip install -e .

--- a/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
+++ b/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
@@ -39,4 +39,7 @@ RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 
 COPY . /olive
 WORKDIR /olive
-RUN pip install -e .
+RUN python -m venv olive-venv
+RUN . olive-venv/bin/activate && \
+    python -m pip install --upgrade setuptools && \
+    python -m pip install -e .

--- a/.azure_pipelines/scripts/run_test.sh
+++ b/.azure_pipelines/scripts/run_test.sh
@@ -7,6 +7,9 @@
 # $5: Path to the test file to run
 # $6: Whether to use coverage tracking (true/false)
 
+# activate venv
+source olive-venv/bin/activate
+
 # Step 1: Install PyTorch
 pip install "$1"
 


### PR DESCRIPTION
## Describe your changes
- The docker image uses system python with older version setuptools. The GPU CI pipeline started failing due to mismatch between the required setuptools and install version. The installed setuptools cannot be upgrade using pip since it's a system package.
- Use venv which is separate from the system python environment.
- Upgrade setuptools
- Note: If pip is upgraded also, autoawq installation fails. It cannot find torch for some reason although it is already installed. Not sure what the cause is. If needed, we could instead use conda instead of venv in the future.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
