### PR TITLE
Add Nvidia TensorRT-RTX Olive recipe for vit, clip and bert examples

### DIFF
--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -5,7 +5,7 @@ This folder contains examples of BERT optimization using different workflows.
 - CPU: [Optimization with PTQ for model from HF/AML](#bert-optimization-with-ptq-on-cpu)
 - CPU: [Optimization with Intel® Neural Compressor PTQ](#bert-optimization-with-intel®-neural-compressor-ptq-on-cpu)
 - CPU: [Optimization with QAT Customized Training Loop](#bert-optimization-with-qat-customized-training-loop-on-cpu)
-- GPU: [Optimization with CUDA/TensorRT](#bert-optimization-with-cudatensorrt-on-gpu)
+- GPU: [Optimization with CUDA/TensorRT/TensorRT-RTX](#bert-optimization-with-cudatensorrt-on-gpu)
 - Qualcomm NPU: [Optimization with PTQ on Qualcomm NPU using QNN EP](./qnn/)
 - Intel® NPU: [Optimization with OpenVINO on Intel® NPU to generate an ONNX OpenVINO IR Encapsulated Model](./openvino/)
 - AMD NPU: [Optimization and Quantization with QDQ format for AMD NPU (VitisAI)](#optimization-and-quantization-for-amd-npu)
@@ -135,6 +135,9 @@ This workflow performs BERT optimization on GPU with CUDA/TensorRT. It performs 
 2. TensorRT: `TensorrtExecutionProvider`
     - *PyTorch Model -> Onnx Model -> ONNX Runtime performance tuning with trt_fp16_enable*
     Config file: [bert_trt_gpu.json](bert_trt_gpu.json)
+3. TensorRT-RTX: `NvTensorRTRTXExecutionProvider`
+    - *PyTorch Model -> Onnx Model -> fp16 Onnx Model*
+    Config file: [bert_trtrtx_gpu.json](bert_trtrtx_gpu.json)
 
 ## How to run
 ### Pip requirements

--- a/examples/bert/bert_trtrtx_gpu.json
+++ b/examples/bert/bert_trtrtx_gpu.json
@@ -1,0 +1,59 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "Intel/bert-base-uncased-mrpc", "task": "text-classification" },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "glue_mrpc",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "glue", "subset": "mrpc", "split": "validation" },
+            "pre_process_data_config": { "input_cols": [ "sentence1", "sentence2" ] },
+            "dataloader_config": { "batch_size": 1 }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "data_config": "glue_mrpc",
+                    "sub_types": [
+                        {
+                            "name": "accuracy_score",
+                            "priority": 1,
+                            "goal": { "type": "max-degradation", "value": 0.01 }
+                        },
+                        { "name": "f1_score" },
+                        { "name": "auroc" }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "glue_mrpc",
+                    "sub_types": [
+                        { "name": "avg", "priority": 2, "goal": { "type": "percent-min-improvement", "value": 20 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ],
+                    "user_config": { "io_bind": false }
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "session_params_tuning": { "type": "OrtSessionParamsTuning", "io_bind": false, "data_config": "glue_mrpc" }
+    },
+    "evaluator": "common_evaluator",
+    "host": "local_system",
+    "target": "local_system",
+    "cache_dir": "cache",
+    "output_dir": "models/bert_trtrtx"
+}

--- a/examples/bert/google_bert_trtrtx.json
+++ b/examples/bert/google_bert_trtrtx.json
@@ -1,0 +1,66 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "google-bert/bert-base-multilingual-cased",
+        "task": "feature-extraction"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "xnli",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "facebook/xnli", "subset": "en", "split": "validation" },
+            "pre_process_data_config": {
+                "input_cols": [ "premise" ],
+                "padding": "max_length",
+                "max_length": 128,
+                "max_samples": 10
+            },
+            "dataloader_config": { "batch_size": 1 }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "xnli",
+                    "sub_types": [
+                        { "name": "avg", "priority": 1, "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "xnli",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "dynamic_shape_to_fixed": {
+            "type": "DynamicToFixedShape",
+            "dim_param": [ "batch_size", "sequence_length" ],
+            "dim_value": [ 1, 128 ]
+        },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "session_params_tuning": { "type": "OrtSessionParamsTuning", "io_bind": false, "data_config": "xnli" }
+    },
+    "host": "local_system",
+    "target": "local_system",
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "output_dir": "models/google_bert_trtrtx",
+    "log_severity_level": 0
+}

--- a/examples/clip/README.md
+++ b/examples/clip/README.md
@@ -5,6 +5,7 @@ This folder contains examples of CLIP VIT quantization using different workflows
 - Qualcomm NPU: [Optimization with PTQ on Qualcomm NPU using QNN EP](./qnn/)
 - Intel® NPU: [Optimization with OpenVINO on Intel® NPU to generate an ONNX OpenVINO IR Encapsulated Model](./openvino/)
 - AMD NPU: [Optimization and Quantization with QDQ format for AMD NPU (VitisAI)](#optimization-and-quantization-for-amd-npu)
+- Nvidia GPU: [With Nvidia TensorRT-RTX execution provider in ONNX Runtime](#optimization-with-nvidia-tensorrt-rtx-execution-provider)
 
 Go to [How to run](#how-to-run)
 
@@ -54,6 +55,15 @@ Accuracy / latency
  - [laion/CLIP-ViT-B-32-laion2B-s34B-b79K](laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qdq_vitis_ai.json)
  - [openai/clip-vit-base-patch16](openai_clip-vit-base-patch16_ptq_qdq_vitis_ai.json)
  - [openai/clip-vit-base-patch32](openai_clip-vit-base-patch32_ptq_qdq_vitis_ai.json)
+
+### Optimization with Nvidia TensorRT-RTX execution provider
+ This example performs optimization with Nvidia TensorRT-RTX execution provider. It performs the optimization pipeline:
+ - *ONNX Model -> fp16 Onnx Model*
+
+ Config files for TensorRT-RTX:
+ - [laion/CLIP-ViT-B-32-laion2B-s34B-b79K](laion_CLIP-ViT-B-32-laion2B-s34B-b79K_trtrtx.json)
+ - [openai/clip-vit-base-patch16](openai_clip-vit-base-patch16_trtrtx.json)
+ - [openai/clip-vit-base-patch32](openai_clip-vit-base-patch32_trtrtx.json)
 
 ## How to run
 ### Pip requirements

--- a/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_trtrtx.json
+++ b/examples/clip/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_trtrtx.json
@@ -1,0 +1,97 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+        "task": "zero-shot-image-classification",
+        "load_kwargs": { "attn_implementation": "eager" },
+        "io_config": {
+            "input_names": [ "input_ids", "pixel_values", "attention_mask" ],
+            "input_shapes": [ [ 10, 77 ], [ 1, 3, 224, 224 ], [ 10, 77 ] ],
+            "input_types": [ "int64", "float32", "int64" ],
+            "output_names": [ "logits_per_image" ],
+            "output_shapes": [ [ 1, 2 ] ]
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 0,
+                "end": 10
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        },
+        {
+            "name": "metric_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 10,
+                "end": 20
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" },
+            "post_process_data_config": { "type": "clip_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "avg", "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ],
+                    "user_config": {
+                        "inference_settings": { "onnx": { "execution_provider": "CPUExecutionProvider" } }
+                    }
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "metric_data_config",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "session_params_tuning": {
+            "type": "OrtSessionParamsTuning",
+            "io_bind": false,
+            "data_config": "quant_data_config"
+        }
+    },
+    "host": "local_system",
+    "target": "local_system",
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "clean_cache": true,
+    "output_dir": "models/CLIP-ViT-B-32-laion2B-s34B-b79K"
+}

--- a/examples/clip/openai_clip-vit-base-patch16_trtrtx.json
+++ b/examples/clip/openai_clip-vit-base-patch16_trtrtx.json
@@ -1,0 +1,94 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "openai/clip-vit-base-patch16",
+        "task": "zero-shot-image-classification",
+        "load_kwargs": { "attn_implementation": "eager" },
+        "io_config": {
+            "input_names": [ "input_ids", "pixel_values", "attention_mask" ],
+            "input_shapes": [ [ 10, 77 ], [ 1, 3, 224, 224 ], [ 10, 77 ] ],
+            "input_types": [ "int64", "float32", "int64" ],
+            "output_names": [ "logits_per_image" ],
+            "output_shapes": [ [ 1, 2 ] ]
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 0,
+                "end": 10
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        },
+        {
+            "name": "metric_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 10,
+                "end": 20
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" },
+            "post_process_data_config": { "type": "clip_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "avg", "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "metric_data_config",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "session_params_tuning": {
+            "type": "OrtSessionParamsTuning",
+            "io_bind": false,
+            "data_config": "quant_data_config"
+        }
+    },
+    "host": "local_system",
+    "target": "local_system",
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "clean_cache": true,
+    "output_dir": "models/clip-vit-base-patch16"
+}

--- a/examples/clip/openai_clip-vit-base-patch32_trtrtx.json
+++ b/examples/clip/openai_clip-vit-base-patch32_trtrtx.json
@@ -1,0 +1,94 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "openai/clip-vit-base-patch32",
+        "task": "zero-shot-image-classification",
+        "load_kwargs": { "attn_implementation": "eager" },
+        "io_config": {
+            "input_names": [ "input_ids", "pixel_values", "attention_mask" ],
+            "input_shapes": [ [ 10, 77 ], [ 1, 3, 224, 224 ], [ 10, 77 ] ],
+            "input_types": [ "int64", "float32", "int64" ],
+            "output_names": [ "logits_per_image" ],
+            "output_shapes": [ [ 1, 2 ] ]
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quant_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 0,
+                "end": 10
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" }
+        },
+        {
+            "name": "metric_data_config",
+            "user_script": "user_script.py",
+            "load_dataset_config": {
+                "type": "clip_dataset",
+                "model_name": "openai/clip-vit-base-patch16",
+                "dataset_name": "nlphuji/flickr30k",
+                "start": 10,
+                "end": 20
+            },
+            "dataloader_config": { "type": "no_auto_batch_dataloader" },
+            "post_process_data_config": { "type": "clip_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "backend": "huggingface_metrics",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "accuracy", "priority": 1, "goal": { "type": "max-degradation", "value": 0.05 } }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "metric_data_config",
+                    "sub_types": [
+                        { "name": "avg", "goal": { "type": "percent-min-improvement", "value": 0.1 } },
+                        { "name": "max" },
+                        { "name": "min" }
+                    ]
+                },
+                {
+                    "name": "throughput",
+                    "type": "throughput",
+                    "data_config": "metric_data_config",
+                    "sub_types": [ { "name": "avg" }, { "name": "max" }, { "name": "min" } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": { "type": "OnnxConversion", "target_opset": 17 },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "session_params_tuning": {
+            "type": "OrtSessionParamsTuning",
+            "io_bind": false,
+            "data_config": "quant_data_config"
+        }
+    },
+    "host": "local_system",
+    "target": "local_system",
+    "evaluator": "common_evaluator",
+    "cache_dir": "cache",
+    "clean_cache": true,
+    "output_dir": "models/clip-vit-base-patch32"
+}

--- a/examples/vit/README.md
+++ b/examples/vit/README.md
@@ -4,6 +4,7 @@ This folder contains examples of ViT quantization using different workflows.
 - Qualcomm NPU: [Optimization with PTQ on Qualcomm NPU using QNN EP](./qnn/)
 - Intel® NPU: [Optimization with OpenVINO on Intel® NPU to generate an ONNX OpenVINO IR Encapsulated Model](./openvino/)
 - AMD NPU: [Optimization and Quantization with QDQ format for AMD NPU (VitisAI)](#optimization-and-quantization-for-amd-npu)
+- Nvidia GPU: [With Nvidia TensorRT-RTX execution provider in ONNX Runtime](#optimization-with-nvidia-tensorrt-rtx-execution-provider)
 
 Go to [How to run](#how-to-run)
 
@@ -31,6 +32,12 @@ Config file: [vit_qdq.json](vit_qdq.json)
 
  Config files for VitisAI:
  - [google/vit-base-patch16-224](vit_qdq_vitis_ai.json)
+
+### Optimization with Nvidia TensorRT-RTX execution provider
+ This example performs optimization with Nvidia TensorRT-RTX execution provider. It performs the optimization pipeline:
+ - *ONNX Model -> fp16 Onnx Model*
+
+ Config file: [vit_trtrtx.json](vit_trtrtx.json)
 
 ## How to run
 ```

--- a/examples/vit/vit_trtrtx.json
+++ b/examples/vit/vit_trtrtx.json
@@ -1,0 +1,76 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "google/vit-base-patch16-224",
+        "task": "image-classification",
+        "io_config": {
+            "input_names": [ "pixel_values" ],
+            "input_shapes": [ [ 1, 3, 224, 224 ] ],
+            "output_names": [ "logits" ]
+        }
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "quantize_data_config",
+            "type": "HuggingfaceContainer",
+            "user_script": "imagenet.py",
+            "load_dataset_config": {
+                "data_name": "imagenet-1k",
+                "split": "validation",
+                "streaming": true,
+                "trust_remote_code": true
+            },
+            "pre_process_data_config": { "type": "dataset_pre_process", "size": 256, "cache_key": "imagenet256" },
+            "post_process_data_config": { "type": "dataset_post_process" }
+        }
+    ],
+    "evaluators": {
+        "common_evaluator": {
+            "metrics": [
+                {
+                    "name": "accuracy",
+                    "type": "accuracy",
+                    "data_config": "quantize_data_config",
+                    "sub_types": [
+                        {
+                            "name": "accuracy_score",
+                            "priority": 1,
+                            "metric_config": { "task": "multiclass", "num_classes": 1001 }
+                        }
+                    ]
+                },
+                {
+                    "name": "latency",
+                    "type": "latency",
+                    "data_config": "quantize_data_config",
+                    "sub_types": [ { "name": "avg", "priority": 2 } ]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "conversion": {
+            "type": "OnnxConversion",
+            "target_opset": 17,
+            "save_as_external_data": true,
+            "all_tensors_to_one_file": true,
+            "use_dynamo_exporter": false
+        },
+        "onnx_float_to_float16": { "type": "OnnxFloatToFloat16" },
+        "session_params_tuning": {
+            "type": "OrtSessionParamsTuning",
+            "io_bind": false,
+            "data_config": "quantize_data_config"
+        }
+    },
+    "host": "local_system",
+    "target": "local_system",
+    "evaluator": "common_evaluator",
+    "output_dir": "models/vit-base-patch16-224"
+}


### PR DESCRIPTION
All recipe use `OnnxFloatToFloat16` pass to convert fp32 model to fp16. Confirmed that accuracy for all these models is same as original fp32 models.
