### PR TITLE
Move Precision enum declaration to global space

### DIFF
--- a/olive/auto_optimizer/__init__.py
+++ b/olive/auto_optimizer/__init__.py
@@ -75,7 +75,7 @@ class AutoOptimizer(RegulatePassConfigMixin):
 
         # if user can tolerate accuracy drop, we can enable more optimization
         default_precisions = [Precision.FP32]
-        if self.evaluator_config and self.evaluator_config.is_accuracy_drop_tolerance:
+        if self.evaluator_config and self.evaluator_config.is_accuracy_drop_tolerant:
             default_precisions = [Precision.FP32, Precision.FP16, Precision.INT8, Precision.INT4]
         self.auto_optimizer_config.precisions = self.auto_optimizer_config.precisions or default_precisions
 

--- a/olive/constants.py
+++ b/olive/constants.py
@@ -32,3 +32,19 @@ class ModelFileFormat(StrEnumBase):
     QNN_SERIALIZED_BIN = "QNN.SERIALIZED.BIN"
     OPENVINO_IR = "OpenVINO.IR"
     COMPOSITE_MODEL = "Composite"
+
+
+class Precision(StrEnumBase):
+    INT4 = "int4"
+    INT8 = "int8"
+    INT16 = "int16"
+    INT32 = "int32"
+    UINT4 = "uint4"
+    UINT8 = "uint8"
+    UINT16 = "uint16"
+    UINT32 = "uint32"
+    FP4 = "fp4"
+    FP8 = "fp8"
+    FP16 = "fp16"
+    FP32 = "fp32"
+    NF4 = "nf4"

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1140,7 +1140,7 @@ class OliveEvaluatorConfig(NestedConfig):
             import_user_module(self.user_script, self.script_dir)
 
     @property
-    def is_accuracy_drop_tolerance(self):
+    def is_accuracy_drop_tolerant(self):
         for metric in self.metrics:
             for sub_metric in metric.sub_types:
                 if metric.type == MetricType.ACCURACY and sub_metric.higher_is_better:

--- a/olive/passes/pass_config.py
+++ b/olive/passes/pass_config.py
@@ -15,6 +15,7 @@ from olive.common.config_utils import (
 )
 from olive.common.pydantic_v1 import Field, create_model, validator
 from olive.common.utils import StrEnumBase
+from olive.constants import Precision
 from olive.hardware.accelerator import Device
 from olive.hardware.constants import DEVICE_TO_EXECUTION_PROVIDERS
 from olive.resource_path import validate_resource_path
@@ -166,21 +167,6 @@ def create_config_class(
 
 
 class PassModuleConfig(ConfigBase):
-    class Precision(StrEnumBase):
-        INT4 = "int4"
-        INT8 = "int8"
-        INT16 = "int16"
-        INT32 = "int32"
-        UINT4 = "uint4"
-        UINT8 = "uint8"
-        UINT16 = "uint16"
-        UINT32 = "uint32"
-        FP4 = "fp4"
-        FP8 = "fp8"
-        FP16 = "fp16"
-        FP32 = "fp32"
-        NF4 = "nf4"
-
     ACCELERATORS: ClassVar[Set[str]] = {v.value for v in Device}
     PRECISIONS: ClassVar[Set[str]] = {v.value for v in Precision}
     EXECUTION_PROVIDERS: ClassVar[Set[str]] = {

--- a/test/unit_test/evaluator/test_olive_evaluator.py
+++ b/test/unit_test/evaluator/test_olive_evaluator.py
@@ -445,7 +445,7 @@ class TestOliveEvaluatorConfig:
             OliveEvaluatorConfig(metrics=metric_config)
 
     @pytest.mark.parametrize(
-        ("metric_args", "is_accuracy_drop_tolerance"),
+        ("metric_args", "is_accuracy_drop_tolerant"),
         [
             ([{"args": [AccuracySubType.ACCURACY_SCORE], "kwargs": {}}], False),
             ([{"args": [AccuracySubType.ACCURACY_SCORE], "kwargs": {"goal_type": "min-improvement"}}], False),
@@ -454,10 +454,10 @@ class TestOliveEvaluatorConfig:
             ([{"args": [AccuracySubType.ACCURACY_SCORE], "kwargs": {"goal_type": "percent-max-degradation"}}], True),
         ],
     )
-    def test_is_accuracy_drop_tolerance(self, metric_args, is_accuracy_drop_tolerance):
+    def test_is_accuracy_drop_tolerant(self, metric_args, is_accuracy_drop_tolerant):
         evaluator_config = [get_accuracy_metric(*m_arg["args"], **m_arg["kwargs"]) for m_arg in metric_args]
         evaluator_config_instance = OliveEvaluatorConfig(metrics=evaluator_config)
-        assert evaluator_config_instance.is_accuracy_drop_tolerance == is_accuracy_drop_tolerance
+        assert evaluator_config_instance.is_accuracy_drop_tolerant == is_accuracy_drop_tolerant
 
     @patch("olive.common.import_lib.import_user_module")
     @patch("olive.evaluator.registry.Registry.get")


### PR DESCRIPTION
## Move Precision enum declaration to global space

Also, fix spelling/grammar in function name.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
