### PR TITLE
Phi3.5 example for NPU

### DIFF
--- a/docs/source/features/onnx-transformations.md
+++ b/docs/source/features/onnx-transformations.md
@@ -746,7 +746,7 @@ graph {
 ```
 
 
-### RMSNormToL2Norm
+### `RMSNormToL2Norm`
 
 #### Description
 
@@ -786,7 +786,55 @@ Transformed model graph:
            (p=2, axis=-1)
 ```
 
-### ReplaceAttentionMaskValue
+### `SimplifiedLayerNormToL2Norm`
+
+#### Description
+Replace Skip/SimplifiedLayerNormalization nodes with L2Norm subgraph.
+
+#### Example
+Initial model graph:
+
+```
+SimplifiedLayerNorm pattern:
+[Root] --> SimplifiedLayerNormalization
+             (axis=-1, epsilon=1e-6)
+
+SkipSimpleLayerNorm pattern:
+[Root1] ------------+
+                    v
+[Root2] --> SkipSimpleLayerNormalization
+               (epsilon=1e-6)
+```
+
+After applying:
+
+```json
+{
+    "type": "GraphSurgeries",
+    "surgeries": [
+        {
+            "surgeon": "SimplifiedLayerNormToL2Norm"
+        }
+    ]
+}
+```
+
+
+Transformed model graph:
+
+```
+[Root] --> LpNormalization -> Mul
+           (p=2, axis=-1)
+
+[Root1] -------> Add
+                  |
+                  v
+[Root2] --> LpNormalization --> Mul
+            (p=2, axis=-1)
+```
+
+
+### `ReplaceAttentionMaskValue`
 
 #### Description
 

--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -1,0 +1,101 @@
+# Phi3.5 Model Optimization for Qualcomm NPU
+
+This repository demonstrates the optimization of the [Microsoft Phi-3.5 Mini Instruct](https://huggingface.co/microsoft/Phi-3.5-mini-instruct) model for deployment on Qualcomm NPUs (such as Snapdragon X Series) using the ONNX Runtime QNNExecutionProvider.
+
+To enable efficient deployment on NPU, we perform a series of optimizations, including quantization, ahead-of-time (AOT) compilation, and handling of dynamic and static input shapes. The result is a model compiled for optimal execution on Qualcomm NPUs.
+
+## Table of Contents
+
+1. [Optimization Process](#optimization-process)
+2. [Handling Dynamic and Static Input Shapes](#handling-dynamic-and-static-input-shapes)
+3. [Resource Optimization Strategy](#resource-optimization-strategy)
+4. [Compilation for NPU Deployment](#compilation-for-npu-deployment)
+5. [Summary of Key Steps](#summary-of-key-steps)
+6. [Requirements](#requirements)
+7. [Usage](#usage)
+
+## Optimization Process
+
+The model optimization process includes the following steps:
+
+1. **Weight Rotation with [QuaRot](https://arxiv.org/abs/2404.00456)**: This step adjusts the model’s weights to make it more suitable for quantization.
+2. **4-bit Per-Channel Symmetric Quantization with [GPTQ](https://arxiv.org/abs/2210.17323)**: Applies weight-only quantization (4-bit) to the transformer linear layers to reduce model size.
+3. **ONNX Graph Capture**: Captures the ONNX graph for subsequent optimizations.
+4. **4-bit Block-wise Quantization**: Quantizes the embedding layer and the language modeling head using weight-only 4-bit quantization.
+5. **16-bit Activation Quantization**: Uses the [ONNX Runtime Quantizer Tool](https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html) to quantize activations to 16-bits for improved model efficiency.
+
+## Handling Dynamic and Static Input Shapes
+
+NPUs require pre-compiled graphs, which means the model must use static input shapes. The text generation process consists of two main stages with different input shape requirements:
+
+- **Prefill (Context/Prompt Processing)**: This stage processes multiple tokens simultaneously.
+- **Token Generation (Iteration)**: This stage processes one token at a time.
+
+To accommodate these differing requirements, we optimize the model by creating two instances: one for prefill and one for token generation. This allows the model to handle both static and dynamic input shapes effectively.
+
+## Resource Optimization Strategy
+
+To optimize resource usage:
+
+- **Embedding Layer and Language Model Head**: These components are executed on the CPU and can handle dynamic input shapes.
+- **Transformer Layers**: These layers are executed on the NPU, which requires static input shapes.
+- **Weight Sharing**: The prefill and token generation models share weights (with different input shapes), minimizing memory usage.
+
+Additionally, we use **[GroupQueryAttention](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.GroupQueryAttention)** to enable dynamic key-value caching, which supports long-context processing and generation during text tasks.
+
+## Compilation for NPU Deployment
+
+After optimization, the model is compiled for deployment on the Qualcomm NPU using the ONNX Runtime QNNExecutionProvider. The process includes the following steps:
+
+1. **Split the Quantized Model**: Divide the model into three parts: embedding layer, transformer layers, and language model head.
+2. **Fix Static Input Shape for Transformer Layers**: Set static input shapes for transformer layers—(1, 64) for prefill (batch size, sequence length) and (1, 1) for token generation.
+3. **Compile with ONNX Runtime QNNExecutionProvider**: Use the QNNExecutionProvider to compile the model with weight sharing.
+
+## Summary of Key Steps
+
+- **Model Quantization**: Apply 4-bit weight-only and 16-bit activation quantization.
+- **Prefill and Token Generation Optimization**: Create two instances of the model to handle dynamic and static input shapes.
+- **Deployment on Qualcomm NPU**: Use ONNX Runtime QNNExecutionProvider for AOT compilation.
+
+This approach ensures efficient execution on Qualcomm NPUs, optimizing memory and computational resources for text generation tasks.
+
+## Requirements
+
+The optimization process requires several computationally intensive quantization steps, and therefore demands GPU resources. In an x64 Python environment with olive-ai installed, the following packages are required:
+
+```bash
+# Common requirements
+pip install -r requirements.txt
+
+# ONNX Runtime packages
+pip install "onnxruntime-gpu>=1.21.0" "onnxruntime-genai-cuda>=0.6.0"
+
+# AutoGPTQ: Install from source (stable package may be slow for weight packing)
+BUILD_CUDA_EXT=0 pip install -vvv --no-build-isolation git+https://github.com/PanQiWei/AutoGPTQ.git
+```
+
+For AOT compilation, the latest nightly x64 build of onnxruntime-qnn is required. In a separate Python environment with olive-ai installed, the following packages are required:
+
+```bash
+# Common requirements
+pip install -r requirements.txt
+
+# ONNX Runtime packages
+# Note: Only Windows AMD64 package is available in this feed; contact the team for the Linux x64 package
+pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
+pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+```
+
+## Usage
+
+The entire workflow is configured via the [phi3_5_config.json](phi3_5_config.json) file. Update the `/path/to/qnn/env/bin` in the config file to point to the Python environment where `onnxruntime-qnn` is installed.
+
+To begin the optimization process, run the following command in the first Python environment:
+
+```bash
+olive run --config phi3_5_config.json
+```
+
+The optimization process will take some time to complete. Once finished, the optimized model will be saved in the `models` directory.
+
+*Note*: If the optimization process fails silently during the context binary generation step, simply rerun the command. The process will resume from the last completed step.

--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -22,7 +22,9 @@ The model optimization process includes the following steps:
 2. **4-bit Per-Channel Symmetric Quantization with [GPTQ](https://arxiv.org/abs/2210.17323)**: Applies weight-only quantization (4-bit) to the transformer linear layers to reduce model size.
 3. **ONNX Graph Capture**: Captures the ONNX graph for subsequent optimizations.
 4. **4-bit Block-wise Quantization**: Quantizes the embedding layer and the language modeling head using weight-only 4-bit quantization.
-5. **16-bit Activation Quantization**: Uses the [ONNX Runtime Quantizer Tool](https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html) to quantize activations to 16-bits for improved model efficiency.
+5. **16-bit Activation Quantization**: Quantize activations to 16-bits, balancing efficiency and precision.
+
+The resulting model is a quantized QDQ (Quantize-Dequantize) model with 4-bit weights and 16-bit activations.
 
 ## Handling Dynamic and Static Input Shapes
 
@@ -41,7 +43,7 @@ To optimize resource usage:
 - **Transformer Layers**: These layers are executed on the NPU, which requires static input shapes.
 - **Weight Sharing**: The prefill and token generation models share weights (with different input shapes), minimizing memory usage.
 
-Additionally, we use **[GroupQueryAttention](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.GroupQueryAttention)** to enable dynamic key-value caching, which supports long-context processing and generation during text tasks.
+Additionally, we use **[GroupQueryAttention](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.GroupQueryAttention)** to enable dynamic key-value caching, which supports long-context processing and token generation.
 
 ## Compilation for NPU Deployment
 
@@ -53,7 +55,7 @@ After optimization, the model is compiled for deployment on the Qualcomm NPU usi
 
 ## Summary of Key Steps
 
-- **Model Quantization**: Apply 4-bit weight-only and 16-bit activation quantization.
+- **Model Quantization**: Apply 4-bit weight and 16-bit activation quantization.
 - **Prefill and Token Generation Optimization**: Create two instances of the model to handle dynamic and static input shapes.
 - **Deployment on Qualcomm NPU**: Use ONNX Runtime QNNExecutionProvider for AOT compilation.
 
@@ -61,7 +63,7 @@ This approach ensures efficient execution on Qualcomm NPUs, optimizing memory an
 
 ## Requirements
 
-The optimization process requires several computationally intensive quantization steps, and therefore demands GPU resources. In an x64 Python environment with olive-ai installed, the following packages are required:
+The optimization process requires several computationally intensive quantization steps, and therefore demands GPU resources. In an [x64 Python environment with olive-ai installed](https://github.com/microsoft/Olive/tree/main/examples#important), the following packages are required:
 
 ```bash
 # Common requirements
@@ -81,7 +83,7 @@ For AOT compilation, the latest nightly x64 build of onnxruntime-qnn is required
 pip install -r requirements.txt
 
 # ONNX Runtime packages
-# Note: Only Windows AMD64 package is available in this feed; contact the team for the Linux x64 package
+# Note: Only Windows x64 package is available in this feed; contact the team for the Linux x64 package
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
 pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
 ```

--- a/examples/phi3_5/phi3_5_config.json
+++ b/examples/phi3_5/phi3_5_config.json
@@ -1,0 +1,83 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "microsoft/Phi-3.5-mini-instruct" },
+    "systems": {
+        "local_cuda_system": { "type": "LocalSystem" },
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [ { "execution_providers": [ "QNNExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "wikitext2_train",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": {
+                "strategy": "line-by-line",
+                "add_special_tokens": false,
+                "max_samples": 128,
+                "max_seq_len": 512
+            }
+        }
+    ],
+    "passes": {
+        "q": { "type": "QuaRot" },
+        "g": { "type": "GptqQuantizer", "sym": true, "group_size": -1 },
+        "cs": { "type": "CaptureSplitInfo", "num_splits": 4, "unique_embeds_lm_head_splits": true },
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_accuracy_level": 4,
+            "int4_op_types_to_quantize": [ "MatMul", "Gather" ],
+            "save_as_external_data": true
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "nodes_to_exclude": [ "/lm_head/MatMul_Q4" ],
+            "save_as_external_data": true
+        },
+        "gs": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "AttentionMaskToSequenceLengths" },
+                { "surgeon": "SimplifiedLayerNormToL2Norm" }
+            ],
+            "save_as_external_data": true
+        },
+        "sq": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "wikitext2_train",
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8",
+            "calibration_providers": [ "CUDAExecutionProvider" ],
+            "prepare_qnn_config": true,
+            "quant_preprocess": true,
+            "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
+            "save_as_external_data": true
+        },
+        "sp": { "type": "SplitModel" },
+        "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_graph_finalization_optimization_mode": "3",
+                "soc_model": "60",
+                "htp_arch": "73",
+                "vtcm_mb": "8"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "host": "local_cuda_system",
+    "target": "qnn_system",
+    "log_severity_level": 0,
+    "output_dir": "models",
+    "cache_dir": "cache",
+    "no_artifacts": true
+}

--- a/examples/phi3_5/requirements.txt
+++ b/examples/phi3_5/requirements.txt
@@ -1,0 +1,3 @@
+datasets
+torch
+transformers

--- a/examples/utils/generator.py
+++ b/examples/utils/generator.py
@@ -8,6 +8,7 @@ import numpy as np
 import onnx
 from kv_cache_utils import DynamicCache, DynamicIOBoundCache, GQASharedCache, StaticCache, StaticIOBoundCache
 from onnxruntime import InferenceSession, OrtValue, SessionOptions, set_default_logger_severity
+from tqdm import tqdm
 from transformers import PreTrainedTokenizer
 
 from olive.common.utils import StrEnumBase, load_weights
@@ -124,6 +125,11 @@ class ORTGenerator:
     def use_position_ids(self) -> bool:
         """Whether the model has position ids."""
         return "position_ids" in self.input_info
+
+    @property
+    def use_past_seq_len(self) -> bool:
+        """Whether the model has past sequence length."""
+        return "past_seq_len" in self.input_info
 
     @staticmethod
     def prepare_sessions(
@@ -264,7 +270,7 @@ class ORTGenerator:
 
         # buffers to keep numpy copy of model inputs, don't want to keep going back and forth between OrtValue and numpy
         np_buffers = {
-            "attention_mask": (inputs["attention_mask"].numpy() if use_io_binding else inputs["attention_mask"].copy())
+            "attention_mask": inputs["attention_mask"].numpy() if use_io_binding else inputs["attention_mask"].copy()
         }
         if self.use_position_ids:
             np_buffers["position_ids"] = (
@@ -274,13 +280,14 @@ class ORTGenerator:
                 .astype(self.input_info["position_ids"]["dtype"])
             )
 
-        for idx in range(max_gen_len):
+        for idx in tqdm(range(max_gen_len)):
+            used_inputs = {k: v for k, v in inputs.items() if k in self.input_info}
             if use_io_binding:
                 if idx < 2:
                     # need to bind logits twice, once for prompt processing and once for token generation
                     # shapes: (batch_size, prompt_length, vocab_size) and (batch_size, 1, vocab_size)
                     io_binding.bind_output("logits", self.device, self.device_id)
-                for k, v in inputs.items():
+                for k, v in used_inputs.items():
                     io_binding.bind_ortvalue_input(k, v)
                 cache.bind_kv_io(io_binding)
 
@@ -291,7 +298,7 @@ class ORTGenerator:
                 outputs = io_binding.get_outputs()
                 logits = outputs[0].numpy()
             else:
-                outputs = session.run(None, {**inputs, **cache.get_kv_inputs()})
+                outputs = session.run(None, {**{used_inputs}, **cache.get_kv_inputs()})
                 logits = outputs[0]
 
             # Decide the next token using your preferred sampling strategy.
@@ -377,6 +384,16 @@ class ORTGenerator:
                 # GQA, or static during token generation
                 inputs["attention_mask"].update_inplace(np_buffers["attention_mask"])
 
+            if self.use_past_seq_len:
+                past_seq_len = (np_buffers["attention_mask"].sum(-1, keepdims=True) - 1).astype(np.int32)
+                total_seq_len = np.array(np_buffers["attention_mask"].shape[1], dtype=np.int32)
+                if use_io_binding:
+                    inputs["past_seq_len"].update_inplace(past_seq_len)
+                    inputs["total_seq_len"].update_inplace(total_seq_len)
+                else:
+                    inputs["past_seq_len"] = past_seq_len
+                    inputs["total_seq_len"] = total_seq_len
+
             # update cache
             cache.update(outputs[1:])
         if use_io_binding:
@@ -418,7 +435,9 @@ class ORTGenerator:
         encodings_dict = self.tokenizer(prompt, return_tensors="np", padding=True)
         input_ids = encodings_dict["input_ids"].astype(self.input_info["input_ids"]["dtype"])
         batch_size, prompt_length = input_ids.shape
-        attention_mask = encodings_dict["attention_mask"].astype(self.input_info["attention_mask"]["dtype"])
+        attention_mask = encodings_dict["attention_mask"]
+        if "attention_mask" in self.input_info:
+            attention_mask = attention_mask.astype(self.input_info["attention_mask"]["dtype"])
 
         cache = self.get_fresh_cache(batch_size, use_io_binding, cache_type, max_cache_len, cache_backend)
         if isinstance(cache, GQASharedCache):
@@ -431,6 +450,9 @@ class ORTGenerator:
             position_ids = np.arange(prompt_length, dtype=np.int64).reshape((1, prompt_length))
             position_ids = np.broadcast_to(position_ids, (batch_size, prompt_length))
             inputs["position_ids"] = position_ids.astype(self.input_info["position_ids"]["dtype"])
+        if self.use_past_seq_len:
+            inputs["past_seq_len"] = (attention_mask.sum(-1, keepdims=True) - 1).astype(np.int32)
+            inputs["total_seq_len"] = np.array(attention_mask.shape[1], dtype=np.int32)
         if use_io_binding:
             inputs = {k: OrtValue.ortvalue_from_numpy(v, self.device, self.device_id) for k, v in inputs.items()}
         return inputs, cache

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -115,6 +115,7 @@ class LLMAugmentedDataLoader:
         self.calibration_providers = calibration_providers
 
         self.position_ids = "position_ids" in self.io_config["input_names"]
+        self.past_seq_len = "past_seq_len" in self.io_config["input_names"]
         self.kv_info = self.get_kv_info(self.io_config)
         self.has_gqa = False
         for node in onnx.load(self.model_path, load_external_data=False).graph.node:
@@ -154,10 +155,6 @@ class LLMAugmentedDataLoader:
                 label = None
             assert isinstance(batch, dict), "Only support dict type batch data"
 
-            if self.position_ids and "position_ids" not in batch:
-                # create position ids from attention mask
-                batch["position_ids"] = self.get_position_ids(batch["input_ids"], batch["attention_mask"])
-
             if self.kv_info and self.kv_info["past_names"][0] not in batch:
                 # GQA: use all tokens for prefill
                 # No GQA: use all - 1 tokens for prefill, last token for decode
@@ -176,8 +173,7 @@ class LLMAugmentedDataLoader:
                     "attention_mask": attention_mask[:, prefill_slice],
                     **self.get_empty_kv_cache(batch["input_ids"].shape[0], self.kv_info, self.has_gqa),
                 }
-                if self.position_ids:
-                    prefill_batch["position_ids"] = batch["position_ids"][:, prefill_slice]
+                self.add_extra_inputs(prefill_batch)
 
                 prefill_label = (
                     label[:, prefill_slice]
@@ -201,8 +197,7 @@ class LLMAugmentedDataLoader:
                     "attention_mask": attention_mask,
                     **{v: session_outputs[k] for k, v in self.kv_info["present_to_past"].items()},
                 }
-                if self.position_ids:
-                    decode_batch["position_ids"] = batch["position_ids"][:, -1:]
+                self.add_extra_inputs(decode_batch)
 
                 decode_label = (
                     label[:, -1:]
@@ -214,6 +209,7 @@ class LLMAugmentedDataLoader:
                 if progress_bar:
                     progress_bar.update(1)
             else:
+                self.add_extra_inputs(batch)
                 yield batch, label
                 if progress_bar:
                     progress_bar.update(1)
@@ -228,17 +224,23 @@ class LLMAugmentedDataLoader:
         self._session = InferenceSession(self.model_path, providers=self.calibration_providers)
         return self._session
 
-    @staticmethod
-    def get_position_ids(input_ids: torch.tensor, attention_mask: torch.tensor) -> torch.tensor:
-        """Return the position ids for the input ids based on the attention mask.
+    def add_extra_inputs(self, batch: Dict[str, torch.Tensor]):
+        """Add extra inputs to the batch.
 
-        :param input_ids: A tensor of input ids.
-        :param attention_mask: A tensor of attention masks.
-        :return: A tensor of position ids.
+        :param batch: A dictionary containing the batch data.
+        :return: The updated batch with extra inputs added.
         """
-        # position ids correspond to input ids
-        # attention mask past + current tokens
-        return (attention_mask.cumsum(-1) - 1)[:, -input_ids.shape[-1] :]
+        attention_mask = batch["attention_mask"]
+        if self.position_ids and "position_ids" not in batch:
+            # position ids: current tokens
+            # attention mask: past + current tokens
+            batch["position_ids"] = (attention_mask.cumsum(-1) - 1)[:, -batch["input_ids"].shape[-1] :]
+        if self.past_seq_len and "past_seq_len" not in batch:
+            # past seq len: past tokens
+            # attention mask: past + current tokens
+            batch["past_seq_len"] = attention_mask.sum(-1, keepdim=True) - 1
+            batch["total_seq_len"] = torch.tensor(attention_mask.shape[-1])
+            del batch["attention_mask"]
 
     @staticmethod
     def get_kv_info(io_config: Dict) -> Optional[Dict]:

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -230,6 +230,10 @@ class LLMAugmentedDataLoader:
         :param batch: A dictionary containing the batch data.
         :return: The updated batch with extra inputs added.
         """
+        if "attention_mask" not in batch:
+            # no attention mask
+            return
+
         attention_mask = batch["attention_mask"]
         if self.position_ids and "position_ids" not in batch:
             # position ids: current tokens

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -30,7 +30,8 @@
             "supported_accelerators": [ "npu" ],
             "supported_precisions": [ "*" ],
             "supported_algorithms": [  ],
-            "supported_quantization_encodings": [  ]
+            "supported_quantization_encodings": [  ],
+            "run_on_target": true
         },
         "ExtractAdapters": {
             "module_path": "olive.passes.onnx.extract_adapters.ExtractAdapters",

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -244,15 +244,13 @@ def get_context_bin_file_names(model_path: Union[str, Path]) -> List[str]:
 def copy_context_bin_files(
     model_path: Union[str, Path],
     model_dir: Union[str, Path],
-    saved_cb_files: Dict[str, str],
-    ignore_missing_cb_bin: bool = False,
+    saved_cb_files: Optional[Dict[str, str]] = None,
 ) -> bool:
     """Copy the context binary files to the model directory.
 
     :param model_path: Path to the original model file.
     :param model_dir: Directory to save the copied context binary files.
     :param saved_cb_files: A dictionary of original file paths to new file names for context binary files.
-    :param ignore_missing_cb_bin: If True, ignore missing context binary files.
     :return: True if the model has context binary files, False otherwise.
     """
     saved_cb_files = {} if saved_cb_files is None else saved_cb_files
@@ -265,9 +263,6 @@ def copy_context_bin_files(
     cb_file_names = get_context_bin_file_names(model_path)
     for cb_file_name in cb_file_names:
         cb_file_path = str(model_path.parent / cb_file_name)
-        if not Path(cb_file_path).exists() and ignore_missing_cb_bin:
-            # happens when weight sharing is enabled but hasn't been stopped yet
-            continue
         if cb_file_path in saved_cb_files:
             continue
         elif cb_file_name in saved_cb_files.values():
@@ -286,7 +281,6 @@ def resave_model(
     new_model_path: Union[str, Path],
     force_external_data: bool = False,
     saved_external_files: Optional[Dict[str, str]] = None,
-    ignore_missing_cb_bin: bool = False,
 ) -> bool:
     """Resave the model along with external data files.
 
@@ -297,7 +291,6 @@ def resave_model(
         Reuse the same file name if the the original file path is already in the dictionary.
         Else, the new file name will be <new_model_path>.data and this dictionary will be updated with the new
         file name.
-    :param ignore_missing_cb_bin: If True, ignore missing context binary files.
     :return: True if the model has external data, False otherwise.
     """
     saved_external_files = {} if saved_external_files is None else saved_external_files
@@ -308,12 +301,7 @@ def resave_model(
     new_model_path.parent.mkdir(parents=True, exist_ok=True)
 
     # copy over context binary files
-    has_cb_files = copy_context_bin_files(
-        model_path,
-        new_model_path.parent,
-        saved_cb_files=saved_external_files,
-        ignore_missing_cb_bin=ignore_missing_cb_bin,
-    )
+    has_cb_files = copy_context_bin_files(model_path, new_model_path.parent, saved_cb_files=saved_external_files)
 
     external_file_names = get_external_data_file_names(model_path)
 

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -603,15 +603,18 @@ class RMSNormToL2Norm(Surgeon):
 
 
 class SimplifiedLayerNormToL2Norm(Surgeon):
-    """Replace Skip/SimplifiedLayerNormalization subgraph with L2Norm subgraph.
+    """Replace Skip/SimplifiedLayerNormalization node with L2Norm subgraph.
 
     SimplifiedLayerNormalization is replaced with:
     [Root] --> LpNormalization --> Mul
                (p=2, axis=-1)
 
     SkipSimplifiedLayerNormalization is replaced with:
-    [Root] --> Add --> LpNormalization --> Mul
-                        (p=2, axis=-1)
+    [Root1] -------> Add
+                      |
+                      v
+    [Root2] --> LpNormalization --> Mul
+                (p=2, axis=-1)
 
     Second input to Mul is the weight of the layer norm multiplied by sqrt(N) where N is equal to the hidden size.
     If the weight is all 1s, it is replaced with a 1D array of sqrt(N).

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -67,6 +67,10 @@ class Surgeon:
                 return initializer
         return None
 
+    @staticmethod
+    def create_new_name(name: str, old_op: str, new_op: str) -> str:
+        return name.replace(old_op, new_op) if old_op in name else f"{name}_{new_op}"
+
 
 class RenameInputs(Surgeon):
     def __init__(self, old_names: List[str], new_names: List[str]):
@@ -473,7 +477,7 @@ class RMSNormToL2Norm(Surgeon):
     [Root] --> LpNormalization --> Mul
                 (p=2, axis=-1)
 
-    Where the weight of the Mul node is multiplied by sqrt(N) where N is equal to the reduced axis size.
+    The weight of the Mul node is multiplied by sqrt(N) where N is equal to the reduced axis size.
     If the weight is all 1s, it is replaced with a 1D array of sqrt(N).
     """
 
@@ -497,11 +501,8 @@ class RMSNormToL2Norm(Surgeon):
             graph_idx = dag.get_graph_idx(node_name)
 
             # name for the new L2Norm node
-            l2norm_node_name = node_name.replace("Pow", "L2Norm") if "Pow" in node_name else f"{node_name}_L2Norm"
-            node_output_name = dag.get_node_outputs(node_name)[0]
-            l2norm_node_output_name = (
-                node_output_name.replace("Pow", "L2Norm") if "Pow" in node_output_name else f"{node_output_name}_L2Norm"
-            )
+            l2norm_node_name = self.create_new_name(node_name, "Pow", "L2Norm")
+            l2norm_node_output_name = f"{l2norm_node_name}_output_0"
 
             # create L2Norm node
             l2norm_node = onnx.helper.make_node(
@@ -521,6 +522,12 @@ class RMSNormToL2Norm(Surgeon):
                 logger.debug("RMSNorm Pattern does not end with Cast or Mul. Found %s", final_node_children)
                 continue
             final_node_output_name = dag.get_node_outputs(final_node_name)[0]
+            # add value info for the new L2Norm node output
+            if final_node_output_vi := dag.get_value_info_proto(final_node_output_name):
+                l2norm_node_output_vi = onnx.ValueInfoProto()
+                l2norm_node_output_vi.CopyFrom(final_node_output_vi)
+                l2norm_node_output_vi.name = l2norm_node_output_name
+                dag.add_value_info(l2norm_node_output_vi, graph_idx)
 
             # Get the weight Mul node
             if dag.get_node_op_type(final_node_children[0]) == "Mul":
@@ -593,6 +600,261 @@ class RMSNormToL2Norm(Surgeon):
                 break
 
         return rmsnorm_nodes if len(rmsnorm_nodes) >= (len(pattern) - 1) else []
+
+
+class SimplifiedLayerNormToL2Norm(Surgeon):
+    """Replace Skip/SimplifiedLayerNormalization subgraph with L2Norm subgraph.
+
+    SimplifiedLayerNormalization is replaced with:
+    [Root] --> LpNormalization --> Mul
+               (p=2, axis=-1)
+
+    SkipSimplifiedLayerNormalization is replaced with:
+    [Root] --> Add --> LpNormalization --> Mul
+                        (p=2, axis=-1)
+
+    Second input to Mul is the weight of the layer norm multiplied by sqrt(N) where N is equal to the hidden size.
+    If the weight is all 1s, it is replaced with a 1D array of sqrt(N).
+    """
+
+    def __init__(self):
+        pass
+
+    def __call__(self, model: ModelProto):
+        dag = OnnxDAG(model)
+
+        modified = 0
+        for node_name in dag.get_node_names():
+            op_type = dag.get_node_op_type(node_name)
+            if op_type not in {"SimplifiedLayerNormalization", "SkipSimplifiedLayerNormalization"}:
+                continue
+
+            if len(dag.get_node_inputs(node_name, True)) != 2 + int(op_type == "SkipSimplifiedLayerNormalization"):
+                # SimplifiedLayerNormalization: X, scale supported
+                # SkipSimplifiedLayerNormalization: input, skip, gamma supported
+                continue
+            if len(dag.get_node_outputs(node_name, True)) > 1 + int(op_type == "SkipSimplifiedLayerNormalization"):
+                # SimplifiedLayerNormalization: output supported
+                # SkipSimplifiedLayerNormalization: output, input_skip_bias_sum (optional) supported
+                continue
+
+            graph_idx = dag.get_graph_idx(node_name)
+
+            if op_type == "SkipSimplifiedLayerNormalization":
+                # SimplifiedLayerNormalization preceded by an Add node
+                add_node_name = self.create_new_name(node_name, op_type, "Add")
+                add_node_output_name = f"{add_node_name}_output_0"
+                dag.add_node(
+                    onnx.helper.make_node(
+                        "Add",
+                        inputs=dag.get_node_inputs(node_name, True)[:2],
+                        outputs=[add_node_output_name],
+                        name=add_node_name,
+                    ),
+                    graph_idx,
+                )
+
+                # input_skip_bias_sum is used downstream
+                if len(dag.get_node_outputs(node_name, True)) == 2:
+                    skip_output_name = dag.get_node_outputs(node_name, True)[1]
+                    if skip_output_vi := dag.get_value_info_proto(skip_output_name):
+                        add_output_vi = onnx.ValueInfoProto()
+                        add_output_vi.CopyFrom(skip_output_vi)
+                        add_output_vi.name = add_node_output_name
+                        dag.add_value_info(add_output_vi, graph_idx)
+
+                    for child_name in dag.get_consumers(skip_output_name):
+                        dag.replace_node_input(child_name, skip_output_name, add_node_output_name)
+
+                l2norm_node_input_name = add_node_output_name
+            else:
+                l2norm_node_input_name = dag.get_node_inputs(node_name, True)[0]
+
+            layernorm_node_output_name = dag.get_node_outputs(node_name, True)[0]
+
+            # add L2Norm node
+            l2norm_node_name = self.create_new_name(node_name, op_type, "L2Norm")
+            l2norm_node_output_name = f"{l2norm_node_name}_output_0"
+            dag.add_node(
+                onnx.helper.make_node(
+                    "LpNormalization",
+                    inputs=[l2norm_node_input_name],
+                    outputs=[l2norm_node_output_name],
+                    name=l2norm_node_name,
+                    axis=-1,
+                    p=2,
+                ),
+                graph_idx,
+            )
+            if layernorm_node_output_vi := dag.get_value_info_proto(layernorm_node_output_name):
+                l2norm_node_output_vi = onnx.ValueInfoProto()
+                l2norm_node_output_vi.CopyFrom(layernorm_node_output_vi)
+                l2norm_node_output_vi.name = l2norm_node_output_name
+                dag.add_value_info(l2norm_node_output_vi, graph_idx)
+
+            # add Mul node
+            mul_weight_name = dag.get_node_inputs(node_name, True)[-1]
+            mul_weight = dag.get_initializer_np_array(mul_weight_name)
+            sqrt_n = np.sqrt(mul_weight.shape[-1])
+            if np.all(mul_weight == 1):
+                # this is possible in a quarot/spinquant rotated model
+                # Multiplying by 1D is probably faster
+                mul_weight = np.array([1], dtype=mul_weight.dtype)
+            mul_weight = sqrt_n * mul_weight
+            dag.replace_initializer(onnx.numpy_helper.from_array(mul_weight, name=mul_weight_name))
+
+            mul_node_name = self.create_new_name(node_name, op_type, "Mul")
+            mul_node_output_name = f"{mul_node_name}_output_0"
+            dag.add_node(
+                onnx.helper.make_node(
+                    "Mul",
+                    inputs=[l2norm_node_output_name, mul_weight_name],
+                    outputs=[mul_node_output_name],
+                    name=mul_node_name,
+                ),
+                graph_idx,
+            )
+            if layernorm_node_output_vi := dag.get_value_info_proto(layernorm_node_output_name):
+                mul_output_vi = onnx.ValueInfoProto()
+                mul_output_vi.CopyFrom(layernorm_node_output_vi)
+                mul_output_vi.name = mul_node_output_name
+                dag.add_value_info(mul_output_vi, graph_idx)
+
+            for child_name in dag.get_consumers(layernorm_node_output_name):
+                dag.replace_node_input(child_name, layernorm_node_output_name, mul_node_output_name)
+
+            # remove node
+            dag.remove_node(node_name)
+
+            modified += 1
+
+        if modified > 0:
+            logger.debug("Replaced %d Skip/SimplifiedLayerNormalization nodes with L2Norm nodes", modified)
+
+        dag.update()
+        return dag.model
+
+
+class RemoveRopeMultiCache(Surgeon):
+    """Remove the multi rope cache from the model."""
+
+    def __init__(self, use_large_cache: bool = False):
+        self.use_large_cache = use_large_cache
+
+    def __call__(self, model: ModelProto):
+        dag = OnnxDAG(model)
+
+        supported_consumer_ops = {"GroupQueryAttention", "RotaryEmbedding"}
+        if not supported_consumer_ops.intersection(set(dag.get_node_op_types())):
+            return dag.model
+
+        # get the first GQA/RotaryEmbedding node
+        first_node = None
+        for node in dag.get_node_names():
+            op_type = dag.get_node_op_type(node)
+            if op_type in supported_consumer_ops:
+                first_node = node
+                break
+        first_node_inputs = dag.get_node_inputs(first_node)
+
+        # check if the GQA node has cos_cache and sin_cache inputs
+        if dag.get_node_op_type(first_node) == "GroupQueryAttention" and len(first_node_inputs) != 9:
+            return dag.model
+
+        # check if cos_cache and sin_cache come from an If node
+        cache_names = {"cos_cache": first_node_inputs[-2], "sin_cache": first_node_inputs[-1]}
+        for cache_name in cache_names.values():
+            if dag.is_input(cache_name) or dag.is_initializer(cache_name):
+                return dag.model
+            if dag.get_node_op_type(dag.get_producer(cache_name)) != "If":
+                return dag.model
+
+        for key, cache_name in cache_names.items():
+            cache_to_use = f"{key}_large" if self.use_large_cache else f"{key}_small"
+            new_cache_name = f"{key}_single"
+
+            if dag.is_initializer(cache_to_use):
+                cache_initializer = onnx.TensorProto()
+                cache_initializer.CopyFrom(dag.get_initializer_proto(cache_to_use))
+                cache_initializer.name = new_cache_name
+            else:
+                cache_producer_name = dag.get_producer(cache_to_use)
+                assert dag.get_node_op_type(cache_producer_name) == "Constant"
+                cache_value = onnx.numpy_helper.to_array(
+                    onnx.helper.get_attribute_value(dag.get_node_proto(cache_producer_name).attribute[0])
+                )
+                cache_initializer = onnx.numpy_helper.from_array(cache_value, new_cache_name)
+
+            dag.add_initializer(cache_initializer, 0)
+            for consumer in dag.get_consumers(cache_name):
+                dag.replace_node_input(consumer, cache_name, new_cache_name)
+
+        # remove the Greater -> If Nodes
+        if_node_name = dag.get_producer(cache_names["cos_cache"])
+        greater_node_name = dag.get_parents(if_node_name)[0]
+        dag.remove_node(if_node_name)
+        dag.remove_node(greater_node_name)
+
+        logger.debug("Removed rope multi cache")
+
+        dag.update()
+        return dag.model
+
+
+class AttentionMaskToSequenceLengths(Surgeon):
+    """Replace attention_mask subgraph in GQA model with past_seq_len and total_seq_len."""
+
+    def __init__(self):
+        pass
+
+    def __call__(self, model: ModelProto):
+        dag = OnnxDAG(model)
+
+        if "GroupQueryAttention" not in dag.get_node_op_types():
+            return dag.model
+
+        # get first GQA node
+        first_node = None
+        for node in dag.get_node_names():
+            if dag.get_node_op_type(node) == "GroupQueryAttention":
+                first_node = node
+                break
+        first_node_inputs = dag.get_node_inputs(first_node)
+
+        seq_len_names = {"past_seq_len": first_node_inputs[5], "total_seq_len": first_node_inputs[6]}
+        # check that both are not already inputs
+        for seq_len_name in seq_len_names.values():
+            if dag.is_input(seq_len_name):
+                return dag.model
+
+        batch_size, _ = dag.get_io_shape("input_ids")
+        seq_len_shapes = {"past_seq_len": [batch_size, 1], "total_seq_len": []}
+        for key, seq_len_name in seq_len_names.items():
+            input_proto = onnx.helper.make_tensor_value_info(key, onnx.TensorProto.INT32, seq_len_shapes[key])
+            dag.add_input(input_proto, 0)
+            for node in dag.get_consumers(seq_len_name):
+                dag.replace_node_input(node, seq_len_name, key)
+
+        # remove attention mask subgraph
+        nodes_to_remove = []
+        visit_stack = dag.get_consumers("attention_mask")
+        while visit_stack:
+            node = visit_stack.pop(0)
+            assert not dag.is_output_producer(node), "Unexpected graph structure"
+            for consumer in dag.get_consumers(node):
+                if dag.get_node_op_type(consumer) == "GroupQueryAttention":
+                    for node_o in dag.get_node_outputs(node):
+                        assert dag.get_node_inputs(consumer).index(node_o) in {5, 6}, "Rope multi cache not supported"
+                    continue
+                visit_stack.append(consumer)
+            nodes_to_remove.append(node)
+        for node in nodes_to_remove[::-1]:
+            dag.remove_node(node)
+
+        logger.debug("atttention mask replaced with sequence length inputs")
+
+        dag.update()
+        return dag.model
 
 
 class ReplaceAttentionMaskValue(Surgeon):

--- a/olive/passes/onnx/onnx_dag.py
+++ b/olive/passes/onnx/onnx_dag.py
@@ -405,12 +405,18 @@ class OnnxDAG:
 
         # remove node from the connections
         for i in node.inputs:
+            if i == "":
+                # some nodes have unnamed, unused inputs
+                continue
             self.ios[i].destination.remove(node_name)
             parent = self.ios[i].source
             if parent not in [SpecialInput.INPUT, SpecialInput.INITIALIZER]:
                 self.connections[parent].remove(node_name)
 
         for o in node.outputs:
+            if o == "":
+                # some nodes have unnamed, unused outputs
+                continue
             del self.ios[o]
 
         del self.connections[node_name]

--- a/olive/passes/onnx/split.py
+++ b/olive/passes/onnx/split.py
@@ -233,6 +233,10 @@ class SplitModel(Pass):
         component_models = []
         component_names = []
         for i, split_dag in enumerate(split_dags):
+            if not split_dag.get_node_names():
+                # no nodes got assigned to this split
+                logger.debug("Skipping empty split %d", i)
+                continue
             split_name = f"split_{i}"
             split_dir = Path(output_model_path).with_suffix("") / split_name
             split_path = resolve_onnx_path(split_dir, f"{split_name}.onnx")

--- a/olive/systems/accelerator_creator.py
+++ b/olive/systems/accelerator_creator.py
@@ -176,6 +176,11 @@ class AcceleratorNormalizer:
                     eps.append(ep)
 
             # remove the unsupported execution providers
+            if not self.skip_supported_eps_check and not eps:
+                raise ValueError(
+                    f"None of the execution providers {accelerator.execution_providers} cannot be found in the target"
+                    " system but at least one is required to run the workflow."
+                )
             accelerator.execution_providers = eps or ["CPUExecutionProvider"]
 
         if ep_not_supported:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ ignore = [
   "N999", # Module names
   "NPY002", # np.random.Generator may not always fit our use cases
   "PERF203", # "try-except-in-loop" only affects Python <3.11, and the improvement is minor; can have false positives
+  "PGH004", # used to make ruff ignore the file
   "PLW0603", # TODO: temp disable global variable check
   "PT004", # Ignore pytest fixture name
   "PT019", # Ignore pytest fixture name

--- a/test/unit_test/data_container/test_dataloader.py
+++ b/test/unit_test/data_container/test_dataloader.py
@@ -13,7 +13,7 @@ from olive.passes.olive_pass import create_pass_from_dict
 
 
 @pytest.mark.parametrize("use_gqa", [True, False])
-def test_llm_augmeted_dataloader(tmp_path, use_gqa):
+def test_llm_augmented_dataloader(tmp_path, use_gqa):
     pytorch_model = make_local_tiny_llama(tmp_path)
     if use_gqa:
         from olive.passes.onnx.model_builder import ModelBuilder

--- a/test/unit_test/passes/onnx/test_context_binary.py
+++ b/test/unit_test/passes/onnx/test_context_binary.py
@@ -95,7 +95,13 @@ def test_ep_context_binary_generator_composite(tmp_path, is_llm):
     assert isinstance(output_model, CompositeModelHandler)
     output_component_map = dict(output_model.get_model_components())
     assert len(output_component_map) == len(component_models)
-    assert output_model.model_attributes == model_attributes
+    if is_llm:
+        assert output_model.model_attributes["llm_pipeline"] == {
+            "embeddings": "embeddings",
+            "context": ["component_0_ctx", "component_1_ctx"],
+            "iterator": ["component_2_ctx", "component_3_ctx"],
+            "lm_head": "lm_head",
+        }
     for name in component_names:
         # print(output_component_map[name].model_path)
         is_skipped = name in ["embeddings", "lm_head"]

--- a/test/unit_test/passes/onnx/test_graph_surgeries.py
+++ b/test/unit_test/passes/onnx/test_graph_surgeries.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import json
 from pathlib import Path
+from test.unit_test.utils import make_local_tiny_llama
 
 import numpy as np
 import onnx
@@ -618,7 +619,7 @@ def test_attention_mask_to_sequence_lengths(tmp_path):
         ModelBuilder,
         {"precision": "fp32"},
         disable_search=True,
-    ).run(HfModelHandler("katuni4ka/tiny-random-phi3"), str(tmp_path / "onnx"))
+    ).run(make_local_tiny_llama(tmp_path), str(tmp_path / "onnx"))
 
     output_folder = str(tmp_path / "output")
     p = create_pass_from_dict(

--- a/test/unit_test/passes/onnx/test_graph_surgeries.py
+++ b/test/unit_test/passes/onnx/test_graph_surgeries.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 from pathlib import Path
 
 import numpy as np
@@ -11,9 +12,10 @@ import torch
 from onnx import TensorProto, helper, numpy_helper
 from onnxruntime import InferenceSession
 
-from olive.model.handler.onnx import ONNXModelHandler
+from olive.model import HfModelHandler, ONNXModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.graph_surgeries import GraphSurgeries
+from olive.passes.onnx.model_builder import ModelBuilder
 from olive.passes.onnx.onnx_dag import OnnxDAG
 
 
@@ -377,6 +379,47 @@ class RMSNorm(torch.nn.Module):
         return self.weight * (hidden_states.to(input_dtype) if self.use_cast else hidden_states)
 
 
+def check_l2norm(
+    original_model_path: str,
+    modified_model_path: str,
+    hidden_size: int,
+    expected_num_nodes: int,
+    check_all_ones: int,
+    has_skip: bool = False,
+):
+    # check output values match
+    input_session = InferenceSession(original_model_path)
+    output_session = InferenceSession(modified_model_path)
+    input_feed = {"x": np.random.randn(1, hidden_size).astype(np.float32)}
+    if has_skip:
+        input_feed["skip"] = np.random.randn(1, hidden_size).astype(np.float32)
+    input_result = input_session.run(None, input_feed)
+    output_result = output_session.run(None, input_feed)
+    for i_r, o_r in zip(input_result, output_result):
+        np.testing.assert_allclose(i_r, o_r, rtol=1e-3, atol=1e-3)
+
+    # count nodes
+    dag = OnnxDAG.from_model_path(modified_model_path)
+    assert len(dag.nodes) == expected_num_nodes
+    assert "LpNormalization" in dag.get_node_op_types()
+
+    # check all ones case
+    if check_all_ones:
+        mul_name = None
+        for node in dag.get_node_names():
+            if dag.get_node_op_type(node) == "Mul":
+                mul_name = node
+                break
+        mul_weight_name = None
+        for input_name in dag.get_node_inputs(mul_name):
+            if dag.is_initializer(input_name):
+                mul_weight_name = input_name
+                break
+        mul_weight = dag.get_initializer_np_array(mul_weight_name)
+        assert mul_weight.shape == (1,)
+        assert np.allclose(mul_weight, np.sqrt(hidden_size))
+
+
 @pytest.mark.parametrize("use_rsqrt", [True, False])
 @pytest.mark.parametrize("use_cast", [True, False])
 @pytest.mark.parametrize("all_ones", [True, False])
@@ -402,32 +445,196 @@ def test_rmsnorm_to_l2norm(tmp_path, use_rsqrt, use_cast, all_ones):
     onnx_model = p.run(input_model, output_folder)
 
     # assert
-    # check output values match
-    input_session = InferenceSession(input_model_path)
-    output_session = InferenceSession(onnx_model.model_path)
-    input_feed = {"x": np.random.randn(1, hidden_size).astype(np.float32)}
-    input_result = input_session.run(None, input_feed)
-    output_result = output_session.run(None, input_feed)
-    np.testing.assert_allclose(input_result[0], output_result[0], rtol=1e-3, atol=1e-3)
-    # count nodes
-    dag = OnnxDAG.from_model_path(onnx_model.model_path)
-    expected_num_nodes = 2 + 2 * int(use_cast)
-    assert len(dag.nodes) == expected_num_nodes
-    # check all ones case
-    if all_ones:
-        mul_name = None
-        for node in dag.get_node_names():
-            if dag.get_node_op_type(node) == "Mul":
-                mul_name = node
-                break
-        mul_weight_name = None
-        for input_name in dag.get_node_inputs(mul_name):
-            if dag.is_initializer(input_name):
-                mul_weight_name = input_name
-                break
-        mul_weight = dag.get_initializer_np_array(mul_weight_name)
-        assert mul_weight.shape == (1,)
-        assert np.allclose(mul_weight, np.sqrt(hidden_size))
+    check_l2norm(
+        str(input_model_path),
+        onnx_model.model_path,
+        hidden_size,
+        2 + 2 * int(use_cast),
+        all_ones,
+    )
+
+
+@pytest.mark.parametrize("all_ones", [True, False])
+def test_simplifiedlayernorm_to_l2norm(tmp_path, all_ones):
+    # setup
+    hidden_size = 3
+    inputs = [
+        onnx.helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, hidden_size]),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, hidden_size]),
+    ]
+    weight = (np.ones(hidden_size) if all_ones else np.random.randn(hidden_size)).astype(np.float32)
+    initializers = [onnx.numpy_helper.from_array(weight, name="weight")]
+    nodes = [
+        onnx.helper.make_node(
+            "SimplifiedLayerNormalization",
+            inputs=["x", "weight"],
+            outputs=["layernorm_output"],
+            name="layernorm/LayerNorm",
+        ),
+        onnx.helper.make_node("Identity", inputs=["layernorm_output"], outputs=["y"], name="Identity"),
+    ]
+    graph = helper.make_graph(
+        nodes=nodes,
+        name="TestGraph",
+        inputs=inputs,
+        outputs=outputs,
+        initializer=initializers,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 20)])
+    onnx.save(model, str(tmp_path / "input_model.onnx"))
+    input_model = ONNXModelHandler(model_path=str(tmp_path / "input_model.onnx"))
+
+    output_folder = str(tmp_path / "output")
+    p = create_pass_from_dict(
+        GraphSurgeries,
+        {"surgeries": [{"surgeon": "SimplifiedLayerNormToL2Norm"}]},
+        disable_search=True,
+    )
+
+    # execute
+    onnx_model = p.run(input_model, output_folder)
+
+    # assert
+    check_l2norm(str(tmp_path / "input_model.onnx"), onnx_model.model_path, hidden_size, 3, all_ones)
+
+
+@pytest.mark.parametrize("all_ones", [True, False])
+@pytest.mark.parametrize("output_skip_sum", [True, False])
+def test_simplifiedlayernorm_to_l2norm_skip(tmp_path, all_ones, output_skip_sum):
+    # setup
+    hidden_size = 3
+    inputs = [
+        onnx.helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, hidden_size]),
+        onnx.helper.make_tensor_value_info("skip", TensorProto.FLOAT, [1, hidden_size]),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, hidden_size]),
+    ]
+    if output_skip_sum:
+        outputs.append(
+            onnx.helper.make_tensor_value_info("skip_sum", TensorProto.FLOAT, [1, hidden_size]),
+        )
+    initializers = [
+        onnx.numpy_helper.from_array(
+            (np.ones(hidden_size) if all_ones else np.random.randn(hidden_size)).astype(np.float32), name="weight"
+        )
+    ]
+    nodes = [
+        onnx.helper.make_node(
+            "SkipSimplifiedLayerNormalization",
+            inputs=["x", "skip", "weight"],
+            outputs=["layernorm_output"] if not output_skip_sum else ["layernorm_output", "", "", "layernorm_skip_sum"],
+            name="layernorm/LayerNorm",
+            domain="com.microsoft",
+        ),
+        onnx.helper.make_node("Identity", inputs=["layernorm_output"], outputs=["y"], name="Identity"),
+    ]
+    if output_skip_sum:
+        nodes.append(
+            onnx.helper.make_node(
+                "Identity", inputs=["layernorm_skip_sum"], outputs=["skip_sum"], name="Identity_skip_sum"
+            )
+        )
+    graph = helper.make_graph(
+        nodes=nodes,
+        name="TestGraph",
+        inputs=inputs,
+        outputs=outputs,
+        initializer=initializers,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 20)])
+    onnx.save(model, str(tmp_path / "input_model.onnx"))
+    input_model = ONNXModelHandler(model_path=str(tmp_path / "input_model.onnx"))
+
+    output_folder = str(tmp_path / "output")
+    p = create_pass_from_dict(
+        GraphSurgeries,
+        {"surgeries": [{"surgeon": "SimplifiedLayerNormToL2Norm"}]},
+        disable_search=True,
+    )
+
+    # execute
+    output_model = p.run(input_model, output_folder)
+
+    # assert
+    check_l2norm(
+        str(tmp_path / "input_model.onnx"),
+        output_model.model_path,
+        hidden_size,
+        4 + int(output_skip_sum),
+        all_ones,
+        has_skip=True,
+    )
+
+
+@pytest.mark.parametrize("use_large_cache", [True, False])
+def test_remove_rope_multi_cache(tmp_path, use_large_cache):
+    # setup
+    tiny_model = HfModelHandler("katuni4ka/tiny-random-phi3")
+    local_tiny_path = tmp_path / "input_model"
+    tiny_model.load_model().save_pretrained(local_tiny_path)
+    tiny_model.save_metadata(local_tiny_path)
+    config_json_path = local_tiny_path / "config.json"
+    with config_json_path.open() as f:
+        config = json.load(f)
+    # change the max position embedding to 10000
+    config["max_position_embeddings"] = 10000
+    config["rope_scaling"] = {
+        "long_factor": [1] * 12,
+        "short_factor": [1] * 12,
+        "type": "longrope",
+    }
+    del config["auto_map"]
+    with config_json_path.open("w") as f:
+        json.dump(config, f)
+
+    input_model = create_pass_from_dict(
+        ModelBuilder,
+        {"precision": "fp32"},
+        disable_search=True,
+    ).run(HfModelHandler(local_tiny_path), str(tmp_path / "onnx"))
+
+    output_folder = str(tmp_path / "output")
+    p = create_pass_from_dict(
+        GraphSurgeries,
+        {"surgeries": [{"surgeon": "RemoveRopeMultiCache", "use_large_cache": use_large_cache}]},
+        disable_search=True,
+    )
+
+    # execute
+    output_model = p.run(input_model, output_folder)
+
+    # assert
+    dag = OnnxDAG.from_model_path(output_model.model_path)
+    assert "If" not in dag.get_node_op_types()
+    assert dag.get_initializer_np_array("cos_cache_single").shape[0] == 10000 if use_large_cache else 4096
+
+
+def test_attention_mask_to_sequence_lengths(tmp_path):
+    # setup
+    input_model = create_pass_from_dict(
+        ModelBuilder,
+        {"precision": "fp32"},
+        disable_search=True,
+    ).run(HfModelHandler("katuni4ka/tiny-random-phi3"), str(tmp_path / "onnx"))
+
+    output_folder = str(tmp_path / "output")
+    p = create_pass_from_dict(
+        GraphSurgeries,
+        {"surgeries": [{"surgeon": "AttentionMaskToSequenceLengths"}]},
+        disable_search=True,
+    )
+
+    # execute
+    output_model = p.run(input_model, output_folder)
+
+    # assert
+    output_model_input_names = output_model.io_config["input_names"]
+    assert "attention_mask" not in output_model_input_names
+    assert "past_seq_len" in output_model_input_names
+    assert "total_seq_len" in output_model_input_names
 
 
 def test_replace_attention_mask_value(tmp_path):

--- a/test/unit_test/passes/pytorch/test_capture_split_info.py
+++ b/test/unit_test/passes/pytorch/test_capture_split_info.py
@@ -28,13 +28,14 @@ class CustomModel(torch.nn.Module):
 
 
 @pytest.mark.parametrize(
-    ("input_model", "block_to_split", "num_splits", "split_assignments"),
+    ("input_model", "block_to_split", "num_splits", "split_assignments", "unique_embeds_lm_head_splits"),
     [
         (
             PyTorchModelHandler(model_loader=lambda _: CustomModel()),
             "layers",
             2,
             {"layers.0": 0, "layers.1": 0, "layers.2": 1, "layers.3": 1},
+            False,
         ),
         # Test not equally divide the axis
         (
@@ -42,31 +43,42 @@ class CustomModel(torch.nn.Module):
             "layers",
             3,
             {"layers.0": 0, "layers.1": 0, "layers.2": 1, "layers.3": 2},
+            False,
         ),
         (
             PyTorchModelHandler(model_loader=lambda _: CustomModel()),
             "",
             3,
             {"before_layer": 0, "layers": 1, "after_layers": 2},
+            False,
         ),
         (
             PyTorchModelHandler(model_loader=lambda _: CustomModel()),
             ["layers", "after_layers"],
             2,
             {"layers.0": 0, "layers.1": 0, "layers.2": 0, "layers.3": 1, "after_layers.0": 1, "after_layers.1": 1},
+            False,
         ),
         (
             HfModelHandler(model_path="hf-internal-testing/tiny-random-LlamaForCausalLM"),
             None,
             2,
             {"model.layers.0": 0, "model.layers.1": 1},
+            False,
+        ),
+        (
+            HfModelHandler(model_path="hf-internal-testing/tiny-random-LlamaForCausalLM"),
+            None,
+            2,
+            {"model.embed_tokens": 0, "model.layers.0": 1, "model.layers.1": 2, "lm_head": 3},
+            True,
         ),
     ],
 )
-def test_capture_split_info_num_splits(input_model, block_to_split, num_splits, split_assignments, tmp_path):
-    config = {
-        "num_splits": num_splits,
-    }
+def test_capture_split_info_num_splits(
+    input_model, block_to_split, num_splits, split_assignments, unique_embeds_lm_head_splits, tmp_path
+):
+    config = {"num_splits": num_splits, "unique_embeds_lm_head_splits": unique_embeds_lm_head_splits}
     if block_to_split is not None:
         config["block_to_split"] = block_to_split
     p = create_pass_from_dict(CaptureSplitInfo, config, disable_search=True)
@@ -85,19 +97,15 @@ def get_cost_model(tmp_path, model_name) -> str:
     return cost_model_path
 
 
-@pytest.mark.parametrize("include_embeds_lm_head", [True, False])
+@pytest.mark.parametrize("unique_embeds_lm_head", [True, False])
 @pytest.mark.parametrize(("memory", "expected_num_splits"), [(1e4, 4), (2e6, 2)])
-def test_capture_split_info_cost_model(memory, expected_num_splits, include_embeds_lm_head, tmp_path):
+def test_capture_split_info_cost_model(memory, expected_num_splits, unique_embeds_lm_head, tmp_path):
     model_name = "hf-internal-testing/tiny-random-LlamaForCausalLM"
     cost_model_path = get_cost_model(tmp_path, model_name)
 
     p = create_pass_from_dict(
         CaptureSplitInfo,
-        {
-            "cost_model": cost_model_path,
-            "exclude_embeds": not include_embeds_lm_head,
-            "exclude_lm_head": not include_embeds_lm_head,
-        },
+        {"cost_model": cost_model_path, "unique_embeds_lm_head_splits": unique_embeds_lm_head},
         # 2 layers
         # each layer is around 10 kB in fp16
         # embed_tokens and lm_head are around 1 MB each in fp16
@@ -109,12 +117,13 @@ def test_capture_split_info_cost_model(memory, expected_num_splits, include_embe
     out = p.run(input_model, str(tmp_path))
     split_assignments = out.model_attributes["split_assignments"]
 
-    if not include_embeds_lm_head:
-        assert "model.embed_tokens" not in split_assignments
-        assert "model.lm_head" not in split_assignments
+    if unique_embeds_lm_head:
         # 2 splits for embeddings and lm_head for 1e4 memory
         # 1 split for embeddings for 2e6 memory
-        expected_num_splits = max(1, expected_num_splits - 2)
+        num_other_splits = max(1, expected_num_splits - 2)
+        assert split_assignments["model.embed_tokens"] == 0
+        assert split_assignments["lm_head"] == num_other_splits + 1
+        expected_num_splits = num_other_splits + 2
     else:
         first_split_members = [k for k, v in split_assignments.items() if v == 0]
         assert first_split_members == ["model.embed_tokens"]


### PR DESCRIPTION
## Describe your changes
New example for preparing llm for NPU. The example uses `phi-3.5-mini-instruct` but the model path can be replaced with other models such as llama, phi-4, qwen2 and deepseek distilled models.

Changes made to enable this:
- New graph surgeries to remove rope multi cache and attention graph to make the quantization simpler.
- New graph surgery to convert (Skip)SimplifiedLayerNormalization nodes to L2Norm subgraph so it can run on NPU.
- Clean up context binary generator logic by removing the tempdir which is not necessary.
- Replace `exclude_embeds` and `exclude_lm_head` options in `CaptureSplitInfo` pass with `unique_embeds_lm_head_splits` which assigns the embedding layer and lm head layers to their own splits.
- Fixed a bug in the accelerator creator where it allowed a workflow to run even when the target system doesn't have the required EP installed.

The example list docs will be updated in a follow up PR since the doc linkcheck requires the example folder to be present in the main branch first.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Closes #1630 