### PR TITLE
Fix lmeval evaluator logic to handle context length larger than max length

### DIFF
--- a/olive/evaluator/lmeval_onnx_model.py
+++ b/olive/evaluator/lmeval_onnx_model.py
@@ -98,7 +98,7 @@ class LMEvalOnnxModelEvaluator(TemplateLM):
 
             cont_len = len(continuation_enc)
             cont_tokens = np.asarray(continuation_enc)
-            greedy_tokens = (output_tokens[ctx_len:])[:cont_len]
+            greedy_tokens = output_tokens[ctx_len - cont_len : ctx_len]
 
             is_greedy = (cont_tokens == greedy_tokens).all()
             log_probs = np.take(log_probs, cont_tokens, 0)


### PR DESCRIPTION
## Fix lmeval evaluator logic to handle context length larger than max length

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
