### PR TITLE
OnnxPeepholeOptimizer: Catch shape inference failure, run right after conversion in auto-opt

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -428,6 +428,7 @@ TEMPLATE = {
             ("model_builder", {"type": "ModelBuilder", "precision": "fp32"}),
             ("genai_config_only", {"type": "ModelBuilder", "precision": "fp32", "metadata_only": True}),
             # model optimization passes
+            ("peephole_optimizer", {"type": "OnnxPeepholeOptimizer"}),
             # use transformer optimizer for fp16 conversion too
             # opt_level set to 0 to avoid graph transformations done by onnxruntime inference sessions
             # that are incompatible with later passes. opt_level > 0 is optional and can be done during session creation
@@ -435,7 +436,6 @@ TEMPLATE = {
                 "transformer_optimizer",
                 {"type": "OrtTransformersOptimization", "opt_level": 0, "float16": False, "keep_io_types": False},
             ),
-            ("peephole_optimizer", {"type": "OnnxPeepholeOptimizer"}),
             # change io types to fp32
             ("fp16_to_fp32", {"type": "OnnxIODataTypeConverter"}),
             # qnn preparation passes

--- a/olive/passes/onnx/peephole_optimizer.py
+++ b/olive/passes/onnx/peephole_optimizer.py
@@ -238,8 +238,17 @@ class ModelOptimizer:
         except ImportError:
             logger.warning("Please install `onnxscript` to apply more optimization.")
             return
-
-        onnxscript.optimizer.optimize(self.model)
+        try:
+            onnxscript.optimizer.optimize(self.model)
+        except Exception as e:
+            if "TypeInferenceError" in str(e):
+                logger.info(
+                    "onnxscript optimizer failed with %s. Rerunning with shape inference disabled.",
+                    str(e),
+                )
+                onnxscript.optimizer.optimize(self.model, onnx_shape_inference=False)
+            else:
+                raise
 
     def onnxoptimizer_optimize(self):
         try:


### PR DESCRIPTION
## Describe your changes
- `onnxscript` optimizer in peephole optimizer fails with shape/type inference failure if the model has contrib ops. Run again with shape inference turned off in such cases to apply other optimizations.
- `auto-opt`: Run peephole optimizer right after onnx conversion

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes #1692 