### PR TITLE
GPTQ/AWQ: set bias correctly during export

### DIFF
--- a/examples/utils/generator.py
+++ b/examples/utils/generator.py
@@ -298,7 +298,7 @@ class ORTGenerator:
                 outputs = io_binding.get_outputs()
                 logits = outputs[0].numpy()
             else:
-                outputs = session.run(None, {**{used_inputs}, **cache.get_kv_inputs()})
+                outputs = session.run(None, {**used_inputs, **cache.get_kv_inputs()})
                 logits = outputs[0]
 
             # Decide the next token using your preferred sampling strategy.

--- a/olive/common/hf/quant.py
+++ b/olive/common/hf/quant.py
@@ -273,6 +273,8 @@ def make_auto_awq_qlinear4bit(qlinear):
         dtype=qlinear.scales.dtype,
     )
     new_qlinear.pack(iweight, izeros, scales)
+    if qlinear.bias is not None:
+        new_qlinear.bias = qlinear.bias.clone()
 
     return new_qlinear
 
@@ -302,6 +304,8 @@ def make_auto_gptq_qlinear4bit(qlinear):
         dtype=qlinear.scales.dtype,
     )
     new_qlinear.pack(iweight, izeros, scales, g_idx)
+    if qlinear.bias is not None:
+        new_qlinear.bias = qlinear.bias.clone()
 
     return new_qlinear
 


### PR DESCRIPTION
## Describe your changes
Bugfix in quantized model export. Bias weight was not set correctly before.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
