### PR TITLE
ComposeOnnxModels: Pass to compose split onnx models

### DIFF
--- a/docs/source/reference/pass.rst
+++ b/docs/source/reference/pass.rst
@@ -170,6 +170,12 @@ EPContextBinaryGenerator
 ------------------------
 .. autoconfigclass:: olive.passes.EPContextBinaryGenerator
 
+.. _compose_onnx_models:
+
+ComposeOnnxModels
+-----------------
+.. autoconfigclass:: olive.passes.ComposeOnnxModels
+
 .. _optimum_conversion:
 
 OptimumConversion

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -8,6 +8,14 @@
             "supported_algorithms": [  ],
             "supported_quantization_encodings": [  ]
         },
+        "ComposeOnnxModels": {
+            "module_path": "olive.passes.onnx.compose.ComposeOnnxModels",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
+            "supported_algorithms": [  ],
+            "supported_quantization_encodings": [  ]
+        },
         "DynamicToFixedShape": {
             "module_path": "olive.passes.onnx.dynamic_to_fixed_shape.DynamicToFixedShape",
             "supported_providers": [ "*" ],

--- a/olive/passes/onnx/compose.py
+++ b/olive/passes/onnx/compose.py
@@ -27,7 +27,18 @@ logger = logging.getLogger(__name__)
 
 
 class ComposeOnnxModels(Pass):
-    """Compose multiple ONNX models into a single model."""
+    """Compose multiple ONNX models into a single model.
+
+    This pass chains multiple ONNX models together by itertively connecting the output of the preceding model to the
+    input of the next model. The final inputs and outputs are the set of all inputs and outputs of the models excluding
+    those used to connect the models together.
+
+    It also handles llm_pipeline models:
+    - embeddings: the embeddings model is saved as is
+    - context: the context model is composed of all models in the context group
+    - iterator: the iterator model is composed of all models in the iterator group
+    - lm_head: the lm_head model is saved as is
+    """
 
     _accepts_composite_model = True
 

--- a/olive/passes/onnx/compose.py
+++ b/olive/passes/onnx/compose.py
@@ -1,0 +1,210 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, Optional, Type, Union
+
+import numpy as np
+
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.model import CompositeModelHandler, ONNXModelHandler
+from olive.model.utils import resolve_onnx_path
+from olive.passes import Pass
+from olive.passes.onnx.common import (
+    copy_context_bin_files,
+    get_context_bin_file_names,
+    get_external_data_config,
+    model_proto_to_file,
+    resave_model,
+)
+from olive.passes.onnx.onnx_dag import OnnxDAG
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
+logger = logging.getLogger(__name__)
+
+
+class ComposeOnnxModels(Pass):
+    """Compose multiple ONNX models into a single model."""
+
+    _accepts_composite_model = True
+
+    @classmethod
+    def _default_config(cls, accelerator_spec: AcceleratorSpec) -> Dict[str, PassConfigParam]:
+        return get_external_data_config()
+
+    def _run_for_config(
+        self,
+        model: CompositeModelHandler,
+        config: Type[BasePassConfig],
+        output_model_path: str,
+    ) -> Union[ONNXModelHandler, CompositeModelHandler]:
+        assert isinstance(model, CompositeModelHandler), "ComposeOnnxModels pass only supports CompositeModelHandler"
+        assert all(
+            isinstance(m, ONNXModelHandler) for m in model.model_components
+        ), "All components must be ONNXModelHandler"
+
+        if llm_pipeline := (model.model_attributes or {}).get("llm_pipeline"):
+            output_model_path = Path(output_model_path).with_suffix("")
+
+            component_map = dict(model.get_model_components())
+            new_component_models = {}
+            new_llm_pipeline = {}
+
+            # resave embeddings model
+            embeddings_model_path = output_model_path / "embeddings.onnx"
+            resave_model(component_map[llm_pipeline["embeddings"]].model_path, embeddings_model_path)
+            new_component_models["embeddings"] = ONNXModelHandler(
+                model_path=output_model_path, onnx_file_name=embeddings_model_path.name
+            )
+            new_llm_pipeline["embeddings"] = "embeddings"
+
+            # compose the context and iterator models
+            composed_suffix = (
+                "_ctx" if get_context_bin_file_names(component_map[llm_pipeline["context"][0]].model_path) else ""
+            )
+            saved_cb_files = {}
+            for group_name in ["context", "iterator"]:
+                composed_name = f"{group_name}{composed_suffix}"
+                new_component_models[composed_name] = self._get_composed_model(
+                    [component_map[component_name].model_path for component_name in llm_pipeline[group_name]],
+                    output_model_path / f"{composed_name}.onnx",
+                    external_config=config.dict(),
+                    saved_cb_files=saved_cb_files,
+                    as_model_dir=True,
+                )
+                new_llm_pipeline[group_name] = [composed_name]
+
+            # resave the lm_head model
+            lm_head_model_path = output_model_path / "lm_head.onnx"
+            resave_model(component_map[llm_pipeline["lm_head"]].model_path, lm_head_model_path)
+            new_component_models["lm_head"] = ONNXModelHandler(
+                model_path=output_model_path, onnx_file_name=lm_head_model_path.name
+            )
+            new_llm_pipeline["lm_head"] = "lm_head"
+
+            new_model_attributes = deepcopy(model.model_attributes)
+            new_model_attributes["llm_pipeline"] = new_llm_pipeline
+            return CompositeModelHandler(
+                list(new_component_models.values()),
+                list(new_component_models.keys()),
+                model_attributes=new_model_attributes,
+            )
+
+        return self._get_composed_model(
+            [component.model_path for component in model.model_components],
+            resolve_onnx_path(output_model_path),
+            external_config=config.dict(),
+        )
+
+    @staticmethod
+    def _get_composed_model(
+        onnx_model_paths: list,
+        output_model_path: Union[str, Path],
+        external_config: dict,
+        saved_cb_files: Optional[dict] = None,
+        as_model_dir: bool = False,
+    ) -> ONNXModelHandler:
+        """Compose multiple ONNX models into a single model.
+
+        :param onnx_model_paths: List of ONNX model paths.
+        :param output_model_path: Path to save the composed ONNX model.
+        :param external_config: Configuration for external data.
+        :param saved_cb_files: Dictionary of saved context binary files.
+        :param as_model_dir: Use model parent directory as output model_path.
+        :return: Composed ONNX model.
+        """
+        dags = [OnnxDAG.from_model_path(path) for path in onnx_model_paths]
+
+        seen_inputs = set()
+        seen_outputs = set()
+        for dag in dags:
+            dag_inputs = set(dag.get_input_names())
+            dag_outputs = set(dag.get_output_names())
+            # avoid circular connection, model_2 output cannot be model_1 input
+            assert dag_outputs.isdisjoint(
+                seen_inputs
+            ), f"Output names {dag_outputs.intersection(seen_inputs)} are already used as input names."
+            # avoid reused output name
+            assert dag_outputs.isdisjoint(
+                seen_outputs
+            ), f"Output names {dag_outputs.intersection(seen_outputs)} are already used as output names."
+
+            # update seen inputs and outputs
+            seen_inputs.update(dag_inputs)
+            seen_outputs.update(dag_outputs)
+
+        # will only keep the unused outputs
+        # inputs will be automatically taken care of during compose
+        final_outputs = seen_outputs - seen_inputs
+
+        # compose
+        composed_dag = dags.pop(0)
+        while dags:
+            dag = dags.pop(0)
+
+            cd_input_names = set(composed_dag.get_input_names())
+            cd_output_names = set(composed_dag.get_output_names())
+            cd_initializer_names = set(composed_dag.get_initializer_names())
+            for input_name in dag.get_input_names():
+                if input_name in cd_input_names | cd_output_names:
+                    assert dag.get_io_shape(input_name) == composed_dag.get_io_shape(
+                        input_name
+                    ), f"Input shape mismatch: {input_name}"
+                    assert dag.get_io_dtype(input_name) == composed_dag.get_io_dtype(
+                        input_name
+                    ), f"Input dtype mismatch: {input_name}"
+                    continue
+
+                # will add to graph 0 for now
+                # this will fail if the connection already exists in the graph = expected behavior.
+                composed_dag.add_input(dag.get_input_proto(input_name), 0)
+
+            for output_name in dag.get_output_names():
+                composed_dag.add_output(dag.get_output_proto(output_name), 0)
+
+            for init_name in dag.get_initializer_names():
+                if init_name in cd_initializer_names:
+                    np.testing.assert_array_equal(
+                        dag.get_initializer_np_array(init_name), composed_dag.get_initializer_np_array(init_name)
+                    ), f"Initializer mismatch: {init_name}"
+                    continue
+
+                composed_dag.add_initializer(dag.get_initializer_proto(init_name), 0)
+
+            for intermediate_name in dag.get_intermediate_names():
+                if value_info := dag.get_value_info_proto(intermediate_name):
+                    composed_dag.add_value_info(value_info, 0)
+
+            for node_name in dag.topological_sort():
+                node = dag.get_node_proto(node_name)
+                if composed_dag.has_node(node_name):
+                    # there might be some dq nodes for initializers that are common between models
+                    # since split model keeps dq with the consumer op
+                    assert composed_dag.get_node_proto(node_name) == node, f"Node mismatch: {node_name}"
+                    continue
+
+                composed_dag.add_node(node, 0)
+
+        for output_name in composed_dag.get_output_names():
+            if output_name not in final_outputs:
+                composed_dag.remove_output(output_name)
+
+        # update the model graph
+        composed_dag.update()
+
+        # save the composed model
+        output_model_path = Path(output_model_path)
+        has_external_data = model_proto_to_file(composed_dag.model, output_model_path, **external_config)
+
+        # copy over context binary files if any
+        saved_cb_files = saved_cb_files if saved_cb_files is not None else {}
+        for path in onnx_model_paths:
+            has_external_data |= copy_context_bin_files(path, output_model_path.parent, saved_cb_files=saved_cb_files)
+
+        return ONNXModelHandler(
+            output_model_path.parent if (has_external_data or as_model_dir) else output_model_path,
+            onnx_file_name=output_model_path.name if (has_external_data or as_model_dir) else None,
+        )

--- a/olive/passes/onnx/onnx_dag.py
+++ b/olive/passes/onnx/onnx_dag.py
@@ -5,7 +5,7 @@
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import onnx
 from onnx import AttributeProto, GraphProto, NodeProto, TensorProto, ValueInfoProto
@@ -253,6 +253,18 @@ class OnnxDAG:
             raise ValueError(f"{name} is not an initializer.")
         proto_list = self.ios[name].proto[:-1] + [initializer]
         self.ios[name].proto = proto_list
+
+    def add_output(self, output_proto: ValueInfoProto, graph_idx: int):
+        """Add an output to the graph.
+
+        :param output_proto: ValueInfoProto of the output.
+        :param graph_idx: index of the graph in the model.
+        """
+        if output_proto.name in self.ios:
+            raise ValueError(f"Output {output_proto.name} already exists in the graph.")
+        self.ios[output_proto.name] = OnnxIO(
+            proto=[output_proto], destination=[SpecialOutput.OUTPUT], graph_idx=graph_idx
+        )
 
     def add_value_info(self, value_info: ValueInfoProto, graph_idx: int, overwrite: bool = False):
         """Add a value info to the graph.
@@ -607,6 +619,13 @@ class OnnxDAG:
         """
         return [i for i in self.ios if self.is_initializer(i)]
 
+    def get_intermediate_names(self) -> List[str]:
+        """Get the names of all intermediate inputs/outputs in the graph.
+
+        :return: list of intermediate input/output names.
+        """
+        return [i for i in self.ios if not any([self.is_input(i), self.is_initializer(i), self.is_output(i)])]
+
     def get_input_proto(self, input_name: str) -> ValueInfoProto:
         """Get the input proto.
 
@@ -625,11 +644,29 @@ class OnnxDAG:
         assert self.is_initializer(initializer_name)
         return self.ios[initializer_name].proto[-1]
 
-    def get_io_shape(self, io_name: str) -> List[Union[int, str]]:
-        """Get the shape of an input/output.
+    def get_output_proto(self, output_name: str) -> ValueInfoProto:
+        """Get the output proto.
+
+        :param output_name: name of the output.
+        :return: ValueInfoProto object.
+        """
+        assert self.is_output(output_name)
+        return self.ios[output_name].proto[0]
+
+    def get_value_info_proto(self, value_info_name: str) -> Optional[ValueInfoProto]:
+        """Get the value info proto.
+
+        :param value_info_name: name of the value info.
+        :return: ValueInfoProto object.
+        """
+        assert value_info_name in self.ios, f"{value_info_name} is not a value info."
+        return self.ios[value_info_name].proto[0] if self.ios[value_info_name].proto else None
+
+    def _get_io_tensor_type(self, io_name: str):
+        """Get the tensor type of an input/output.
 
         :param io_name: name of the input/output.
-        :return: shape of the input/output.
+        :return: tensor type of the input/output.
         """
         proto = self.ios[io_name].proto[0]
         tensor_type = proto.type.tensor_type
@@ -638,7 +675,25 @@ class OnnxDAG:
             # TODO(jambayk): add support for different types
             # refer to https://github.com/lutzroeder/netron/blob/main/source/onnx.js#L1424
             tensor_type = proto.type.sequence_type.elem_type.tensor_type
+        return tensor_type
+
+    def get_io_shape(self, io_name: str) -> List[Union[int, str]]:
+        """Get the shape of an input/output.
+
+        :param io_name: name of the input/output.
+        :return: shape of the input/output.
+        """
+        tensor_type = self._get_io_tensor_type(io_name)
         return [dim.dim_param if dim.dim_param else dim.dim_value for dim in tensor_type.shape.dim]
+
+    def get_io_dtype(self, io_name: str) -> str:
+        """Get the data type of an input/output.
+
+        :param io_name: name of the input/output.
+        :return: data type of the input/output.
+        """
+        tensor_type = self._get_io_tensor_type(io_name)
+        return str(onnx.helper.tensor_dtype_to_np_dtype(tensor_type.elem_type))
 
     def get_graph_idx(self, name: str) -> int:
         """Get the index of the graph containing the input/output or node."""

--- a/test/unit_test/passes/onnx/test_compose.py
+++ b/test/unit_test/passes/onnx/test_compose.py
@@ -1,0 +1,99 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from pathlib import Path
+from test.unit_test.utils import make_local_tiny_llama
+
+import pytest
+
+from olive.model import CompositeModelHandler, ONNXModelHandler
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.compose import ComposeOnnxModels
+from olive.passes.onnx.conversion import OnnxConversion
+from olive.passes.onnx.model_builder import ModelBuilder
+from olive.passes.onnx.split import SplitModel
+from olive.passes.onnx.static_llm import StaticLLM
+
+
+@pytest.mark.parametrize("use_mb", [True, False])
+def test_compose_onnx_models_composite(tmp_path, use_mb):
+    # setup
+    pytorch_model = make_local_tiny_llama(tmp_path)
+    onnx_model = create_pass_from_dict(
+        ModelBuilder if use_mb else OnnxConversion, {"precision": "fp32"} if use_mb else {}, disable_search=True
+    ).run(pytorch_model, tmp_path / "onnx_model")
+    split_model = create_pass_from_dict(
+        SplitModel,
+        {
+            "split_assignments": {
+                "model.embed_tokens": 0,
+                "model.layers.0": 1,
+                "model.layers.1": 2,
+                "lm_head": 3,
+            }
+        },
+        disable_search=True,
+    ).run(onnx_model, tmp_path / "split_model")
+
+    p = create_pass_from_dict(ComposeOnnxModels, {}, disable_search=True)
+
+    # execute
+    output_model_path = tmp_path / "output_model"
+    output_model = p.run(split_model, output_model_path)
+
+    # check
+    assert isinstance(output_model, ONNXModelHandler)
+    assert Path(output_model.model_path).exists()
+    expected_io_config = onnx_model.io_config
+    actual_io_config = output_model.io_config
+    for io_key in ["input", "output"]:
+        # check the i/o names match
+        assert set(actual_io_config[f"{io_key}_names"]) == set(expected_io_config[f"{io_key}_names"])
+        # check the i/o shapes/types match
+        for info_key in ["shapes", "types"]:
+            expected_info_dict = dict(
+                zip(expected_io_config[f"{io_key}_names"], expected_io_config[f"{io_key}_{info_key}"])
+            )
+            actual_info_dict = dict(zip(actual_io_config[f"{io_key}_names"], actual_io_config[f"{io_key}_{info_key}"]))
+            for name, value in expected_info_dict.items():
+                assert actual_info_dict[name] == value
+
+
+def test_compose_onnx_models_llm_pipeline(tmp_path):
+    # setup
+    pytorch_model = make_local_tiny_llama(tmp_path)
+    onnx_model = create_pass_from_dict(ModelBuilder, {"precision": "fp32"}, disable_search=True).run(
+        pytorch_model, tmp_path / "onnx_model"
+    )
+    split_model = create_pass_from_dict(
+        SplitModel,
+        {
+            "split_assignments": {
+                "model.embed_tokens": 0,
+                "model.layers.0": 1,
+                "model.layers.1": 2,
+                "lm_head": 3,
+            }
+        },
+        disable_search=True,
+    ).run(onnx_model, tmp_path / "split_model")
+    llm_model = create_pass_from_dict(StaticLLM, {"batch_size": 1, "context_length": 64}, disable_search=True).run(
+        split_model, tmp_path / "llm_model"
+    )
+
+    p = create_pass_from_dict(ComposeOnnxModels, {}, disable_search=True)
+
+    # execute
+    output_model_path = tmp_path / "output_model"
+    output_model = p.run(llm_model, output_model_path)
+
+    # check
+    assert isinstance(output_model, CompositeModelHandler)
+    assert output_model.model_attributes["llm_pipeline"] == {
+        "embeddings": "embeddings",
+        "context": ["context"],
+        "iterator": ["iterator"],
+        "lm_head": "lm_head",
+    }
+    assert len(list(output_model.model_components)) == 4


### PR DESCRIPTION
## Describe your changes
New pass `ComposeOnnxModels` added to compose split onnx models. This is useful in cases where a large model is split into components for processing such as context binary generation, quantization, etc due to resource or compiler limitations.
It handles both regular composite models and llm pipeline models with/without context binaries.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Also fixes #1605 