### PR TITLE
QNN: Attention mask surgery for more tensors, Clip example update

### DIFF
--- a/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq.json
+++ b/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq.json
@@ -174,7 +174,6 @@
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
             "data_config": "quant_data_config",
-            "op_types_to_quantize": [ "MatMul", "LayerNormalization", "Gemm", "Sigmoid", "Gelu" ],
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax"

--- a/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq_ctx.json
+++ b/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq_ctx.json
@@ -140,7 +140,6 @@
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
             "data_config": "quant_data_config",
-            "op_types_to_quantize": [ "MatMul", "LayerNormalization", "Gemm", "Sigmoid", "Gelu" ],
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax"

--- a/examples/clip/openai_clip-vit-base-patch16_ptq_qnn_qdq.json
+++ b/examples/clip/openai_clip-vit-base-patch16_ptq_qnn_qdq.json
@@ -177,7 +177,6 @@
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
             "data_config": "quant_data_config",
-            "op_types_to_exclude": [ "Softmax", "Add" ],
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax"

--- a/examples/clip/openai_clip-vit-base-patch16_ptq_qnn_qdq_ctx.json
+++ b/examples/clip/openai_clip-vit-base-patch16_ptq_qnn_qdq_ctx.json
@@ -143,7 +143,6 @@
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
             "data_config": "quant_data_config",
-            "op_types_to_exclude": [ "Softmax", "Add" ],
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax"

--- a/examples/clip/openai_clip-vit-base-patch32_ptq_qnn_qdq.json
+++ b/examples/clip/openai_clip-vit-base-patch32_ptq_qnn_qdq.json
@@ -177,7 +177,6 @@
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
             "data_config": "quant_data_config",
-            "op_types_to_exclude": [ "Softmax", "Add" ],
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax"

--- a/examples/clip/openai_clip-vit-base-patch32_ptq_qnn_qdq_ctx.json
+++ b/examples/clip/openai_clip-vit-base-patch32_ptq_qnn_qdq_ctx.json
@@ -143,7 +143,6 @@
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
             "data_config": "quant_data_config",
-            "op_types_to_exclude": [ "Softmax", "Add" ],
             "activation_type": "QUInt16",
             "weight_type": "QUInt8",
             "calibrate_method": "MinMax"

--- a/test/unit_test/passes/onnx/test_graph_surgeries.py
+++ b/test/unit_test/passes/onnx/test_graph_surgeries.py
@@ -346,9 +346,9 @@ def test_expose_quantized_output(tmp_path):
     # Validate that the scale node and its initializer exist in the modified model
     assert any(node.name == scale_node_name for node in output_model.graph.node), "Scale node not added."
     scale_initializer = next(init for init in output_model.graph.initializer if init.name == scale_initializer_name)
-    assert np.allclose(
-        numpy_helper.to_array(scale_initializer), np.array([original_scale_value], dtype=np.float32)
-    ), "Scale value mismatch."
+    assert np.allclose(numpy_helper.to_array(scale_initializer), np.array([original_scale_value], dtype=np.float32)), (
+        "Scale value mismatch."
+    )
 
     # Validate that the zero_point node and its initializer exist in the modified model
     assert any(node.name == zero_point_node_name for node in output_model.graph.node), "Zero point node not added."

--- a/test/unit_test/passes/onnx/test_graph_surgeries.py
+++ b/test/unit_test/passes/onnx/test_graph_surgeries.py
@@ -346,9 +346,9 @@ def test_expose_quantized_output(tmp_path):
     # Validate that the scale node and its initializer exist in the modified model
     assert any(node.name == scale_node_name for node in output_model.graph.node), "Scale node not added."
     scale_initializer = next(init for init in output_model.graph.initializer if init.name == scale_initializer_name)
-    assert np.allclose(numpy_helper.to_array(scale_initializer), np.array([original_scale_value], dtype=np.float32)), (
-        "Scale value mismatch."
-    )
+    assert np.allclose(
+        numpy_helper.to_array(scale_initializer), np.array([original_scale_value], dtype=np.float32)
+    ), "Scale value mismatch."
 
     # Validate that the zero_point node and its initializer exist in the modified model
     assert any(node.name == zero_point_node_name for node in output_model.graph.node), "Zero point node not added."
@@ -645,14 +645,20 @@ def test_replace_attention_mask_value(tmp_path):
         helper.make_tensor_value_info("input1", TensorProto.INT64, [1]),
         helper.make_tensor_value_info("input2", TensorProto.FLOAT, [1]),
         helper.make_tensor_value_info("input3", TensorProto.FLOAT, [1]),
+        helper.make_tensor_value_info("input4", TensorProto.FLOAT, [1]),
     ]
     output_tensors = [
         helper.make_tensor_value_info("output1", TensorProto.FLOAT, [1]),
         helper.make_tensor_value_info("output2", TensorProto.FLOAT, [1]),
         helper.make_tensor_value_info("output3", TensorProto.FLOAT, [1]),
+        helper.make_tensor_value_info("output4", TensorProto.FLOAT, [4, 1, 2, 2]),
+        helper.make_tensor_value_info("output5", TensorProto.FLOAT, [1, 1, 2, 2]),
     ]
+    expand_init = np.array([[[[0, min_value], [min_value, min_value]]]], dtype=np.float32)
     initializers = [
         helper.make_tensor("init", TensorProto.FLOAT, [], [min_value]),
+        numpy_helper.from_array(expand_init, name="add_init"),
+        helper.make_tensor("expand_shape", TensorProto.INT64, [4], [4, 1, 2, 2]),
     ]
     nodes = [
         helper.make_node(
@@ -680,6 +686,25 @@ def test_replace_attention_mask_value(tmp_path):
             inputs=["input3", "init"],
             outputs=["output3"],
             name="Mul_init",
+        ),
+        helper.make_node(
+            "Constant",
+            inputs=[],
+            outputs=["expand_constant"],
+            name="Constant_expand",
+            value=numpy_helper.from_array(expand_init, name=""),
+        ),
+        helper.make_node(
+            "Expand",
+            inputs=["expand_constant", "expand_shape"],
+            outputs=["output4"],
+            name="Expand_constant",
+        ),
+        helper.make_node(
+            "Add",
+            inputs=["input4", "add_init"],
+            outputs=["output5"],
+            name="Add_init",
         ),
     ]
     graph = helper.make_graph(
@@ -714,9 +739,16 @@ def test_replace_attention_mask_value(tmp_path):
             "input1": np.array([1], dtype=np.int64),
             "input2": np.array([1], dtype=np.float32),
             "input3": np.array([1], dtype=np.float32),
+            "input4": np.array([0], dtype=np.float32),
         },
     )
-    assert all(o == -1e4 for o in outputs)
+    assert all(o == -1e4 for o in outputs[:3])
+    expected_output_4 = np.repeat(expand_init, 4, axis=0)
+    expected_output_4[expected_output_4 == min_value] = -1e4
+    assert np.array_equal(outputs[3], expected_output_4)
+    expected_output_5 = expand_init.copy()
+    expected_output_5[expected_output_5 == min_value] = -1e4
+    assert np.array_equal(outputs[4], expected_output_5)
 
 
 def test_matmul_add_to_gemm(tmp_path):


### PR DESCRIPTION
## Describe your changes
- Attention mask surgery is generalized to all tensors. 
- Some filters on the consumer type to avoid checking large weights
- clip models can now quantize all ops without accuracy issues

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
