### PR TITLE
[exporter] Align to ort_fusion updates

### DIFF
--- a/olive/passes/onnx/onnxscript_fusion.py
+++ b/olive/passes/onnx/onnxscript_fusion.py
@@ -39,7 +39,7 @@ class OnnxScriptFusion(Pass):
         output = ort_fusions.optimize_for_ort(model_ir)
         if isinstance(output, tuple):
             model_ir, function_stats = output
-            logger.info("Function stats: %s", function_stats)
+            logger.debug("Function stats: %s", function_stats)
         else:
             model_ir = output
         model_proto = ir.to_proto(model_ir)

--- a/olive/passes/onnx/onnxscript_fusion.py
+++ b/olive/passes/onnx/onnxscript_fusion.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 from pathlib import Path
 from typing import Dict, Type
 
@@ -14,6 +15,8 @@ from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
+logger = logging.getLogger(__name__)
 
 
 class OnnxScriptFusion(Pass):
@@ -33,7 +36,9 @@ class OnnxScriptFusion(Pass):
         model_ir = ir.from_proto(model_proto)
 
         # TODO(exporter team): Different fusions support different devices
-        ort_fusions.optimize_for_ort(model_ir)
+        model_ir, function_stats = ort_fusions.optimize_for_ort(model_ir)
+
+        logger.info("Function stats: %s", function_stats)
 
         model_proto = ir.to_proto(model_ir)
         # save the model to the output path and return the model

--- a/olive/passes/onnx/onnxscript_fusion.py
+++ b/olive/passes/onnx/onnxscript_fusion.py
@@ -36,10 +36,12 @@ class OnnxScriptFusion(Pass):
         model_ir = ir.from_proto(model_proto)
 
         # TODO(exporter team): Different fusions support different devices
-        model_ir, function_stats = ort_fusions.optimize_for_ort(model_ir)
-
-        logger.info("Function stats: %s", function_stats)
-
+        output = ort_fusions.optimize_for_ort(model_ir)
+        if isinstance(output, tuple):
+            model_ir, function_stats = output
+            logger.info("Function stats: %s", function_stats)
+        else:
+            model_ir = output
         model_proto = ir.to_proto(model_ir)
         # save the model to the output path and return the model
         return model_proto_to_olive_model(model_proto, output_model_path, config)


### PR DESCRIPTION
## Describe your changes

`ort_fusion` had an internal bug that has been fixed in https://github.com/microsoft/onnxscript/pull/2159. Olive needs to align with the new return values.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
