### PR TITLE
add metadata to RunConfig

### DIFF
--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -112,6 +112,7 @@ class RunConfig(NestedConfig):
     workflow_host: SystemConfig = Field(
         None, description="Workflow host. None by default. If provided, the workflow will be run on the specified host."
     )
+    metadata: Any = Field(description="Metadata to save embedded information for the workflow.")
 
     @root_validator(pre=True)
     def patch_evaluators(cls, values):


### PR DESCRIPTION
## Describe your changes

Needed for Model Lab to store some metadata (like to guide the changeable parameters etc.) for the olive config.

Else we will face
 ```
pydantic.v1.error_wrappers.ValidationError: 5 validation errors for RunConfig
engine -> metadata
  extra fields not permitted (type=value_error.extra)
```

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
