### PR TITLE
Extract multiple adapters from PyTorch model

### DIFF
--- a/olive/cli/convert_adapters.py
+++ b/olive/cli/convert_adapters.py
@@ -54,6 +54,26 @@ class ConvertAdaptersCommand(BaseOliveCLICommand):
                 " quantization scales. Default is float32."
             ),
         )
+        # int4 quantization options for adapter weights
+        sub_parser.add_argument(
+            "--quantize_int4",
+            action="store_true",
+            help="Quantize the adapter weights to int4 using blockwise quantization.",
+        )
+        sub_parser.add_argument(
+            "--int4_block_size",
+            type=int,
+            default=32,
+            choices=[16, 32, 64, 128, 256],
+            help="Block size for int4 quantization of adapter weights. Default is 32.",
+        )
+        sub_parser.add_argument(
+            "--int4_quantization_mode",
+            type=str,
+            default="symmetric",
+            choices=["symmetric", "asymmetric"],
+            help="Quantization mode for int4 quantization of adapter weights. Default is symmetric.",
+        )
         add_logging_options(sub_parser)
         sub_parser.set_defaults(func=ConvertAdaptersCommand)
 

--- a/olive/cli/convert_adapters.py
+++ b/olive/cli/convert_adapters.py
@@ -54,26 +54,6 @@ class ConvertAdaptersCommand(BaseOliveCLICommand):
                 " quantization scales. Default is float32."
             ),
         )
-        # int4 quantization options for adapter weights
-        sub_parser.add_argument(
-            "--quantize_int4",
-            action="store_true",
-            help="Quantize the adapter weights to int4 using blockwise quantization.",
-        )
-        sub_parser.add_argument(
-            "--int4_block_size",
-            type=int,
-            default=32,
-            choices=[16, 32, 64, 128, 256],
-            help="Block size for int4 quantization of adapter weights. Default is 32.",
-        )
-        sub_parser.add_argument(
-            "--int4_quantization_mode",
-            type=str,
-            default="symmetric",
-            choices=["symmetric", "asymmetric"],
-            help="Quantization mode for int4 quantization of adapter weights. Default is symmetric.",
-        )
         add_logging_options(sub_parser)
         sub_parser.set_defaults(func=ConvertAdaptersCommand)
 

--- a/olive/cli/extract_adapters.py
+++ b/olive/cli/extract_adapters.py
@@ -55,26 +55,6 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
             default="cache_dir",
             help="Cache dir to store temporary files in. Default is `cache_dir`.",
         )
-        # int4 quantization options for adapter weights
-        sub_parser.add_argument(
-            "--quantize_int4",
-            action="store_true",
-            help="Quantize the adapter weights to int4 using blockwise quantization.",
-        )
-        sub_parser.add_argument(
-            "--int4_block_size",
-            type=int,
-            default=32,
-            choices=[16, 32, 64, 128, 256],
-            help="Block size for int4 quantization of adapter weights. Default is 32.",
-        )
-        sub_parser.add_argument(
-            "--int4_quantization_mode",
-            type=str,
-            default="symmetric",
-            choices=["symmetric", "asymmetric"],
-            help="Quantization mode for int4 quantization of adapter weights. Default is symmetric.",
-        )
         add_logging_options(sub_parser)
         sub_parser.set_defaults(func=ExtractAdaptersCommand)
 

--- a/olive/cli/extract_adapters.py
+++ b/olive/cli/extract_adapters.py
@@ -1,0 +1,168 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import math
+from argparse import ArgumentParser
+from typing import TYPE_CHECKING, Tuple
+
+from olive.cli.base import BaseOliveCLICommand, add_logging_options
+from olive.common.utils import WeightsFileFormat, save_weights
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+class ExtractAdaptersCommand(BaseOliveCLICommand):
+    @staticmethod
+    def register_subcommand(parser: ArgumentParser):
+        sub_parser = parser.add_parser(
+            "extract-adapters",
+            help="Extract LoRAs from PyTorch model to separate files",
+        )
+        sub_parser.add_argument(
+            "-m",
+            "--model",
+            type=str,
+            required=True,
+            help="Path to the PyTorch model. Can be a local folder or Hugging Face id.",
+        )
+        sub_parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            choices=[el.value for el in WeightsFileFormat],
+            required=True,
+            help="Format to save the LoRAs in.",
+        )
+        sub_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            required=True,
+            help="Output folder to save the LoRAs in the requested format.",
+        )
+        sub_parser.add_argument(
+            "--dtype",
+            type=str,
+            default="float32",
+            choices=["float32", "float16", "int4"],
+            help="Data type to save LoRAs as. Default is float32.",
+        )
+        sub_parser.add_argument(
+            "--cache_dir",
+            type=str,
+            default="cache_dir",
+            help="Cache dir to store temporary files in. Default is `cache_dir`.",
+        )
+        # int4 quantization options for adapter weights
+        sub_parser.add_argument(
+            "--quantize_int4",
+            action="store_true",
+            help="Quantize the adapter weights to int4 using blockwise quantization.",
+        )
+        sub_parser.add_argument(
+            "--int4_block_size",
+            type=int,
+            default=32,
+            choices=[16, 32, 64, 128, 256],
+            help="Block size for int4 quantization of adapter weights. Default is 32.",
+        )
+        sub_parser.add_argument(
+            "--int4_quantization_mode",
+            type=str,
+            default="symmetric",
+            choices=["symmetric", "asymmetric"],
+            help="Quantization mode for int4 quantization of adapter weights. Default is symmetric.",
+        )
+        add_logging_options(sub_parser)
+        sub_parser.set_defaults(func=ExtractAdaptersCommand)
+
+    def run(self):
+        # Reference: https://huggingface.co/microsoft/Phi-4-multimodal-instruct-onnx/blob/05f620b467891affcb00b464e5a73e7cf2de61f9/onnx/builder.py#L318
+        from huggingface_hub import HfApi
+        from peft import PeftConfig, PeftModel
+        from transformers import AutoConfig, AutoModelForCausalLM
+        from torch import float16, float32
+        import os
+
+        torch_dtype = float16 if self.args.dtype == "float16" else float32
+
+        # Check if model is Transformers or Peft
+        if os.path.exists(self.args.model):
+            is_peft = os.path.exists(os.path.join(self.args.model, "adapter_config.json"))
+        else:
+            is_peft = "adapter_config.json" in HfApi().list_repo_files(self.args.model)
+
+        # Load LoRA config and LoRA model
+        if is_peft:
+            # Peft model
+            peft_config = PeftConfig.from_pretrained(self.args.model, cache_dir=self.args.cache_dir, trust_remote_code=True)
+            config = AutoConfig.from_pretrained(peft_config.base_model_name_or_path, cache_dir=self.args.cache_dir, trust_remote_code=True)
+            model = PeftModel.from_pretrained(peft_config.base_model_name_or_path, self.args.model, cache_dir=self.args.cache_dir, trust_remote_code=True)
+        else:
+            # Transformers model
+            config = AutoConfig.from_pretrained(self.args.model, cache_dir=self.args.cache_dir, trust_remote_code=True)
+            model = AutoModelForCausalLM.from_pretrained(self.args.model, cache_dir=self.args.cache_dir, trust_remote_code=True)
+
+        head_size = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        query_size = config.num_attention_heads * head_size
+        key_value_size = config.num_key_value_heads * head_size
+        intermediate_size = config.intermediate_size
+
+        adapter_sets = {}
+        for key, val in model.state_dict().items():
+            # Map name in graph as key
+            new_dict = {}
+            key_name = key.replace("self_attn", "attn").replace("lora_A", "lora_A.MatMul").replace("lora_B", "lora_B.MatMul")
+
+            if "lora_A" in key_name:
+                # LoRA_A is shared across projections
+                if "qkv_proj" in key_name:
+                    new_dict[key_name.replace("qkv_proj", "q_proj")] = val
+                    new_dict[key_name.replace("qkv_proj", "k_proj")] = val
+                    new_dict[key_name.replace("qkv_proj", "v_proj")] = val
+                elif "gate_up_proj" in key_name:
+                    new_dict[key_name.replace("gate_up_proj", "gate_proj")] = val
+                    new_dict[key_name.replace("gate_up_proj", "up_proj")] = val
+                else:
+                    new_dict[key_name] = val
+
+            elif "lora_B" in key_name:
+                # LoRA_B is split across projections
+                if "qkv_proj" in key_name:
+                    new_dict[key_name.replace("qkv_proj", "q_proj")] = val[: query_size, :]
+                    new_dict[key_name.replace("qkv_proj", "k_proj")] = val[query_size : query_size + key_value_size, :]
+                    new_dict[key_name.replace("qkv_proj", "v_proj")] = val[query_size + key_value_size :, :]
+                elif "gate_up_proj" in key_name:
+                    new_dict[key_name.replace("gate_up_proj", "gate_proj")] = val[: intermediate_size, :]
+                    new_dict[key_name.replace("gate_up_proj", "up_proj")] = val[intermediate_size :, :]
+                else:
+                    new_dict[key_name] = val
+
+            else:
+                continue
+
+            # Use negative indices to access `module_path` since prefix can be multiple options
+            # (e.g. `model`, `model.model`, etc)
+            module_path = key.split(".")
+            layer_id = module_path[-6]
+            class_name = module_path[-5]  # e.g. self_attn, mlp, etc.
+            class_attr_name = module_path[-4]  # e.g. qkv_proj, gate_up_proj, etc.
+            lora_name = module_path[-3]  # e.g. lora_A, lora_B, etc.
+            adapter_name = module_path[-2]  # e.g. default, speech, etc.
+
+            if adapter_name not in adapter_sets:
+                adapter_sets[adapter_name] = {}
+
+            prefix = "base_model.model" if is_peft else "model"            
+            scale_val = eval(f"{prefix}.model.layers[{layer_id}].{class_name}.{class_attr_name}.scaling['{adapter_name}']")
+            for new_key, new_val in new_dict.items():
+                new_key = new_key.replace(f".{adapter_name}", "")
+                np_data = new_val.detach().cpu().to(torch_dtype).numpy().transpose() * (scale_val if "lora_B" in key else 1)
+                adapter_sets[adapter_name][new_key] = np_data
+
+        # Save each LoRA set to disk
+        for adapter_name, adapter_set in adapter_sets.items():
+            output_path = save_weights(adapter_set, os.path.join(self.args.output, adapter_name), self.args.format)
+            print(f"Exported {adapter_name} adapter weights to {output_path}")

--- a/olive/cli/launcher.py
+++ b/olive/cli/launcher.py
@@ -10,6 +10,7 @@ from olive.cli.auto_opt import AutoOptCommand
 from olive.cli.capture_onnx import CaptureOnnxGraphCommand
 from olive.cli.configure_qualcomm_sdk import ConfigureQualcommSDKCommand
 from olive.cli.convert_adapters import ConvertAdaptersCommand
+from olive.cli.extract_adapters import ExtractAdaptersCommand
 from olive.cli.finetune import FineTuneCommand
 from olive.cli.generate_adapter import GenerateAdapterCommand
 from olive.cli.generate_cost_model import GenerateCostModelCommand
@@ -44,6 +45,7 @@ def get_cli_parser(called_as_console_script: bool = True) -> ArgumentParser:
     ConfigureQualcommSDKCommand.register_subcommand(commands_parser)
     ManageAMLComputeCommand.register_subcommand(commands_parser)
     SharedCacheCommand.register_subcommand(commands_parser)
+    ExtractAdaptersCommand.register_subcommand(commands_parser)
 
     return parser
 

--- a/olive/passes/onnx/extract_adapters.py
+++ b/olive/passes/onnx/extract_adapters.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExtractAdapters(Pass):
-    """Extract adapter weights from model and save them as external weights file.
+    """Extract adapter weights from ONNX model and save them as external weights file.
 
     If make_inputs is False, model proto is invalid after this pass as the adapter weights point to non-existent
     external files. Inference session must be created by first loading the adapter weights using

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -272,5 +272,27 @@ def test_quantize_command(mock_repo_exists, mock_run, algorithm_name, tmp_path):
     assert mock_run.call_count == 1
 
 
+@patch("huggingface_hub.repo_exists", return_value=True)
+def test_extract_adapters_command(mock_repo_exists, tmp_path):
+    # setup
+    output_dir = tmp_path / "output_dir"
+    model_id = "microsoft/Phi-4-multimodal-instruct"
+    command_args = [
+        "extract-adapters",
+        "-m",
+        model_id,
+        "-o",
+        str(output_dir),
+        "-f",
+        "onnx_adapter",
+    ]
+
+    # execute
+    cli_main(command_args)
+
+    assert (output_dir / "vision.onnx_adapter").exists()
+    assert (output_dir / "speech.onnx_adapter").exists()
+
+
 # TODO(anyone): Add tests for ManageAMLComputeCommand
 # Test for ConvertAdaptersCommand is added as part of test/unit_test/passes/onnx/test_extract_adapters.py


### PR DESCRIPTION
### Description

This PR adds the ability to extract multiple adapters from a PyTorch model using the Olive CLI and save them in the desired format.

Example usage:
```bash
olive extract-adapters -m microsoft/Phi-4-multimodal-instruct -o phi-4-mm -f onnx_adapter
```

### Motivation and Context

The Phi-4 multimodal model contains two sets of adapters that are pre-loaded into the PyTorch model when running `AutoModelForCausalLM.from_pretrained`. The model is not a PEFT model but is a Transformers model with PEFT's `LoraLinear` layers inserted. Other Olive CLI commands do not have the ability to extract multiple adapters from a PyTorch model.