### PR TITLE
LoRA/QLoRA: `evaluation_strategy` -> `eval_strategy`, Default `paged_adamw_32bit` optim only for QLoRA

### DIFF
--- a/olive/passes/pytorch/lora.py
+++ b/olive/passes/pytorch/lora.py
@@ -69,7 +69,7 @@ class HFTrainingArguments(BaseHFTrainingArguments):
         description="Learning rate schedule. Constant a bit better than cosine, and has advantage for analysis.",
     )
     warmup_ratio: float = Field(0.03, description="Fraction of steps to do a warmup for.")
-    evaluation_strategy: str = Field(
+    eval_strategy: str = Field(
         None,
         description=(
             "The evaluation strategy to use. Forced to 'no' if eval_dataset is not provided. Otherwise, 'steps' unless"
@@ -407,11 +407,11 @@ class LoRA(Pass):
         train_dataset, eval_dataset = self.get_datasets(config)
 
         # get training arguments
-        orig_eval_strat = config.training_args.evaluation_strategy
-        config.training_args.evaluation_strategy = "no"
+        orig_eval_strat = config.training_args.eval_strategy
+        config.training_args.eval_strategy = "no"
         if eval_dataset:
             # default to "steps" if eval dataset is provided
-            config.training_args.evaluation_strategy = "steps" if orig_eval_strat in {None, "no"} else orig_eval_strat
+            config.training_args.eval_strategy = "steps" if orig_eval_strat in {None, "no"} else orig_eval_strat
 
         # We always create a temp dir even if output_dir is provided because we want the temp dir to be deleted
         # after training or if there is an error
@@ -574,14 +574,18 @@ class LoRAVariant(LoRA):
             "rank_pattern": PassConfigParam(
                 type_=dict,
                 default_value={},
-                description="The mapping from layer names or regexp expression "
-                "to ranks which are different from the default rank specified by r.",
+                description=(
+                    "The mapping from layer names or regexp expression "
+                    "to ranks which are different from the default rank specified by r."
+                ),
             ),
             "alpha_pattern": PassConfigParam(
                 type_=dict,
                 default_value={},
-                description="The mapping from layer names or regexp expression "
-                "to alphas which are different from the default alpha specified by alpha.",
+                description=(
+                    "The mapping from layer names or regexp expression "
+                    "to alphas which are different from the default alpha specified by alpha."
+                ),
             ),
         }
         config.update(super()._default_config(accelerator_spec))

--- a/olive/passes/pytorch/train_utils.py
+++ b/olive/passes/pytorch/train_utils.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import transformers
+from packaging import version
+from transformers import __version__ as transformers_version
 
 from olive.common.config_utils import NestedConfig
 from olive.common.pydantic_v1 import Field, validator
@@ -73,6 +75,8 @@ class BaseHFTrainingArguments(NestedConfig):
             args["deepspeed"] = deepcopy(DEFAULT_DEEPSPEED_CONFIG)
         elif args["deepspeed"] is False:
             del args["deepspeed"]
+        if version.parse(transformers_version) < version.parse("4.41") and "eval_strategy" in args:
+            args["evaluation_strategy"] = args.pop("eval_strategy")
         extra_args = args.pop("extra_args")
         return transformers.TrainingArguments(**args, **extra_args)
 

--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -51,7 +51,6 @@ def get_pass_config(model_name, task, **kwargs):
             "gradient_checkpointing": False,
             "max_steps": 2,
             "logging_steps": 1,
-            "optim": "adamw_hf",
         },
         **kwargs,
     }


### PR DESCRIPTION
## Describe your changes
- Compatibility with transformers 4.51 by replacing `evaluation_strategy` with `eval_strategy`. `eval_strategy` was added and preferred since 4.41. 
- Only make `paged_adamw_32bit` the default optimizer for QLoRA/LoftQ passes since it's part of the bitsandbytes package.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
