### PR TITLE
Handle device and search options for lm evaluator

### DIFF
--- a/olive/evaluator/lmeval_onnx_model.py
+++ b/olive/evaluator/lmeval_onnx_model.py
@@ -36,6 +36,9 @@ class LMEvalOnnxModelEvaluator(TemplateLM):
 
         self._params = og.GeneratorParams(self._model)
 
+        search_options = {"max_length": self._max_length}
+        self._params.set_search_options(**search_options)
+
     @property
     def eot_token_id(self):
         # we use EOT because end of *text* is more accurate for what we're doing than end of *sentence*

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1082,13 +1082,13 @@ class LMEvaluator(OliveEvaluator):
             else:
                 raise ValueError("Failed to automatically deduce model class. Provide it in user input!")
 
-        device = _OliveEvaluator.device_string_to_torch_device(device)
-        # device = torch.device("cuda:5")
         pretrained = None
         tokenizer = None
         if self.model_class == "hf":
             tokenizer = model.get_hf_tokenizer()
             pretrained = model.load_model().eval().to(device)
+            device = _OliveEvaluator.device_string_to_torch_device(device)
+
         elif self.model_class == "onnx":
             import onnxruntime_genai as og
 
@@ -1098,6 +1098,7 @@ class LMEvaluator(OliveEvaluator):
             model_path = model_path.parent if model_path.is_file() else model_path
             pretrained = og.Model(str(model_path))
             tokenizer = og.Tokenizer(pretrained)
+            device = None
 
         lmmodel = lm_eval.api.registry.get_model(self.model_class)(
             pretrained=pretrained,


### PR DESCRIPTION
## Handle device and search options for lm evaluator

Device isn't used for generative ONNX model so set it to None and be ignored. Setup search options (to pass down max_length) for GenAI generator.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
