### PR TITLE
Add support for Nvidia TensorRT RTX execution provider in Olive

### DIFF
--- a/docs/source/getting-started/getting-started.md
+++ b/docs/source/getting-started/getting-started.md
@@ -91,7 +91,7 @@ olive auto-opt \
 - The `model_name_or_path` can be either (a) the Hugging Face Repo ID for the model `{username}/{repo-name}` or (b) a path on local disk to the model or (c) an Azure AI Model registry ID.
 - `output_path` is the path on local disk to store the optimized model.
 - `device` is the device the model will execute on - CPU/NPU/GPU.
-- `provider` is the hardware provider of the device to inference the model on. For example, Nvidia CUDA (`CUDAExecutionProvider`), DirectML (`DmlExecutionProvider`), AMD (`MIGraphXExecutionProvider`, `ROCMExecutionProvider`), OpenVINO (`OpenVINOExecutionProvider`), Qualcomm (`QNNExecutionProvider`), TensorRT (`TensorrtExecutionProvider`).
+- `provider` is the hardware provider of the device to inference the model on. For example, Nvidia CUDA (`CUDAExecutionProvider`), DirectML (`DmlExecutionProvider`), AMD (`MIGraphXExecutionProvider`, `ROCMExecutionProvider`), OpenVINO (`OpenVINOExecutionProvider`), Qualcomm (`QNNExecutionProvider`), Nvidia TensorRT (`TensorrtExecutionProvider`, `NvTensorRTRTXExecutionProvider`).
 - `precision` is the precision for the optimized model (`fp16`, `fp32`, `int4`, `int8`).
 - `use_ort_genai` will create the configuration files so that you can consume the model using the Generate API for ONNX Runtime.
 

--- a/examples/resnet/README.md
+++ b/examples/resnet/README.md
@@ -9,6 +9,7 @@ This folder contains examples of ResNet optimization using different workflows.
 - Qualcomm NPU: [with QNN execution provider in ONNX Runtime](./qnn/)
 - Intel® NPU: [Optimization with OpenVINO on Intel® NPU to generate an ONNX OpenVINO IR Encapsulated Model](./openvino/)
 - AMD NPU: [Optimization and Quantization with QDQ format for AMD NPU (VitisAI)](#optimization-and-quantization-for-amd-npu)
+- Nvidia GPU:[With Nvidia TensorRT-RTX execution provider in ONNX Runtime](#resnet-optimization-with-nvidia-tensorrt-rtx-execution-provider)
 
 Go to [How to run](#how-to-run)
 
@@ -72,6 +73,12 @@ This example performs ResNet optimization with OpenVINO and DML execution provid
 - *ONNX Model -> ONNX Runtime performance tuning on multiple ep*
 
 Config file: [resnet_multiple_ep.json](resnet_multiple_ep.json)
+
+### ResNet optimization with Nvidia TensorRT-RTX execution provider
+This example performs ResNet optimization with Nvidia TensorRT-RTX execution provider. It performs the optimization pipeline:
+- *ONNX Model -> fp16 Onnx Model*
+
+Config file: [resnet_trtrtx.json](resnet_trtrtx.json)
 
 ## How to run
 ### Pip requirements

--- a/examples/resnet/resnet_trtrtx.json
+++ b/examples/resnet/resnet_trtrtx.json
@@ -1,0 +1,71 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "microsoft/resnet-50",
+        "task": "image-classification",
+        "io_config": {
+            "input_names": [ "pixel_values" ],
+            "input_shapes": [ [ 1, 3, 224, 224 ] ],
+            "output_names": [ "logits" ]
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "imagenet.py",
+            "load_dataset_config": {
+                "data_name": "evanarlian/imagenet_1k_resized_256",
+                "split": "val",
+                "streaming": true,
+                "trust_remote_code": true
+            },
+            "pre_process_data_config": { "type": "dataset_pre_process", "size": 256, "cache_key": "imagenet" },
+            "post_process_data_config": { "type": "imagenet_post_fun" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "data_config": "data_config",
+                    "sub_types": [
+                        {
+                            "name": "accuracy_score",
+                            "priority": 1,
+                            "metric_config": { "task": "multiclass", "num_classes": 1001 }
+                        }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "data_config",
+                    "sub_types": [ { "name": "avg" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "onnx_conversion": { "type": "OnnxConversion", "target_opset": 13 },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16"},
+        "session_params_tuning": {
+            "type": "OrtSessionParamsTuning",
+            "io_bind": false,
+            "data_config": "data_config"
+        }
+    },
+    "host": "local_system",
+    "target": "local_system",
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "output_dir": "models/resnet_trtrtx"
+}

--- a/examples/resnet/resnet_trtrtx.json
+++ b/examples/resnet/resnet_trtrtx.json
@@ -56,12 +56,8 @@
     },
     "passes": {
         "onnx_conversion": { "type": "OnnxConversion", "target_opset": 13 },
-        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16"},
-        "session_params_tuning": {
-            "type": "OrtSessionParamsTuning",
-            "io_bind": false,
-            "data_config": "data_config"
-        }
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "session_params_tuning": { "type": "OrtSessionParamsTuning", "io_bind": false, "data_config": "data_config" }
     },
     "host": "local_system",
     "target": "local_system",

--- a/olive/hardware/constants.py
+++ b/olive/hardware/constants.py
@@ -27,6 +27,7 @@ DEVICE_TO_EXECUTION_PROVIDERS = {
         "ROCMExecutionProvider",
         "MIGraphXExecutionProvider",
         "TensorrtExecutionProvider",
+        "NvTensorRTRTXExecutionProvider",
         "OpenVINOExecutionProvider",
         "JsExecutionProvider",
     },


### PR DESCRIPTION
Adding recipe for ResNet optimization with Nvidia TensorRT-RTX execution provider

- Convert the model to float16 using `OnnxFloatToFloat16` pass.
- The accuracy for the fp16 model is same as fp32
