### PR TITLE
Disable Win integ test in pipeline

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -143,13 +143,14 @@ jobs:
       pool: $(OLIVE_POOL_UBUNTU2004)
       test_type: 'integ_test'
 
-  - template: job_templates/olive-test-cpu-template.yaml
-    parameters:
-      name: Windows_CPU_CI_Integration_Test
-      pool: $(OLIVE_POOL_WIN2019)
-      test_type: 'integ_test'
-      onnxruntime: onnxruntime==1.21.1
-      windows: True
+  # Re-enable this when the cluster is ready
+  # - template: job_templates/olive-test-cpu-template.yaml
+  #   parameters:
+  #     name: Windows_CPU_CI_Integration_Test
+  #     pool: $(OLIVE_POOL_WIN2019)
+  #     test_type: 'integ_test'
+  #     onnxruntime: onnxruntime==1.21.1
+  #     windows: True
 
   # Multiple EP Linux testing
   - template: job_templates/olive-test-cpu-template.yaml


### PR DESCRIPTION
## Describe your changes

Disable Win integ test in pipeline. Re-enable this when the cluster is ready.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
