### PR TITLE
CI: Enable fork builds

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-linux-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-linux-template.yaml
@@ -7,7 +7,7 @@ parameters:
   device: 'cpu'
   dockerfile: '.azure_pipelines/dockerfiles/linux-cpu.dockerfile'
   docker_image: 'olive-pipeline:latest'
-  base_image: 'ubuntu:22.04'
+  base_image: 'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04'
   trt_version: ''
   onnxruntime: 'onnxruntime'
   subfolder: 'local'
@@ -63,7 +63,6 @@ jobs:
       -e PIPELINE_TEST_ACCOUNT_NAME=$(pipeline-test-account-name) \
       -e PIPELINE_TEST_CONTAINER_NAME=$(pipeline-test-container-name) \
       -e KEYVAULT_NAME=$(keyvault-name) \
-      -e HF_TOKEN=$(hf_token) \
       ${{ parameters.docker_image }} \
       bash .azure_pipelines/scripts/${{ parameters.test_script }} \
       ${{ parameters.torch }} \

--- a/.azure_pipelines/job_templates/olive-example-win-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-win-template.yaml
@@ -52,7 +52,6 @@ jobs:
       PIPELINE_TEST_ACCOUNT_NAME: $(pipeline-test-account-name)
       PIPELINE_TEST_CONTAINER_NAME: $(pipeline-test-container-name)
       KEYVAULT_NAME: $(keyvault-name)
-      HF_TOKEN: $(hf_token)
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/.azure_pipelines/job_templates/olive-test-linux-gpu-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-linux-gpu-template.yaml
@@ -6,7 +6,7 @@ parameters:
   test_type: ''
   dockerfile: '.azure_pipelines/dockerfiles/linux-gpu.dockerfile'
   docker_image: 'olive-pipeline:latest'
-  base_image: 'nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04'
+  base_image: 'mcr.microsoft.com/mirror/nvcr/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
   trt_version: '10.5.0.18-1+cuda12.6'
   python_version: '3.10'
   onnxruntime: 'onnxruntime-gpu'

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -120,7 +120,7 @@ jobs:
     onnxruntime: onnxruntime-gpu
     dockerfile: '.azure_pipelines/dockerfiles/linux-gpu.dockerfile'
     base_image: 'mcr.microsoft.com/mirror/nvcr/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
-    trt_version: '10.5.0.18-1+cuda12.4'
+    trt_version: '10.5.0.18-1+cuda12.6'
     examples:
       bert_cuda_gpu:
         exampleFolder: bert

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -119,8 +119,8 @@ jobs:
     device: 'gpu'
     onnxruntime: onnxruntime-gpu
     dockerfile: '.azure_pipelines/dockerfiles/linux-gpu.dockerfile'
-    base_image: 'nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04'
-    trt_version: '10.5.0.18-1+cuda12.6'
+    base_image: 'mcr.microsoft.com/mirror/nvcr/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
+    trt_version: '10.5.0.18-1+cuda12.4'
     examples:
       bert_cuda_gpu:
         exampleFolder: bert

--- a/.azure_pipelines/olive-examples.yaml
+++ b/.azure_pipelines/olive-examples.yaml
@@ -71,7 +71,7 @@ jobs:
     device: 'gpu'
     onnxruntime: onnxruntime-gpu
     dockerfile: '.azure_pipelines/dockerfiles/linux-gpu.dockerfile'
-    base_image: 'nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04'
+    base_image: 'mcr.microsoft.com/mirror/nvcr/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
     trt_version: '10.5.0.18-1+cuda12.6'
     examples:
       mistral:

--- a/.azure_pipelines/olive-ort-nightly.yaml
+++ b/.azure_pipelines/olive-ort-nightly.yaml
@@ -98,7 +98,7 @@ jobs:
     onnxruntime: onnxruntime-gpu
     onnxruntime_nightly: true
     dockerfile: '.azure_pipelines/dockerfiles/linux-gpu.dockerfile'
-    base_image: 'nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04'
+    base_image: 'mcr.microsoft.com/mirror/nvcr/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
     trt_version: '10.5.0.18-1+cuda12.6'
     examples:
       bert_cuda_gpu:


### PR DESCRIPTION
## Describe your changes
Forks build have issues after the migration to docker.
- Use mcr images since dockerhub is rate limiting. Use cuda 12.4 instead of 12.6 image since mcr doesn't have a mirror for 12.6 image yet.
- Remove `HF_TOKEN` env from pipeline yamls so it's not used and is a pipeline secret unavailable to fork builds.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
