### PR TITLE
Allow cli to take capture-onnx-graph output model

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -39,7 +39,9 @@ class BaseOliveCLICommand(ABC):
             run_config = self._get_run_config(tempdir)
             if self.args.save_config_file:
                 self._save_config_file(run_config)
-            return olive_run(run_config)
+            output = olive_run(run_config)
+            print(f"Model is saved at {self.args.output_path}")
+            return output
 
     @staticmethod
     def _save_config_file(config: dict):
@@ -505,6 +507,12 @@ def add_dataset_options(sub_parser, required=True, include_train=True, include_e
         default=1,
         help="Batch size.",
     )
+    dataset_group.add_argument(
+        "--input_cols",
+        type=str,
+        nargs="+",
+        help="List of input column names. Provide one or more names separated by space. Example: --input_cols sentence1 sentence2",
+    )
 
     return dataset_group, text_group
 
@@ -529,6 +537,7 @@ def update_dataset_options(args, config):
         ((*preprocess_key, "chat_template"), args.use_chat_template),
         ((*preprocess_key, "max_seq_len"), args.max_seq_len),
         ((*preprocess_key, "add_special_tokens"), args.add_special_tokens),
+        ((*preprocess_key, "input_cols"), args.input_cols),
         ((*preprocess_key, "max_samples"), args.max_samples),
         ((*dataloader_key, "batch_size"), args.batch_size),
     ]

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -40,7 +40,10 @@ class BaseOliveCLICommand(ABC):
             if self.args.save_config_file:
                 self._save_config_file(run_config)
             output = olive_run(run_config)
-            print(f"Model is saved at {self.args.output_path}")
+            if output is None:
+                print("No output model produced. Please check the log for details.")
+            else:
+                print(f"Model is saved at {self.args.output_path}")
             return output
 
     @staticmethod

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -126,8 +126,8 @@ class QuantizeCommand(BaseOliveCLICommand):
             ):
                 if not self._check_data_name_arg(pinfo):
                     raise ValueError(
-                        f"Dataset is required for pass {r['pass_type']} but no dataset is provided. "
-                        "Please provide a dataset using --data_name option."
+                        f"Quantization for {algo} {precision} {impl} implementation with QDQ {self.args.use_qdq_encoding}"
+                        " requires dataset. Please provide a dataset using --data_name option."
                     )
                 else:
                     pass_list.append(r["pass_type"])

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -6,7 +6,6 @@
 # ruff: noqa: T201
 # ruff: noqa: RUF012
 
-import logging
 from argparse import ArgumentParser
 from copy import deepcopy
 from typing import Any
@@ -26,8 +25,6 @@ from olive.cli.base import (
 from olive.common.utils import set_nested_dict_value
 from olive.constants import QuantAlgorithm
 from olive.package_config import OlivePackageConfig
-
-logger = logging.getLogger(__name__)
 
 
 class QuantizeCommand(BaseOliveCLICommand):
@@ -125,8 +122,8 @@ class QuantizeCommand(BaseOliveCLICommand):
                 and (not self.args.use_qdq_encoding or "qdq" in pinfo.supported_quantization_encodings)
             ):
                 if not self._check_data_name_arg(pinfo):
-                    raise ValueError(
-                        f"Quantization for {algo} {precision} {impl} implementation with QDQ {self.args.use_qdq_encoding}"
+                    print(
+                        f"Warning: Quantization for {algo} {precision} {impl} implementation with QDQ {self.args.use_qdq_encoding}"
                         " requires dataset. Please provide a dataset using --data_name option."
                     )
                 else:
@@ -137,7 +134,7 @@ class QuantizeCommand(BaseOliveCLICommand):
                 f"Quantiation for precision {precision}, algorithm {algo} and implementation {impl} "
                 f"with QDQ {self.args.use_qdq_encoding} is not supported"
             )
-        logger.info("pass list: %s", pass_list)
+        print(f"pass list: {pass_list}")
         return pass_list
 
     def _get_passes_dict(self, pass_list):
@@ -169,7 +166,7 @@ class QuantizeCommand(BaseOliveCLICommand):
             if to_add.get(p) is not None:
                 pd.update(dict(to_add[p].items()))
             passes_dict[p.lower()] = pd
-        logger.info("selected pass configs: %s", passes_dict)
+        print(f"selected pass configs: {passes_dict}")
         return passes_dict
 
     def _customize_config(self, config):

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -134,7 +134,8 @@ class QuantizeCommand(BaseOliveCLICommand):
 
         if not pass_list:
             raise ValueError(
-                f"Quantiation for precision {precision}, algorithm {algo} and implementation {impl} is not supported"
+                f"Quantiation for precision {precision}, algorithm {algo} and implementation {impl} "
+                f"with QDQ {self.args.use_qdq_encoding} is not supported"
             )
         logger.info("pass list: %s", pass_list)
         return pass_list
@@ -150,7 +151,7 @@ class QuantizeCommand(BaseOliveCLICommand):
         to_add = {
             "AutoAWQQuantizer": {"w_bit": precision_in_bits},
             "GptqQuantizer": {"bits": precision_in_bits},
-            "OnnxBnB4Quantization": {"quant_type": precision_in_bits},
+            "OnnxBnB4Quantization": {"quant_type": self.args.precision},
             "NVModelOptQuantization": {"precision": precision_in_bits, "algorithm": self.args.algorithm.upper()},
             "OnnxDynamicQuantization": {"weight_type": wtypes, "quant_format": quant_format},
             "OnnxStaticQuantization": {

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -123,9 +123,14 @@ class QuantizeCommand(BaseOliveCLICommand):
                 and (algo is None or algo in pinfo.supported_algorithms)
                 and (precision is None or precision in pinfo.supported_precisions)
                 and (not self.args.use_qdq_encoding or "qdq" in pinfo.supported_quantization_encodings)
-                and self._check_data_name_arg(pinfo)
             ):
-                pass_list.append(r["pass_type"])
+                if not self._check_data_name_arg(pinfo):
+                    raise ValueError(
+                        f"Dataset is required for pass {r['pass_type']} but no dataset is provided. "
+                        "Please provide a dataset using --data_name option."
+                    )
+                else:
+                    pass_list.append(r["pass_type"])
 
         if not pass_list:
             raise ValueError(

--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -126,15 +126,17 @@ class OnnxConversion(Pass):
     ) -> Union[DistributedOnnxModelHandler, ONNXModelHandler]:
         output_model = self._run_for_config_internal(model, config, output_model_path)
 
-        if isinstance(model, HfModelHandler) and config.save_metadata_for_token_generation:
-            # output_model can only be an ONNXModelHandler
-            output_dir = output_model.change_model_path_to_dir()
-
+        if isinstance(model, HfModelHandler):
             output_model.model_attributes = model_attributes = output_model.model_attributes or {}
-            model_attributes["additional_files"] = additional_files = model_attributes.get("additional_files", [])
-            # quantization config is already popped from the model and included in model_attributes
-            # don't want the information to be saved in metadata (issues with generation config save)
-            additional_files.extend(model.save_metadata(str(output_dir), exclude_load_keys=["quantization_config"]))
+            model_attributes["hf_task"] = model.task
+
+            if config.save_metadata_for_token_generation:
+                # output_model can only be an ONNXModelHandler
+                output_dir = output_model.change_model_path_to_dir()
+                model_attributes["additional_files"] = additional_files = model_attributes.get("additional_files", [])
+                # quantization config is already popped from the model and included in model_attributes
+                # don't want the information to be saved in metadata (issues with generation config save)
+                additional_files.extend(model.save_metadata(str(output_dir), exclude_load_keys=["quantization_config"]))
 
         return output_model
 

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -161,9 +161,19 @@ class RunConfig(NestedConfig):
             v = v.dict()
 
         # all model related info used for auto filling
+        task = None
+        model_name = None
+        if input_model_config["type"].lower() == "onnxmodel":
+            # Only valid for onnx model converted from Olive Conversion pass
+            task = input_model_config["config"]["model_attributes"].get("hf_task", DEFAULT_HF_TASK)
+            model_name = input_model_config["config"]["model_attributes"].get("_name_or_path")
+        else:
+            task = input_model_config["config"].get("task", DEFAULT_HF_TASK)
+            model_name = input_model_config["config"]["model_path"]
+
         model_info = {
-            "model_name": input_model_config["config"]["model_path"],
-            "task": input_model_config["config"].get("task", DEFAULT_HF_TASK),
+            "model_name": model_name,
+            "task": task,
             "trust_remote_code": input_model_config["config"].get("load_kwargs", {}).get("trust_remote_code"),
         }
         kv_cache = input_model_config.get("io_config", {}).get("kv_cache")

--- a/olive/workflows/run/config.py
+++ b/olive/workflows/run/config.py
@@ -163,7 +163,7 @@ class RunConfig(NestedConfig):
         # all model related info used for auto filling
         task = None
         model_name = None
-        if input_model_config["type"].lower() == "onnxmodel":
+        if input_model_config["type"].lower() == "onnxmodel" and "model_attributes" in input_model_config["config"]:
             # Only valid for onnx model converted from Olive Conversion pass
             task = input_model_config["config"]["model_attributes"].get("hf_task", DEFAULT_HF_TASK)
             model_name = input_model_config["config"]["model_attributes"].get("_name_or_path")


### PR DESCRIPTION
## Describe your changes

1. Print CLI output model save path (not sure why this was removed before).
2. Add `input_cols` option to dataset for cli for text-classification task.
3. Update error message when missing dataset, otherwise it will say the precision is not supported.
4. Save `hf_task` to `model_attributes` from Conversion pass, this will be used for later pass.
5. Correct model name and task for dataset config when input model is `onnxmodel`.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
