### PR TITLE
Skip windows incompatible tests

### DIFF
--- a/test/unit_test/passes/onnx/test_onnxscript_fusion.py
+++ b/test/unit_test/passes/onnx/test_onnxscript_fusion.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import platform
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,8 @@ from olive.passes.onnx.conversion import OnnxConversion
 from olive.passes.onnx.onnxscript_fusion import OnnxScriptFusion
 
 
+# TODO(anyone): Remove the skip condition once the issue is resolved
+@pytest.mark.skipif(platform.system() == "Windows", reason="Skip on Windows due to export failure")
 @pytest.mark.skipif(version.parse(torch.__version__) < version.parse("2.7.0"), reason="Requires PyTorch 2.7 or higher")
 def test_onnxscript_fusion_pass_works(tmp_path):
     base_model = HfModelHandler(model_path="katuni4ka/tiny-random-phi3")

--- a/test/unit_test/passes/onnx/test_quantization.py
+++ b/test/unit_test/passes/onnx/test_quantization.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+import platform
 from unittest.mock import patch
 
 import onnx
@@ -159,6 +160,10 @@ def test_nodes_and_ops(mock_quantize_static, tmp_path, kwargs, expected, is_qnn)
     ],
 )
 def test_matmul_4bit_quantization_without_dataloader(tmp_path, algorithm, weight_only_quant_configs):
+    if algorithm == "rtn" and platform.system() == "Windows":
+        # neural-compressor calls 'wmic' which is not available anymore
+        pytest.skip("RTN quantization requires neural-compressor which is incompatible with newer versions of Windows.")
+
     input_model = get_onnx_model()
     config = {
         "block_size": 32,
@@ -177,6 +182,10 @@ def test_matmul_4bit_quantization_without_dataloader(tmp_path, algorithm, weight
     assert out is not None
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="GPTQ quantization requires neural-compressor which is incompatible with newer versions of Windows.",
+)
 def test_matmul_4bits_gptq_with_dataloader(tmp_path, caplog):
     input_model = get_onnx_model()
     config = {


### PR DESCRIPTION
## Describe your changes
- Skip matmul4bits quantizer tests that require neural-compressor. neural compressor calls `wmic` in a subprocess but this executable is not available in newer windows versions.
- onnxscript fusion test fails on windows because of export failure.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
