### PR TITLE
Remove limitation on protobuf version

### DIFF
--- a/.azure_pipelines/job_templates/olive-test-cpu-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-cpu-template.yaml
@@ -45,7 +45,7 @@ jobs:
           call curl --output openvino_toolkit.zip https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0.1/windows/w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64.zip
           call 7z x openvino_toolkit.zip
           call w_openvino_toolkit_windows_2023.0.1.11005.fa1c41994f3_x86_64\\setupvars.bat
-          call python -m pip install numpy psutil coverage protobuf==3.20.3
+          call python -m pip install numpy psutil coverage
           call coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml $(Build.SourcesDirectory)/test/$(testType) --basetemp $(PYTEST_BASETEMP)
           call coverage xml
       displayName: Test Olive

--- a/examples/directml/llm/requirements.txt
+++ b/examples/directml/llm/requirements.txt
@@ -2,7 +2,6 @@ huggingface-hub
 markdown
 mdtex2html
 optimum
-protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing large models
 Pygments
 sentencepiece
 tabulate

--- a/examples/directml/stable_diffusion_xl/requirements-common.txt
+++ b/examples/directml/stable_diffusion_xl/requirements-common.txt
@@ -4,7 +4,6 @@ invisible-watermark
 onnx
 optimum
 pillow
-protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 torch
 # StableDiffusionSafetyChecker vision_model ignores attn_implementation
 transformers<4.43.0

--- a/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/examples/directml/stable_diffusion_xl/stable_diffusion_xl.py
@@ -318,13 +318,6 @@ def optimize(
     unoptimized_model_dir: Path,
     optimized_model_dir: Path,
 ):
-    from google.protobuf import __version__ as protobuf_version
-
-    # protobuf 4.x aborts with OOM when optimizing unet
-    if version.parse(protobuf_version) > version.parse("3.20.3"):
-        print("This script requires protobuf 3.20.3. Please ensure your package version matches requirements.txt.")
-        sys.exit(1)
-
     ort.set_default_logger_severity(4)
     script_dir = Path(__file__).resolve().parent
 

--- a/examples/llama2/requirements.txt
+++ b/examples/llama2/requirements.txt
@@ -1,7 +1,6 @@
 datasets>=2.8.0
 onnx>=1.14.0
 optimum>=1.17.0
-protobuf==3.20.2
 torch
 # transformers optimizer fusions don't match in newer versions
 transformers>=4.33.2,<= 4.37.2

--- a/examples/stable_diffusion/requirements-common.txt
+++ b/examples/stable_diffusion/requirements-common.txt
@@ -3,7 +3,6 @@ accelerate
 diffusers<0.30.0
 onnx
 pillow
-protobuf==3.20.3 # protobuf 4.x aborts with OOM when optimizing unet
 tabulate
 torch
 # StableDiffusionSafetyChecker vision_model ignores attn_implementation

--- a/examples/stable_diffusion/stable_diffusion.py
+++ b/examples/stable_diffusion/stable_diffusion.py
@@ -200,13 +200,6 @@ def optimize(
     unoptimized_model_dir: Path,
     optimized_model_dir: Path,
 ):
-    from google.protobuf import __version__ as protobuf_version
-
-    # protobuf 4.x aborts with OOM when optimizing unet
-    if version.parse(protobuf_version) > version.parse("3.20.3"):
-        print("This script requires protobuf 3.20.3. Please ensure your package version matches requirements.txt.")
-        sys.exit(1)
-
     script_dir = Path(__file__).resolve().parent
 
     # Clean up previously optimized models, if any.

--- a/examples/stable_diffusion/stable_diffusion.py
+++ b/examples/stable_diffusion/stable_diffusion.py
@@ -13,7 +13,6 @@ from typing import Dict
 import numpy as np
 import torch
 from diffusers import DiffusionPipeline
-from packaging import version
 from sd_utils import config
 from user_script import get_base_model_name
 

--- a/olive/systems/python_environment/common_requirements.txt
+++ b/olive/systems/python_environment/common_requirements.txt
@@ -1,4 +1,4 @@
 numpy<2.0
-protobuf<4.0.0
+protobuf
 psutil
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ onnx
 onnxscript
 optuna
 pandas
-protobuf<4.0.0
+protobuf<6.0.0
 pydantic
 pyyaml
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ onnx
 onnxscript
 optuna
 pandas
-protobuf<6.0.0
 pydantic
 pyyaml
 torch

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -27,7 +27,6 @@ optimum>=1.17.0
 pandas
 peft
 plotly
-protobuf==3.20.3
 psutil
 pytest
 pytorch_lightning


### PR DESCRIPTION
ONNX 1.18 is starting to require protobuf >4 (https://github.com/onnx/onnx/blob/e82b8a37c3251d0d66f695130a3e311d951ede62/requirements.txt#L2). Remove protobuf from requirements because we get it from onnx.
