### PR TITLE
HfModel: fix kv cache io for no past and no cache

### DIFF
--- a/olive/common/hf/model_io.py
+++ b/olive/common/hf/model_io.py
@@ -90,7 +90,10 @@ def get_export_config(model_name: str, task: str, **kwargs) -> Optional["OnnxCon
         # need kv cache for both input and output
         export_config = export_config.__class__(
             model_config,
-            use_past=export_config.use_past,
+            # if use_cache is False, there is no kv cache output
+            # else both text-generation and text-generation-with-past have kv cache output
+            use_past=kwargs.get("use_cache", True),
+            # only text-generation-with-past has kv cache input
             use_past_in_inputs=export_config.use_past,
             # text-generation-with-past doesn't return position_ids
             task="text-generation",


### PR DESCRIPTION
## Describe your changes
Based on the task and `use_cache` load kwargs, there are four scenairos for text gen models:
- `text-generation-with-past`
  - `use_cache = True`: kv cache inputs, kv cache outputs
  - `use_cache = False`: kv cache inputs
- `test-generation`
  - `use_cache = True`: kv cache outputs
  - `use_cache = False`: None

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
