### PR TITLE
CI: Fix flaky `test_mnb_to_qdq`

### DIFF
--- a/test/unit_test/passes/onnx/test_mnb_to_qdq.py
+++ b/test/unit_test/passes/onnx/test_mnb_to_qdq.py
@@ -127,6 +127,6 @@ def test_mnb_to_qdq(
         # Pre transposed DQ model does not match the expected output on x64 CPU
         # check for assertion failure so we know when the test is fixed
         with pytest.raises(AssertionError):
-            np.testing.assert_allclose(original_output, qdq_output, rtol=1e-3, atol=1e-3)
+            np.testing.assert_allclose(original_output, qdq_output, rtol=1e-4, atol=1e-4)
     else:
-        np.testing.assert_allclose(original_output, qdq_output, rtol=1e-3, atol=1e-3)
+        np.testing.assert_allclose(original_output, qdq_output, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## Describe your changes
This test has become flaky recently and is not rasing the expected assertion error. Decreasing the tolerance.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
