### PR TITLE
Use int8 as default precision in quantize CLI

### DIFF
--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -59,7 +59,7 @@ class QuantizeCommand(BaseOliveCLICommand):
         sub_parser.add_argument(
             "--precision",
             type=str,
-            default="int4",
+            default="int8",
             choices=["int4", "int8", "int16", "uint4", "uint8", "uint16", "fp4", "fp8", "fp16", "nf4"],
             help="The precision of the quantized model.",
         )


### PR DESCRIPTION
## Describe your changes
Use int8 as the default precision in quantize CLI
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
