### PR TITLE
Remove ort version pin

### DIFF
--- a/.azure_pipelines/job_templates/olive-example-win-template.yaml
+++ b/.azure_pipelines/job_templates/olive-example-win-template.yaml
@@ -46,6 +46,7 @@ jobs:
         python -m pip install pytest
         python -m pip install azure-identity azure-storage-blob tabulate
         python -m pip install -r $(Build.SourcesDirectory)/examples/$(exampleFolder)/$(exampleRequirements)
+        python -m pip list
         python -m pytest -v -s --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test_examples-TestOlive.xml $(Build.SourcesDirectory)/examples/test/${{ parameters.subfolder }}/test_$(exampleName).py --basetemp $(PYTEST_BASETEMP)
     displayName: Test Examples
     env:

--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -64,14 +64,12 @@ jobs:
     name: Linux_CPU_CI_Unit_Test
     pool: $(OLIVE_POOL_UBUNTU2004)
     test_type: 'unit_test'
-    onnxruntime: onnxruntime==1.21.1
 
 - template: job_templates/olive-test-linux-gpu-template.yaml
   parameters:
     name: Linux_GPU_CI_Unit_Test
     pool: $(OLIVE_POOL_UBUNTU2004_GPU_V100)
     test_type: 'unit_test'
-    onnxruntime: onnxruntime-gpu==1.21.1
 
 # Windows unit tests
 - template: job_templates/olive-test-cpu-template.yaml
@@ -103,7 +101,6 @@ jobs:
   parameters:
     name: Windows_CI
     pool: $(OLIVE_POOL_WIN2019)
-    onnxruntime: onnxruntime==1.21.1
     examples:
       bert_ptq_cpu:
         exampleFolder: bert
@@ -149,7 +146,6 @@ jobs:
   #     name: Windows_CPU_CI_Integration_Test
   #     pool: $(OLIVE_POOL_WIN2019)
   #     test_type: 'integ_test'
-  #     onnxruntime: onnxruntime==1.21.1
   #     windows: True
 
   # Multiple EP Linux testing


### PR DESCRIPTION
## Describe your changes

Remove ort version pin as ort-genai has released new version. It is compatible with onnxruntime 1.22.0 now.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
