### PR TITLE
HfModelHandler: fix condition for no dummy inputs

### DIFF
--- a/olive/model/handler/hf.py
+++ b/olive/model/handler/hf.py
@@ -117,15 +117,14 @@ class HfModelHandler(PyTorchModelHandlerBase, MLFlowTransformersMixin, HfMixin):
             filter_hook=filter_hook,
             filter_hook_kwargs=filter_hook_kwargs,
         )
-        if dummy_inputs:
+        if dummy_inputs is not None:
             return dummy_inputs
 
         logger.debug("Trying hf optimum export config to get dummy inputs")
         dummy_inputs = self.get_hf_dummy_inputs()
-        if dummy_inputs:
+        if dummy_inputs is not None:
             logger.debug("Got dummy inputs from hf optimum export config")
-
-        if dummy_inputs is None:
+        else:
             raise ValueError(
                 "Unable to get dummy inputs for the model. Please provide io_config or install an optimum version that"
                 " supports the model for export."


### PR DESCRIPTION
## Describe your changes
Same fix as #1682. When the dummy inputs is a single tensor, `if dummy_inputs` is ambiguous and leads to an error. Check for `not None` instead.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
