### PR TITLE
Create genai_config for NPU llms, inference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The ONNX Runtime (ORT) is a fast and light-weight cross-platform inference engin
 The following code creates a simple console-based chat interface that inferences your optimized model - **select Python and/or C# to expand the code:**
 
 <details>
-<summary><b>Python</b></summary
+<summary><b>Python</b></summary>
 
 Create a Python file called `app.py` and copy and paste the following code:
 ```python

--- a/examples/deepseek/README.md
+++ b/examples/deepseek/README.md
@@ -2,4 +2,6 @@
 
 Sample use cases of Olive to optimize a [DeepSeek R1 Distill](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B) using Olive.
 - [Finetune and Optimize for CPU/CUDA](../getting_started/olive-deepseek-finetune.ipynb)
-- [Optimize for Qualcomm NPU](../phi3_5/README.md): Replace `model_path` in `config.json` with `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.
+- [Optimize for Qualcomm NPU](../phi3_5/README.md):
+  - Replace `model_path` in `config.json` with `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.
+  - Chat template is `"<｜User｜>{input}<｜Assistant｜><think>"`.

--- a/examples/llama3/README.md
+++ b/examples/llama3/README.md
@@ -2,7 +2,9 @@
 
 Sample use cases of Olive to optimize a [Llama 3.2 1B Instruct](meta-llama/Llama-3.2-1B-Instruct) model using Olive.
 - [Quantize, Finetune and Optimize for CPU/CUDA](../getting_started/olive-awq-ft-llama.ipynb)
-- [Optimize for Qualcomm NPU](../phi3_5/README.md): Replace `model_path` in `config.json` with `meta-llama/Llama-3.2-1B-Instruct`.
+- [Optimize for Qualcomm NPU](../phi3_5/README.md):
+  - Replace `model_path` in `config.json` with `meta-llama/Llama-3.2-1B-Instruct`.
+  - Chat template is `"<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"`
 
 **NOTE:**
 - Access to the model is gated and therefore you will need to request access to the model. Once you have access to the model, you'll need to log-in to Hugging Face with a [user access token](https://huggingface.co/docs/hub/security-tokens) so that Olive can download it.

--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -13,6 +13,7 @@ To enable efficient deployment on NPU, we perform a series of optimizations, inc
 5. [Summary of Key Steps](#summary-of-key-steps)
 6. [Requirements](#requirements)
 7. [Usage](#usage)
+8. [Inference](#inference)
 
 ## Optimization Process
 
@@ -73,7 +74,13 @@ pip install -r requirements.txt
 pip install "onnxruntime-gpu>=1.21.0" "onnxruntime-genai-cuda>=0.6.0"
 
 # AutoGPTQ: Install from source (stable package may be slow for weight packing)
-BUILD_CUDA_EXT=0 pip install -vvv --no-build-isolation git+https://github.com/PanQiWei/AutoGPTQ.git
+# set the environment variable to disable the CUDA extension build, not required since we are not doing inference
+# Linux
+export BUILD_CUDA_EXT=0
+# Windows
+# set BUILD_CUDA_EXT=0
+# Install AutoGPTQ from source
+pip install --no-build-isolation git+https://github.com/PanQiWei/AutoGPTQ.git
 ```
 
 For AOT compilation, the latest nightly x64 build of onnxruntime-qnn is required. In a separate Python environment with olive-ai installed, the following packages are required:
@@ -89,7 +96,15 @@ pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/Pub
 
 ## Usage
 
-The entire workflow is configured via the [config.json](config.json) file. Update the `/path/to/qnn/env/bin` in the config file to point to the Python environment where `onnxruntime-qnn` is installed.
+The entire workflow is configured via the [config.json](config.json) file. Update the `/path/to/qnn/env/bin` in the config file to point to the Python environment where `onnxruntime-qnn` is installed. You can find this path by running the following command in the second Python environment:
+
+```bash
+# Linux
+command -v python
+# Windows
+# where python
+```
+This command will return the path to the Python executable. Set the parent directory of the executable as the `/path/to/qnn/env/bin` in the config file.
 
 To begin the optimization process, run the following command in the first Python environment:
 
@@ -100,3 +115,79 @@ olive run --config config.json
 The optimization process will take some time to complete. Once finished, the optimized model will be saved in the `models` directory.
 
 *Note*: If the optimization process fails silently during the context binary generation step, simply rerun the command. The process will resume from the last completed step.
+
+## Inference
+The optimized model can be used for inference using the ONNX Runtime QNNExecutionProvider and ONNX Runtime GenAI. The inference must be run on a Windows Copilot+ PC with Qualcomm NPU.
+
+In an arm64 Python environment, the following packages are required:
+
+```bash
+# ONNX Runtime packages
+pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
+pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+
+# ONNX Runtime GenAI
+pip install "onnxruntime-genai>=0.7.0rc2"
+```
+
+The following code creates a simple console-based chat interface that inferences your optimized model.
+Create a Python file called app.py and copy and paste the following code:
+
+```python
+# app.py
+import onnxruntime_genai as og
+
+model_folder = "models/phi3_5/model"
+
+# Load the base model and tokenizer
+model = og.Model(model_folder)
+tokenizer = og.Tokenizer(model)
+tokenizer_stream = tokenizer.create_stream()
+
+# Set the max length to something sensible by default,
+# since otherwise it will be set to the entire context length
+search_options = {}
+search_options['max_length'] = 200
+
+chat_template = "<|user|>\n{input} <|end|>\n<|assistant|>"
+
+# Keep asking for input prompts in a loop
+while True:
+    text = input("Prompt (Use quit() to exit): ")
+    if not text:
+        print("Error, input cannot be empty")
+        continue
+
+    if text == "quit()":
+        break
+
+    # Generate prompt (prompt template + input)
+    prompt = f'{chat_template.format(input=text)}'
+
+    # Encode the prompt using the tokenizer
+    input_tokens = tokenizer.encode(prompt)
+
+    # Create params and generator
+    params = og.GeneratorParams(model)
+    params.set_search_options(**search_options)
+    generator = og.Generator(model, params)
+
+    # Append input tokens to the generator
+    generator.append_tokens(input_tokens)
+
+    print("")
+    print("Output: ", end='', flush=True)
+    # Stream the output
+    try:
+        while not generator.is_done():
+            generator.generate_next_token()
+
+            new_token = generator.get_next_tokens()[0]
+            print(tokenizer_stream.decode(new_token), end='', flush=True)
+    except KeyboardInterrupt:
+        print("  --control+c pressed, aborting generation--")
+    print()
+    print()
+
+    del generator
+```

--- a/examples/phi3_5/config.json
+++ b/examples/phi3_5/config.json
@@ -65,11 +65,11 @@
         "cb": {
             "type": "EPContextBinaryGenerator",
             "provider_options": {
+                "htp_performance_mode": "burst",
                 "htp_graph_finalization_optimization_mode": "3",
-                "soc_model": "60",
-                "htp_arch": "73",
-                "vtcm_mb": "8"
+                "soc_model": "60"
             },
+            "session_options": { "intra_op_num_threads": 2, "inter_op_num_threads": 1 },
             "weight_sharing": true
         },
         "cp": { "type": "ComposeOnnxModels" }
@@ -77,7 +77,7 @@
     "host": "local_cuda_system",
     "target": "qnn_system",
     "log_severity_level": 0,
-    "output_dir": "models",
-    "cache_dir": "cache",
+    "output_dir": "models/phi3_5",
+    "cache_dir": "cache/phi3_5",
     "no_artifacts": true
 }

--- a/examples/qwen2_5/README.md
+++ b/examples/qwen2_5/README.md
@@ -1,0 +1,6 @@
+# Qwen 2.5 Optimization
+
+Sample use cases of Olive to optimize a [Qwen 2.5 1.5B Instruct](Qwen/Qwen2.5-1.5B-Instruct) model using Olive.
+- [Optimize for Qualcomm NPU](../phi3_5/README.md):
+  - Replace `model_path` in `config.json` with `Qwen/Qwen2.5-1.5B-Instruct`.
+  - Chat template is `"<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n"`

--- a/olive/common/hf/wrapper.py
+++ b/olive/common/hf/wrapper.py
@@ -261,7 +261,7 @@ class ModelWrapper:
             self.config.tie_word_embeddings = False
             self.model.config.tie_word_embeddings = False
 
-            self.get_lm_head(False).weight.data = self.get_embeds(False)[0].weight.data.clone()
+            self.get_lm_head(False).weight = nn.Parameter(self.get_embeds(False)[0].weight.clone().detach())
             logger.debug("Untied word embeddings.")
 
     def maybe_unpack_qkv(self):

--- a/olive/model/handler/composite.py
+++ b/olive/model/handler/composite.py
@@ -12,6 +12,7 @@ from olive.hardware.accelerator import Device
 from olive.model.config.model_config import ModelConfig
 from olive.model.config.registry import model_handler_registry
 from olive.model.handler.base import OliveModelHandler
+from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
 
 logger = logging.getLogger(__name__)
 
@@ -27,14 +28,18 @@ class CompositeModelHandler(OliveModelHandler):
     CompositeModelHandler is a collection of Models. All the child model in the container should have same model type.
     """
 
+    resource_keys: Tuple[str, ...] = ("model_path",)
+    json_config_keys: Tuple[str, ...] = ("model_component_names",)
+
     def __init__(
         self,
         model_components: List[Union[OliveModelHandler, Dict[str, Any]]],
         model_component_names: List[str],
+        model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         model_attributes: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
-            model_path=None,
+            model_path=model_path,
             framework=Framework.ONNX,
             model_file_format=ModelFileFormat.COMPOSITE_MODEL,
             model_attributes=model_attributes,
@@ -58,10 +63,7 @@ class CompositeModelHandler(OliveModelHandler):
             yield m
 
     def to_json(self, check_object: bool = False):
-        json_dict = {
-            "type": self.model_type,
-            "config": {"model_attributes": self.model_attributes, "model_component_names": self.model_component_names},
-        }
+        json_dict = super().to_json(check_object)
         json_dict["config"]["model_components"] = []
         for m in self._model_components:
             component_json = m.to_json(check_object)

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -2,16 +2,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 import logging
 import re
+from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import onnx
 from onnx import external_data_helper
 
 from olive.common.utils import hardlink_copy_file
-from olive.model import ONNXModelHandler
+from olive.model import CompositeModelHandler, ONNXModelHandler
 from olive.passes.onnx.onnx_dag import OnnxDAG
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.resource_path import LocalFile, LocalFolder
@@ -145,6 +147,7 @@ def model_proto_to_olive_model(
     check_model: bool = False,
     external_initializers_file_name: Optional[str] = None,
     constant_inputs_file_name: Optional[str] = None,
+    force_model_dir: bool = False,
 ) -> ONNXModelHandler:
     """Save the ONNX model to the specified path and return the ONNXModelHandler.
 
@@ -155,6 +158,8 @@ def model_proto_to_olive_model(
     :param check_model: If True, run onnx.checker.check_model on the model before returning.
     :param external_initializers_file_name: The name of the external initializers file.
     :param constant_inputs_file_name: The name of the constant inputs file.
+    :param force_model_dir: If True, use the parent directory of the output model path as the model directory
+        regardless of whether external data is used.
 
     :return: The ONNXModelHandler.
     """
@@ -170,7 +175,7 @@ def model_proto_to_olive_model(
     has_external_data = model_proto_to_file(
         model_proto, output_model_path, **{k: external_data_config[k] for k in config_keys if k in external_data_config}
     )
-    if has_external_data or external_initializers_file_name or constant_inputs_file_name:
+    if has_external_data or external_initializers_file_name or constant_inputs_file_name or force_model_dir:
         model_path = LocalFolder({"path": Path(output_model_path).parent})
 
         onnx_file_name = Path(output_model_path).name
@@ -409,3 +414,123 @@ def fix_input_shapes(model_proto: onnx.ModelProto, input_names: List[str], input
 
     # update the output shapes to make them fixed
     _fix_output_shapes(model_proto)
+
+
+def process_llm_pipeline(
+    model: CompositeModelHandler,
+    llm_pipeline: List,
+    process_func: Callable,
+    output_dir: Union[str, Path],
+    decoder_config_extra: Optional[Dict[str, Any]] = None,
+    group_session_options: Optional[Dict[str, Any]] = None,
+) -> CompositeModelHandler:
+    """Process an LLM pipeline with the given function.
+
+    :param model_handler: The composite model with the pipeline.
+    :param llm_pipeline: The pipeline to process.
+    :param process_func: The function to apply to the context and iterator groups.
+        Must accept a mapping from component name to component handler, pipeline, and output directory.
+        Returns a
+    :param output_dir: The directory to save the processed model.
+    :param decoder_config_extra: Extra configuration for the decoder.
+    :param group_session_options: Session options for the context and iterator groups.
+    :return: The processed composite model handler.
+    """
+    output_dir = Path(output_dir)
+    component_models = dict(model.get_model_components())
+
+    new_component_models = {}
+    new_llm_pipeline = {}
+
+    # resave embeddings model
+    embeddings_model_path = output_dir / "embeddings.onnx"
+    resave_model(component_models[llm_pipeline["embeddings"]].model_path, embeddings_model_path)
+    new_component_models["embeddings"] = ONNXModelHandler(
+        model_path=output_dir, onnx_file_name=embeddings_model_path.name
+    )
+    new_llm_pipeline["embeddings"] = "embeddings"
+
+    # process the context and iterator models
+    new_groups = process_func(component_models, llm_pipeline, output_dir)
+    for key, group in new_groups.items():
+        new_component_models.update(group)
+        new_llm_pipeline[key] = list(group.keys())
+
+    # resave the lm_head model
+    lm_head_model_path = output_dir / "lm_head.onnx"
+    resave_model(component_models[llm_pipeline["lm_head"]].model_path, lm_head_model_path)
+    new_component_models["lm_head"] = ONNXModelHandler(model_path=output_dir, onnx_file_name=lm_head_model_path.name)
+    new_llm_pipeline["lm_head"] = "lm_head"
+
+    # create new model attributes
+    new_model_attributes = deepcopy(model.model_attributes) or {}
+    new_model_attributes["llm_pipeline"] = new_llm_pipeline
+
+    # update genai_config if it exists
+    genai_config_path = None
+    for file_path in new_model_attributes.get("additional_files") or []:
+        if Path(file_path).name == "genai_config.json":
+            genai_config_path = file_path
+            break
+
+    if genai_config_path:
+        with open(genai_config_path) as f:
+            genai_config = json.load(f)
+
+        # update model_type
+        genai_config["model"]["type"] = "decoder-pipeline"
+
+        # update decoder config
+        decoder_config = genai_config["model"]["decoder"]
+        decoder_config.pop("filename", None)
+        for key, value in (decoder_config_extra or {}).items():
+            exisiting_value = decoder_config.get(key)
+            if isinstance(exisiting_value, dict):
+                exisiting_value.update(value)
+            elif isinstance(exisiting_value, list):
+                exisiting_value.extend(value)
+            else:
+                decoder_config[key] = value
+
+        # get group session options
+        group_session_options = group_session_options or decoder_config.get("pipeline", [{}])[0].get(
+            llm_pipeline["context"][0], {}
+        ).get("session_options")
+
+        # update pipeline config
+        pipeline_config = {}
+        for name in [
+            new_llm_pipeline["embeddings"],
+            *new_llm_pipeline["context"],
+            *new_llm_pipeline["iterator"],
+            new_llm_pipeline["lm_head"],
+        ]:
+            component = new_component_models[name]
+            component_io_config = component.io_config
+            pipeline_config[name] = {
+                "filename": Path(component.model_path).name,
+                "inputs": component_io_config["input_names"],
+                "outputs": component_io_config["output_names"],
+            }
+
+        for group, dont_run_on in zip(["context", "iterator"], ["token_gen", "prompt"]):
+            for name in new_llm_pipeline[group]:
+                if group_session_options:
+                    pipeline_config[name]["session_options"] = group_session_options
+                pipeline_config[name][f"run_on_{dont_run_on}"] = False
+
+        decoder_config["pipeline"] = [pipeline_config]
+
+        # save the updated genai_config
+        new_genai_config_path = output_dir / "genai_config.json"
+        with new_genai_config_path.open("w") as f:
+            json.dump(genai_config, f, indent=4)
+        new_model_attributes["additional_files"].remove(genai_config_path)
+        new_model_attributes["additional_files"].append(str(new_genai_config_path))
+
+    return CompositeModelHandler(
+        list(new_component_models.values()),
+        list(new_component_models.keys()),
+        model_path=output_dir,
+        model_attributes=new_model_attributes,
+    )

--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -6,7 +6,7 @@ import logging
 import platform
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Type, Union
+from typing import Dict, Optional, Type, Union
 
 from packaging import version
 
@@ -14,7 +14,7 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import CompositeModelHandler, ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
-from olive.passes.onnx.common import get_context_bin_file_names, resave_model
+from olive.passes.onnx.common import get_context_bin_file_names, process_llm_pipeline
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,11 @@ class EPContextBinaryGenerator(Pass):
                 default_value=None,
                 description="Provider options for the EP.",
             ),
+            "session_options": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                description="Session options for the EP.",
+            ),
             "disable_cpu_fallback": PassConfigParam(
                 type_=bool,
                 default_value=False,
@@ -74,6 +79,7 @@ class EPContextBinaryGenerator(Pass):
         generate_kwargs = {
             "execution_provider": self.accelerator_spec.execution_provider,
             "provider_options": config.provider_options,
+            "session_options": config.session_options,
             "embed_context": config.embed_context,
             "disable_cpu_fallback": config.disable_cpu_fallback,
         }
@@ -95,57 +101,57 @@ class EPContextBinaryGenerator(Pass):
 
         new_component_models = {}
         new_model_attributes = deepcopy(model.model_attributes) or {}
-        if llm_pipeline := (model.model_attributes or {}).get("llm_pipeline"):
-            new_llm_pipeline = {}
+        if pipeline := (model.model_attributes or {}).get("llm_pipeline"):
 
-            # resave embeddings model
-            embeddings_model_path = output_model_path / "embeddings.onnx"
-            resave_model(component_map[llm_pipeline["embeddings"]].model_path, embeddings_model_path)
-            new_component_models["embeddings"] = ONNXModelHandler(
-                model_path=output_model_path, onnx_file_name=embeddings_model_path.name
-            )
-            new_llm_pipeline["embeddings"] = "embeddings"
-
-            # iterate over the context/iterator models
-            new_llm_pipeline["context"] = []
-            new_llm_pipeline["iterator"] = []
-            for ctx_model_name, iter_model_name in zip(llm_pipeline["context"], llm_pipeline["iterator"]):
-                # potentially share context binary between corresponding context/iterator components
-                new_ctx_model_name = f"{ctx_model_name}_ctx"
-                new_iter_model_name = f"{iter_model_name}_ctx"
-                new_component_models.update(
-                    self._generate_composite_binaries(
+            def process_context_iterator(component_models, llm_pipeline, output_dir):
+                new_groups = {
+                    "context": {},
+                    "iterator": {},
+                }
+                for ctx_model_name, iter_model_name in zip(llm_pipeline["context"], llm_pipeline["iterator"]):
+                    # potentially share context binary between corresponding context/iterator components
+                    new_ctx_model_name = f"{ctx_model_name}_ctx"
+                    new_iter_model_name = f"{iter_model_name}_ctx"
+                    composite_binaries = self._generate_composite_binaries(
                         model_paths_map={
-                            new_ctx_model_name: component_map[ctx_model_name].model_path,
-                            new_iter_model_name: component_map[iter_model_name].model_path,
+                            new_ctx_model_name: component_models[ctx_model_name].model_path,
+                            new_iter_model_name: component_models[iter_model_name].model_path,
                         },
-                        output_model_dir=output_model_path,
+                        output_model_dir=output_dir,
                         generate_kwargs=generate_kwargs,
                         weight_sharing=config.weight_sharing,
                     )
-                )
-                new_llm_pipeline["context"].append(new_ctx_model_name)
-                new_llm_pipeline["iterator"].append(new_iter_model_name)
+                    new_groups["context"][new_ctx_model_name] = composite_binaries[new_ctx_model_name]
+                    new_groups["iterator"][new_iter_model_name] = composite_binaries[new_iter_model_name]
 
-            # resave the lm_head model
-            lm_head_model_path = output_model_path / "lm_head.onnx"
-            resave_model(component_map[llm_pipeline["lm_head"]].model_path, lm_head_model_path)
-            new_component_models["lm_head"] = ONNXModelHandler(
-                model_path=output_model_path, onnx_file_name=lm_head_model_path.name
-            )
-            new_llm_pipeline["lm_head"] = "lm_head"
+                return new_groups
 
-            new_model_attributes["llm_pipeline"] = new_llm_pipeline
-        else:
-            new_component_models = self._generate_composite_binaries(
-                model_paths_map={f"{name}_ctx": component.model_path for name, component in component_map.items()},
-                output_model_dir=output_model_path,
-                generate_kwargs=generate_kwargs,
-                weight_sharing=config.weight_sharing,
+            group_session_options = config.session_options or {}
+            provider_options = config.provider_options or {}
+            if self.accelerator_spec.execution_provider == "QNNExecutionProvider":
+                provider_options["backend_path"] = "QnnHtp.dll"
+            group_session_options["provider_options"] = [
+                {self.accelerator_spec.execution_provider.lower().replace("executionprovider", ""): provider_options}
+            ]
+
+            return process_llm_pipeline(
+                model,
+                pipeline,
+                process_context_iterator,
+                output_model_path,
+                group_session_options=group_session_options,
             )
+
+        new_component_models = self._generate_composite_binaries(
+            model_paths_map={f"{name}_ctx": component.model_path for name, component in component_map.items()},
+            output_model_dir=output_model_path,
+            generate_kwargs=generate_kwargs,
+            weight_sharing=config.weight_sharing,
+        )
         return CompositeModelHandler(
             list(new_component_models.values()),
             list(new_component_models.keys()),
+            model_path=output_model_path,
             model_attributes=new_model_attributes,
         )
 
@@ -187,7 +193,8 @@ class EPContextBinaryGenerator(Pass):
         model_path: str,
         output_model_path: Union[str, Path],
         execution_provider: str,
-        provider_options: dict,
+        provider_options: Optional[dict] = None,
+        session_options: Optional[dict] = None,
         embed_context: bool = False,
         disable_cpu_fallback: bool = False,
         share_ep_contexts: bool = False,
@@ -217,12 +224,19 @@ class EPContextBinaryGenerator(Pass):
                 provider_options["enable_htp_weight_sharing"] = "1"
 
         # prepare session options
-        session_options = SessionOptions()
-        session_options.add_session_config_entry("ep.context_enable", "1")
-        session_options.add_session_config_entry("ep.context_embed_mode", str(int(embed_context)))
-        session_options.add_session_config_entry("session.disable_cpu_ep_fallback", str(int(disable_cpu_fallback)))
-        session_options.add_session_config_entry("ep.share_ep_contexts", str(int(share_ep_contexts)))
-        session_options.add_session_config_entry("ep.stop_share_ep_contexts", str(int(stop_share_ep_contexts)))
+        session_options = session_options or {}
+        session_options.update(
+            {
+                "ep.context_enable": "1",
+                "ep.context_embed_mode": int(embed_context),
+                "session.disable_cpu_ep_fallback": int(disable_cpu_fallback),
+                "ep.share_ep_contexts": int(share_ep_contexts),
+                "ep.stop_share_ep_contexts": int(stop_share_ep_contexts),
+            }
+        )
+        sess_options = SessionOptions()
+        for key, value in session_options.items():
+            sess_options.add_session_config_entry(key, str(value))
 
         output_model_path = Path(output_model_path)
         output_model_path.parent.mkdir(parents=True, exist_ok=True)
@@ -234,13 +248,13 @@ class EPContextBinaryGenerator(Pass):
             logger.debug("Context binary bin file %s already exists. Deleting it.", str(file_name))
             file_name.unlink()
         # set the context file path
-        session_options.add_session_config_entry("ep.context_file_path", str(output_model_path))
+        sess_options.add_session_config_entry("ep.context_file_path", str(output_model_path))
 
         # create the inference session
         logger.debug("Creating context binary for model %s", str(model_path))
         InferenceSession(
             model_path,
-            sess_options=session_options,
+            sess_options=sess_options,
             providers=[execution_provider],
             provider_options=[provider_options],
         )

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -554,7 +554,7 @@ class RMSNormToL2Norm(Surgeon):
                 # rotated models have all 1s and might share initializer
                 # don't want to multiply by sqrt(N) multiple times even though it is fine in all 1s case
                 rmsnorm_weight = dag.get_initializer_np_array(rmsnorm_weight_name)
-                sqrt_n = np.sqrt(rmsnorm_weight.shape[-1])
+                sqrt_n = np.sqrt(rmsnorm_weight.shape[-1]).astype(rmsnorm_weight.dtype)
                 if np.all(rmsnorm_weight == 1):
                     # this is possible in a quarot/spinquant rotated model
                     # Multiplying by 1D is probably faster
@@ -698,7 +698,7 @@ class SimplifiedLayerNormToL2Norm(Surgeon):
             # add Mul node
             mul_weight_name = dag.get_node_inputs(node_name, True)[-1]
             mul_weight = dag.get_initializer_np_array(mul_weight_name)
-            sqrt_n = np.sqrt(mul_weight.shape[-1])
+            sqrt_n = np.sqrt(mul_weight.shape[-1]).astype(mul_weight.dtype)
             if np.all(mul_weight == 1):
                 # this is possible in a quarot/spinquant rotated model
                 # Multiplying by 1D is probably faster

--- a/olive/passes/onnx/optimum_conversion.py
+++ b/olive/passes/onnx/optimum_conversion.py
@@ -127,4 +127,4 @@ class OptimumConversion(Pass):
             )
             model_component_names.append(component_name)
 
-        return CompositeModelHandler(model_components, model_component_names)
+        return CompositeModelHandler(model_components, model_component_names, model_path=output_model_path)

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from typing import Dict, Type, Union
+from typing import Dict, Type
 
 from onnx import ModelProto
 
@@ -44,7 +44,7 @@ class OptimumMerging(Pass):
 
     def _run_for_config(
         self, model: CompositeModelHandler, config: Type[BasePassConfig], output_model_path: str
-    ) -> Union[ONNXModelHandler, CompositeModelHandler]:
+    ) -> ONNXModelHandler:
         import onnxruntime
 
         assert len(model.model_components) == 2

--- a/olive/passes/onnx/split.py
+++ b/olive/passes/onnx/split.py
@@ -232,19 +232,23 @@ class SplitModel(Pass):
 
         component_models = []
         component_names = []
+        output_model_dir = Path(output_model_path).with_suffix("")
+        output_model_dir.mkdir(parents=True, exist_ok=True)
+        # will save the split models directly in the output dir
         for i, split_dag in enumerate(split_dags):
             if not split_dag.get_node_names():
                 # no nodes got assigned to this split
                 logger.debug("Skipping empty split %d", i)
                 continue
-            split_name = f"split_{i}"
-            split_dir = Path(output_model_path).with_suffix("") / split_name
-            split_path = resolve_onnx_path(split_dir, f"{split_name}.onnx")
             split_dag.update()
-            component_models.append(model_proto_to_olive_model(split_dag.model, split_path, config))
+            split_name = f"split_{i}"
+            split_path = resolve_onnx_path(output_model_dir, f"{split_name}.onnx")
+            component_models.append(
+                model_proto_to_olive_model(split_dag.model, split_path, config, force_model_dir=True)
+            )
             component_names.append(split_name)
 
-        return CompositeModelHandler(component_models, component_names)
+        return CompositeModelHandler(component_models, component_names, model_path=output_model_dir)
 
     def get_assignment(self, node_name: str, split_assignments: Dict[str, int]) -> Optional[int]:
         name_components = node_name.replace("/", ".").lstrip(".").split(".")

--- a/olive/passes/onnx/static_llm.py
+++ b/olive/passes/onnx/static_llm.py
@@ -27,6 +27,11 @@ class StaticLLM(Pass):
         - context model (sequence length = context_length)
         - iterator model (sequence length = 1)
     embeddings and lm_head keep their original shapes.
+    The output model has an attribute "llm_pipeline" that contains the mapping of the components with keys:
+        - embeddings: name of the embeddings model
+        - context: list of context model names
+        - iterator: list of iterator model names
+        - lm_head: name of the lm_head model
     """
 
     _accepts_composite_model = True

--- a/olive/passes/pytorch/rotate.py
+++ b/olive/passes/pytorch/rotate.py
@@ -319,7 +319,7 @@ class SpinQuant(RotateBase):
                 "training_args": PassConfigParam(
                     type_=Union[HFTrainingArguments, Dict],
                     default_value=None,
-                    description=("Training arguments. If None, will use default arguments."),
+                    description="Training arguments. If None, will use default arguments.",
                 ),
             }
         )

--- a/test/unit_test/passes/onnx/test_context_binary.py
+++ b/test/unit_test/passes/onnx/test_context_binary.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 from test.unit_test.utils import get_onnx_model
 
 import onnxruntime
@@ -60,13 +61,17 @@ def test_ep_context_binary_generator_composite(tmp_path, is_llm):
     model_attributes = None
     if is_llm:
         component_names = ["embeddings", *component_names, "lm_head"]
+        with open(parent_dir / "genai_config.json", "w") as f:
+            json.dump({"model": {"decoder": {}, "type": "decoder-pipeline"}}, f)
+
         model_attributes = {
             "llm_pipeline": {
                 "embeddings": "embeddings",
                 "context": ["component_0", "component_1"],
                 "iterator": ["component_2", "component_3"],
                 "lm_head": "lm_head",
-            }
+            },
+            "additional_files": [str(parent_dir / "genai_config.json")],
         }
     component_models = []
     for name in component_names:
@@ -82,7 +87,15 @@ def test_ep_context_binary_generator_composite(tmp_path, is_llm):
         EPContextBinaryGenerator,
         # weight sharing requires a qdq model
         # might also have issues in pytest environment
-        {"weight_sharing": False},
+        {
+            "weight_sharing": False,
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "soc_model": "60",
+            },
+            "session_options": {"intra_op_num_threads": 2, "inter_op_num_threads": 1},
+        },
         disable_search=True,
         accelerator_spec=accelerator_spec,
     )
@@ -102,6 +115,14 @@ def test_ep_context_binary_generator_composite(tmp_path, is_llm):
             "iterator": ["component_2_ctx", "component_3_ctx"],
             "lm_head": "lm_head",
         }
+        with open(output_model_path / "genai_config.json") as f:
+            genai_config = json.load(f)
+        assert set(genai_config["model"]["decoder"]["pipeline"][0].keys()) == set(output_model.model_component_names)
+        session_options = genai_config["model"]["decoder"]["pipeline"][0]["component_0_ctx"]["session_options"]
+        assert session_options["intra_op_num_threads"] == 2
+        assert "qnn" in session_options["provider_options"][0]
+        assert session_options["provider_options"][0]["qnn"]["htp_performance_mode"] == "burst"
+        assert session_options["provider_options"][0]["qnn"]["backend_path"] == "QnnHtp.dll"
     for name in component_names:
         # print(output_component_map[name].model_path)
         is_skipped = name in ["embeddings", "lm_head"]

--- a/test/unit_test/passes/onnx/test_static_llm.py
+++ b/test/unit_test/passes/onnx/test_static_llm.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 from test.unit_test.utils import make_local_tiny_llama
 
 from olive.model import CompositeModelHandler, ONNXModelHandler
@@ -11,13 +12,17 @@ from olive.passes.onnx.static_llm import StaticLLM
 
 def test_static_llm(tmp_path):
     # setup
+    from olive.passes.onnx.graph_surgeries import GraphSurgeries
     from olive.passes.onnx.model_builder import ModelBuilder
     from olive.passes.onnx.split import SplitModel
 
-    pytorch_model = make_local_tiny_llama(tmp_path)
+    pytorch_model = make_local_tiny_llama(tmp_path / "input_model")
     onnx_model = create_pass_from_dict(ModelBuilder, {"precision": "fp32"}, disable_search=True).run(
         pytorch_model, tmp_path / "onnx_model"
     )
+    post_op_model = create_pass_from_dict(
+        GraphSurgeries, {"surgeries": [{"surgeon": "AttentionMaskToSequenceLengths"}]}, disable_search=True
+    ).run(onnx_model, tmp_path / "post_op_model")
 
     split_model = create_pass_from_dict(
         SplitModel,
@@ -31,7 +36,7 @@ def test_static_llm(tmp_path):
             }
         },
         disable_search=True,
-    ).run(onnx_model, tmp_path / "split_model")
+    ).run(post_op_model, tmp_path / "split_model")
 
     p = create_pass_from_dict(StaticLLM, {"batch_size": 1, "context_length": 64}, disable_search=True)
 
@@ -50,3 +55,12 @@ def test_static_llm(tmp_path):
         "iterator": ["iterator_0", "iterator_1"],
         "lm_head": "lm_head",
     }
+    with (output_model_path / "genai_config.json").open() as f:
+        genai_config = json.load(f)
+    assert genai_config["model"]["type"] == "decoder-pipeline"
+    for i_name in ["input_ids", "past_sequence_length"]:
+        assert i_name in genai_config["model"]["decoder"]["inputs"]
+    assert genai_config["model"]["decoder"]["sliding_window"]["window_size"] == 64
+    assert set(genai_config["model"]["decoder"]["pipeline"][0].keys()) == set(output_model.model_component_names)
+    assert not genai_config["model"]["decoder"]["pipeline"][0]["context_0"]["run_on_token_gen"]
+    assert not genai_config["model"]["decoder"]["pipeline"][0]["iterator_0"]["run_on_prompt"]


### PR DESCRIPTION
## Describe your changes
Fixes and updates:
  - `CompositeModelHandler` now has an optional `model_path` resource to store additional files. In practice, most of the composite models that are output of passes use the same directory for the component models. 
  - Abstracted out the common llm-pipeline logic from the passes. It also automatically updates the genai config with the correct model io and session options.
  - Fixed untie word embedding implementation in hf model wrapper.
  - Fixed the data type of the layernorm weight in the rms norm graph surgeries. In numpy 2.0+, the data type after multiplication with `sqrt_n` gets promoted to double. but we want float.
  - Additional files carry over now supports composite models as well. Removed unnecessary check for input model dir. It was a remnant from the original implementation.

Examples:
- Instructions and example inference script added
- Qwen 2.5 example added.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
