### PR TITLE
GPTQ: latest transformers support, CI: unpin transformers version

### DIFF
--- a/docs/source/features/peft-adapters.md
+++ b/docs/source/features/peft-adapters.md
@@ -1,4 +1,4 @@
-# PEFT Adapaters
+# PEFT Adapters
 
 Parameter Efficient Finetuning (PEFT) techniques, such as LoRA enables user to efficiently finetune a model.
 
@@ -71,57 +71,6 @@ This pass only supports HfModels. Please refer to [LoftQ](loftq) for more detail
 }
 ```
 Please refer to [LoftQ HFTrainingArguments](lora_hf_training_arguments) for more details on supported the `"training_args"` and their default values.
-
-## Quantization Aware Training
-The Quantization Aware Training (QAT) technique is used to improve the performance and efficiency of deep learning models by quantizing their
-weights and activations to lower bit-widths. The technique is applied during training, where the weights and activations are fake quantized
-to lower bit-widths using the specified QConfig.
-
-Olive provides `QuantizationAwareTraining` that performs QAT on a PyTorch model.
-
-Please refer to [QuantizationAwareTraining](quantization_aware_training) for more details about the pass and its config parameters.
-
-### Example Configuration
-Olive provides the 3 ways to run QAT training process:
-
-a. Run QAT training with customized training loop.
-```json
-{
-    "type": "QuantizationAwareTraining",
-    "user_script": "user_script.py",
-    "training_loop_func": "training_loop_func"
-}
-```
-
-Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/bert/user_script.py)
-for an example implementation of `"user_script.py"` and `"training_loop_func"`.
-
-b. Run QAT training with PyTorch Lightning.
-```json
-{
-    "type": "QuantizationAwareTraining",
-    "user_script": "user_script.py",
-    "num_epochs": 5,
-    "ptl_data_module": "PTLDataModule",
-    "ptl_module": "PTLModule"
-}
-```
-
-Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/resnet/user_script.py)
-for an example implementation of `"user_script.py"`, `"PTLDataModule"` and `"PTLModule"`.
-
-
-c. Run QAT training with default training loop.
-```json
-{
-    "type": "QuantizationAwareTraining",
-    "num_epochs": 5,
-    "train_data_config": "train_data_config"
-}
-```
-
-Check out [this file](https://github.com/microsoft/Olive/blob/main/examples/resnet/user_script.py)
-for an example implementation of `"user_script.py"` and `"train_data_config/dataloader_config/type"`.
 
 ## MergeAdapterWeights
 Merge Lora weights into a complete model. After running the LoRA pass, the model will only have LoRA adapters. This pass merges the LoRA adapters into the original model and download the context(config/generation_config/tokenizer) of the model.

--- a/docs/source/how-to/cli/cli-quantize.md
+++ b/docs/source/how-to/cli/cli-quantize.md
@@ -13,7 +13,7 @@ Some methods require a GPU and/or a calibration dataset.
 ```
 
 | Implementation | Description | Model format(s) | Algorithm | GPU required |
-| ------ | ------------ | ------------ | ------------------ | ------------------ | ------------------- |
+| -------------- | ----------- | --------------- | --------- | ------------ |
 | AWQ | Activation-aware Weight Quantization (AWQ) creates 4-bit quantized models and it speeds up models by 3x and reduces memory requirements by 3x compared to FP16.  | PyTorch <br> ONNX| Awq | ✔️ |
 | GPTQ | Generative Pre-trained Transformer Quantization (GPTQ) is a one-shot weight quantization method. You can quantize your favorite language model to 8, 4, 3 or even 2 bits.  | PyTorch <br> ONNX |  GptQ  | ✔️ |
 | BitsAndBytes | Is a MatMul with weight quantized with N bits (e.g., 2, 3, 4, 5, 6, 7). | ONNX | RTN | ❌ |

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -106,7 +106,7 @@ For more complex scenarios, you can create fully customize workflows where you c
 
       Learn how to configure passes.
 
-      :octicon:`arrow-right;1em;sd-text-info` `Configure pass <configure-workflows/pass/pass-configuration.html>`_
+      :octicon:`arrow-right;1em;sd-text-info` `Configure pass <configure-workflows/pass-configuration.html>`_
 
    .. grid-item-card::
 

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -111,10 +111,10 @@ class OnnxConversion(Pass):
             "optimize": PassConfigParam(
                 type_=bool,
                 default_value=True,
-                description=("Whether to export the model with constant folding and redundancies elimination."),
+                description="Whether to export the model with constant folding and redundancies elimination.",
             ),
             "dynamic": PassConfigParam(
-                type_=bool, default_value=True, description=("Whether to export the model with dynamic axes/shapes.")
+                type_=bool, default_value=True, description="Whether to export the model with dynamic axes/shapes."
             ),
         }
 
@@ -449,7 +449,7 @@ class OnnxConversion(Pass):
                     args[pkv_index] = EncoderDecoderCache.from_legacy_cache(args[pkv_index])
                 else:
                     raise ValueError(
-                        f"past_key_values should have either 2 or 4 elements, "
+                        "past_key_values should have either 2 or 4 elements, "
                         f"but it has {len(args[pkv_index][0])} elements"
                     )
             elif (
@@ -463,7 +463,7 @@ class OnnxConversion(Pass):
                     kwargs["past_key_values"] = EncoderDecoderCache.from_legacy_cache(kwargs["past_key_values"])
                 else:
                     raise ValueError(
-                        f"past_key_values should have either 2 or 4 elements, "
+                        "past_key_values should have either 2 or 4 elements, "
                         f"but it has {len(kwargs['past_key_values'][0])} elements"
                     )
 

--- a/olive/passes/pytorch/autoawq.py
+++ b/olive/passes/pytorch/autoawq.py
@@ -182,11 +182,6 @@ class AutoAWQQuantizer(Pass):
         from awq import __version__ as autoawq_version
         from transformers import __version__ as transformers_version
 
-        # https://github.com/huggingface/transformers/issues/32420
-        # there is an issue in transformers with the rotary embedding where some tensors are still on CPU
-        # causing device mismatch error
-        # max limit on awq version in case fix is released
-        # transformers releases too frequently so we can't keep track of all versions
         if version.parse(transformers_version) >= version.parse("4.43") and version.parse(
             autoawq_version
         ) <= version.parse("0.2.6"):

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -306,16 +306,16 @@ class GptqQuantizer(Pass):
         from transformers import __version__ as transformers_version
 
         # almost all model types have rotary embeddings at model.model.rotary_emb so won't keep a mapping
-        rotart_embed_module_name = "model.rotary_emb"
+        rotary_embed_module_name = "model.rotary_emb"
         if (
             version.parse(transformers_version) >= version.parse("4.43")
             and version.parse(autogptq_version).release < version.parse("0.8.0").release
-            and get_attr(gptq_model.model, rotart_embed_module_name)
+            and get_attr(gptq_model.model, rotary_embed_module_name)
         ):
-            rotary_embed_module = get_attr(gptq_model.model, rotart_embed_module_name)
+            rotary_embed_module = get_attr(gptq_model.model, rotary_embed_module_name)
 
-            if rotart_embed_module_name not in gptq_model.outside_layer_modules:
-                gptq_model.outside_layer_modules.append(rotart_embed_module_name)
+            if rotary_embed_module_name not in gptq_model.outside_layer_modules:
+                gptq_model.outside_layer_modules.append(rotary_embed_module_name)
 
             # add a dummy parameter to the module so that it gets moved to device
             rotary_embed_module.register_parameter("dummy", torch.nn.Parameter(torch.zeros(0), requires_grad=False))

--- a/test/requirements-test-gpu.txt
+++ b/test/requirements-test-gpu.txt
@@ -1,6 +1,6 @@
 -r requirements-test.txt
-auto-gptq
-autoawq
+auto-gptq==0.7.1
+autoawq==0.2.8
 bitsandbytes
 onnxruntime-genai-cuda
 triton

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -44,6 +44,3 @@ sentencepiece
 soundfile
 tabulate
 torchvision
-# num_logits_to_keep is causing extra input.
-# TODO(anyone): Remove this once the issue is resolved
-transformers>=4.42.0, <4.45.0

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -12,14 +12,6 @@ cppimport
 datasets
 docker>=7.1.0
 evaluate
-# microsoft/TransformerCompression has dependency on transformers==4.41.0
-# and it's not compatible with transformers>=4.42.0.
-# Use the forked version of TransformerCompression for now.
-# https://github.com/microsoft/TransformerCompression/issues/183
-# TODO(team): Switch back to the original version once it's compatible with transformers>=4.42.0
-git+https://github.com/xiaoyu-work/TransformerCompression.git ; python_version >= "3.10"
-# latest 3.24.0 will break the pipeline
-# TODO(team): 55399 Switch back to the latest version once it's compatible with the pipeline
 marshmallow<3.24.0
 mlflow>=2.4.0, <2.20.0
 neural-compressor<2.4

--- a/test/unit_test/passes/onnx/test_split_model.py
+++ b/test/unit_test/passes/onnx/test_split_model.py
@@ -27,11 +27,11 @@ def input_model_info_fixture(request, tmp_path_factory):
     all_models = {}
 
     # input model
-    model_name = "katuni4ka/tiny-random-phi3"
-    input_model = HfModelHandler(
-        model_path=model_name,
-        load_kwargs={"trust_remote_code": False, "revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"},
-    )
+    # phi-3 has issues with calibration for transformers 4.48.0
+    # might be something to do with the how qkv projection is split
+    # TODO(jambayk): consider adding phi-3 to test once the issue is investigated and fixed
+    model_name = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+    input_model = HfModelHandler(model_path=model_name)
 
     # add split info to the model
     capture_config = {}
@@ -78,7 +78,7 @@ def input_model_info_fixture(request, tmp_path_factory):
         disable_search=True,
     ).run(all_models["convert_fp32"], tmp_path / "qdq")
 
-    return all_models, request.param, 4 if request.param else 2
+    return all_models, request.param, 3 if request.param else 2
 
 
 @pytest.mark.parametrize(

--- a/test/unit_test/passes/pytorch/test_gptq.py
+++ b/test/unit_test/passes/pytorch/test_gptq.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
+from test.unit_test.utils import make_local_tiny_llama
 
 import pytest
 import torch
@@ -39,12 +40,15 @@ test_gptq_dc_config = DataConfig(
     [
         ("katuni4ka/tiny-random-phi3", "Phi3ForCausalLM", None),
         ("katuni4ka/tiny-random-phi3", "Phi3ForCausalLM", test_gptq_dc_config),
-        ("facebook/opt-125m", "OPTForCausalLM", test_gptq_dc_config),
+        ("tiny-llama", "LlamaForCausalLM", None),
     ],
 )
 def test_gptq_default(tmp_path: Path, model_path: str, expected_model_type: str, data_config: DataConfig):
     # setup
-    input_model = HfModelHandler(model_path=model_path)
+    if model_path == "tiny-llama":
+        input_model = make_local_tiny_llama(tmp_path / "input_model")
+    else:
+        input_model = HfModelHandler(model_path=model_path)
     p = create_pass_from_dict(
         GptqQuantizer,
         {"data_config": data_config},


### PR DESCRIPTION
## Describe your changes
- Update `GptqQuantizer` with a patch to support newer versions of transformers.
  - we previously asked users to install auto-gptq from source but that is inconvenient.
  - new patch avoids the issue with the rotary embedding module not being on the expected device
  - 0.7.1 validated for transformers 4.42-4.49
- `AutoAWQQuantizer`:
  - 0.2.8 validated 4.43-4.47 (although package req is 4.45-4.47)
- Test requirements
  - remove transformers version pin
  - pin auto-gptq and autoawq versions
  - remove transformercompression installation since the slicegpt test is skipped and it has `datasets` dependency conflict with autoawq
- Some doc fixes 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
