### PR TITLE
LLM Augmented data loader

### DIFF
--- a/examples/whisper/test_transcription.py
+++ b/examples/whisper/test_transcription.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import onnxruntime as ort
 from prepare_whisper_configs import download_audio_test_data
 
-from olive.evaluator.olive_evaluator import OnnxEvaluator
+from olive.common.utils import format_data
 from olive.model import ONNXModelHandler
 
 sys.path.append(str(Path(__file__).parent / "code"))
@@ -112,7 +112,7 @@ def main(raw_args=None):
 
     # get output
     input_data, _ = dataset[0]
-    input_data = OnnxEvaluator.format_input(input_data, olive_model.io_config)
+    input_data = format_data(input_data, olive_model.io_config)
     # output is an list of numpy arrays, first element is the transcription 1Xnum_return_sequences
     # [["transcription1", "transcription2"]]
     output = olive_model.run_session(session, input_data)

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -275,6 +275,41 @@ def tensor_data_to_dtype(data, dtype):
     return data
 
 
+def format_data(data, io_config):
+    """Format data based on io_config.
+
+    :param data: data to format. Consists of torch tensors or numpy arrays.
+        Single tensor or list of tensors: zipped with input names.
+        Dict: Keys not in input names are ignored. So unused data is allowed.
+        Caller needs to ensure the required inputs are present in the data.
+    :param io_config: io config to use for formatting.
+        input_names: list of input names.
+        input_types: list of numpy input types.
+    :return: formatted data. Consists of numpy arrays.
+    """
+    import numpy as np
+    import torch
+
+    input_names = io_config["input_names"]
+    name_to_type = dict(zip(io_config["input_names"], io_config["input_types"]))
+    if isinstance(data, list):
+        # the input is just a list of tensors
+        data = dict(zip(input_names, data))
+    elif isinstance(data, (torch.Tensor, np.ndarray)):
+        # input is a single tensor
+        data = dict(zip(input_names, [data]))
+    elif not isinstance(data, dict):
+        raise ValueError(f"Invalid input data format: {data}")
+    return {
+        k: np.ascontiguousarray(
+            data[k].cpu().numpy() if isinstance(data[k], torch.Tensor) else data[k],
+            dtype=name_to_type[k],
+        )
+        for k in data
+        if k in input_names
+    }
+
+
 def resolve_torch_dtype(dtype):
     """Get torch dtype from string or torch dtype.
 

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -3,9 +3,17 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from typing import List, Union
+import logging
+import re
+from typing import Dict, List, Optional, Union
 
+import torch
+
+from olive.common.utils import format_data
 from olive.data.registry import Registry
+from olive.logging import get_verbosity
+
+logger = logging.getLogger(__name__)
 
 
 @Registry.register_dataloader()
@@ -48,13 +56,20 @@ def no_auto_batch_dataloader(dataset, **kwargs):
 
 
 @Registry.register_dataloader()
-def default_calibration_dataloader(dataloader, **kwargs):
-    # TODO(trajep): consider other quantization calibration interface in SNPE/INC/OpenVINO/Torch and etc.
+def default_calibration_dataloader(
+    dataloader,
+    model_path: Optional[str] = None,
+    io_config: Optional[Dict] = None,
+    calibration_providers: Optional[List[str]] = None,
+    **kwargs,
+):
     from onnxruntime.quantization import CalibrationDataReader
 
     class _CalibrationDataReader(CalibrationDataReader):
-        def __init__(self, dataloader, **kwargs):
+        # pylint: disable=W0223
+        def __init__(self, dataloader, io_config=None, **kwargs):
             self.dataloader = dataloader
+            self.io_config = io_config
             self.kwargs = kwargs
             self.data_iter = iter(self.dataloader)
 
@@ -65,13 +80,243 @@ def default_calibration_dataloader(dataloader, **kwargs):
                 batch = next(self.data_iter)
             except StopIteration:
                 return None
-            if isinstance(batch, list):
+            if isinstance(batch, (list, tuple)):
+                # [input, label] or (input, label)
                 batch = batch[0]
-            if isinstance(batch, dict):
+
+            assert isinstance(batch, dict), "Only support dict type batch data"
+
+            if self.io_config:
+                batch = format_data(batch, self.io_config)
+            else:
                 batch = {k: v.detach().cpu().numpy() for k, v in batch.items()}
             return batch
 
         def rewind(self):
             self.data_iter = None
 
-    return _CalibrationDataReader(dataloader, **kwargs)
+    if model_path and io_config:
+        # there is no overhead for non-llm models
+        dataloader = LLMAugmentedDataLoader(
+            dataloader, model_path, io_config, calibration_providers=calibration_providers
+        )
+
+    return _CalibrationDataReader(dataloader, io_config, **kwargs)
+
+
+# TODO(jambayk): generalize this and make this available for dataloaders
+class LLMAugmentedDataLoader:
+    def __init__(self, dataloader, model_path: str, io_config: Dict, calibration_providers: Optional[List[str]] = None):
+        import onnx
+
+        self.dataloader = dataloader
+        self.model_path = model_path
+        self.io_config = io_config
+        self.calibration_providers = calibration_providers
+
+        self.position_ids = "position_ids" in self.io_config["input_names"]
+        self.kv_info = self.get_kv_info(self.io_config)
+        self.has_gqa = False
+        for node in onnx.load(self.model_path, load_external_data=False).graph.node:
+            if node.op_type == "GroupQueryAttention":
+                self.has_gqa = True
+                logger.debug("Model has GroupQueryAttention: %s", self.has_gqa)
+                break
+
+        self._session = None
+
+    def __len__(self):
+        try:
+            return len(self.dataloader) * (
+                2
+                if not self.has_gqa
+                and self.kv_info
+                and self.kv_info["past_names"][0] not in next(iter(self.dataloader))[0]
+                else 1
+            )
+        except (TypeError, NotImplementedError):
+            # len() not implemented for dataloader
+            return 0
+
+    def __iter__(self):
+        # progress bar
+        progress_bar = None
+        if get_verbosity() == logging.DEBUG and len(self) > 0:
+            from tqdm import tqdm
+
+            progress_bar = tqdm(total=len(self), desc="LLMAugmentedDataLoader")
+
+        for data in self.dataloader:
+            if isinstance(data, (list, tuple)):
+                batch, label = data
+            else:
+                batch = data
+                label = None
+            assert isinstance(batch, dict), "Only support dict type batch data"
+
+            if self.position_ids and "position_ids" not in batch:
+                # create position ids from attention mask
+                batch["position_ids"] = self.get_position_ids(batch["input_ids"], batch["attention_mask"])
+
+            if self.kv_info and self.kv_info["past_names"][0] not in batch:
+                # GQA: use all tokens for prefill
+                # No GQA: use all - 1 tokens for prefill, last token for decode
+                prefill_slice = slice(0, None) if self.has_gqa else slice(None, -1)
+
+                attention_mask = batch["attention_mask"]
+                # prepend mask for past keys and values
+                if not self.has_gqa:
+                    # GQA: no past. Quantizer needs to exclude GQA from calibration
+                    # No GQA: one unattended past token so that the calibrator data collection works
+                    attention_mask = torch.cat([torch.zeros_like(attention_mask[:, :1]), attention_mask], dim=-1)
+
+                # prefill: all - 1 tokens
+                prefill_batch = {
+                    "input_ids": batch["input_ids"][:, prefill_slice],
+                    "attention_mask": attention_mask[:, prefill_slice],
+                    **self.get_empty_kv_cache(batch["input_ids"].shape[0], self.kv_info, self.has_gqa),
+                }
+                if self.position_ids:
+                    prefill_batch["position_ids"] = batch["position_ids"][:, prefill_slice]
+
+                prefill_label = (
+                    label[:, prefill_slice]
+                    if (isinstance(label, torch.Tensor) and label.shape == batch["input_ids"].shape)
+                    else label
+                )
+
+                yield prefill_batch, prefill_label
+                if progress_bar:
+                    progress_bar.update(1)
+
+                if self.has_gqa:
+                    continue
+
+                # decode: last token, all - 1 past keys/values generated from prefill
+                session_outputs = self.session.run(None, format_data(prefill_batch, self.io_config))
+                session_outputs = dict(zip(self.io_config["output_names"], session_outputs))
+
+                decode_batch = {
+                    "input_ids": batch["input_ids"][:, -1:],
+                    "attention_mask": attention_mask,
+                    **{v: session_outputs[k] for k, v in self.kv_info["present_to_past"].items()},
+                }
+                if self.position_ids:
+                    decode_batch["position_ids"] = batch["position_ids"][:, -1:]
+
+                decode_label = (
+                    label[:, -1:]
+                    if (isinstance(label, torch.Tensor) and label.shape == batch["input_ids"].shape)
+                    else label
+                )
+
+                yield decode_batch, decode_label
+                if progress_bar:
+                    progress_bar.update(1)
+            else:
+                yield batch, label
+                if progress_bar:
+                    progress_bar.update(1)
+
+    @property
+    def session(self):
+        from onnxruntime import InferenceSession
+
+        if self._session is not None:
+            return self._session
+
+        self._session = InferenceSession(self.model_path, providers=self.calibration_providers)
+        return self._session
+
+    @staticmethod
+    def get_position_ids(input_ids: torch.tensor, attention_mask: torch.tensor) -> torch.tensor:
+        """Return the position ids for the input ids based on the attention mask.
+
+        :param input_ids: A tensor of input ids.
+        :param attention_mask: A tensor of attention masks.
+        :return: A tensor of position ids.
+        """
+        # position ids correspond to input ids
+        # attention mask past + current tokens
+        return (attention_mask.cumsum(-1) - 1)[:, -input_ids.shape[-1] :]
+
+    @staticmethod
+    def get_kv_info(io_config: Dict) -> Optional[Dict]:
+        """Return the kv_info dictionary containing information about past keys and values.
+
+        :param io_config: A dictionary containing the input and output names and shapes.
+        :return: A dictionary with keys "past_names", "present_to_past", "num_kv_heads", and "head_size".
+            If no kv_info is found, returns None. Only dynamic shapes are accepted currently.
+        """
+        # assuming batch_size, num_kv_heads, past_seq_len, head_size
+        kv_options = {
+            r"past_key_values.(\d+).key": {
+                "past_key": "past_key_values.%d.key",
+                "past_value": "past_key_values.%d.value",
+                "present_key": "present.%d.key",
+                "present_value": "present.%d.value",
+            },
+            r"past_key_(\d+)": {
+                "past_key": "past_key_%d",
+                "past_value": "past_value_%d",
+                "present_key": "present_key_%d",
+                "present_value": "present_value_%d",
+            },
+        }
+
+        # Find the format of the past keys and values
+        # only accept dynamic shapes for now
+        kv_format = None
+        for idx, i_name in enumerate(io_config["input_names"]):
+            for pattern in kv_options:
+                if re.match(pattern, i_name) and not isinstance(io_config["input_shapes"][idx][2], int):
+                    kv_format = pattern
+                    break
+            if kv_format:
+                break
+
+        if kv_format is None:
+            return None
+
+        # find the number of layers
+        num_layers = 0
+        for i_name in io_config["input_names"]:
+            num_layers += int(re.match(kv_format, i_name) is not None)
+        logger.debug("Found %d layers with past keys/values", num_layers)
+
+        past_names = []
+        present_to_past = {}
+        for k in ["key", "value"]:
+            past_names.extend([kv_options[kv_format][f"past_{k}"] % i for i in range(num_layers)])
+            present_to_past.update(
+                {
+                    kv_options[kv_format][f"present_{k}"] % i: kv_options[kv_format][f"past_{k}"] % i
+                    for i in range(num_layers)
+                }
+            )
+
+        past_shape = io_config["input_shapes"][io_config["input_names"].index(past_names[0])]
+
+        return {
+            "past_names": past_names,
+            "present_to_past": present_to_past,
+            "num_kv_heads": past_shape[1],
+            "head_size": past_shape[3],
+        }
+
+    @staticmethod
+    def get_empty_kv_cache(batch_size: int, kv_info: Dict, has_gqa: bool):
+        """Return an empty cache for past keys and values.
+
+        :param batch_size: The batch size.
+        :param kv_info: A dictionary containing information about the keys and values.
+        :param has_gqa: A boolean indicating whether the model has GQA.
+        :return: A dictionary with empty tensors for past keys and values.
+            If the model has GQA, the past keys and values will have a length of 0, else they will have a length of 1.
+        """
+        return {
+            k: torch.zeros(
+                (batch_size, kv_info["num_kv_heads"], 0 if has_gqa else 1, kv_info["head_size"]), dtype=torch.float32
+            )
+            for k in kv_info["past_names"]
+        }

--- a/olive/data/container/data_container.py
+++ b/olive/data/container/data_container.py
@@ -46,10 +46,12 @@ class DataContainer(BaseModel):
         pre_process_dataset = self.pre_process(dataset)
         return self.dataloader(pre_process_dataset)
 
-    def create_calibration_dataloader(self):
+    def create_calibration_dataloader(self, model_path=None, io_config=None, calibration_providers=None):
         """Create calibration dataloader."""
         dataloader = self.create_dataloader()
-        return default_calibration_dataloader(dataloader)
+        return default_calibration_dataloader(
+            dataloader, model_path=model_path, io_config=io_config, calibration_providers=calibration_providers
+        )
 
     def get_first_batch(self, dataloader=None):
         """Get first batch of dataloader."""

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -20,7 +20,7 @@ from olive.common.import_lib import import_user_module
 from olive.common.ort_inference import OrtInferenceSession, prepare_io_bindings
 from olive.common.pydantic_v1 import Field, root_validator, validator
 from olive.common.user_module_loader import UserModuleLoader
-from olive.common.utils import load_weights, tensor_data_to_device
+from olive.common.utils import format_data, load_weights, tensor_data_to_device
 from olive.constants import Framework
 from olive.data.config import DataConfig
 from olive.data.container.dummy_data_container import TRANSFORMER_DUMMY_DATA_CONTAINER
@@ -337,24 +337,6 @@ class _OliveEvaluator(OliveEvaluator):
 class OnnxEvaluatorMixin:
 
     @staticmethod
-    def format_input(input_data, io_config):
-        """Format input data to ONNX input format."""
-        input_names = io_config["input_names"]
-        name_to_type = dict(zip(io_config["input_names"], io_config["input_types"]))
-        if isinstance(input_data, list):
-            input_data = dict(zip(input_names, input_data))
-        elif not isinstance(input_data, dict):
-            input_data = dict(zip(input_names, [input_data]))
-        return {
-            k: np.ascontiguousarray(
-                input_data[k].cpu().numpy() if isinstance(input_data[k], torch.Tensor) else input_data[k],
-                dtype=name_to_type[k],
-            )
-            for k in input_data
-            if k in input_names
-        }
-
-    @staticmethod
     def get_inference_settings(metric: Metric, model: ONNXModelHandler) -> Dict[str, Any]:
         # user.config.inference_settings > model.inference_settings > default inference_settings
         # when user.config.inference_settings is None, the model.inference_settings
@@ -399,12 +381,12 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         use_fp16 = any(v == "float16" for v in io_config["input_types"])
         input_feed = None
         if io_bind and shared_kv_buffer and use_fp16:
-            input_feed = OnnxEvaluator.format_input(next(iter(dataloader))[0], io_config)
+            input_feed = format_data(next(iter(dataloader))[0], io_config)
 
         # load constant inputs if any
         constant_inputs = None
         if model.constant_inputs_path:
-            constant_inputs = OnnxEvaluator.format_input(load_weights(model.constant_inputs_path), io_config)
+            constant_inputs = format_data(load_weights(model.constant_inputs_path), io_config)
 
         # create session wrapper
         session_wrapper = OrtInferenceSession(
@@ -441,7 +423,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         output_names = io_config["output_names"]
         is_single_tensor_output = len(output_names) == 1
         for input_data, labels in dataloader:
-            input_feed = OnnxEvaluator.format_input(input_data, io_config)
+            input_feed = format_data(input_data, io_config)
             result = model.run_session(session, input_feed, **run_kwargs)
             if is_single_tensor_output:
                 result = torch.Tensor(result[0])
@@ -497,7 +479,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         io_config = model.io_config
 
         input_data, _ = next(iter(dataloader))
-        input_feed = OnnxEvaluator.format_input(input_data, io_config)
+        input_feed = format_data(input_data, io_config)
 
         latencies = session.time_run(
             input_feed,
@@ -546,7 +528,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         logits = []
         output_names = io_config["output_names"]
         for _, (input_data, labels) in enumerate(dataloader):
-            input_dict = OnnxEvaluator.format_input(input_data, io_config)
+            input_dict = format_data(input_data, io_config)
             MPI.COMM_WORLD.barrier()  # Synchronize before starting each run
             output = session.run(None, input_dict)
             output = torch.Tensor(output[0]) if len(output_names) == 1 else torch.Tensor(output)
@@ -624,7 +606,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         io_config = model.io_config
 
         input_feed, _ = next(iter(dataloader))
-        input_feed = OnnxEvaluator.format_input(input_feed, io_config)
+        input_feed = format_data(input_feed, io_config)
         kv_cache_ortvalues = {} if metric.user_config.shared_kv_buffer else None
 
         io_bind = OnnxEvaluator.io_bind_enabled(metric, model.inference_settings)

--- a/olive/logging.py
+++ b/olive/logging.py
@@ -41,6 +41,14 @@ def set_verbosity_from_env():
     set_verbosity(log_level)
 
 
+def get_verbosity() -> int:
+    """Get the current verbosity level of the olive logger.
+
+    :return: Verbosity level as an integer.
+    """
+    return get_olive_logger().getEffectiveLevel()
+
+
 def get_logger_level(level):
     """Get Python logging level for the integer level.
 

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -226,9 +226,11 @@ _static_optional_config = {
 }
 
 
-def get_calibration_dataloader(config):
+def get_calibration_dataloader(config, model_path=None, io_config=None, calibration_providers=None):
     data_config = validate_config(config.data_config, DataConfig)
-    return data_config.to_data_container().create_calibration_dataloader()
+    return data_config.to_data_container().create_calibration_dataloader(
+        model_path=model_path, io_config=io_config, calibration_providers=calibration_providers
+    )
 
 
 class OnnxQuantization(Pass):
@@ -431,7 +433,9 @@ class OnnxQuantization(Pass):
 
         if is_static:
             # get the dataloader
-            dataloader = get_calibration_dataloader(config)
+            dataloader = get_calibration_dataloader(
+                config, model.model_path, model.io_config, config.calibration_providers
+            )
             # TODO(anyone): generalize this option to prepare_qdq_config so that other NPU eps can use it
             # to call get_qdq_config
             if config.prepare_qnn_config:

--- a/olive/systems/isolated_ort/isolated_ort_system.py
+++ b/olive/systems/isolated_ort/isolated_ort_system.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union
 
 import numpy as np
 
-from olive.common.utils import load_weights, run_subprocess, save_weights
+from olive.common.utils import format_data, load_weights, run_subprocess, save_weights
 from olive.evaluator.metric import get_latency_config_from_metric
 from olive.evaluator.olive_evaluator import OliveEvaluator, OliveModelOutput, OnnxEvaluatorMixin, _OliveEvaluator
 from olive.evaluator.registry import Registry
@@ -171,7 +171,7 @@ class IsolatedORTEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             num_batches = 0
             for idx, (input_data, labels) in enumerate(dataloader):
                 # save input data
-                np.savez(input_dir / f"input_{idx}.npz", **self.format_input(input_data, io_config))
+                np.savez(input_dir / f"input_{idx}.npz", **format_data(input_data, io_config))
                 # save labels
                 targets.append(labels.cpu())
                 num_batches += 1
@@ -271,7 +271,7 @@ class IsolatedORTEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             output_dir.mkdir(parents=True, exist_ok=True)
 
             # save input data
-            np.savez(input_dir / "input.npz", **self.format_input(next(iter(dataloader))[0], io_config))
+            np.savez(input_dir / "input.npz", **format_data(next(iter(dataloader))[0], io_config))
 
             # save inference config
             config_path = temp_dir_path / "config.json"

--- a/test/unit_test/data_container/test_dataloader.py
+++ b/test/unit_test/data_container/test_dataloader.py
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from test.unit_test.utils import make_local_tiny_llama
+
+import pytest
+
+from olive.data.component.dataloader import LLMAugmentedDataLoader
+from olive.data.template import huggingface_data_config_template
+from olive.passes.olive_pass import create_pass_from_dict
+
+
+@pytest.mark.parametrize("use_gqa", [True, False])
+def test_llm_augmeted_dataloader(tmp_path, use_gqa):
+    pytorch_model = make_local_tiny_llama(tmp_path)
+    if use_gqa:
+        from olive.passes.onnx.model_builder import ModelBuilder
+
+        onnx_model = create_pass_from_dict(ModelBuilder, {"precision": "fp32"}, disable_search=True).run(
+            pytorch_model, tmp_path / "onnx_model"
+        )
+    else:
+        from olive.passes.onnx.conversion import OnnxConversion
+
+        onnx_model = create_pass_from_dict(OnnxConversion, {}, disable_search=True).run(
+            pytorch_model, tmp_path / "onnx_model"
+        )
+
+    data_config = huggingface_data_config_template(
+        model_name=pytorch_model.model_name_or_path,
+        task="text-generation",
+        load_dataset_config={"data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train"},
+        pre_process_data_config={"add_special_tokens": False, "max_seq_len": 10, "max_samples": 1},
+    )
+
+    augmented_dataloader = LLMAugmentedDataLoader(
+        data_config.to_data_container().create_dataloader(),
+        model_path=onnx_model.model_path,
+        io_config=onnx_model.io_config,
+    )
+
+    assert len(augmented_dataloader) == 1 if use_gqa else 2
+
+    for idx, (batch, _) in enumerate(augmented_dataloader):
+        assert isinstance(batch, dict)
+        assert "input_ids" in batch
+        assert "attention_mask" in batch
+        assert "past_key_values.0.key" in batch
+        assert "past_key_values.0.value" in batch
+        if not use_gqa:
+            assert "position_ids" in batch
+            assert batch["past_key_values.0.key"].shape[2] == (1 if idx % 2 == 0 else 10)
+        else:
+            assert batch["past_key_values.0.key"].shape[2] == 0

--- a/test/unit_test/passes/onnx/test_model_builder.py
+++ b/test/unit_test/passes/onnx/test_model_builder.py
@@ -3,40 +3,18 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
+from test.unit_test.utils import make_local_tiny_llama
 
 import pytest
 
-from olive.model import HfModelHandler, ONNXModelHandler
+from olive.model import ONNXModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.model_builder import ModelBuilder
 
 
-def make_local_model(save_path, model_type="hf"):
-    input_model = HfModelHandler(model_path="hf-internal-testing/tiny-random-LlamaForCausalLM")
-    loaded_model = input_model.load_model()
-    # this checkpoint has an invalid generation config that cannot be saved
-    loaded_model.generation_config.pad_token_id = 1
-
-    save_path.mkdir(parents=True, exist_ok=True)
-    if model_type == "hf":
-        loaded_model.save_pretrained(save_path)
-    else:
-        onnx_file_path = save_path / "model.onnx"
-        onnx_file_path.write_text("dummy onnx file")
-        loaded_model.config.save_pretrained(save_path)
-        loaded_model.generation_config.save_pretrained(save_path)
-    input_model.get_hf_tokenizer().save_pretrained(save_path)
-
-    return (
-        HfModelHandler(model_path=save_path)
-        if model_type == "hf"
-        else ONNXModelHandler(model_path=save_path, onnx_file_name="model.onnx")
-    )
-
-
 @pytest.mark.parametrize("metadata_only", [True, False])
 def test_model_builder(tmp_path, metadata_only):
-    input_model = make_local_model(tmp_path / "input_model", "onnx" if metadata_only else "hf")
+    input_model = make_local_tiny_llama(tmp_path / "input_model", "onnx" if metadata_only else "hf")
 
     p = create_pass_from_dict(ModelBuilder, {"precision": "fp32", "metadata_only": metadata_only}, disable_search=True)
     output_folder = tmp_path / "output_model"

--- a/test/unit_test/passes/pytorch/test_rotate.py
+++ b/test/unit_test/passes/pytorch/test_rotate.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from test.unit_test.utils import make_local_tiny_llama
 from unittest.mock import patch
 
 import pytest
@@ -18,11 +19,7 @@ def common_test_rotate(rotate_pass, tmp_path, model_path, rotate_mode, atol, **c
     if input_model.get_hf_model_type() == "llama":
         # this checkpoint has an invalid generation config that cannot be saved
         model_path = str(tmp_path / "model")
-        loaded_model = input_model.load_model()
-        loaded_model.generation_config.pad_token_id = 1
-        loaded_model.save_pretrained(model_path)
-        input_model.get_hf_tokenizer().save_pretrained(model_path)
-        input_model = HfModelHandler(model_path=model_path)
+        input_model = make_local_tiny_llama(model_path, "hf")
 
     p = create_pass_from_dict(rotate_pass, {"rotate_mode": rotate_mode, **config_kwargs}, disable_search=True)
 

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -341,3 +341,27 @@ def create_raw_data(raw_data_dir, input_names, input_shapes, input_types=None, n
             data[input_name].append(data_i)
 
     return data
+
+
+def make_local_tiny_llama(save_path, model_type="hf"):
+    input_model = HfModelHandler(model_path="hf-internal-testing/tiny-random-LlamaForCausalLM")
+    loaded_model = input_model.load_model()
+    # this checkpoint has an invalid generation config that cannot be saved
+    loaded_model.generation_config.pad_token_id = 1
+
+    save_path = Path(save_path)
+    save_path.mkdir(parents=True, exist_ok=True)
+    if model_type == "hf":
+        loaded_model.save_pretrained(save_path)
+    else:
+        onnx_file_path = save_path / "model.onnx"
+        onnx_file_path.write_text("dummy onnx file")
+        loaded_model.config.save_pretrained(save_path)
+        loaded_model.generation_config.save_pretrained(save_path)
+    input_model.get_hf_tokenizer().save_pretrained(save_path)
+
+    return (
+        HfModelHandler(model_path=save_path)
+        if model_type == "hf"
+        else ONNXModelHandler(model_path=save_path, onnx_file_name="model.onnx")
+    )


### PR DESCRIPTION
## Describe your changes
- Augment the data loader for llms with kv cache and other missing inputs.
- This augmentation is only done for quantization calibration dataloader for now since it requires model specific information. If needed, we could generalize this to the regular dataloader.
- There are two cases:
   - Models with GQA: kv cache with empty tensors provided. This assumes that GQA nodes won't be calibrated.
   - Models without GQA: Each sample leads to two calibration samples. first one with dummy single past length kv cache. second one with the present outputs from the model run. This way the calibration data sees real world kv cache data.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
