### PR TITLE
[WIP] Fix a wrong test with dummy input

### DIFF
--- a/examples/resnet/resnet_ptq_qnn.json
+++ b/examples/resnet/resnet_ptq_qnn.json
@@ -108,7 +108,7 @@
             "save_as_external_data": true,
             "all_tensors_to_one_file": true,
             "dynamic": false,
-            "use_dynamo_exporter": false
+            "use_dynamo_exporter": true
         },
         "QNNPreprocess": { "type": "QNNPreprocess" },
         "OnnxQuantization": {

--- a/examples/resnet/resnet_ptq_qnn.json
+++ b/examples/resnet/resnet_ptq_qnn.json
@@ -104,11 +104,11 @@
         "conversion": {
             "device": "cpu",
             "type": "OnnxConversion",
-            "target_opset": 17,
+            "target_opset": 18,
             "save_as_external_data": true,
             "all_tensors_to_one_file": true,
             "dynamic": false,
-            "use_dynamo_exporter": true
+            "use_dynamo_exporter": false
         },
         "QNNPreprocess": { "type": "QNNPreprocess" },
         "OnnxQuantization": {

--- a/olive/model/handler/hf.py
+++ b/olive/model/handler/hf.py
@@ -117,7 +117,7 @@ class HfModelHandler(PyTorchModelHandlerBase, MLFlowTransformersMixin, HfMixin):
             filter_hook=filter_hook,
             filter_hook_kwargs=filter_hook_kwargs,
         )
-        if dummy_inputs:
+        if dummy_inputs is not None:
             return dummy_inputs
 
         logger.debug("Trying hf optimum export config to get dummy inputs")


### PR DESCRIPTION
## Describe your changes
``if tensor`` must be replace by ``if tensor is not None``.

``python -m olive capture-onnx-graph -m microsoft/resnet-50 -t image-classification -o dump --use_dynamo_export``  works, ``python -m olive run --config resnet_ptq_qnn.json`` fails at convert time. The model is modified somewhere.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
