### PR TITLE
Add hqq to quantize cli & update docs

### DIFF
--- a/docs/source/extending/index.rst
+++ b/docs/source/extending/index.rst
@@ -39,4 +39,5 @@ Extending Olive
 
    design
    how-to-add-optimization-pass
+   custom-model-evaluator
    custom-scripts

--- a/docs/source/features/quantization.md
+++ b/docs/source/features/quantization.md
@@ -62,6 +62,18 @@ This pass only supports HuggingFace transformer PyTorch models.
 }
 ```
 
+## HQQ
+`HQQ (Half-Quadratic Quantization)` is a fast, calibration-free weight quantization method that enables low-bit quantization of large models without relying on gradient-based optimization. Unlike data-dependent approaches like GPTQ, [HQQ](https://mobiusml.github.io/hqq_blog/) uses half-quadratic splitting to minimize weight quantization error efficiently.
+
+This pass only supports ONNX models, and will only quantize `MatMul` nodes to 4 bits.
+
+### Example Configuration
+```json
+{
+    "type": "OnnxHqqQuantization"
+}
+```
+
 ## Quantize with onnxruntime
 Quantization is a technique to compress deep learning models by reducing the precision of the model weights from 32 bits to 8 bits. This
 technique is used to reduce the memory footprint and improve the inference performance of the model. Quantization can be applied to the

--- a/docs/source/how-to/cli/cli-quantize.md
+++ b/docs/source/how-to/cli/cli-quantize.md
@@ -20,6 +20,7 @@ Some methods require a GPU and/or a calibration dataset.
 | ORT | Static and dynamic quantizations. | ONNX | RTN | ❌ |
 | INC | Intel® Neural Compressor model compression tool. | ONNX | GPTQ | ❌ |
 | NVMO | NVIDIA TensorRT Model Optimizer is a library comprising state-of-the-art model optimization techniques including quantization, sparsity, distillation, and pruning to compress models. | ONNX | AWQ | ❌ |
+| Olive | Olive implemented Half-Quadratic Quantization for MatMul to 4 bits | ONNX | HQQ | ❌ |
 
 ## {octicon}`zap` Quickstart
 

--- a/docs/source/how-to/cli/cli-quantize.md
+++ b/docs/source/how-to/cli/cli-quantize.md
@@ -16,6 +16,8 @@ Some methods require a GPU and/or a calibration dataset.
 | -------------- | ----------- | --------------- | --------- | ------------ |
 | AWQ | Activation-aware Weight Quantization (AWQ) creates 4-bit quantized models and it speeds up models by 3x and reduces memory requirements by 3x compared to FP16.  | PyTorch <br> ONNX| Awq | ✔️ |
 | GPTQ | Generative Pre-trained Transformer Quantization (GPTQ) is a one-shot weight quantization method. You can quantize your favorite language model to 8, 4, 3 or even 2 bits.  | PyTorch <br> ONNX |  GptQ  | ✔️ |
+| Quarot | QuaRot enables full 4-bit quantization of LLMs, including weights, activations, and KV cache, by using Hadamard rotations to remove outliers | PyTorch | quarot | ❌ |
+| Spinquant | SpinQuant is a quantization method that learns rotation matrices to eliminate outliers in weights and activations, improving low-bit quantization without altering model architecture. | PyTorch | spinquant | ❌ |
 | BitsAndBytes | Is a MatMul with weight quantized with N bits (e.g., 2, 3, 4, 5, 6, 7). | ONNX | RTN | ❌ |
 | ORT | Static and dynamic quantizations. | ONNX | RTN | ❌ |
 | INC | Intel® Neural Compressor model compression tool. | ONNX | GPTQ | ❌ |

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -109,7 +109,6 @@ How to customize configuration
    configure-workflows/model-packaging
    configure-workflows/systems
    configure-workflows/engine-configuration
-   configure-workflows/custom-model-evaluator
 
 For more complex scenarios, you can customize configuration where you can run any of the 40+ supported optimization techniques in a sequence.
 

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -62,7 +62,6 @@ class QuantizeCommand(BaseOliveCLICommand):
         sub_parser.add_argument(
             "--implementation",
             type=str,
-            # choices=sorted(TEMPLATE["passes"].keys()),
             help="The specific implementation of quantization algorithms to use.",
         )
         sub_parser.add_argument(
@@ -216,5 +215,6 @@ ONNX_QUANT_IMPLEMENTATION_MAPPING = [
     {"impl_name": "ort", "pass_type": "OnnxStaticQuantization"},
     {"impl_name": "nvmo", "pass_type": "NVModelOptQuantization"},
     {"impl_name": "inc", "pass_type": "IncDynamicQuantization"},
+    {"pass_type": "OnnxHqqQuantization"},
     # "impl_name": "inc", "pass_type": "IncStaticQuantization"},
 ]

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -161,7 +161,7 @@
             "supported_providers": [ "CPUExecutionProvider", "CUDAExecutionProvider", "DmlExecutionProvider" ],
             "supported_accelerators": [ "cpu", "gpu" ],
             "supported_precisions": [ "int4" ],
-            "supported_algorithms": [ "rtn", "hqq" ],
+            "supported_algorithms": [ "rtn" ],
             "supported_quantization_encodings": [ "qdq" ]
         },
         "OnnxHqqQuantization": {


### PR DESCRIPTION
## Describe your changes

Add hqq to quantize cli & update docs. Quantize cli works with `olive quantize --algorithm hqq --precision int4 -m <model_name>`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
