### PR TITLE
Use ONNX IR in graph surgeries

### DIFF
--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -3,13 +3,11 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-# ruff: noqa: RUF012
-
 import inspect
 import logging
 import math
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Sequence, Type
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Sequence, Type
 
 import numpy as np
 import onnx
@@ -160,7 +158,7 @@ class ReorderInputs(Surgeon):
 
 
 class ReplaceErfWithTanh(ProtoSurgeon):
-    DTYPE_MAP = {
+    DTYPE_MAP: Mapping = {
         TensorProto.FLOAT: np.float32,
         TensorProto.FLOAT16: np.float16,
         TensorProto.DOUBLE: np.float64,

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -147,7 +147,7 @@ class ReorderInputs(Surgeon):
             raise ValueError("Invalid permutation: permutation must be a rearrangement of input indices.")
 
         reordered_inputs = [inputs[idx] for idx in self.permutation]
-        del model.graph.inputs[:]
+        model.graph.inputs.clear()
         model.graph.inputs.extend(reordered_inputs)
 
         return model

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -326,13 +326,13 @@ class RemoveInputs(Surgeon):
 
 
 class ExposeOutputs(Surgeon):
-    def __init__(self, names):
-        self.names = names
+    def __init__(self, names: Sequence[str]):
+        self.names = set(names)
 
-    def __call__(self, model: ModelProto):
-        for node in model.graph.node:
+    def call_ir(self, model: ir.Model) -> ir.Model:
+        for node in model.graph:
             if node.name in self.names:
-                model.graph.output.extend([onnx.ValueInfoProto(name=node.output[0])])
+                model.graph.outputs.append(node.output[0])
         return model
 
 

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -2,12 +2,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
 import inspect
 import logging
 import math
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Mapping, Optional, Sequence, Type
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Sequence, Tuple, Type
 
 import numpy as np
 import onnx
@@ -38,6 +37,9 @@ class Surgeon:
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         Surgeon.registry[cls.__name__.lower()] = cls
+
+    def __init__(self):
+        pass
 
     def __call__(self, model: ModelProto) -> ModelProto:
         return ir.to_proto(self.call_ir(ir.from_proto(model)))
@@ -1137,7 +1139,7 @@ class GraphSurgeries(Pass):
         return surgeon_class(**init_params)
 
     @staticmethod
-    def get_surgeon_parameters(surgeon_class):
+    def get_surgeon_parameters(surgeon_class: Type[Surgeon]) -> Tuple[List[str], List[str]]:
         parameters = inspect.signature(surgeon_class.__init__).parameters
 
         positional_args = [

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -43,6 +43,36 @@ class Surgeon:
         raise NotImplementedError
 
     @staticmethod
+    def get_node_by_name(model, name: str, match_output: bool = False):
+        for node in model.graph.node:
+            if (match_output and node.output[0] == name) or (not match_output and node.name == name):
+                return node
+        return None
+
+    @staticmethod
+    def get_tensor_shapes(model) -> Dict[str, List[int]]:
+        return {info.name: [x.dim_value for x in info.type.tensor_type.shape.dim] for info in model.graph.value_info}
+
+    @staticmethod
+    def get_tensor_types(model):
+        return {info.name: info.type.tensor_type.elem_type for info in model.graph.value_info}
+
+    @staticmethod
+    def get_initializer_types(model):
+        return {initializer.name: initializer.data_type for initializer in model.graph.initializer}
+
+    @staticmethod
+    def get_initializer_shapes(model) -> Dict[str, List[int]]:
+        return {initializer.name: initializer.dims for initializer in model.graph.initializer}
+
+    @staticmethod
+    def get_initializer_by_name(model, name: str):
+        for initializer in model.graph.initializer:
+            if initializer.name == name:
+                return initializer
+        return None
+
+    @staticmethod
     def create_new_name(name: str, old_op: str, new_op: str) -> str:
         return name.replace(old_op, new_op) if old_op in name else f"{name}_{new_op}"
 

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -37,7 +37,7 @@ class Surgeon:
         Surgeon.registry[cls.__name__.lower()] = cls
 
     def __call__(self, model: ModelProto) -> ModelProto:
-        return ir.to_proto(self.call(ir.from_proto(model)))
+        return ir.to_proto(self.call_ir(ir.from_proto(model)))
 
     def call_ir(self, model: ir.Model) -> ir.Model:
         raise NotImplementedError

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -84,9 +84,9 @@ class RenameInputs(Surgeon):
 
     def call_ir(self, model: ir.Model) -> ir.Model:
         replacement = dict(zip(self.old_names, self.new_names))
-        for input in model.graph.inputs:
-            if input.name in replacement:
-                input.name = replacement[input.name]
+        for inp in model.graph.inputs:
+            if inp.name in replacement:
+                inp.name = replacement[inp.name]
 
 
 class RenameOutputs(Surgeon):

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -127,7 +127,7 @@ class RemoveInitializerFromInputs(Surgeon):
         pass
 
     def call_ir(self, model: ir.Model) -> ir.Model:
-        while model.graph.inputs[-1].name in model.graph.initializers:
+        while model.graph.inputs and (model.graph.inputs[-1].name in model.graph.initializers):
             # Initializers are always at the end of the input list
             model.graph.inputs.pop()
         return model

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -334,7 +334,7 @@ class ExposeOutputs(Surgeon):
     def call_ir(self, model: ir.Model) -> ir.Model:
         for node in model.graph:
             if node.name in self.names:
-                model.graph.outputs.append(node.output[0])
+                model.graph.outputs.append(node.outputs[0])
         return model
 
 

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -40,7 +40,8 @@ class Surgeon:
         return ir.to_proto(self.call_ir(ir.from_proto(model)))
 
     def call_ir(self, model: ir.Model) -> ir.Model:
-        raise NotImplementedError
+        # Override this method in subclasses to implement the surgery with ONNX IR
+        return model
 
     @staticmethod
     def get_node_by_name(model, name: str, match_output: bool = False):
@@ -87,6 +88,7 @@ class RenameInputs(Surgeon):
         for inp in model.graph.inputs:
             if inp.name in replacement:
                 inp.name = replacement[inp.name]
+        return model
 
 
 class RenameOutputs(Surgeon):


### PR DESCRIPTION
## Describe your changes

Use ONNX IR in graph surgeries to replace some proto manipulation. This PR adds a `call_ir` in the base class that is called when `__call__` is not overriden. This way the changes can be incremental and compatible with existing usages of the `Surgeon` class.

Refactoring:
- Renamed the Surgeon class that operates on proto to ProtoSurgeon to make the intention clear. Developers can subclass ProtoSurgeon to operate on proto and subclass Surgion to transform graphs directly with IR.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
