### PR TITLE
Remove torch and transformers version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We recommend installing Olive in a [virtual environment](https://docs.python.org
 
 ```
 pip install olive-ai[auto-opt]
-pip install transformers==4.44.2 onnxruntime-genai
+pip install transformers onnxruntime-genai
 ```
 > [!NOTE]
 > Olive has optional dependencies that can be installed to enable additional features. Please refer to [Olive package config](./olive/olive_config.json) for the list of extras and their dependencies.

--- a/docs/source/getting-started/getting-started.md
+++ b/docs/source/getting-started/getting-started.md
@@ -29,7 +29,7 @@ If your machine only has a CPU device, install the following libraries:
 
 ```bash
 pip install olive-ai[cpu,finetune]
-pip install transformers==4.44.2 onnxruntime-genai
+pip install transformers onnxruntime-genai
 ```
 :::
 
@@ -38,7 +38,7 @@ If your machine has a GPU device (e.g. CUDA), install the following libraries:
 
 ```bash
 pip install olive-ai[gpu,finetune]
-pip install transformers==4.44.2 onnxruntime-genai-cuda
+pip install transformers onnxruntime-genai-cuda
 ```
 :::
 
@@ -47,7 +47,7 @@ DirectML provides GPU acceleration on Windows for machine learning tasks across 
 
 ```bash
 pip install olive-ai[directml,finetune]
-pip install transformers==4.44.2 onnxruntime-genai-directml
+pip install transformers onnxruntime-genai-directml
 ```
 :::
 

--- a/examples/getting_started/olive_quickstart.ipynb
+++ b/examples/getting_started/olive_quickstart.ipynb
@@ -39,7 +39,7 @@
     "%%capture\n",
     "\n",
     "%pip install olive-ai[auto-opt]\n",
-    "%pip install transformers==4.44.2 onnxruntime-genai"
+    "%pip install transformers onnxruntime-genai"
    ]
   },
   {

--- a/examples/opt_125m/requirements.txt
+++ b/examples/opt_125m/requirements.txt
@@ -1,3 +1,2 @@
 optimum
-# version mismatch between torch in autoawq and transformers
-transformers==4.41.2
+transformers

--- a/examples/phi3/requirements-awq.txt
+++ b/examples/phi3/requirements-awq.txt
@@ -1,5 +1,3 @@
 autoawq
-# awq export only added in 0.4.0
-onnxruntime-genai>=0.4.0
-# autoawq requires older torch but newer transformers imports missing torch submodules
-transformers==4.41.2
+onnxruntime-genai
+transformers

--- a/examples/phi3/requirements-nvmo-awq.txt
+++ b/examples/phi3/requirements-nvmo-awq.txt
@@ -1,5 +1,5 @@
 cppimport==22.8.2
 cupy-cuda12x
 datasets>=2.14.4
-torch==2.4.0
-transformers==4.44.0
+torch
+transformers

--- a/test/integ_test/aml_model_test/conda.yaml
+++ b/test/integ_test/aml_model_test/conda.yaml
@@ -11,6 +11,6 @@ dependencies:
       - onnxruntime
       - datasets
       - scipy
-      - transformers==4.31.0 # TODO(team): 55036 Fixed error and update to latest version
+      - transformers
       - onnxconverter_common
       - git+https://github.com/microsoft/Olive.git

--- a/test/integ_test/aml_model_test/conda.yaml
+++ b/test/integ_test/aml_model_test/conda.yaml
@@ -11,6 +11,6 @@ dependencies:
       - onnxruntime
       - datasets
       - scipy
-      - transformers
+      - transformers==4.31.0 # TODO(team): 55036 Fixed error and update to latest version
       - onnxconverter_common
       - git+https://github.com/microsoft/Olive.git


### PR DESCRIPTION
## Describe your changes
- transformers pin to 4.44.2 is not required anymore
- autoawq now supports newer transformers versions as well
- this resolved dependabot issues due to security risks with old packages

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
