### PR TITLE
Fix resave_model bug

### DIFF
--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -225,6 +225,8 @@ def change_external_data_location(model_proto: onnx.ModelProto, new_location: st
             external_data_helper.set_external_data(
                 tensor, new_location, offset=info.offset, length=info.length, checksum=info.checksum
             )
+            # clear the raw_data field to avoid saving it and overwriting the info above
+            tensor.ClearField("raw_data")
 
 
 def get_context_bin_file_names(model_path: Union[str, Path]) -> List[str]:

--- a/test/unit_test/passes/onnx/test_common.py
+++ b/test/unit_test/passes/onnx/test_common.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from test.unit_test.utils import ONNX_MODEL_PATH
+from test.unit_test.utils import ONNX_MODEL_PATH, get_hf_model
 
 import onnx
 import pytest
 
-from olive.passes.onnx.common import model_proto_to_olive_model
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.onnx.common import model_proto_to_olive_model, resave_model
+from olive.passes.onnx.conversion import OnnxConversion
 
 
 @pytest.mark.parametrize(
@@ -29,3 +31,21 @@ def test_model_proto_to_olive_model(external_data_config, tmp_path):
     model_proto = onnx.load(ONNX_MODEL_PATH)
     olive_model = model_proto_to_olive_model(model_proto, tmp_path / "test.onnx", external_data_config)
     assert olive_model, "Failed to save ONNX proto to Olive model"
+
+
+@pytest.mark.parametrize("has_external_data", [True, False])
+def test_resave_model(has_external_data, tmp_path):
+    # setup
+    input_model = create_pass_from_dict(
+        OnnxConversion, {"save_as_external_data": has_external_data}, disable_search=True
+    ).run(get_hf_model(), str(tmp_path / "input"))
+
+    # execute
+    resave_path = tmp_path / "resave" / "resave.onnx"
+    resave_model(input_model.model_path, resave_path)
+
+    # assert
+    assert resave_path.exists()
+    if has_external_data:
+        assert (resave_path.parent / "resave.onnx.data").exists()
+    assert onnx.load(resave_path) == onnx.load(input_model.model_path)


### PR DESCRIPTION
## Describe your changes
`resave_model` has a bug where the model after saving had zero length since the `raw_data` field was still present with `b""` and it unintentionally triggered this code path in `onnx.save_model` https://github.com/onnx/onnx/blob/1854a08c9daab2666b1dc0096afe3930659fcff1/onnx/external_data_helper.py#L326.

Fixed by clearing `raw_data` field after the external data file is renamed.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes #1722