### PR TITLE
CLI: Allow overrides for input_model, output_dir, log_severity_level for `olive run`

### DIFF
--- a/examples/deepseek/README.md
+++ b/examples/deepseek/README.md
@@ -4,10 +4,10 @@ Sample use cases of Olive to optimize a [DeepSeek R1 Distill](https://huggingfac
 
 - [Finetune and Optimize for CPU/CUDA](../getting_started/olive-deepseek-finetune.ipynb)
 - [QDQ Model with 4-bit Weights & 16-bit Activations](../phi3_5/README.md):
-  - Replace `model_path` in `qdq_config.json` with `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.
+  - Run the workflow with `olive run --config qdq_config.json -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -o models/deepseek-r1-qdq`.
 - [AMD NPU: Optimization and Quantization with for VitisAI](../phi3_5/README.md):
-  - Replace `model_path` in `qdq_config_vitis_ai.json` with `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.
+  - Run the workflow with `olive run --config qdq_config_vitis_ai.json -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -o models/deepseek-r1-vai`.
 - [PTQ + AOT Compilation for Qualcomm NPUs using QNN EP](../phi3_5/README.md):
-  - Replace `model_path` in `qnn_config.json` with `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.
-  - Chat template is `"<｜User｜>{input}<｜Assistant｜><think>"`.
+  - Run the workflow with `olive run --config qnn_config.json -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -o models/deepseek-r1-qnn`.
+  - Run the inference with `python app.py -m models/deepseek-r1-qnn -c "<｜User｜>{input}<｜Assistant｜><think>"`.
 - [PTQ + AWQ ONNX OVIR Encapsulated 4-bit weight compression using Optimum OpenVINO](./openvino/)

--- a/examples/llama3/README.md
+++ b/examples/llama3/README.md
@@ -4,12 +4,12 @@ Sample use cases of Olive to optimize [meta-llama/Llama-3.2-1B-Instruct](https:/
 
 - [Quantize, Finetune and Optimize for CPU/CUDA](../getting_started/olive-awq-ft-llama.ipynb)
 - [QDQ Model with 4-bit Weights & 16-bit Activations](../phi3_5/README.md):
-  - Replace `model_path` in `qdq_config.json` with `meta-llama/Llama-3.2-1B-Instruct`.
+  - Run the workflow with `olive run --config qdq_config.json -m meta-llama/Llama-3.2-1B-Instruct -o models/llama3-qdq`.
 - [AMD NPU: Optimization and Quantization with for VitisAI](../phi3_5/README.md):
-  - Replace `model_path` in `qdq_config_vitis_ai.json` with `meta-llama/Llama-3.2-1B-Instruct`.
+  - Run the workflow with `olive run --config qdq_config_vitis_ai.json -m meta-llama/Llama-3.2-1B-Instruct -o models/llama3-vai`.
 - [PTQ + AOT Compilation for Qualcomm NPUs using QNN EP](../phi3_5/README.md):
-  - Replace `model_path` in `qnn_config.json` with `meta-llama/Llama-3.2-1B-Instruct`.
-  - Chat template is `"<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"`
+  - Run the workflow with `olive run --config qnn_config.json -m meta-llama/Llama-3.2-1B-Instruct -o models/llama3-qnn`.
+  - Run the inference with `python app.py -m models/llama3-qnn -c "<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"`.
 - [PTQ + AWQ ONNX OVIR Encapsulated 4-bit weight compression using Optimum OpenVINO](./openvino/)
 
 **NOTE:**

--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -101,7 +101,7 @@ Follow above mentioned setup instruction and run the below command to generate t
 olive run --config qdq_config_vitis_ai.json.json
 ```
 
-✅ Optimized model saved in: `models/phi3_5_qdq/`
+✅ Optimized model saved in: `models/phi3_5_qdq_vai/`
 
 ## **PTQ + AOT Compilation for Qualcomm NPUs using QNN EP**
 
@@ -203,7 +203,7 @@ pip install "onnxruntime-genai>=0.7.0rc2"
 Open ARM64 Native Tools Command Prompt for VS2022 and execute the provided [`app.py`](app.py) script:
 
 ```bash
-python app.py
+python app.py -m models/phi3_5_qnn
 ```
 
 ## **PTQ + AOT Compilation for Intel® NPUs using Optimum Intel®**

--- a/examples/phi3_5/app.py
+++ b/examples/phi3_5/app.py
@@ -1,11 +1,28 @@
 # app.py
 # ruff: noqa: T201
+from argparse import ArgumentParser
+
 import onnxruntime_genai as og
 
-model_folder = "models/phi3_5/model"
+parser = ArgumentParser(description="Run a simple chat application with the Phi-3.5 model.")
+parser.add_argument(
+    "-m",
+    "--model_folder",
+    type=str,
+    default="models/phi3_5_qdq",
+    help="Path to the folder containing the outputs of Olive run",
+)
+parser.add_argument(
+    "-c",
+    "--chat_template",
+    type=str,
+    default="<|user|>\n{input} <|end|>\n<|assistant|>",
+    help="Template for the chat input",
+)
+args = parser.parse_args()
 
 # Load the base model and tokenizer
-model = og.Model(model_folder)
+model = og.Model(f"{args.model_folder}/model")
 tokenizer = og.Tokenizer(model)
 tokenizer_stream = tokenizer.create_stream()
 
@@ -13,8 +30,6 @@ tokenizer_stream = tokenizer.create_stream()
 # since otherwise it will be set to the entire context length
 search_options = {}
 search_options["max_length"] = 200
-
-chat_template = "<|user|>\n{input} <|end|>\n<|assistant|>"
 
 # Keep asking for input prompts in a loop
 while True:
@@ -27,7 +42,7 @@ while True:
         break
 
     # Generate prompt (prompt template + input)
-    prompt = f"{chat_template.format(input=text)}"
+    prompt = f"{args.chat_template.format(input=text)}"
 
     # Encode the prompt using the tokenizer
     input_tokens = tokenizer.encode(prompt)

--- a/examples/phi3_5/qdq_config.json
+++ b/examples/phi3_5/qdq_config.json
@@ -22,8 +22,7 @@
             "precision": "int4",
             "int4_block_size": 32,
             "int4_accuracy_level": 4,
-            "int4_op_types_to_quantize": [ "MatMul", "Gather" ],
-            "save_as_external_data": true
+            "int4_op_types_to_quantize": [ "MatMul", "Gather" ]
         },
         "mq": {
             "type": "MatMulNBitsToQDQ",

--- a/examples/phi3_5/qdq_config_vitis_ai.json
+++ b/examples/phi3_5/qdq_config_vitis_ai.json
@@ -71,7 +71,7 @@
         }
     },
     "log_severity_level": 1,
-    "output_dir": "models/phi3_5_qdq",
-    "cache_dir": "cache/phi3_5",
+    "output_dir": "models/phi3_5_qdq_vai",
+    "cache_dir": "cache",
     "no_artifacts": true
 }

--- a/examples/phi3_5/qdq_config_vitis_ai.json
+++ b/examples/phi3_5/qdq_config_vitis_ai.json
@@ -22,8 +22,7 @@
             "precision": "int4",
             "int4_block_size": 32,
             "int4_accuracy_level": 4,
-            "int4_op_types_to_quantize": [ "MatMul", "Gather" ],
-            "save_as_external_data": true
+            "int4_op_types_to_quantize": [ "MatMul", "Gather" ]
         },
         "mq": {
             "type": "MatMulNBitsToQDQ",

--- a/examples/phi3_5/qnn_config.json
+++ b/examples/phi3_5/qnn_config.json
@@ -29,8 +29,7 @@
             "precision": "int4",
             "int4_block_size": 32,
             "int4_accuracy_level": 4,
-            "int4_op_types_to_quantize": [ "MatMul", "Gather" ],
-            "save_as_external_data": true
+            "int4_op_types_to_quantize": [ "MatMul", "Gather" ]
         },
         "mq": {
             "type": "MatMulNBitsToQDQ",

--- a/examples/qwen2_5/README.md
+++ b/examples/qwen2_5/README.md
@@ -3,10 +3,10 @@
 Sample use cases of Olive to optimize a [Qwen/Qwen 2.5 1.5B Instruct](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct) model using Olive.
 
 - [QDQ Model with 4-bit Weights & 16-bit Activations](../phi3_5/README.md):
-  - Replace `model_path` in `qdq_config.json` with `Qwen/Qwen2.5-1.5B-Instruct`.
+  - Run the workflow with `olive run --config qdq_config.json -m Qwen/Qwen2.5-1.5B-Instruct -o models/qwen2_5-qdq`.
 - [AMD NPU: Optimization and Quantization with for VitisAI](../phi3_5/README.md):
-  - Replace `model_path` in `qdq_config_vitis_ai.json` with `Qwen/Qwen2.5-1.5B-Instruct`.
+  - Run the workflow with `olive run --config qdq_config_vitis_ai.json -m Qwen/Qwen2.5-1.5B-Instruct -o models/qwen2_5-vai`.
 - [PTQ + AOT Compilation for Qualcomm NPUs using QNN EP](../phi3_5/README.md):
-  - Replace `model_path` in `qnn_config.json` with `Qwen/Qwen2.5-1.5B-Instruct`.
-  - Chat template is `"<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n"`
+  - Run the workflow with `olive run --config qnn_config.json -m Qwen/Qwen2.5-1.5B-Instruct -o models/qwen2_5-qnn`.
+  - Run the inference with `python app.py -m models/qwen2_5-qnn -c "<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n"`.
 - [PTQ + AWQ ONNX OVIR Encapsulated 4-bit weight compression using Intel® Optimum OpenVINO](./openvino/)

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -13,6 +13,7 @@ from typing import ClassVar, Optional, Union
 import yaml
 
 from olive.cli.constants import CONDA_CONFIG
+from olive.common.constants import DEFAULT_HF_TASK
 from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import hash_dict, hf_repo_exists, set_nested_dict_value, unescaped_str
 from olive.hardware.accelerator import AcceleratorSpec
@@ -166,7 +167,7 @@ def _get_pt_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     return input_model_config
 
 
-def get_input_model_config(args: Namespace) -> dict:
+def get_input_model_config(args: Namespace, required: bool = True) -> Optional[dict]:
     """Parse the model_name_or_path and return the input model config.
 
     Check model_name_or_path formats in order:
@@ -188,6 +189,9 @@ def get_input_model_config(args: Namespace) -> dict:
             # pytorch model with model_script, model_path is optional
             print("model_name_or_path is not provided. Using model_script to load the model.")
             return _get_pt_input_model(args, None)
+        if not required:
+            # optional model_name_or_path, return empty config
+            return None
         raise ValueError("model_name_or_path is required.")
 
     model_path = Path(model_name_or_path)
@@ -259,13 +263,13 @@ def update_input_model_options(args, config):
     config["input_model"] = get_input_model_config(args)
 
 
-def add_logging_options(sub_parser: ArgumentParser):
+def add_logging_options(sub_parser: ArgumentParser, default: int = 3):
     """Add logging options to the sub_parser."""
     sub_parser.add_argument(
         "--log_level",
         type=int,
-        default=3,
-        help="Logging level. Default is 3. level 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL",
+        default=default,
+        help=f"Logging level. Default is {default}. level 0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL",
     )
     return sub_parser
 
@@ -323,6 +327,7 @@ def add_input_model_options(
     enable_onnx: bool = False,
     default_output_path: Optional[str] = None,
     directory_output: bool = True,
+    required: bool = True,
 ):
     """Add model options to the sub_parser.
 
@@ -339,7 +344,7 @@ def add_input_model_options(
         "--model_name_or_path",
         type=str,
         # only pytorch model doesn't require model_name_or_path
-        required=not enable_pt,
+        required=required and not enable_pt,
         help=(
             "Path to the input model. "
             "See https://microsoft.github.io/Olive/reference/cli.html#providing-input-models "
@@ -347,7 +352,12 @@ def add_input_model_options(
         ),
     )
     if enable_hf:
-        model_group.add_argument("-t", "--task", type=str, help="Task for which the huggingface model is used.")
+        model_group.add_argument(
+            "-t",
+            "--task",
+            type=str,
+            help=f"Task for which the huggingface model is used. Default task is {DEFAULT_HF_TASK}.",
+        )
         model_group.add_argument(
             "--trust_remote_code", action="store_true", help="Trust remote code when loading a huggingface model."
         )
@@ -371,16 +381,21 @@ def add_input_model_options(
             type=str,
             help=(
                 "The directory containing the local PyTorch model script file."
-                "See https://microsoft.github.io/Olive/reference/cli.html#model-script-file-information "
+                " See https://microsoft.github.io/Olive/reference/cli.html#model-script-file-information "
                 "for more information."
             ),
         )
-    model_group.add_argument("--is_generative_model", type=bool, default=True, help="Is this a generative model?")
+    model_group.add_argument(
+        "--is_generative_model",
+        type=bool,
+        default=True,
+        help="Is this a generative model? Inferered as True for text generation HF models.",
+    )
     model_group.add_argument(
         "-o",
         "--output_path",
         type=output_path_type if directory_output else str,
-        required=default_output_path is None,
+        required=required and default_output_path is None,
         default=default_output_path,
         help="Path to save the command output.",
     )
@@ -514,7 +529,10 @@ def add_dataset_options(sub_parser, required=True, include_train=True, include_e
         "--input_cols",
         type=str,
         nargs="+",
-        help="List of input column names. Provide one or more names separated by space. Example: --input_cols sentence1 sentence2",
+        help=(
+            "List of input column names. Provide one or more names separated by space. Example: --input_cols sentence1"
+            " sentence2"
+        ),
     )
 
     return dataset_group, text_group

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -186,9 +186,14 @@ def get_input_model_config(args: Namespace, required: bool = True) -> Optional[d
 
     if model_name_or_path is None:
         if hasattr(args, "model_script"):
-            # pytorch model with model_script, model_path is optional
-            print("model_name_or_path is not provided. Using model_script to load the model.")
-            return _get_pt_input_model(args, None)
+            if args.model_script:
+                # pytorch model with model_script, model_path is optional
+                print("model_name_or_path is not provided. Using model_script to load the model.")
+                return _get_pt_input_model(args, None)
+            elif required:
+                raise ValueError(
+                    "model_name_or_path is required. Either model_name_or_path or model_script is required."
+                )
         if not required:
             # optional model_name_or_path, return empty config
             return None

--- a/olive/cli/run.py
+++ b/olive/cli/run.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 from argparse import ArgumentParser
 
-from olive.cli.base import BaseOliveCLICommand
+from olive.cli.base import BaseOliveCLICommand, add_input_model_options, add_logging_options, get_input_model_config
 
 
 class WorkflowRunCommand(BaseOliveCLICommand):
@@ -27,11 +27,37 @@ class WorkflowRunCommand(BaseOliveCLICommand):
                 "Configuration might also include user owned/proprietary/private pass implementations."
             ),
         )
+        add_logging_options(sub_parser, default=None)
+        add_input_model_options(
+            sub_parser.add_argument_group("Model options (not required)"),
+            enable_hf=True,
+            enable_hf_adapter=True,
+            enable_pt=True,
+            enable_onnx=True,
+            required=False,
+        )
         sub_parser.set_defaults(func=WorkflowRunCommand)
 
     def run(self):
+        from olive.common.config_utils import load_config_file
         from olive.workflows import run as olive_run
 
-        var_args = vars(self.args)
-        del var_args["func"]
-        olive_run(**var_args)
+        run_config = load_config_file(self.args.run_config)
+        if input_model_config := get_input_model_config(self.args, required=False):
+            print("Replacing input model config in run config")
+            run_config["input_model"] = input_model_config
+        for arg_key, rc_key in [("output_path", "output_dir"), ("log_level", "log_severity_level")]:
+            if (arg_value := getattr(self.args, arg_key)) is not None:
+                print(f"Replacing {rc_key} in run config with {arg_value}")
+                # remove value from engine config if it exists
+                run_config.get("engine", {}).pop(rc_key, None)
+                # add value to run config directly
+                run_config[rc_key] = arg_value
+
+        olive_run(
+            run_config,
+            setup=self.args.setup,
+            packages=self.args.packages,
+            tempdir=self.args.tempdir,
+            package_config=self.args.package_config,
+        )

--- a/olive/common/config_utils.py
+++ b/olive/common/config_utils.py
@@ -93,6 +93,19 @@ def serialize_to_json(obj: Any, check_object: bool = False, make_absolute: bool 
     return json.loads(raw_json)
 
 
+def load_config_file(file_path: Union[str, Path]) -> dict:
+    """Load a file into a dictionary."""
+    file_path = Path(file_path)
+    if file_path.suffix in {".yaml", ".yml"}:
+        with open(file_path) as f:
+            return yaml.safe_load(f)
+    elif file_path.suffix == ".json":
+        with open(file_path) as f:
+            return json.load(f)
+    else:
+        raise ValueError(f"Unsupported file type: {file_path.suffix}")
+
+
 class ConfigBase(BaseModel):
     class Config:
         arbitrary_types_allowed = True
@@ -116,14 +129,11 @@ class ConfigBase(BaseModel):
         :return: ConfigBase object.
         """
         if isinstance(file_or_obj, dict):
-            return cls.parse_obj(file_or_obj)
+            obj = file_or_obj
+        else:
+            obj = load_config_file(file_or_obj)
 
-        file_path = Path(file_or_obj)
-        if file_path.suffix in {".yaml", ".yml"}:
-            with open(file_path) as f:
-                return cls.parse_obj(yaml.safe_load(f))
-
-        return cls.parse_file(file_path)
+        return cls.parse_obj(obj)
 
 
 class ConfigListBase(ConfigBase):

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -5,6 +5,7 @@
 import json
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -83,9 +84,11 @@ def test_unknown_args():
 @pytest.mark.parametrize("setup", [True, False])
 @pytest.mark.parametrize("tempdir", [None, "tempdir"])
 @patch("olive.workflows.run")
-def test_workflow_run_command(mock_run, tempdir, setup, packages):
+def test_workflow_run_command(mock_run, tempdir, setup, packages, tmp_path):
     # setup
-    command_args = ["run", "--run-config", "config.json"]
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"key": "value"}))  # Create a dummy config file
+    command_args = ["run", "--run-config", str(config_path)]
     if packages:
         command_args.append("--packages")
     if setup:
@@ -98,7 +101,48 @@ def test_workflow_run_command(mock_run, tempdir, setup, packages):
 
     # assert
     mock_run.assert_called_once_with(
-        run_config="config.json", setup=setup, package_config=None, tempdir=tempdir, packages=packages
+        {"key": "value"}, setup=setup, package_config=None, tempdir=tempdir, packages=packages
+    )
+
+
+@patch("olive.workflows.run")
+def test_workflow_run_command_with_overrides(mock_run, tmp_path):
+    # setup
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"input_model": {"key": "value"}, "engine": {"log_severity_level": 3}, "output_dir": "output"})
+    )
+    command_args = [
+        "run",
+        "--run-config",
+        str(config_path),
+        "--model_name_or_path",
+        "hf-internal-testing/tiny-random-LlamaForCausalLM",
+        "--output_path",
+        "new_output_path",
+        "--log_level",
+        "2",
+    ]
+
+    # execute
+    cli_main(command_args)
+    # assert
+    mock_run.assert_called_once_with(
+        {
+            "input_model": {
+                "type": "HfModel",
+                "model_path": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+                "generative": True,
+                "load_kwargs": {"attn_implementation": "eager", "trust_remote_code": False},
+            },
+            "engine": {},
+            "output_dir": str(Path("new_output_path").resolve()),
+            "log_severity_level": 2,
+        },
+        setup=False,
+        package_config=None,
+        tempdir=None,
+        packages=False,
     )
 
 


### PR DESCRIPTION
## Describe your changes
- Allow overriding the values for `input_model`, `output_dir` and `log_severity_level` for `olive run` using the same options available to other CLI commands
- This lets us chain `run` command with other cli commands. 
- Reusing the same config for different models like in the NPU llm examples is also easier now

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
