### PR TITLE
Quantization: Prepare qdq config, new quantization parameters

### DIFF
--- a/examples/bge/bge-small-en-v1.5_ptq_qnn.json
+++ b/examples/bge/bge-small-en-v1.5_ptq_qnn.json
@@ -69,8 +69,7 @@
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax",
-            "quant_preprocess": true,
-            "prepare_qnn_config": true
+            "quant_preprocess": true
         }
     },
     "evaluator": "common_evaluator",

--- a/examples/llama2/llama2_template.json
+++ b/examples/llama2/llama2_template.json
@@ -105,7 +105,7 @@
             "op_types_to_quantize": [ "MatMul", "Gemm" ],
             "per_channel": false,
             "reduce_range": false,
-            "MatMulConstBOnly": true
+            "extra_options": { "MatMulConstBOnly": true }
         },
         "blockwise_quant_int4": {
             "type": "OnnxMatMul4Quantizer",

--- a/examples/phi3_5/config.json
+++ b/examples/phi3_5/config.json
@@ -55,7 +55,6 @@
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibration_providers": [ "CUDAExecutionProvider" ],
-            "prepare_qnn_config": true,
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
             "save_as_external_data": true

--- a/examples/resnet/resnet_ptq_qnn.json
+++ b/examples/resnet/resnet_ptq_qnn.json
@@ -117,8 +117,7 @@
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax",
-            "quant_preprocess": true,
-            "prepare_qnn_config": true
+            "quant_preprocess": true
         }
     },
     "host": "qnn_system",

--- a/examples/sentence_transformers/sentence_transformer_config.json
+++ b/examples/sentence_transformers/sentence_transformer_config.json
@@ -45,8 +45,7 @@
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax",
-            "quant_preprocess": true,
-            "prepare_qnn_config": true
+            "quant_preprocess": true
         }
     },
     "evaluate_input_model": false,

--- a/examples/table_transformer_detection/ttd_config.json
+++ b/examples/table_transformer_detection/ttd_config.json
@@ -54,8 +54,7 @@
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax",
-            "quant_preprocess": true,
-            "prepare_qnn_config": true
+            "quant_preprocess": true
         }
     },
     "evaluator": "common_evaluator",

--- a/examples/vit/vit_qnn_config.json
+++ b/examples/vit/vit_qnn_config.json
@@ -70,8 +70,7 @@
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax",
-            "quant_preprocess": true,
-            "prepare_qnn_config": true
+            "quant_preprocess": true
         }
     },
     "host": "qnn_system",

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -304,18 +304,18 @@ class OnnxQuantization(Pass):
         if not super().validate_config(config, accelerator_spec):
             return False
 
-        if config.quant_mode == "static":
-            if (
-                config.weight_type == "QInt8"
-                and config.activation_type == "QInt8"
-                and config.quant_format == "QOperator"
-            ):
-                # S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general.
-                # https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
-                # But we still allow it for users to try at their own risk. Olive just warns this to users.
-                logger.warning(
-                    "S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general, try QDQ instead."
-                )
+        if (
+            config.quant_mode == "static"
+            and config.weight_type == "QInt8"
+            and config.activation_type == "QInt8"
+            and config.quant_format == "QOperator"
+        ):
+            # S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general.
+            # https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
+            # But we still allow it for users to try at their own risk. Olive just warns this to users.
+            logger.warning(
+                "S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general, try QDQ instead."
+            )
         return True
 
     def _run_for_config(

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -29,7 +29,7 @@ from olive.passes.onnx.common import (
 )
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.resource_path import LocalFile
-from olive.search.search_parameter import Boolean, Categorical, Conditional, ConditionalDefault
+from olive.search.search_parameter import Boolean, Categorical, Conditional, ConditionalDefault, SpecialParamValue
 
 logger = logging.getLogger(__name__)
 
@@ -106,34 +106,20 @@ _onnx_quantization_config = {
             https://onnxruntime.ai/docs/performance/quantization.html#pre-processing
         """,
     ),
-}
-
-_exposed_extra_options_config = {
-    "extra.Sigmoid.nnapi": PassConfigParam(type_=bool, default_value=False, description=""),
-    "ActivationSymmetric": PassConfigParam(
-        type_=bool, default_value=False, description="symmetrize calibration data for activations"
-    ),
-    "WeightSymmetric": PassConfigParam(
-        type_=bool, default_value=True, description="symmetrize calibration data for weights"
-    ),
-    "EnableSubgraph": PassConfigParam(
-        type_=bool,
-        default_value=False,
-        description="If enabled, subgraph will be quantized. Dynamic mode currently is supported.",
-    ),
-    "ForceQuantizeNoInputCheck": PassConfigParam(
+    "activation_symmetric": PassConfigParam(
         type_=bool,
         default_value=False,
         description="""
-            By default, some latent operators like maxpool, transpose, do not quantize if their input is not
-            quantized already. Setting to True to force such operator always quantize input and so generate
-            quantized output. Also the True behavior could be disabled per node using the nodes_to_exclude.
+            Symmetric quantization for activations.
         """,
     ),
-    "MatMulConstBOnly": PassConfigParam(
+    "weight_symmetric": PassConfigParam(
         type_=bool,
-        default_value=ConditionalDefault(parents=("quant_mode",), support={("dynamic",): True, ("static",): False}),
-        description="If enabled, only MatMul with const B will be quantized.",
+        default_value=None,
+        description="""
+            Symmetric quantization for weights. Defaults to None. If set to None, it is assumed true if
+            weight_type is signed, false otherwise.
+        """,
     ),
 }
 
@@ -141,12 +127,12 @@ _extra_options_config = {
     "extra_options": PassConfigParam(
         type_=dict,
         default_value=None,
-        description=f"""
+        description="""
             Key value pair dictionary for `extra_options` in quantization. Please refer to
             https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/quantization/quantize.py
             for details about the supported options. If an option is one of
-            {list(_exposed_extra_options_config.keys())}, it will be overwritten by the corresponding config parameter
-            value.
+            ActivationSymmetric, WeightSymmetric, MinimumRealRange or TensorQuantOverrides, it will be overwritten
+            by the corresponding config parameter value.
         """,
     ),
 }
@@ -206,21 +192,26 @@ _static_optional_config = {
             https://onnxruntime.ai/docs/performance/quantization.html for more details on data type selection
         """,
     ),
-    "prepare_qnn_config": PassConfigParam(
-        type_=bool,
-        default_value=False,
+    "min_real_range": PassConfigParam(
+        type_=float,
+        default_value=None,
         description="""
-            Whether to generate a suitable quantization config for the input model.
-            Should be set to True if model is targeted for QNN EP.
+            Minimum real range for quantization. If set, enforces the minimum range between rmin and rmax.
         """,
     ),
-    "qnn_extra_options": PassConfigParam(
+    "tensor_quant_overrides": PassConfigParam(
         type_=dict,
         default_value=None,
         description="""
-            Extra options for QNN quantization. Please refer to get_qnn_qdq_config at
-            https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py.
-            By default, the options are set to None. Options are only used if prepare_qnn_config is set to True.
+            tensor-level quantization overrides.
+        """,
+    ),
+    "prepare_qdq_config": PassConfigParam(
+        type_=bool,
+        default_value=True,
+        description="""
+            Generate a quantization configuration for a full integer QDQ model. Otherwise, only a limited set of
+            operators are quantized. Only supported after onnxruntime 1.21.0 for EPs other than QNN.
         """,
     ),
 }
@@ -231,6 +222,14 @@ def get_calibration_dataloader(config, model_path=None, io_config=None, calibrat
     return data_config.to_data_container().create_calibration_dataloader(
         model_path=model_path, io_config=io_config, calibration_providers=calibration_providers
     )
+
+
+_param_extra_options_mapping = {
+    "ActivationSymmetric": "activation_symmetric",
+    "WeightSymmetric": "weight_symmetric",
+    "MinimumRealRange": "min_real_range",
+    "TensorQuantOverrides": "tensor_quant_overrides",
+}
 
 
 class OnnxQuantization(Pass):
@@ -290,7 +289,6 @@ class OnnxQuantization(Pass):
         config.update(static_optional_config)
 
         # exposed extra options config
-        config.update(deepcopy(_exposed_extra_options_config))
         config.update(deepcopy(_extra_options_config))
 
         # external data config
@@ -318,9 +316,6 @@ class OnnxQuantization(Pass):
                 logger.warning(
                     "S8S8 with QOperator will be slow on x86-64 CPUs and should be avoided in general, try QDQ instead."
                 )
-            if config.EnableSubgraph is True:
-                logger.info("EnableSubgraph is not supported for static quantization.")
-                return False
         return True
 
     def _run_for_config(
@@ -352,16 +347,19 @@ class OnnxQuantization(Pass):
         # extra config
         extra_options = deepcopy(config.extra_options) or {}
         # keys in extra_options that are already exposed
-        intersection = set(extra_options.keys()).intersection(set(_exposed_extra_options_config.keys()))
+        intersection = set(extra_options.keys()).intersection(set(_param_extra_options_mapping.keys()))
         if intersection:
             logger.warning(
                 "Extra config keys %s are already exposed in the pass config. They will be overwritten by"
                 " the corresponding pass config parameter values.",
                 intersection,
             )
-        for key in _exposed_extra_options_config:
-            extra_options[key] = run_config[key]
-            del run_config[key]
+        for key, value in _param_extra_options_mapping.items():
+            if run_config.get(value) is not None and not isinstance(run_config[value], SpecialParamValue):
+                # add the value to extra_options
+                extra_options[key] = run_config[value]
+            # remove the key from run_config
+            run_config.pop(value, None)
 
         # preprocess the model
         # we hash the entire path of the input model to ensure we are not accidentally using a preprocessed model
@@ -383,8 +381,7 @@ class OnnxQuantization(Pass):
         to_delete = [
             "quant_mode",
             "quant_preprocess",
-            "prepare_qnn_config",
-            "qnn_extra_options",
+            "prepare_qdq_config",
             "op_types_to_exclude",
             *_dataloader_config.keys(),
             *get_external_data_config().keys(),
@@ -418,12 +415,11 @@ class OnnxQuantization(Pass):
         run_config = exclude_keys(run_config, to_delete)
 
         # there is no op_types_to_exclude in the quantizer, will exclude indirectly through nodes_to_exclude
-        nodes_to_exclude = run_config["nodes_to_exclude"] or []
+        run_config["nodes_to_exclude"] = nodes_to_exclude = run_config.get("nodes_to_exclude") or []
         if config.op_types_to_exclude:
             for node in onnx.load(model.model_path, load_external_data=False).graph.node:
                 if node.op_type in config.op_types_to_exclude:
                     nodes_to_exclude.append(node.name)
-        run_config["nodes_to_exclude"] = nodes_to_exclude
 
         # to be safe, run the quantizer with use_external_data_format set to `True` and
         # `model_output` to a temporary directory
@@ -432,63 +428,11 @@ class OnnxQuantization(Pass):
         tmp_model_path = str(Path(new_tmp_dir.name) / Path(output_model_path).name)
 
         if is_static:
-            # get the dataloader
-            dataloader = get_calibration_dataloader(
-                config, model.model_path, model.io_config, config.calibration_providers
-            )
-            # TODO(anyone): generalize this option to prepare_qdq_config so that other NPU eps can use it
-            # to call get_qdq_config
-            if config.prepare_qnn_config:
-                from onnxruntime.quantization.execution_providers.qnn import get_qnn_qdq_config
-
-                qnn_extra_options = config.qnn_extra_options or {}
-                if init_overrides := _get_qnn_init_overrides(model, config):
-                    qnn_extra_options["init_overrides"] = init_overrides
-
-                # TODO(anyone): remove the version check once minimum version is 1.21.0
-                additional_options = {}
-                if not ort_less_than_1_21:
-                    additional_options = {
-                        "calibration_providers": run_config["calibration_providers"],
-                        "op_types_to_quantize": run_config["op_types_to_quantize"],
-                        "nodes_to_exclude": run_config["nodes_to_exclude"],
-                    }
-
-                qnn_config = get_qnn_qdq_config(
-                    model_input=model.model_path,
-                    calibration_data_reader=dataloader,
-                    calibrate_method=run_config["calibrate_method"],
-                    activation_type=run_config["activation_type"],
-                    weight_type=run_config["weight_type"],
-                    per_channel=run_config["per_channel"],
-                    activation_symmetric=config.ActivationSymmetric,
-                    weight_symmetric=config.WeightSymmetric,
-                    **qnn_extra_options,
-                    **additional_options,
-                )
-                # override the run_config with qnn_config
-                # get all attributes of qnn_config
-                run_config = {k: v for k, v in inspect.getmembers(qnn_config) if not k.startswith("_")}
-                # remove the calibration_data_reader from run_config
-                run_config = exclude_keys(run_config, ("calibration_data_reader", "use_external_data_format"))
-                # TODO(jambayk): raise this > 1.21.0 if quantizer tool changes don't make it to 1.20.0
-                if ort_less_than_1_21:
-                    if nodes_to_exclude:
-                        run_config["nodes_to_exclude"].extend(nodes_to_exclude)
-                    if config.op_types_to_quantize:
-                        run_config["op_types_to_quantize"] = config.op_types_to_quantize
-                    elif config.op_types_to_exclude:
-                        # op_types_to_quantize takes precedence over op_types_to_exclude
-                        run_config["op_types_to_quantize"] = list(
-                            set(run_config["op_types_to_quantize"]) - set(config.op_types_to_exclude)
-                        )
-
+            run_config = self.get_static_run_config(model, config, run_config, ort_less_than_1_21)
             try:
                 quantize_static(
                     model_input=model.model_path,
                     model_output=tmp_model_path,
-                    calibration_data_reader=dataloader,
-                    use_external_data_format=True,
                     **run_config,
                 )
             except (AttributeError, ValueError) as e:
@@ -544,6 +488,75 @@ class OnnxQuantization(Pass):
 
         # since this is only used internally, we will just treat it as a model file
         return ONNXModelHandler(LocalFile({"path": output_model_path}))
+
+    def get_static_run_config(
+        self, model: ONNXModelHandler, config: Type[BasePassConfig], run_config: Dict, ort_less_than_1_21: bool
+    ) -> Dict:
+        """Prepare the run config for static quantization."""
+        dataloader = get_calibration_dataloader(config, model.model_path, model.io_config, config.calibration_providers)
+        if config.quant_format != "QDQ" or not config.prepare_qdq_config:
+            run_config.update({"calibration_data_reader": dataloader, "use_external_data_format": True})
+            return run_config
+
+        is_qnn_ep = self.accelerator_spec.execution_provider == "QNNExecutionProvider"
+
+        if is_qnn_ep:
+            from onnxruntime.quantization.execution_providers.qnn import get_qnn_qdq_config as get_qdq_config
+        else:
+            if ort_less_than_1_21:
+                raise ValueError("prepare_qdq_config is only supported for onnxruntime>=1.21.0.")
+            from onnxruntime.quantization.quantize import get_qdq_config
+
+        get_qdq_config_kwargs = {
+            "model_input": model.model_path,
+            "calibration_data_reader": dataloader,
+        }
+        # copy values from run_config
+        for key in ["calibrate_method", "activation_type", "weight_type", "per_channel"]:
+            get_qdq_config_kwargs[key] = run_config[key]
+        if not ort_less_than_1_21:
+            # only available in onnxruntime>=1.21.0 for prepare_qnn_config
+            for key in ["calibration_providers", "op_types_to_quantize", "nodes_to_exclude"]:
+                get_qdq_config_kwargs[key] = run_config[key]
+        # put the exposed extra options in the get_qdq_config_kwargs
+        extra_options = deepcopy(run_config["extra_options"])
+        for key, qdq_key in _param_extra_options_mapping.items():
+            if key in extra_options:
+                get_qdq_config_kwargs[qdq_key] = extra_options[key]
+                # remove the key from extra_options
+                extra_options.pop(key, None)
+        if extra_options:
+            get_qdq_config_kwargs["extra_options"] = extra_options
+        # tensor_quant_overrides is init_overrides in qnn
+        if is_qnn_ep:
+            if "tensor_quant_overrides" in get_qdq_config_kwargs:
+                get_qdq_config_kwargs["init_overrides"] = get_qdq_config_kwargs.pop("tensor_quant_overrides")
+            elif init_overrides := _get_qnn_init_overrides(model, config):
+                get_qdq_config_kwargs["init_overrides"] = init_overrides
+            if "min_real_range" in get_qdq_config_kwargs:
+                # min_real_range is not supported in QNN EP which enforces 1e-4
+                get_qdq_config_kwargs.pop("min_real_range")
+
+        # get the qdq config
+        qdq_config = get_qdq_config(**get_qdq_config_kwargs)
+
+        # override the run_config with qdq_config
+        new_run_config = {k: v for k, v in inspect.getmembers(qdq_config) if not k.startswith("_")}
+        # always run with use_external_data_format
+        new_run_config["use_external_data_format"] = True
+        if ort_less_than_1_21:
+            # only available in onnxruntime>=1.21.0 for prepare_qnn_config
+            if run_config["nodes_to_exclude"]:
+                new_run_config["nodes_to_exclude"].extend(run_config["nodes_to_exclude"])
+            if config.op_types_to_quantize:
+                new_run_config["op_types_to_quantize"] = config.op_types_to_quantize
+            elif config.op_types_to_exclude:
+                # op_types_to_quantize takes precedence over op_types_to_exclude
+                new_run_config["op_types_to_quantize"] = list(
+                    set(new_run_config["op_types_to_quantize"]) - set(config.op_types_to_exclude)
+                )
+
+        return new_run_config
 
 
 class OnnxQuantizationPreprocess(Pass):
@@ -627,8 +640,6 @@ class OnnxDynamicQuantization(OnnxQuantization):
         }
         # common quantization config
         config.update(deepcopy(_onnx_quantization_config))
-        # exposed extra options config
-        config.update(deepcopy(_exposed_extra_options_config))
         config.update(deepcopy(_extra_options_config))
         # external data config
         config.update(get_external_data_config())
@@ -649,7 +660,6 @@ class OnnxStaticQuantization(OnnxQuantization):
         config.update(deepcopy(_dataloader_config))
         config.update(deepcopy(_static_optional_config))
         # exposed extra options config
-        config.update(deepcopy(_exposed_extra_options_config))
         config.update(deepcopy(_extra_options_config))
         # external data config
         config.update(get_external_data_config())
@@ -660,11 +670,12 @@ class OnnxStaticQuantization(OnnxQuantization):
             # TODO(jiapli): remove this workaround once figure out the Int16/UInt16 in latest quantization
             config["activation_type"].search_defaults = Categorical(["QInt8", "QUInt8", "QUInt16", "QInt16"])
             config["weight_type"].search_defaults = Categorical(["QInt8", "QUInt8", "QUInt16", "QInt16"])
-            config["prepare_qnn_config"].default_value = True
-            # in QNN EP, the default value WeightSymmetric is None
-            # but in base quantizer, the default value is True.
-            config["WeightSymmetric"].default_value = None
         return config
+
+    @staticmethod
+    def is_accelerator_agnostic(accelerator_spec: AcceleratorSpec) -> bool:
+        """Override this method to return False by using the accelerator spec information."""
+        return False
 
 
 class OnnxMatMul4Quantizer(Pass):
@@ -875,8 +886,7 @@ def _get_qnn_init_overrides(model_handler: ONNXModelHandler, config: Type[BasePa
     model_attributes = model_handler.model_attributes or {}
     mp_init_overrides = model_attributes.get("mixed_precision_overrides") or {}
     init_overrides = {}
-    config.qnn_extra_options = config.qnn_extra_options or {}
-    if mp_init_overrides and "init_overrides" not in config.qnn_extra_options:
+    if mp_init_overrides:
         from onnxruntime.quantization import QuantType
 
         # use QuantType to get the quantization type

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -45,30 +45,23 @@ class DummyCalibrationDataReader(CalibrationDataReader):
 
 
 @Registry.register_dataloader()
-def _test_quat_dataloader(dataset, batch_size, **kwargs):
+def _test_quant_dataloader(dataset, batch_size, **kwargs):
     return DummyCalibrationDataReader(batch_size=batch_size)
 
 
-@pytest.mark.parametrize("calibrate_method", ["MinMax", "Entropy", "Percentile"])
-def test_static_quantization(calibrate_method, tmp_path):
-    if version.parse(OrtVersion) >= version.parse("1.19.0") and calibrate_method != "MinMax":
-        pytest.skip(
-            "Entropy and Percentile calibration methods sometimes hit nan issue during histogram computation in"
-            " onnxruntime>=1.19.0"
-        )
-
+@pytest.mark.parametrize("quant_format", ["QOperator", "QDQ"])
+def test_static_quantization(quant_format, tmp_path):
     input_model = get_onnx_model()
     config = {
         "quant_mode": "static",
-        "calibrate_method": calibrate_method,
-        "quant_format": "QOperator",
-        "MatMulConstBOnly": False,
+        "calibrate_method": "MinMax",
+        "quant_format": quant_format,
         "per_channel": True,
         "reduce_range": True,
         "data_config": DataConfig(
             name="test_quant_dc_config",
             load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
+            dataloader_config=DataComponentConfig(type="_test_quant_dataloader"),
         ),
         "weight_type": "QUInt8",
         "activation_type": "QUInt8",
@@ -111,59 +104,50 @@ def test_quantization_preprocess(tmp_path):
         ),
     ],
 )
+@pytest.mark.parametrize("is_qnn", [True, False])
 @patch("onnxruntime.quantization.quantize_static")
-def test_nodes_and_ops(mock_quantize_static, tmp_path, kwargs, expected):
+def test_nodes_and_ops(mock_quantize_static, tmp_path, kwargs, expected, is_qnn):
+    if not is_qnn and version.parse(OrtVersion) < version.parse("1.21.0"):
+        pytest.skip("prepare_qdq_config is only supported in onnxruntime>=1.21.0")
     input_model = get_onnx_model()
     config = {
-        "quant_mode": "static",
-        "prepare_qnn_config": True,
+        "quant_format": "QDQ",
+        "prepare_qdq_config": True,
+        "weight_symmetric": True,
+        "activation_symmetric": True,
+        "min_real_range": 5e-4,
         "data_config": DataConfig(
             name="test_quant_dc_config",
             load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
+            dataloader_config=DataComponentConfig(type="_test_quant_dataloader"),
         ),
         **kwargs,
     }
+    accelerator_spec = (
+        AcceleratorSpec(
+            accelerator_type="NPU",
+            execution_provider="QNNExecutionProvider",
+        )
+        if is_qnn
+        else None
+    )
 
     def dummy_quantize_static(model_input, model_output, **kwargs):
         onnx.save(onnx.load(model_input), model_output)
 
     mock_quantize_static.side_effect = dummy_quantize_static
 
-    p = create_pass_from_dict(OnnxQuantization, config, disable_search=True)
+    p = create_pass_from_dict(OnnxStaticQuantization, config, disable_search=True, accelerator_spec=accelerator_spec)
     out = p.run(input_model, tmp_path)
     assert out is not None
 
     mocked_kwargs = mock_quantize_static.call_args.kwargs
     for key in ["op_types_to_quantize", "nodes_to_exclude"]:
         assert set(mocked_kwargs[key]) == set(expected.get(key, []))
-
-
-def test_qnn_quantization(tmp_path):
-    input_model = get_onnx_model()
-    config = {
-        "quant_format": "QDQ",
-        "data_config": DataConfig(
-            name="test_quant_dc_config",
-            load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
-        ),
-        "weight_type": "QUInt8",
-        "activation_type": "QUInt16",
-        "WeightSymmetric": None,
-        "ActivationSymmetric": True,
-        "qnn_extra_options": {
-            "init_overrides": None,
-            "add_qtype_converts": True,
-        },
-    }
-    accelerator_spec = AcceleratorSpec(
-        accelerator_type="NPU",
-        execution_provider="QNNExecutionProvider",
-    )
-    p = create_pass_from_dict(OnnxStaticQuantization, config, disable_search=True, accelerator_spec=accelerator_spec)
-    out = p.run(input_model, tmp_path)
-    assert out is not None
+    extra_options = mocked_kwargs.get("extra_options", {})
+    assert extra_options.get("MinimumRealRange") == (1e-4 if is_qnn else 5e-4)
+    assert extra_options.get("WeightSymmetric") is True
+    assert extra_options.get("ActivationSymmetric") is True
 
 
 @pytest.mark.parametrize(
@@ -205,7 +189,7 @@ def test_matmul_4bits_gptq_with_dataloader(tmp_path, caplog):
         "data_config": DataConfig(
             name="test_quant_dc_config",
             load_dataset_config=DataComponentConfig(type="simple_dataset"),
-            dataloader_config=DataComponentConfig(type="_test_quat_dataloader"),
+            dataloader_config=DataComponentConfig(type="_test_quant_dataloader"),
         ),
         "weight_only_quant_configs": {"percdamp": 0.01, "block_size": 128, "use_less_config": 1},
     }

--- a/test/unit_test/search/samplers/test_tpe_sampler.py
+++ b/test/unit_test/search/samplers/test_tpe_sampler.py
@@ -115,34 +115,12 @@ class TestTPESampler:
                                         ),
                                     ),
                                     (
-                                        "prepare_qnn_config",
+                                        "prepare_qdq_config",
                                         Conditional(
                                             parents=("quant_mode",),
                                             support={
                                                 ("static",): Categorical([False]),
                                                 ("dynamic",): Conditional.get_ignored_choice(),
-                                            },
-                                            default=Conditional.get_invalid_choice(),
-                                        ),
-                                    ),
-                                    (
-                                        "qnn_extra_options",
-                                        Conditional(
-                                            parents=("quant_mode",),
-                                            support={
-                                                ("static",): Categorical([None]),
-                                                ("dynamic",): Conditional.get_ignored_choice(),
-                                            },
-                                            default=Conditional.get_invalid_choice(),
-                                        ),
-                                    ),
-                                    (
-                                        "MatMulConstBOnly",
-                                        Conditional(
-                                            parents=("quant_mode",),
-                                            support={
-                                                ("dynamic",): Categorical([True]),
-                                                ("static",): Categorical([False]),
                                             },
                                             default=Conditional.get_invalid_choice(),
                                         ),


### PR DESCRIPTION
## Describe your changes
- Static quantization now uses `get_qdq_config` by default in order to get a fully quantized qdq model.
  - get_qnn_qdq_config is used instead if the target EP is QNN EP. So, the pass is now not EP agnositic.
  - Required ort 1.21+ for eps other than QNN.
- `prepare_qnn_config` and `qnn_extra_options` options have been replaced with `prepare_qdq_config`. This option can be set to False if the old behavior of only quantizing some operators is desired. 
- The names for exposed extra options have been updated to match the qdq config params. Don't expect backward compatibility issues since we did not use them much before. But I expected the activation/weight symmetric options to be used more going forward so it's better to standardize the names.
  - WeightSymmetric -> weight_symmetric
  - ActivationSymmetric -> activation_symmetric
- New exposed extra options:
  -  MinimumRealRange as min_real_range
  - TensorQuantOverrides as tensor_quant_overrides
- Removed exposed extra options:
  - extra.Sigmoid.nnapi
  - EnableSubgraph
  - ForceQuantizeNoInputCheck
  - MatMulConstBOnly

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
