### PR TITLE
EPContextBinaryGenerator: Pass to create EP specific context binary onnx models

### DIFF
--- a/docs/source/reference/pass.rst
+++ b/docs/source/reference/pass.rst
@@ -164,6 +164,12 @@ StaticLLM
 ----------
 .. autoconfigclass:: olive.passes.StaticLLM
 
+.. _ep_context_binary_generator:
+
+EPContextBinaryGenerator
+------------------------
+.. autoconfigclass:: olive.passes.EPContextBinaryGenerator
+
 .. _optimum_conversion:
 
 OptimumConversion

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -16,16 +16,24 @@
             "supported_algorithms": [  ],
             "supported_quantization_encodings": [  ]
         },
-        "GraphSurgeries": {
-            "module_path": "olive.passes.onnx.graph_surgeries.GraphSurgeries",
-            "supported_providers": [ "*" ],
-            "supported_accelerators": [ "*" ],
+        "EPContextBinaryGenerator": {
+            "module_path": "olive.passes.onnx.context_binary.EPContextBinaryGenerator",
+            "supported_providers": [ "QNNExecutionProvider" ],
+            "supported_accelerators": [ "npu" ],
             "supported_precisions": [ "*" ],
             "supported_algorithms": [  ],
             "supported_quantization_encodings": [  ]
         },
         "ExtractAdapters": {
             "module_path": "olive.passes.onnx.extract_adapters.ExtractAdapters",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
+            "supported_algorithms": [  ],
+            "supported_quantization_encodings": [  ]
+        },
+        "GraphSurgeries": {
+            "module_path": "olive.passes.onnx.graph_surgeries.GraphSurgeries",
             "supported_providers": [ "*" ],
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ],

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -222,11 +222,27 @@ def change_external_data_location(model_proto: onnx.ModelProto, new_location: st
             )
 
 
+def get_context_bin_file_names(model_path: Union[str, Path]) -> List[str]:
+    """Get the context binary file names from the model.
+
+    :param model_path: Path to the model file.
+    :return: List of context binary file names.
+    """
+    file_names = set()
+    for node in onnx.load(model_path, load_external_data=False).graph.node:
+        if node.op_type == "EPContext":
+            for attr in node.attribute:
+                if attr.name == "ep_cache_context":
+                    file_names.add(attr.s.decode("utf-8"))
+    return list(file_names)
+
+
 def resave_model(
     model_path: Union[str, Path],
     new_model_path: Union[str, Path],
     force_external_data: bool = False,
     saved_external_files: Optional[Dict[str, str]] = None,
+    ignore_missing_cb_bin: bool = False,
 ) -> bool:
     """Resave the model along with external data files.
 
@@ -237,12 +253,28 @@ def resave_model(
         Reuse the same file name if the the original file path is already in the dictionary.
         Else, the new file name will be <new_model_path>.data and this dictionary will be updated with the new
         file name.
+    :param ignore_missing_cb_bin: If True, ignore missing context binary files.
     :return: True if the model has external data, False otherwise.
     """
+    saved_external_files = saved_external_files or {}
+
     model_path = Path(model_path).resolve()
     new_model_path = Path(new_model_path).resolve()
     assert new_model_path.suffix == ".onnx", "new_model_path must be .onnx file"
     new_model_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # copy over context binary files
+    # TODO(jambayk): consider renaming cb files
+    cb_file_names = get_context_bin_file_names(model_path)
+    for cb_file_name in cb_file_names:
+        cb_file_path = str(model_path.parent / cb_file_name)
+        if not Path(cb_file_path).exists() and ignore_missing_cb_bin:
+            # happens when weight sharing is enabled but hasn't been stopped yet
+            continue
+        if cb_file_path not in saved_external_files:
+            hardlink_copy_file(cb_file_path, new_model_path.parent / cb_file_name)
+            saved_external_files[cb_file_path] = cb_file_name
+    has_cb_files = bool(cb_file_names)
 
     external_file_names = get_external_data_file_names(model_path)
 
@@ -254,7 +286,7 @@ def resave_model(
 
         # no external data, so we can just copy the model
         hardlink_copy_file(model_path, new_model_path)
-        return False
+        return has_cb_files or False
 
     if len(external_file_names) > 1:
         # save the model with single external data file
@@ -262,16 +294,15 @@ def resave_model(
         return True
 
     external_file_path = str(model_path.parent / external_file_names[0])
-    if saved_external_files and external_file_path in saved_external_files:
+    if external_file_path in saved_external_files:
         # already saved, model will refer to the same file
         new_external_file_name = saved_external_files[external_file_path]
     else:
         new_external_file_name = f"{new_model_path.name}.data"
         # copy the external data file to the new location
         hardlink_copy_file(external_file_path, new_model_path.parent / new_external_file_name)
-        if saved_external_files is not None:
-            # update the saved external files mapping
-            saved_external_files[external_file_path] = new_external_file_name
+        # update the saved external files mapping
+        saved_external_files[external_file_path] = new_external_file_name
 
     # change the external data location and save the model file
     model_proto = onnx.load(model_path, load_external_data=False)

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -233,7 +233,11 @@ def get_context_bin_file_names(model_path: Union[str, Path]) -> List[str]:
         if node.op_type == "EPContext":
             for attr in node.attribute:
                 if attr.name == "ep_cache_context":
-                    file_names.add(attr.s.decode("utf-8"))
+                    try:
+                        file_names.add(attr.s.decode("utf-8"))
+                    except UnicodeDecodeError:
+                        # embedded context binary file
+                        continue
     return list(file_names)
 
 
@@ -256,7 +260,7 @@ def resave_model(
     :param ignore_missing_cb_bin: If True, ignore missing context binary files.
     :return: True if the model has external data, False otherwise.
     """
-    saved_external_files = saved_external_files or {}
+    saved_external_files = {} if saved_external_files is None else saved_external_files
 
     model_path = Path(model_path).resolve()
     new_model_path = Path(new_model_path).resolve()

--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -5,10 +5,12 @@
 import logging
 import platform
 import tempfile
+from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Type, Union
+from typing import Dict, Type, Union
 
 import onnx
+from packaging import version
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import CompositeModelHandler, ONNXModelHandler
@@ -16,9 +18,6 @@ from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import model_proto_to_file, resave_model
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
-
-if TYPE_CHECKING:
-    from onnxruntime import SessionOptions
 
 logger = logging.getLogger(__name__)
 
@@ -44,13 +43,6 @@ class EPContextBinaryGenerator(Pass):
                     " models."
                 ),
             ),
-            "compose": PassConfigParam(
-                type_=bool,
-                default_value=False,
-                description=(
-                    "Whether to compose the component models into a single model. Only applicable to composite models."
-                ),
-            ),
             "provider_options": PassConfigParam(
                 type_=dict,
                 default_value=None,
@@ -69,72 +61,115 @@ class EPContextBinaryGenerator(Pass):
         config: Type[BasePassConfig],
         output_model_path: str,
     ) -> Union[ONNXModelHandler, CompositeModelHandler]:
-        # validate and support other NPU EPs
-        assert self.accelerator_spec.execution_provider == "QNNExecutionProvider", "Only QNN EP is supported for now."
+        from onnxruntime import __version__ as OrtVersion
+        from onnxruntime import get_available_providers
 
-        from onnxruntime import SessionOptions
-
-        provider_options = config.provider_options or {}
-        provider_options.update(
-            {
-                "backend_path": "libQnnHtp.so" if platform.system() == "Linux" else "QnnHtp.dll",
-            }
+        # TODO(jambayk): validate and support other NPU EPs
+        assert (
+            self.accelerator_spec.execution_provider == "QNNExecutionProvider"
+        ), "Only QNNExecutionProvider is supported for now."
+        assert self.accelerator_spec.execution_provider in get_available_providers(), (
+            f"Execution provider {self.accelerator_spec.execution_provider} is not available. Available providers:"
+            f" {get_available_providers()}"
         )
 
-        session_options = SessionOptions()
-        session_options.add_session_config_entry("ep.context_enable", "1")
-        session_options.add_session_config_entry("ep.context_embed_mode", str(int(config.embed_context)))
-        session_options.add_session_config_entry(
-            "session.disable_cpu_ep_fallback", str(int(config.disable_cpu_fallback))
-        )
+        generate_kwargs = {
+            "execution_provider": self.accelerator_spec.execution_provider,
+            "provider_options": config.provider_options,
+            "embed_context": config.embed_context,
+            "disable_cpu_fallback": config.disable_cpu_fallback,
+        }
 
         if isinstance(model, ONNXModelHandler):
             return self._generate_context_binary(
                 model_path=model.model_path,
                 output_model_path=resolve_onnx_path(output_model_path, f"{Path(model.model_path).stem}_ctx.onnx"),
-                execution_provider=self.accelerator_spec.execution_provider,
-                provider_options=provider_options,
-                session_options=session_options,
+                **generate_kwargs,
             )
 
-        output_model_path = Path(output_model_path).with_suffix("")
+        if config.weight_sharing and (version.parse(OrtVersion).release < version.parse("1.22.0").release):
+            raise ValueError("weight sharing is only supported in onnxruntime >= 1.22.0")
 
-        # set options for weight sharing
-        if config.weight_sharing:
-            provider_options["enable_htp_weight_sharing"] = "1"
-            session_options.add_session_config_entry("ep.share_ep_contexts", "1")
+        output_model_path = Path(output_model_path).with_suffix("")
 
         # name: model
         component_map = dict(model.get_model_components())
 
+        new_component_models = {}
         if llm_pipeline := (model.model_attributes or {}).get("llm_pipeline"):
-            raise NotImplementedError(
-                f"Generating context binary for {llm_pipeline} is not supported. Please implement this method."
+            # resave embeddings model
+            embeddings_model_path = output_model_path / "embeddings.onnx"
+            resave_model(component_map["embeddings"].model_path, embeddings_model_path)
+            new_component_models["embeddings"] = ONNXModelHandler(
+                model_path=output_model_path, onnx_file_name=embeddings_model_path.name
             )
 
-        # create context binary for each component
-        new_component_names = []
-        new_component_models = []
-        for idx, (component_name, component_model) in enumerate(component_map.items()):
-            if config.weight_sharing and idx == len(component_map) - 1:
-                # stop context sharing at the last component
-                session_options.add_session_config_entry("ep.stop_share_ep_contexts", "1")
-            new_component_names.append(component_name)
-            new_component_models.append(
-                self._generate_context_binary(
-                    model_path=component_model.model_path,
-                    output_model_path=output_model_path / f"{component_name}_ctx.onnx",
-                    execution_provider=self.accelerator_spec.execution_provider,
-                    provider_options=provider_options,
-                    session_options=session_options,
-                    ignore_missing_cb_bin=config.weight_sharing and (idx != len(component_map) - 1),
+            # iterate over the context/iterator models
+            for ctx_model_name, iter_model_name in zip(llm_pipeline["context"], llm_pipeline["iterator"]):
+                # potentially share context binary between corresponding context/iterator components
+                new_component_models.update(
+                    self._generate_composite_binaries(
+                        model_paths_map={
+                            ctx_model_name: component_map[ctx_model_name].model_path,
+                            iter_model_name: component_map[iter_model_name].model_path,
+                        },
+                        output_model_dir=output_model_path,
+                        generate_kwargs=generate_kwargs,
+                        weight_sharing=config.weight_sharing,
+                    )
                 )
+
+            # resave the lm_head model
+            lm_head_model_path = output_model_path / "lm_head.onnx"
+            resave_model(component_map["lm_head"].model_path, lm_head_model_path)
+            new_component_models["lm_head"] = ONNXModelHandler(
+                model_path=output_model_path, onnx_file_name=lm_head_model_path.name
+            )
+        else:
+            new_component_models = self._generate_composite_binaries(
+                model_paths_map={name: component.model_path for name, component in component_map.items()},
+                output_model_dir=output_model_path,
+                generate_kwargs=generate_kwargs,
+                weight_sharing=config.weight_sharing,
+            )
+        return CompositeModelHandler(
+            list(new_component_models.values()),
+            list(new_component_models.keys()),
+            model_attributes=model.model_attributes,
+        )
+
+    @classmethod
+    def _generate_composite_binaries(
+        cls,
+        model_paths_map: Dict[str, str],
+        output_model_dir: str,
+        generate_kwargs: Dict[str, str],
+        weight_sharing: bool = False,
+    ) -> Dict[str, ONNXModelHandler]:
+        """Generate context binary for each model in the composite model.
+
+        :param model_paths_map: Map of model names to model paths.
+        :param output_model_dir: Directory to save the output model files.
+        :param generate_kwargs: Additional arguments for the context binary generation.
+        :param weight_sharing: Whether to enable weight sharing between the models.
+        :return: Map of model names to ONNXModelHandler for the generated context binaries.
+        """
+        new_models = {}
+        for idx, (model_name, model_path) in enumerate(model_paths_map.items()):
+            generate_kwargs = deepcopy(generate_kwargs)
+            if weight_sharing:
+                generate_kwargs["share_ep_contexts"] = True
+                generate_kwargs["stop_share_ep_contexts"] = idx == len(model_paths_map) - 1
+                generate_kwargs["embed_context"] = False
+                generate_kwargs["ignore_missing_cb_bin"] = idx != len(model_paths_map) - 1
+
+            new_models[f"{model_name}_ctx"] = cls._generate_context_binary(
+                model_path=model_path,
+                output_model_path=Path(output_model_dir) / f"{model_name}_ctx.onnx",
+                **generate_kwargs,
             )
 
-        if config.compose:
-            raise NotImplementedError("Composing context binary is not supported yet.")
-
-        return CompositeModelHandler(new_component_models, new_component_names)
+        return new_models
 
     @staticmethod
     def _generate_context_binary(
@@ -142,7 +177,10 @@ class EPContextBinaryGenerator(Pass):
         output_model_path: Union[str, Path],
         execution_provider: str,
         provider_options: dict,
-        session_options: "SessionOptions",
+        embed_context: bool = False,
+        disable_cpu_fallback: bool = False,
+        share_ep_contexts: bool = False,
+        stop_share_ep_contexts: bool = False,
         ignore_missing_cb_bin: bool = False,
     ) -> ONNXModelHandler:
         """Generate context binary for the model.
@@ -151,14 +189,29 @@ class EPContextBinaryGenerator(Pass):
         :param output_model_path: Path to the output model file.
         :param execution_provider: Execution provider to use.
         :param provider_options: Provider options for the execution provider.
-        :param session_options: Session options for the execution provider.
-        :return: ONNXModelHandler with the context binary.
+        :param embed_context: Whether to embed context bin into the model.
+        :param disable_cpu_fallback: Whether to disable CPU fallback.
+        :param share_ep_contexts: Whether to share EP contexts.
+        :param stop_share_ep_contexts: Whether to stop sharing EP contexts.
+        :param ignore_missing_cb_bin: Whether to ignore missing context binary files.
+        :return: ONNXModelHandler for the generated context binary.
         """
-        from onnxruntime import InferenceSession, get_available_providers
+        from onnxruntime import InferenceSession, SessionOptions
 
-        assert (
-            execution_provider in get_available_providers()
-        ), f"Execution provider {execution_provider} is not available. Available providers: {get_available_providers()}"
+        # prepare provider options
+        provider_options = provider_options or {}
+        if execution_provider == "QNNExecutionProvider":
+            provider_options["backend_path"] = "libQnnHtp.so" if platform.system() == "Linux" else "QnnHtp.dll"
+            if share_ep_contexts:
+                provider_options["enable_htp_weight_sharing"] = "1"
+
+        # prepare session options
+        session_options = SessionOptions()
+        session_options.add_session_config_entry("ep.context_enable", "1")
+        session_options.add_session_config_entry("ep.context_embed_mode", str(int(embed_context)))
+        session_options.add_session_config_entry("session.disable_cpu_ep_fallback", str(int(disable_cpu_fallback)))
+        session_options.add_session_config_entry("ep.share_ep_contexts", str(int(share_ep_contexts)))
+        session_options.add_session_config_entry("ep.stop_share_ep_contexts", str(int(stop_share_ep_contexts)))
 
         output_model_path = Path(output_model_path)
         output_model_path.parent.mkdir(parents=True, exist_ok=True)

--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -1,0 +1,202 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+import platform
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Type, Union
+
+import onnx
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import CompositeModelHandler, ONNXModelHandler
+from olive.model.utils import resolve_onnx_path
+from olive.passes import Pass
+from olive.passes.onnx.common import model_proto_to_file, resave_model
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
+if TYPE_CHECKING:
+    from onnxruntime import SessionOptions
+
+logger = logging.getLogger(__name__)
+
+
+class EPContextBinaryGenerator(Pass):
+    """Generate EP specific context binary for the model."""
+
+    _accepts_composite_model = True
+
+    @classmethod
+    def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        return {
+            "embed_context": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="Whether to embed context bin into the model.",
+            ),
+            "weight_sharing": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description=(
+                    "Whether to enable weight sharing between the component models. Only applicable to composite"
+                    " models."
+                ),
+            ),
+            "compose": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description=(
+                    "Whether to compose the component models into a single model. Only applicable to composite models."
+                ),
+            ),
+            "provider_options": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                description="Provider options for the EP.",
+            ),
+            "disable_cpu_fallback": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="Whether to disable CPU fallback.",
+            ),
+        }
+
+    def _run_for_config(
+        self,
+        model: Union[ONNXModelHandler, CompositeModelHandler],
+        config: Type[BasePassConfig],
+        output_model_path: str,
+    ) -> Union[ONNXModelHandler, CompositeModelHandler]:
+        # validate and support other NPU EPs
+        assert self.accelerator_spec.execution_provider == "QNNExecutionProvider", "Only QNN EP is supported for now."
+
+        from onnxruntime import SessionOptions
+
+        provider_options = config.provider_options or {}
+        provider_options.update(
+            {
+                "backend_path": "libQnnHtp.so" if platform.system() == "Linux" else "QnnHtp.dll",
+            }
+        )
+
+        session_options = SessionOptions()
+        session_options.add_session_config_entry("ep.context_enable", "1")
+        session_options.add_session_config_entry("ep.context_embed_mode", str(int(config.embed_context)))
+        session_options.add_session_config_entry(
+            "session.disable_cpu_ep_fallback", str(int(config.disable_cpu_fallback))
+        )
+
+        if isinstance(model, ONNXModelHandler):
+            return self._generate_context_binary(
+                model_path=model.model_path,
+                output_model_path=resolve_onnx_path(output_model_path, f"{Path(model.model_path).stem}_ctx.onnx"),
+                execution_provider=self.accelerator_spec.execution_provider,
+                provider_options=provider_options,
+                session_options=session_options,
+            )
+
+        output_model_path = Path(output_model_path).with_suffix("")
+
+        # set options for weight sharing
+        if config.weight_sharing:
+            provider_options["enable_htp_weight_sharing"] = "1"
+            session_options.add_session_config_entry("ep.share_ep_contexts", "1")
+
+        # name: model
+        component_map = dict(model.get_model_components())
+
+        if llm_pipeline := (model.model_attributes or {}).get("llm_pipeline"):
+            raise NotImplementedError(
+                f"Generating context binary for {llm_pipeline} is not supported. Please implement this method."
+            )
+
+        # create context binary for each component
+        new_component_names = []
+        new_component_models = []
+        for idx, (component_name, component_model) in enumerate(component_map.items()):
+            if config.weight_sharing and idx == len(component_map) - 1:
+                # stop context sharing at the last component
+                session_options.add_session_config_entry("ep.stop_share_ep_contexts", "1")
+            new_component_names.append(component_name)
+            new_component_models.append(
+                self._generate_context_binary(
+                    model_path=component_model.model_path,
+                    output_model_path=output_model_path / f"{component_name}_ctx.onnx",
+                    execution_provider=self.accelerator_spec.execution_provider,
+                    provider_options=provider_options,
+                    session_options=session_options,
+                    ignore_missing_cb_bin=config.weight_sharing and (idx != len(component_map) - 1),
+                )
+            )
+
+        if config.compose:
+            raise NotImplementedError("Composing context binary is not supported yet.")
+
+        return CompositeModelHandler(new_component_models, new_component_names)
+
+    @staticmethod
+    def _generate_context_binary(
+        model_path: str,
+        output_model_path: Union[str, Path],
+        execution_provider: str,
+        provider_options: dict,
+        session_options: "SessionOptions",
+        ignore_missing_cb_bin: bool = False,
+    ) -> ONNXModelHandler:
+        """Generate context binary for the model.
+
+        :param model_path: Path to the model file.
+        :param output_model_path: Path to the output model file.
+        :param execution_provider: Execution provider to use.
+        :param provider_options: Provider options for the execution provider.
+        :param session_options: Session options for the execution provider.
+        :return: ONNXModelHandler with the context binary.
+        """
+        from onnxruntime import InferenceSession, get_available_providers
+
+        assert (
+            execution_provider in get_available_providers()
+        ), f"Execution provider {execution_provider} is not available. Available providers: {get_available_providers()}"
+
+        output_model_path = Path(output_model_path)
+        output_model_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # hardlink/copy the original model into a tempdir under parent_dir
+        # for easier clean up and file management
+        # TODO(jambayk): avoid this if the cost is too high
+        with tempfile.TemporaryDirectory(dir=output_model_path.parent, prefix="olive_tmp") as tmp_dir:
+            # resave the model to a temp dir
+            temp_model_path = Path(tmp_dir) / Path(model_path).name
+            resave_model(model_path, temp_model_path)
+
+            # path to create the context binary
+            tmp_ctx_path = Path(tmp_dir) / output_model_path.name
+            session_options.add_session_config_entry("ep.context_file_path", str(tmp_ctx_path))
+
+            # create the inference session
+            logger.debug("Creating context binary for model %s", str(model_path))
+            InferenceSession(
+                str(temp_model_path),
+                sess_options=session_options,
+                providers=[execution_provider],
+                provider_options=[provider_options],
+            )
+
+            assert tmp_ctx_path.exists(), f"Context binary not found at {tmp_ctx_path}"
+
+            # load and resave the _ctx.onnx model so that it doesn't refer to the original external data files
+            model_proto = onnx.load(str(tmp_ctx_path))
+            tmp_ctx_path.unlink()
+            model_proto_to_file(model_proto, tmp_ctx_path)
+
+            # move _ctx.onnx, .bin and external data files to the output model path
+            has_external_data = resave_model(
+                tmp_ctx_path, output_model_path, ignore_missing_cb_bin=ignore_missing_cb_bin
+            )
+
+        return ONNXModelHandler(
+            model_path=output_model_path.parent if has_external_data else output_model_path,
+            onnx_file_name=output_model_path.name if has_external_data else None,
+        )

--- a/test/unit_test/passes/onnx/test_context_binary.py
+++ b/test/unit_test/passes/onnx/test_context_binary.py
@@ -1,0 +1,107 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from test.unit_test.utils import get_onnx_model
+
+import onnxruntime
+import pytest
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import CompositeModelHandler, ONNXModelHandler
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.common import resave_model
+from olive.passes.onnx.context_binary import EPContextBinaryGenerator
+
+
+@pytest.mark.skipif(
+    "QNNExecutionProvider" not in onnxruntime.get_available_providers(),
+    reason="QNNExecutionProvider is not available in this environment",
+)
+@pytest.mark.parametrize("embed_context", [True, False])
+def test_ep_context_binary_generator(tmp_path, embed_context):
+    # setup
+    model = get_onnx_model()
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type="NPU",
+        execution_provider="QNNExecutionProvider",
+    )
+    p = create_pass_from_dict(
+        EPContextBinaryGenerator,
+        {"embed_context": embed_context},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    # execute
+    output_model = p.run(model, tmp_path)
+
+    # assert
+    assert isinstance(output_model, ONNXModelHandler)
+    ctx_path = tmp_path / "dummy_model_ctx.onnx"
+    assert output_model.model_path == str(ctx_path)
+    assert ctx_path.exists()
+    assert len(list(tmp_path.glob("dummy_model_ctx*.bin"))) == int(not embed_context)
+
+
+@pytest.mark.skipif(
+    "QNNExecutionProvider" not in onnxruntime.get_available_providers(),
+    reason="QNNExecutionProvider is not available in this environment",
+)
+@pytest.mark.parametrize("is_llm", [True, False])
+def test_ep_context_binary_generator_composite(tmp_path, is_llm):
+    # setup
+    model = get_onnx_model()
+
+    # create a composite model
+    parent_dir = tmp_path / "composite_model"
+    parent_dir.mkdir(parents=True, exist_ok=True)
+    component_names = ["component_0", "component_1", "component_2", "component_3"]
+    model_attributes = None
+    if is_llm:
+        component_names = ["embeddings", *component_names, "lm_head"]
+        model_attributes = {
+            "llm_pipeline": {
+                "embeddings": "embeddings",
+                "context": ["component_0", "component_1"],
+                "iterator": ["component_2", "component_3"],
+                "lm_head": "lm_head",
+            }
+        }
+    component_models = []
+    for name in component_names:
+        component_path = parent_dir / f"{name}.onnx"
+        resave_model(model.model_path, str(component_path))
+        component_models.append(ONNXModelHandler(component_path))
+    composite_model = CompositeModelHandler(component_models, component_names, model_attributes=model_attributes)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type="NPU",
+        execution_provider="QNNExecutionProvider",
+    )
+    p = create_pass_from_dict(
+        EPContextBinaryGenerator,
+        # weight sharing requires a qdq model
+        # might also have issues in pytest environment
+        {"weight_sharing": False},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    # execute
+    output_model_path = tmp_path / "output_model"
+    output_model = p.run(composite_model, output_model_path)
+
+    # assert
+    assert isinstance(output_model, CompositeModelHandler)
+    output_component_map = dict(output_model.get_model_components())
+    assert len(output_component_map) == len(component_models)
+    assert output_model.model_attributes == model_attributes
+    for name in component_names:
+        # print(output_component_map[name].model_path)
+        is_skipped = name in ["embeddings", "lm_head"]
+        expected_name = name if is_skipped else f"{name}_ctx"
+        expected_model_path = output_model_path / f"{expected_name}.onnx"
+        assert output_component_map[expected_name].model_path == str(expected_model_path)
+        assert expected_model_path.exists()
+        if not is_skipped:
+            assert len(list(output_model_path.glob(f"{name}_ctx*.bin"))) == 1


### PR DESCRIPTION
## Describe your changes
New pass `EPContextBinaryGenerator` added to generate context binary onnx models for NPU EPs.
- Only tested with QNN Execution Provider currently
- The options and behaviors for other EPs are expected to be the same. New eps will be enabled once validated.
- Accepts:
  - single onnx model
  - composite onnx model
    - with/without weight sharing. Spill fill buffer not supported yet (only works on linux + needs extra model processing)
    - special handling for static llm models through the `llm_pipeline` model attribute passed down between passes  

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
