### PR TITLE
Rollback WinML specific changes and make the logic depend on ORT version

### DIFF
--- a/olive/model/handler/mixin/onnx_ep.py
+++ b/olive/model/handler/mixin/onnx_ep.py
@@ -15,7 +15,7 @@ class OnnxEpValidateMixin:
         # It should be a bug for onnxruntime where the execution provider is not be fallback.
         import onnxruntime as ort
 
-        from olive.common.ort_inference import is_winml_installation
+        from olive.common.ort_inference import ort_supports_ep_devices
 
         sess_options = ort.SessionOptions()
         if self.use_ort_extensions:
@@ -26,11 +26,8 @@ class OnnxEpValidateMixin:
 
         valid = True
         e = None
-        if is_winml_installation():
-            sess_options.add_provider_for_devices(
-                [ep_device for ep_device in ort.get_ep_devices() if ep_device.ep_name == ep], {}
-            )
-            valid = sess_options.has_providers()
+        if ort_supports_ep_devices():
+            valid = bool([ep_device for ep_device in ort.get_ep_devices() if ep_device.ep_name == ep])
         else:
             try:
                 ort.InferenceSession(filepath, sess_options, providers=[ep])

--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -227,7 +227,7 @@ class EPContextBinaryGenerator(Pass):
         """
         import onnxruntime as ort
 
-        from olive.common.ort_inference import initialize_inference_session_options_for_winml, is_winml_installation
+        from olive.common.ort_inference import initialize_inference_session_options, ort_supports_ep_devices
 
         # prepare provider options
         provider_options = provider_options or {}
@@ -267,10 +267,8 @@ class EPContextBinaryGenerator(Pass):
         logger.debug("Creating context binary for model %s", str(model_path))
 
         sess_kwargs = {}
-        if is_winml_installation():
-            initialize_inference_session_options_for_winml(
-                sess_options, device, [execution_provider], [provider_options or {}]
-            )
+        if ort_supports_ep_devices():
+            initialize_inference_session_options(sess_options, device, [execution_provider], [provider_options or {}])
         else:
             sess_kwargs.update({"providers": [execution_provider], "provider_options": [provider_options]})
         ort.InferenceSession(model_path, sess_options=sess_options, **sess_kwargs)

--- a/olive/passes/onnx/optimum_merging.py
+++ b/olive/passes/onnx/optimum_merging.py
@@ -46,7 +46,7 @@ class OptimumMerging(Pass):
     ) -> ONNXModelHandler:
         import onnxruntime as ort
 
-        from olive.common.ort_inference import initialize_inference_session_options_for_winml, is_winml_installation
+        from olive.common.ort_inference import initialize_inference_session_options, ort_supports_ep_devices
 
         assert len(model.model_components) == 2
 
@@ -83,8 +83,8 @@ class OptimumMerging(Pass):
 
         execution_provider = self.accelerator_spec.execution_provider
         sess_kwargs = {}
-        if is_winml_installation():
-            initialize_inference_session_options_for_winml(
+        if ort_supports_ep_devices():
+            initialize_inference_session_options(
                 sess_options, self.accelerator_spec.accelerator_type, [execution_provider], [{}]
             )
         else:


### PR DESCRIPTION
## Rollback WinML specific changes and make the logic depend on ORT version

Olive doesn't explicitly support AutoEP features but WinML does. ORT v1.22+ requires EPs to be pre-registered and use alternative API to query for supported EPs. Branching the logic based on version instead to keep things independent of package releases that embed Olive as a dependent module.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
