### PR TITLE
[VitisAI] Add QDQ recipes for VitisAI EP

### DIFF
--- a/examples/bert/bert_ptq_qdq_vitis_ai.json
+++ b/examples/bert/bert_ptq_qdq_vitis_ai.json
@@ -1,0 +1,85 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Intel/bert-base-uncased-mrpc",
+        "task": "text-classification",
+        "load_kwargs": { "attn_implementation": "eager" }
+    },
+    "data_configs": [
+        {
+            "name": "glue_mrpc",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "glue", "subset": "mrpc", "split": "validation" },
+            "pre_process_data_config": {
+                "max_length": 128,
+                "padding": "max_length",
+                "input_cols": [ "sentence1", "sentence2" ],
+                "max_samples": 100
+            },
+            "dataloader_config": { "batch_size": 1 }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "glue_mrpc",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } },
+                        { "name": "f1" }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "glue_mrpc",
+                    "sub_types": [
+                        { "name": "avg", "priority": 2, "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "glue_mrpc",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "dynamic_shape_to_fixed": {
+            "type": "DynamicToFixedShape",
+            "dim_param": [ "batch_size", "sequence_length" ],
+            "dim_value": [ 1, 128 ]
+        },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "transformer_optimizer": {
+            "type": "orttransformersoptimization",
+            "model_type": "bert",
+            "opt_level": 1,
+            "optimization_options": {
+                "enable_gelu": true,
+                "enable_bias_gelu": false,
+                "enable_layer_norm": true,
+                "enable_skip_layer_norm": false,
+                "enable_bias_skip_layer_norm": false,
+                "enable_attention": false
+            }
+        },
+        "quantization": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "glue_mrpc",
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8"
+        }
+    },
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "output_dir": "models/bert_ptq_qdq_with_Gelu"
+}

--- a/examples/bert/google_bert_qdq_vitis_ai.json
+++ b/examples/bert/google_bert_qdq_vitis_ai.json
@@ -1,0 +1,75 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "google-bert/bert-base-multilingual-cased",
+        "task": "feature-extraction"
+    },
+    "data_configs": [
+        {
+            "name": "xnli",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "facebook/xnli", "subset": "en", "split": "validation" },
+            "pre_process_data_config": {
+                "input_cols": [ "premise" ],
+                "padding": "max_length",
+                "max_length": 128,
+                "max_samples": 10
+            },
+            "dataloader_config": { "batch_size": 1 }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "xnli",
+                    "sub_types": [
+                        { "name": "avg", "priority": 1, "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "xnli",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "transformer_optimizer": {
+            "type": "orttransformersoptimization",
+            "model_type": "bert",
+            "opt_level": 1,
+            "optimization_options": {
+                "enable_gelu": true,
+                "enable_bias_gelu": false,
+                "enable_layer_norm": true,
+                "enable_skip_layer_norm": false,
+                "enable_bias_skip_layer_norm": false,
+                "enable_attention": false
+            }
+        },
+        "dynamic_shape_to_fixed": {
+            "type": "DynamicToFixedShape",
+            "dim_param": [ "batch_size", "sequence_length" ],
+            "dim_value": [ 1, 128 ]
+        },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "quantization": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "xnli",
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8"
+        }
+    },
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "output_dir": "models/google_bert",
+    "log_severity_level": 0
+}

--- a/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qdq_vitis_ai.json
+++ b/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qdq_vitis_ai.json
@@ -1,0 +1,114 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+        "task": "zero-shot-image-classification",
+        "load_kwargs": { "attn_implementation": "eager" },
+        "io_config": {
+            "input_names": [ "input_ids", "pixel_values", "attention_mask" ],
+            "input_shapes": [ [ 10, 77 ], [ 1, 3, 224, 224 ], [ 10, 77 ] ],
+            "input_types": [ "int64", "float32", "int64" ],
+            "output_names": [ "logits_per_image" ],
+            "output_shapes": [ [ 1, 2 ] ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 0,
+                "end": 10
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        },
+        {
+            "name": "metric_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 10,
+                "end": 20
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" },
+            "post_process_data_config": { "type": "clip_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "avg", "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ],
+                    "user_config": {
+                        "inference_settings": { "onnx": { "execution_provider": "CPUExecutionProvider" } }
+                    }
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "metric_data_config",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "transformer_optimizer": {
+            "type": "orttransformersoptimization",
+            "model_type": "clip",
+            "opt_level": 1,
+            "optimization_options": {
+                "enable_gelu": true,
+                "enable_bias_gelu": false,
+                "enable_layer_norm": true,
+                "enable_skip_layer_norm": false,
+                "enable_bias_skip_layer_norm": false,
+                "enable_attention": false
+            }
+        },
+        "quantization": {
+            "type": "OnnxStaticQuantization",
+            "quant_preprocess": true,
+            "data_config": "quant_data_config",
+            "op_types_to_quantize": [
+                "MatMul",
+                "LayerNormalization",
+                "Gemm",
+                "Sigmoid",
+                "Gelu",
+                "Mul",
+                "Conv",
+                "Transpose"
+            ],
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8",
+            "calibrate_method": "MinMax"
+        }
+    },
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "clean_cache": true,
+    "output_dir": "models/CLIP-ViT-B-32-laion2B-s34B-b79K"
+}

--- a/examples/clip/openai_clip-vit-base-patch16_ptq_qdq_vitis_ai.json
+++ b/examples/clip/openai_clip-vit-base-patch16_ptq_qdq_vitis_ai.json
@@ -1,0 +1,111 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "openai/clip-vit-base-patch16",
+        "task": "zero-shot-image-classification",
+        "load_kwargs": { "attn_implementation": "eager" },
+        "io_config": {
+            "input_names": [ "input_ids", "pixel_values", "attention_mask" ],
+            "input_shapes": [ [ 10, 77 ], [ 1, 3, 224, 224 ], [ 10, 77 ] ],
+            "input_types": [ "int64", "float32", "int64" ],
+            "output_names": [ "logits_per_image" ],
+            "output_shapes": [ [ 1, 2 ] ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 0,
+                "end": 10
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        },
+        {
+            "name": "metric_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 10,
+                "end": 20
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" },
+            "post_process_data_config": { "type": "clip_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "avg", "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "metric_data_config",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "transformer_optimizer": {
+            "type": "orttransformersoptimization",
+            "model_type": "clip",
+            "opt_level": 1,
+            "optimization_options": {
+                "enable_gelu": true,
+                "enable_bias_gelu": false,
+                "enable_layer_norm": true,
+                "enable_skip_layer_norm": false,
+                "enable_bias_skip_layer_norm": false,
+                "enable_attention": false
+            }
+        },
+        "quantization": {
+            "type": "OnnxStaticQuantization",
+            "quant_preprocess": true,
+            "data_config": "quant_data_config",
+            "op_types_to_quantize": [
+                "MatMul",
+                "LayerNormalization",
+                "Gemm",
+                "Sigmoid",
+                "QuickGelu",
+                "Mul",
+                "Conv",
+                "Transpose"
+            ],
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8",
+            "calibrate_method": "MinMax"
+        }
+    },
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "clean_cache": true,
+    "output_dir": "models/clip-vit-base-patch16"
+}

--- a/examples/clip/openai_clip-vit-base-patch32_ptq_qdq_vitis_ai.json
+++ b/examples/clip/openai_clip-vit-base-patch32_ptq_qdq_vitis_ai.json
@@ -1,0 +1,111 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "openai/clip-vit-base-patch32",
+        "task": "zero-shot-image-classification",
+        "load_kwargs": { "attn_implementation": "eager" },
+        "io_config": {
+            "input_names": [ "input_ids", "pixel_values", "attention_mask" ],
+            "input_shapes": [ [ 10, 77 ], [ 1, 3, 224, 224 ], [ 10, 77 ] ],
+            "input_types": [ "int64", "float32", "int64" ],
+            "output_names": [ "logits_per_image" ],
+            "output_shapes": [ [ 1, 2 ] ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 0,
+                "end": 10
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        },
+        {
+            "name": "metric_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 10,
+                "end": 20
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" },
+            "post_process_data_config": { "type": "clip_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "avg", "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "metric_data_config",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "transformer_optimizer": {
+            "type": "orttransformersoptimization",
+            "model_type": "clip",
+            "opt_level": 1,
+            "optimization_options": {
+                "enable_gelu": true,
+                "enable_bias_gelu": false,
+                "enable_layer_norm": true,
+                "enable_skip_layer_norm": false,
+                "enable_bias_skip_layer_norm": false,
+                "enable_attention": false
+            }
+        },
+        "quantization": {
+            "type": "OnnxStaticQuantization",
+            "quant_preprocess": true,
+            "data_config": "quant_data_config",
+            "op_types_to_quantize": [
+                "MatMul",
+                "LayerNormalization",
+                "Gemm",
+                "Sigmoid",
+                "QuickGelu",
+                "Mul",
+                "Conv",
+                "Transpose"
+            ],
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8",
+            "calibrate_method": "MinMax"
+        }
+    },
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache/clip-32",
+    "clean_cache": false,
+    "output_dir": "models/clip-vit-base-patch32"
+}

--- a/examples/phi3_5/qdq_config_vitis_ai.json
+++ b/examples/phi3_5/qdq_config_vitis_ai.json
@@ -1,0 +1,61 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "microsoft/Phi-3.5-mini-instruct" },
+    "data_configs": [
+        {
+            "name": "wikitext2_train",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": {
+                "strategy": "line-by-line",
+                "add_special_tokens": false,
+                "max_samples": 128,
+                "max_seq_len": 512
+            }
+        }
+    ],
+    "passes": {
+        "q": { "type": "QuaRot" },
+        "g": { "type": "GptqQuantizer", "sym": true, "group_size": -1 },
+        "cs": { "type": "CaptureSplitInfo", "num_splits": 1, "unique_embeds_lm_head_splits": true },
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_accuracy_level": 4,
+            "int4_op_types_to_quantize": [ "MatMul", "Gather" ],
+            "save_as_external_data": true
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "nodes_to_exclude": [ "/lm_head/MatMul_Q4" ],
+            "save_as_external_data": true
+        },
+        "gs": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "AttentionMaskToSequenceLengths" },
+                { "surgeon": "SimplifiedLayerNormToL2Norm" }
+            ],
+            "save_as_external_data": true
+        },
+        "sq": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "wikitext2_train",
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8",
+            "calibration_providers": [ "CUDAExecutionProvider" ],
+            "quant_preprocess": true,
+            "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
+            "save_as_external_data": true
+        },
+        "sp": { "type": "SplitModel" },
+        "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 }
+    },
+    "log_severity_level": 1,
+    "output_dir": "models/phi3_5_qdq",
+    "cache_dir": "cache",
+    "no_artifacts": true
+}

--- a/examples/vit/vit_qdq_vitis_ai.json
+++ b/examples/vit/vit_qdq_vitis_ai.json
@@ -1,0 +1,84 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "google/vit-base-patch16-224",
+        "task": "image-classification",
+        "io_config": {
+            "input_names": [ "pixel_values" ],
+            "input_shapes": [ [ 1, 3, 224, 224 ] ],
+            "output_names": [ "logits" ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quantize_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "imagenet.py",
+            "load_dataset_config": {
+                "data_name": "imagenet-1k",
+                "split": "validation",
+                "streaming": true,
+                "trust_remote_code": true
+            },
+            "pre_process_data_config": { "type": "dataset_pre_process", "size": 256, "cache_key": "imagenet256" },
+            "post_process_data_config": { "type": "dataset_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "data_config": "quantize_data_config",
+                    "sub_types": [
+                        {
+                            "name": "accuracy_score",
+                            "priority": 1,
+                            "metric_config": { "task": "multiclass", "num_classes": 1001 }
+                        }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "quantize_data_config",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": {
+            "device": "cpu",
+            "type": "OnnxConversion",
+            "target_opset": 17,
+            "save_as_external_data": true,
+            "all_tensors_to_one_file": true,
+            "use_dynamo_exporter": false
+        },
+        "transformer_optimizer": {
+            "type": "orttransformersoptimization",
+            "model_type": "vit",
+            "opt_level": 1,
+            "optimization_options": {
+                "enable_gelu": true,
+                "enable_bias_gelu": false,
+                "enable_layer_norm": true,
+                "enable_skip_layer_norm": false,
+                "enable_bias_skip_layer_norm": false,
+                "enable_attention": false
+            }
+        },
+        "OnnxQuantization": {
+            "type": "OnnxQuantization",
+            "data_config": "quantize_data_config",
+            "activation_type": "QUInt16",
+            "weight_type": "QUInt8",
+            "calibrate_method": "MinMax",
+            "quant_preprocess": true
+        }
+    },
+    "evaluator": "common_evaluator",
+    "output_dir": "models/vit-base-patch16-224_Gelu"
+}

--- a/olive/passes/onnx/transformer_optimization.py
+++ b/olive/passes/onnx/transformer_optimization.py
@@ -226,7 +226,7 @@ class OrtTransformersOptimization(Pass):
         keys_to_remove += get_external_data_config()
         run_config = exclude_keys(run_config, keys_to_remove)
 
-        if model.model_attributes:
+        if model.model_attributes and run_config["model_type"] != "clip":
             model_wrapper = ModelWrapper(model.model_attributes)
 
             model_type = MODEL_TYPE_MAPPING.get(model_wrapper.model_type, model_wrapper.model_type)


### PR DESCRIPTION
## [VitisAI] Add QDQ recipes for VitisAI EP

Adds recipes for
  - Intel BERT
  - Google BERT
  - OpenAI Clip (16 and 32)
  - Laion Clip
  - Google VIT
  - Phi3.5

contributor: VishalX https://github.com/VishalX/Olive/tree/vitis_ai_recipes


## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
