### PR TITLE
Update pytest config for readability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.pytest.ini_options]
-addopts = "-rsfEX --tb=short --color=yes"
-
 [tool.pylint.BASIC]
 good-names = [
   "a",
@@ -80,6 +77,9 @@ disable = [
   "used-before-assignment",
   "wrong-import-order" # import order is handled by the formatter (ruff)
 ]
+
+[tool.pytest.ini_options]
+addopts = "-rsfEX --tb=short --color=yes"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+addopts = "-rsfEX --tb=short --color=yes"
+
 [tool.pylint.BASIC]
 good-names = [
   "a",


### PR DESCRIPTION
Currently in CI the pytest errors return full functions in the error stack, which I think is overly verbose and not readable. I updated the ini options taken from https://github.com/microsoft/onnxscript/blob/main/pyproject.toml to make the pytest errors more readable.
