### PR TITLE
QuaRot: Keep model in original precision

### DIFF
--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -24,7 +24,7 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.model.utils.path_utils import normalize_path_suffix
 from olive.passes import Pass
-from olive.passes.pass_config import BasePassConfig, PassConfigParam, get_user_script_data_config
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf, inherit_pytorch_from_pytorch
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,6 @@ class GptqQuantizer(Pass):
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> dict[str, PassConfigParam]:
         return {
-            **get_user_script_data_config(),
             "bits": PassConfigParam(
                 type_=PrecisionBits,
                 default_value=PrecisionBits.BITS4,

--- a/olive/passes/pytorch/rotate.py
+++ b/olive/passes/pytorch/rotate.py
@@ -85,7 +85,8 @@ class RotateBase(Pass):
             model.set_resource("adapter_path", None)
 
         # load pytorch model
-        torch_dtype = None
+        # use "auto" by default to keep the original dtype
+        torch_dtype = model.get_load_kwargs().get("torch_dtype") or "auto"
         if training_args:
             torch_dtype = torch.bfloat16 if training_args.bf16 else torch.float16
         pytorch_model = load_hf_base_model(model, torch_dtype=torch_dtype)


### PR DESCRIPTION
## Describe your changes
- QuaRot: The model was loaded with `torch_dtype=None` which loads the model in `float32` precision. Most hf models are originally saved in `bfloat16` or `float16` precision. Use `torch_dtype="auto"` if the model handler doesn't provide, to keep the model in its original precision.
- GPTQ: Remove unused user script pass params that were part of dataloader option that was replaced with data config before.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
