### PR TITLE
StaticLLM: pass to create static shaped llms

### DIFF
--- a/docs/source/reference/pass.rst
+++ b/docs/source/reference/pass.rst
@@ -158,6 +158,12 @@ SplitModel
 ----------
 .. autoconfigclass:: olive.passes.SplitModel
 
+.. _static_llm:
+
+StaticLLM
+----------
+.. autoconfigclass:: olive.passes.StaticLLM
+
 .. _optimum_conversion:
 
 OptimumConversion

--- a/olive/cache.py
+++ b/olive/cache.py
@@ -11,7 +11,7 @@ import shutil
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from olive.common.config_utils import ConfigBase, convert_configs_to_dicts, validate_config
 from olive.common.constants import DEFAULT_CACHE_DIR, DEFAULT_WORKFLOW_ID
@@ -385,20 +385,51 @@ class OliveCache:
         if model_json["type"].lower() == "compositemodel":
             model_json_config = model_json["config"]
             copied_components = []
-            for component_names, component in zip(
+            saved_external_files = {}
+            for component_name, component in zip(
                 model_json_config["model_component_names"], model_json_config["model_components"]
             ):
-                copied_components.append(
-                    self._save_model(
-                        component,
-                        output_dir=output_dir,
-                        overwrite=overwrite,
-                        only_cache_files=only_cache_files,
-                        path_prefix=component_names,
+                if component["type"].lower() != "onnxmodel":
+                    # save each component with a prefix
+                    # e.g. "component_1" -> "component_1_{resource_name}"
+                    copied_components.append(
+                        self._save_model(
+                            component,
+                            output_dir=output_dir,
+                            overwrite=overwrite,
+                            only_cache_files=only_cache_files,
+                            path_prefix=component_name,
+                        )
                     )
-                )
+                else:
+                    # save all onnx files into the same directory
+                    component_model_json, component_local_resource_names = self._replace_with_local_resources(
+                        component, only_cache_files=only_cache_files
+                    )
+
+                    for resource_name in component_local_resource_names:
+                        if resource_name != "model_path":
+                            # this case does not exist in the current code
+                            # but we need to handle it for future use
+                            component_model_json["config"][resource_name] = component_model_json["config"][
+                                resource_name
+                            ].save_to_dir(output_dir, resource_name, overwrite)
+                        else:
+                            from olive.passes.onnx.common import resave_model
+
+                            resave_model(
+                                ModelConfig.parse_obj(component_model_json).create_model().model_path,
+                                output_dir / "model" / f"{component_name}.onnx",
+                                saved_external_files=saved_external_files,
+                            )
+                            component_model_json["config"][resource_name] = str(output_dir / "model")
+                            component_model_json["config"]["onnx_file_name"] = f"{component_name}.onnx"
+
+                    copied_components.append(component_model_json)
+
             model_json_config["model_components"] = copied_components
-            model_json = self._save_additional_files(model_json, output_dir)
+            # save additional files
+            model_json = self._save_additional_files(model_json, output_dir / "model")
         else:
             model_json = self._save_model(model_json, output_dir, overwrite)
 
@@ -415,10 +446,32 @@ class OliveCache:
         only_cache_files: bool = False,
         path_prefix: str = None,
     ) -> dict:
-        # create model object so that we can get the resource paths
-        model_config: ModelConfig = ModelConfig.from_json(model_json)
-        resource_paths = model_config.get_resource_paths()
-        for resource_name, resource_path in resource_paths.items():
+        # get updated model json with local resources
+        model_json, local_resource_names = self._replace_with_local_resources(
+            model_json, only_cache_files=only_cache_files
+        )
+
+        # save local resources to output directory
+        for resource_name in local_resource_names:
+            path_name = resource_name.replace("_path", "")
+            if path_prefix:
+                path_name = f"{path_prefix}_{path_name}"
+            # TODO(anyone): consider using hardlink_copy_file/dir instead of copy
+            # to avoid copying large files
+            model_json["config"][resource_name] = model_json["config"][resource_name].save_to_dir(
+                output_dir, path_name, overwrite
+            )
+
+        # we only have additional files for onnx models so saving to "model" is safe
+        model_path_name = "model"
+        if path_prefix:
+            model_path_name = f"{path_prefix}_{model_path_name}"
+        return self._save_additional_files(model_json, output_dir / model_path_name)
+
+    def _replace_with_local_resources(self, model_json: dict, only_cache_files: bool = False) -> Tuple[dict, List[str]]:
+        local_resource_names = []
+        # get the resource paths from the model config
+        for resource_name, resource_path in ModelConfig.from_json(model_json).get_resource_paths().items():
             if (
                 not resource_path
                 or resource_path.is_string_name()
@@ -448,17 +501,10 @@ class OliveCache:
                         model_json["config"][resource_name] = resource_json["source"]
                         continue
 
-            # save resource to output directory
-            path_name = resource_name.replace("_path", "")
-            if path_prefix:
-                path_name = f"{path_prefix}_{path_name}"
-            model_json["config"][resource_name] = local_resource_path.save_to_dir(output_dir, path_name, overwrite)
+            model_json["config"][resource_name] = local_resource_path
+            local_resource_names.append(resource_name)
 
-        # we only have additional files for onnx models so saving to "model" is safe
-        model_path_name = "model"
-        if path_prefix:
-            model_path_name = f"{path_prefix}_{model_path_name}"
-        return self._save_additional_files(model_json, output_dir / model_path_name)
+        return model_json, local_resource_names
 
     def _save_additional_files(self, model_json: dict, output_dir: Path) -> dict:
         # Copy "additional files" to the model folder

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -360,13 +360,8 @@ class Engine:
             logger.warning("Flow %s is pruned due to failed or invalid config for pass '%s'", pass_flow, failed_pass)
             return Footprint()
 
-        # use output_model_dir if there is only one pass flow
-        # else output_model_dir/pass_flow
-        flow_output_dir = output_model_dir / "-".join(pass_flow) if len(pass_flow) > 1 else output_model_dir
-        flow_output_dir.mkdir(parents=True, exist_ok=True)
-
         if signal is not None and not self.skip_saving_artifacts:
-            results_path = flow_output_dir / "metrics.json"
+            results_path = output_model_dir / "metrics.json"
             with open(results_path, "w") as f:
                 json.dump(signal.to_json(), f, indent=4)
             logger.info("Saved evaluation results of output model to %s", results_path)

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -211,6 +211,12 @@
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ]
         },
+        "StaticLLM": {
+            "module_path": "olive.passes.onnx.static_llm.StaticLLM",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ]
+        },
         "OpenVINOConversion": {
             "module_path": "olive.passes.openvino.conversion.OpenVINOConversion",
             "supported_providers": [ "*" ],

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -5,10 +5,12 @@
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 import onnx
+from onnx import external_data_helper
 
+from olive.common.utils import hardlink_copy_file
 from olive.model import ONNXModelHandler
 from olive.passes.onnx.onnx_dag import OnnxDAG
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
@@ -88,7 +90,7 @@ def model_proto_to_file(
     """
     output_path = Path(output_path)
     if output_path.exists():
-        logger.info("Deleting existing onnx file: %s", output_path)
+        logger.debug("Deleting existing onnx file: %s", output_path)
         output_path.unlink()
 
     # parent directory of .onnx file
@@ -189,6 +191,95 @@ def model_proto_to_olive_model(
     return olive_model
 
 
+def get_external_data_file_names(model_path: Union[str, Path]) -> List[str]:
+    """Get the external data file names from the model.
+
+    :param model_path: Path to the model file.
+    :return: List of external data file names.
+    """
+    file_names = set()
+    for tensor in external_data_helper._get_all_tensors(  # pylint: disable=W0212
+        onnx.load(model_path, load_external_data=False)
+    ):
+        if external_data_helper.uses_external_data(tensor):
+            file_names.add(external_data_helper.ExternalDataInfo(tensor).location)
+    return list(file_names)
+
+
+def change_external_data_location(model_proto: onnx.ModelProto, new_location: str):
+    """Change the external data location in the model.
+
+    :param model_proto: The model proto to modify.
+    :param new_location: The new location for the external data.
+    """
+    for tensor in external_data_helper._get_all_tensors(model_proto):  # pylint: disable=W0212
+        if external_data_helper.uses_external_data(tensor):
+            # set dummy raw_data since set_external_data expected the field
+            tensor.raw_data = b""
+            info = external_data_helper.ExternalDataInfo(tensor)
+            external_data_helper.set_external_data(
+                tensor, new_location, offset=info.offset, length=info.length, checksum=info.checksum
+            )
+
+
+def resave_model(
+    model_path: Union[str, Path],
+    new_model_path: Union[str, Path],
+    force_external_data: bool = False,
+    saved_external_files: Optional[Dict[str, str]] = None,
+) -> bool:
+    """Resave the model along with external data files.
+
+    :param model_path: Path to the original model file.
+    :param new_model_path: Path to the new model file.
+    :param force_external_data: If True, force the model to be saved with external data.
+    :param saved_external_files: A dictionary of original file paths to new file names for external data files.
+        Reuse the same file name if the the original file path is already in the dictionary.
+        Else, the new file name will be <new_model_path>.data and this dictionary will be updated with the new
+        file name.
+    :return: True if the model has external data, False otherwise.
+    """
+    model_path = Path(model_path).resolve()
+    new_model_path = Path(new_model_path).resolve()
+    assert new_model_path.suffix == ".onnx", "new_model_path must be .onnx file"
+    new_model_path.parent.mkdir(parents=True, exist_ok=True)
+
+    external_file_names = get_external_data_file_names(model_path)
+
+    if not external_file_names:
+        if force_external_data:
+            # save the model with single external data file
+            model_proto_to_file(onnx.load(model_path), new_model_path, {"save_as_external_data": True})
+            return True
+
+        # no external data, so we can just copy the model
+        hardlink_copy_file(model_path, new_model_path)
+        return False
+
+    if len(external_file_names) > 1:
+        # save the model with single external data file
+        model_proto_to_file(onnx.load(model_path), new_model_path, {"save_as_external_data": True})
+        return True
+
+    external_file_path = str(model_path.parent / external_file_names[0])
+    if saved_external_files and external_file_path in saved_external_files:
+        # already saved, model will refer to the same file
+        new_external_file_name = saved_external_files[external_file_path]
+    else:
+        new_external_file_name = f"{new_model_path.name}.data"
+        # copy the external data file to the new location
+        hardlink_copy_file(external_file_path, new_model_path.parent / new_external_file_name)
+        if saved_external_files is not None:
+            # update the saved external files mapping
+            saved_external_files[external_file_path] = new_external_file_name
+
+    # change the external data location and save the model file
+    model_proto = onnx.load(model_path, load_external_data=False)
+    change_external_data_location(model_proto, new_external_file_name)
+    model_proto_to_file(model_proto, new_model_path)
+    return True
+
+
 LORA_NAME_PATTERNS = [
     f".*[./]{name}[./]{matmul}$"
     for name in ["default_0", "default_0_1", "default", "default_1", "lora_A", "lora_B"]
@@ -209,3 +300,54 @@ def model_has_adapters(model_path: Union[str, Path]) -> bool:
         if op_type in {"MatMul", "MatMulNBits"} and any(re.match(pattern, node_name) for pattern in LORA_NAME_PATTERNS):
             return True
     return False
+
+
+def _fix_output_shapes(model_proto: onnx.ModelProto):
+    """Run shape inference on the model and update the output shapes to make them fixed."""
+    from onnxruntime.tools.onnx_model_utils import is_fixed_size_tensor
+    from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+
+    # use the onnxruntime shape inference tool since it can handle large models as well as contrib ops
+    inferred_proto = SymbolicShapeInference.infer_shapes(model_proto, auto_merge=True, guess_output_rank=True)
+
+    for idx, o in enumerate(model_proto.graph.output):
+        if not is_fixed_size_tensor(o):
+            new_o = inferred_proto.graph.output[idx]
+            if is_fixed_size_tensor(new_o):
+                o.type.tensor_type.shape.CopyFrom(new_o.type.tensor_type.shape)
+
+
+def fix_dim_params(model_proto: onnx.ModelProto, dim_params: List[str], dim_values: List[int]):
+    """Fix the dimension parameters in the model.
+
+    :param dim_params: The dimension parameters to fix.
+    :param dim_values: The values to set for the dimension parameters.
+    """
+    from onnxruntime.tools.onnx_model_utils import make_dim_param_fixed
+
+    assert len(dim_params) == len(dim_values), "dim_params and dim_values must have the same number of elements."
+    assert all(i >= 0 for i in dim_values), "dim_values must be all >= 0"
+
+    for param, value in zip(dim_params, dim_values):
+        make_dim_param_fixed(model_proto.graph, param, value)
+
+    # update the output shapes to make them fixed
+    _fix_output_shapes(model_proto)
+
+
+def fix_input_shapes(model_proto: onnx.ModelProto, input_names: List[str], input_shapes: List[List[int]]):
+    """Fix the input shapes in the model.
+
+    :param input_names: The input names to fix.
+    :param input_shapes: The shapes to set for the inputs.
+    """
+    from onnxruntime.tools.onnx_model_utils import make_input_shape_fixed
+
+    assert len(input_names) == len(input_shapes), "input_names and input_shapes must have the same number of elements."
+    assert all(all(i > 0 for i in shape) for shape in input_shapes), "input_shapes must be all > 0"
+
+    for name, shape in zip(input_names, input_shapes):
+        make_input_shape_fixed(model_proto.graph, name, shape)
+
+    # update the output shapes to make them fixed
+    _fix_output_shapes(model_proto)

--- a/olive/passes/onnx/static_llm.py
+++ b/olive/passes/onnx/static_llm.py
@@ -1,0 +1,165 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+from pathlib import Path
+from typing import Dict, Type
+
+import onnx
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import CompositeModelHandler, ONNXModelHandler
+from olive.passes import Pass
+from olive.passes.onnx.common import fix_dim_params, resave_model
+from olive.passes.onnx.onnx_dag import OnnxDAG
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
+logger = logging.getLogger(__name__)
+
+
+class StaticLLM(Pass):
+    """Convert a dynamic shaped LLM into a static shaped LLM.
+
+    Expects a CompositeModelHandler with at least 3 components: embeddings, transformer layers, and lm_head.
+    transformer layers can be split into multiple components. Each transformer layers component produces two
+    new components:
+        - context model (sequence length = context_length)
+        - iterator model (sequence length = 1)
+    embeddings and lm_head keep their original shapes.
+    """
+
+    _accepts_composite_model = True
+
+    @classmethod
+    def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        return {
+            "batch_size": PassConfigParam(
+                type_=int,
+                default_value=1,
+                description="Batch size of the model.",
+            ),
+            "context_length": PassConfigParam(
+                type_=int,
+                default_value=64,
+                description="Input length of the context model.",
+            ),
+        }
+
+    def _run_for_config(
+        self, model: CompositeModelHandler, config: Type[BasePassConfig], output_model_path: str
+    ) -> CompositeModelHandler:
+        assert isinstance(model, CompositeModelHandler), "StaticLLM pass only supports CompositeModelHandler"
+        model_components = list(model.model_components)
+        assert all(isinstance(m, ONNXModelHandler) for m in model_components), "All components must be ONNXModelHandler"
+        assert (
+            len(model_components) >= 3
+        ), "There should be at least 3 components in the model: embedding, transformer, and lm_head."
+
+        # only gqa models are supported for now
+        assert (
+            "GroupQueryAttention"
+            in OnnxDAG(onnx.load(model_components[1].model_path, load_external_data=False)).get_node_op_types()
+        ), "Only GQA models are supported for now."
+
+        output_model_path = Path(output_model_path).with_suffix("")
+
+        new_components = {}
+        # resave embeddings model
+        embeddings_model_path = output_model_path / "embeddings.onnx"
+        resave_model(model_components[0].model_path, embeddings_model_path)
+        new_components["embeddings"] = ONNXModelHandler(
+            model_path=output_model_path, onnx_file_name=embeddings_model_path.name
+        )
+
+        # get dimension params from embeddings model
+        batch_size, sequence_length = OnnxDAG(onnx.load(embeddings_model_path, load_external_data=False)).get_io_shape(
+            "input_ids"
+        )
+        assert isinstance(batch_size, str), "Batch size must be a symbolic dimension"
+        assert isinstance(sequence_length, str), "Sequence length must be a symbolic dimension"
+
+        # mapping from params to fixed values
+        param_mapping_dict = {
+            "context": {
+                batch_size: config.batch_size,
+                sequence_length: config.context_length,
+            },
+            "iterator": {batch_size: config.batch_size, sequence_length: 1},
+        }
+        pipeline = {"embeddings": "embeddings", "context": [], "iterator": []}
+
+        # update the param mapping with the new shapes from the embeddings model
+        for param_mapping in param_mapping_dict.values():
+            self.fix_shape(
+                onnx.load(embeddings_model_path, load_external_data=False),
+                param_mapping,
+            )
+
+        is_split = len(model_components) > 3
+        for idx, component in enumerate(model_components[1:-1]):
+            suffix = f"_{idx}" if is_split else ""
+
+            # resave the model with external data
+            intermediate_model_path = output_model_path / f"transformer{suffix}.onnx"
+            resave_model(component.model_path, intermediate_model_path, force_external_data=True)
+
+            for key, param_mapping in param_mapping_dict.items():
+                component_name = f"{key}{suffix}"
+
+                component_proto = onnx.load(intermediate_model_path, load_external_data=False)
+                self.fix_shape(component_proto, param_mapping)
+
+                # save the model with fixed shapes
+                component_model_path = output_model_path / f"{component_name}.onnx"
+                onnx.save_model(component_proto, component_model_path)
+                new_components[component_name] = ONNXModelHandler(
+                    model_path=output_model_path, onnx_file_name=component_model_path.name
+                )
+                pipeline[key].append(component_name)
+
+            # delete the intermediate model
+            intermediate_model_path.unlink()
+
+        # resave the lm_head model
+        lm_head_model_path = output_model_path / "lm_head.onnx"
+        resave_model(model_components[-1].model_path, lm_head_model_path)
+        new_components["lm_head"] = ONNXModelHandler(
+            model_path=output_model_path, onnx_file_name=lm_head_model_path.name
+        )
+        pipeline["lm_head"] = "lm_head"
+
+        model_attributes = model.model_attributes or {}
+        model_attributes["llm_pipeline"] = pipeline
+
+        return CompositeModelHandler(
+            list(new_components.values()), list(new_components.keys()), model_attributes=model_attributes
+        )
+
+    @staticmethod
+    def fix_shape(model_proto: onnx.ModelProto, param_mapping: Dict[str, int]):
+        """Fix the shape of the model based on the param mapping.
+
+        :param model_path: Path to the model.
+        :param param_mapping: Mapping from params to fixed values. This gets updated with the output shapes of the new
+            model.
+        """
+        original_shapes = {}
+        dag = OnnxDAG(model_proto)
+        for output_name in dag.get_output_names():
+            original_shapes[output_name] = dag.get_io_shape(output_name)
+
+        # fix dim params
+        fix_dim_params(dag.model, param_mapping.keys(), param_mapping.values())
+
+        # update the param mapping with the new shapes
+        for output_name, original_shape in original_shapes.items():
+            new_shape = dag.get_io_shape(output_name)
+
+            for old_dim, new_dim in zip(original_shape, new_shape):
+                if isinstance(old_dim, str) and isinstance(new_dim, int):
+                    if old_dim in param_mapping:
+                        assert (
+                            param_mapping[old_dim] == new_dim
+                        ), f"Param {old_dim} already exists with different value. Something is wrong."
+                    param_mapping[old_dim] = new_dim

--- a/test/unit_test/passes/onnx/test_static_llm.py
+++ b/test/unit_test/passes/onnx/test_static_llm.py
@@ -1,0 +1,52 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from test.unit_test.utils import make_local_tiny_llama
+
+from olive.model import CompositeModelHandler, ONNXModelHandler
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.static_llm import StaticLLM
+
+
+def test_static_llm(tmp_path):
+    # setup
+    from olive.passes.onnx.model_builder import ModelBuilder
+    from olive.passes.onnx.split import SplitModel
+
+    pytorch_model = make_local_tiny_llama(tmp_path)
+    onnx_model = create_pass_from_dict(ModelBuilder, {"precision": "fp32"}, disable_search=True).run(
+        pytorch_model, tmp_path / "onnx_model"
+    )
+
+    split_model = create_pass_from_dict(
+        SplitModel,
+        {
+            "split_assignments": {
+                "model.embed_tokens": 0,
+                "model.attn_mask_reformat": 0,
+                "model.layers.0": 1,
+                "model.layers.1": 2,
+                "lm_head": 3,
+            }
+        },
+        disable_search=True,
+    ).run(onnx_model, tmp_path / "split_model")
+
+    p = create_pass_from_dict(StaticLLM, {"batch_size": 1, "context_length": 64}, disable_search=True)
+
+    # run
+    output_model_path = tmp_path / "output_model"
+    output_model = p.run(split_model, output_model_path)
+
+    # check
+    assert isinstance(output_model, CompositeModelHandler)
+    model_components = list(output_model.model_components)
+    assert all(isinstance(m, ONNXModelHandler) for m in model_components)
+    assert len(model_components) == 6
+    assert output_model.model_attributes["llm_pipeline"] == {
+        "embeddings": "embeddings",
+        "context": ["context_0", "context_1"],
+        "iterator": ["iterator_0", "iterator_1"],
+        "lm_head": "lm_head",
+    }


### PR DESCRIPTION
New pass `StaticLLM` added to convert dynamic shaped llm into a static shaped llm for NPUs.
- Only GQA models supported currently to allow for long context through sliding window. Only the batch size and input sequence length are fixed. 
- Models without GQA are complicated and need more work. Will be added in the future if needed. 

Cache model save for composite model handlers has been improved.
- all component onnx model files are saved in the same directory
- hardlink_copy_file is used

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
