### PR TITLE
Temporary patch for WinML support to auto register execution providers

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -143,13 +143,14 @@ jobs:
       pool: $(OLIVE_POOL_UBUNTU2004)
       test_type: 'integ_test'
 
-  - template: job_templates/olive-test-cpu-template.yaml
-    parameters:
-      name: Windows_CPU_CI_Integration_Test
-      pool: $(OLIVE_POOL_WIN2019)
-      test_type: 'integ_test'
-      onnxruntime: onnxruntime==1.21.1
-      windows: True
+  # Re-enable this when the cluster is ready
+  # - template: job_templates/olive-test-cpu-template.yaml
+  #   parameters:
+  #     name: Windows_CPU_CI_Integration_Test
+  #     pool: $(OLIVE_POOL_WIN2019)
+  #     test_type: 'integ_test'
+  #     onnxruntime: onnxruntime==1.21.1
+  #     windows: True
 
   # Multiple EP Linux testing
   - template: job_templates/olive-test-cpu-template.yaml

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -64,12 +64,14 @@ jobs:
     name: Linux_CPU_CI_Unit_Test
     pool: $(OLIVE_POOL_UBUNTU2004)
     test_type: 'unit_test'
+    onnxruntime: onnxruntime==1.21.1
 
 - template: job_templates/olive-test-linux-gpu-template.yaml
   parameters:
     name: Linux_GPU_CI_Unit_Test
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     test_type: 'unit_test'
+    onnxruntime: onnxruntime-gpu==1.21.1
 
 # Windows unit tests
 - template: job_templates/olive-test-cpu-template.yaml
@@ -101,7 +103,7 @@ jobs:
   parameters:
     name: Windows_CI
     pool: $(OLIVE_POOL_WIN2019)
-    onnxruntime: onnxruntime
+    onnxruntime: onnxruntime==1.21.1
     examples:
       bert_ptq_cpu:
         exampleFolder: bert
@@ -146,6 +148,7 @@ jobs:
       name: Windows_CPU_CI_Integration_Test
       pool: $(OLIVE_POOL_WIN2019)
       test_type: 'integ_test'
+      onnxruntime: onnxruntime==1.21.1
       windows: True
 
   # Multiple EP Linux testing

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -71,9 +71,7 @@ def get_ort_execution_provider_device_policy(policy: str):
     return None
 
 
-def initialize_inference_session_options_for_winml(
-    sess_options, device, providers, provider_options, provider_selection_policy=None
-):
+def initialize_ort_session_options(sess_options, device, providers, provider_options, provider_selection_policy=None):
     import onnxruntime as ort
 
     providers = providers or []
@@ -174,9 +172,11 @@ def get_ort_inference_session(
     for idx, provider in enumerate(providers):
         if provider in ["CUDAExecutionProvider", "DmlExecutionProvider"] and device_id is not None:
             provider_options[idx]["device_id"] = str(device_id)
-        elif provider == "QNNExecutionProvider":
+        elif provider == "QNNExecutionProvider" and "backend_path" not in provider_options[idx]:
             # add backend_path for QNNExecutionProvider
-            provider_options[idx]["backend_path"] = "QnnHtp.dll"
+            # WinML should not use provider options
+            # provider_options[idx]["backend_path"] = "QnnHtp.dll"
+            pass
     logger.debug("Normalized providers: %s, provider_options: %s", providers, provider_options)
 
     # dml specific settings
@@ -185,7 +185,7 @@ def get_ort_inference_session(
 
     sess_kwargs = {}
     if is_winml_installation():
-        initialize_inference_session_options_for_winml(
+        initialize_ort_session_options(
             sess_options, device, providers, provider_options, inference_settings.get("provider_selection_policy")
         )
     else:

--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -227,7 +227,7 @@ class EPContextBinaryGenerator(Pass):
         """
         import onnxruntime as ort
 
-        from olive.common.ort_inference import initialize_inference_session_options_for_winml, is_winml_installation
+        from olive.common.ort_inference import initialize_ort_session_options, is_winml_installation
 
         # prepare provider options
         provider_options = provider_options or {}
@@ -268,9 +268,7 @@ class EPContextBinaryGenerator(Pass):
 
         sess_kwargs = {}
         if is_winml_installation():
-            initialize_inference_session_options_for_winml(
-                sess_options, device, [execution_provider], [provider_options or {}]
-            )
+            initialize_ort_session_options(sess_options, device, [execution_provider], [provider_options or {}])
         else:
             sess_kwargs.update({"providers": [execution_provider], "provider_options": [provider_options]})
         ort.InferenceSession(model_path, sess_options=sess_options, **sess_kwargs)

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -46,7 +46,7 @@ class OptimumMerging(Pass):
     ) -> ONNXModelHandler:
         import onnxruntime as ort
 
-        from olive.common.ort_inference import initialize_inference_session_options_for_winml, is_winml_installation
+        from olive.common.ort_inference import initialize_ort_session_options, is_winml_installation
 
         assert len(model.model_components) == 2
 
@@ -84,7 +84,7 @@ class OptimumMerging(Pass):
         execution_provider = self.accelerator_spec.execution_provider
         sess_kwargs = {}
         if is_winml_installation():
-            initialize_inference_session_options_for_winml(
+            initialize_ort_session_options(
                 sess_options, self.accelerator_spec.accelerator_type, [execution_provider], [{}]
             )
         else:

--- a/test/requirements-test-cpu.txt
+++ b/test/requirements-test-cpu.txt
@@ -1,2 +1,3 @@
 -r requirements-test.txt
+onnxruntime-genai
 

--- a/test/requirements-test.txt
+++ b/test/requirements-test.txt
@@ -22,7 +22,6 @@ onnx-graphsurgeon
 onnxconverter_common
 onnxmltools
 onnxoptimizer
-onnxruntime-genai
 onnxruntime_extensions
 onnxscript>=0.2.4
 openvino>=2025.1.0


### PR DESCRIPTION
## Temporary patch for WinML support to auto register execution providers

ORT WinML is ORTv1.22.0 + a few cherry picked PRs and so version check alone can't be used for auto registering the execution providers (required for auto ep selection feature in WinML).

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
