### PR TITLE
Remove "generative" flag from input_model and "is_generative" command line option

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -74,7 +74,6 @@ def _get_hf_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     input_model = {
         "type": "HfModel",
         "model_path": model_path,
-        "generative": args.is_generative_model,
         "load_kwargs": {
             "attn_implementation": "eager",
         },
@@ -138,7 +137,6 @@ def _get_pt_input_model(args: Namespace, model_path: OLIVE_RESOURCE_ANNOTATIONS)
     input_model_config = {
         "type": "PyTorchModel",
         "model_script": args.model_script,
-        "generative": args.is_generative_model,
     }
 
     if args.script_dir:
@@ -375,7 +373,6 @@ def add_input_model_options(
                 "for more information."
             ),
         )
-    model_group.add_argument("--is_generative_model", type=bool, default=True, help="Is this a generative model?")
     model_group.add_argument(
         "-o",
         "--output_path",

--- a/olive/engine/packaging/packaging_config.py
+++ b/olive/engine/packaging/packaging_config.py
@@ -106,7 +106,6 @@ class PackagingConfig(NestedConfig):
     type: PackagingType = PackagingType.Zipfile
     name: str = "OutputModels"
     config: CommonPackagingConfig = None
-    generative: bool = False
 
     @validator("config", pre=True, always=True)
     def _validate_config(cls, v, values):

--- a/olive/model/handler/pytorch.py
+++ b/olive/model/handler/pytorch.py
@@ -31,7 +31,6 @@ class PyTorchModelHandlerBase(OliveModelHandler, DummyInputsMixin, PytorchKvCach
         model_path: OLIVE_RESOURCE_ANNOTATIONS = None,
         model_attributes: Optional[dict[str, Any]] = None,
         io_config: Union[dict[str, Any], "IoConfig", str, Callable] = None,
-        generative: bool = False,
     ):
         super().__init__(
             framework=Framework.PYTORCH,
@@ -40,7 +39,6 @@ class PyTorchModelHandlerBase(OliveModelHandler, DummyInputsMixin, PytorchKvCach
             model_attributes=model_attributes,
             io_config=io_config,
         )
-        self.generative = generative
 
     def prepare_session(
         self,
@@ -58,9 +56,9 @@ class PyTorchModelHandlerBase(OliveModelHandler, DummyInputsMixin, PytorchKvCach
         **kwargs: dict[str, Any],
     ) -> Any:
         if isinstance(inputs, dict):
-            results = session.generate(**inputs, **kwargs) if self.generative else session(**inputs, **kwargs)
+            results = session(**inputs, **kwargs)
         else:
-            results = session.generate(inputs, **kwargs) if self.generative else session(inputs, **kwargs)
+            results = session(inputs, **kwargs)
         return results
 
     @staticmethod
@@ -101,7 +99,7 @@ class PyTorchModelHandler(PyTorchModelHandlerBase):  # pylint: disable=too-many-
     """
 
     resource_keys: tuple[str, ...] = ("model_path", "script_dir", "model_script")
-    json_config_keys: tuple[str, ...] = ("model_file_format", "model_loader", "dummy_inputs_func", "generative")
+    json_config_keys: tuple[str, ...] = ("model_file_format", "model_loader", "dummy_inputs_func")
 
     def __init__(
         self,
@@ -113,7 +111,6 @@ class PyTorchModelHandler(PyTorchModelHandlerBase):  # pylint: disable=too-many-
         io_config: Union[dict[str, Any], IoConfig, str, Callable] = None,
         dummy_inputs_func: Union[str, Callable] = None,
         model_attributes: Optional[dict[str, Any]] = None,
-        generative: bool = False,
     ):
         if not (isinstance(model_loader, Callable) or (isinstance(model_loader, str) and model_script) or model_path):
             raise ValueError(
@@ -126,7 +123,6 @@ class PyTorchModelHandler(PyTorchModelHandlerBase):  # pylint: disable=too-many-
             model_path=model_path,
             model_attributes=model_attributes,
             io_config=io_config,
-            generative=generative,
         )
         self.add_resources(locals())
 

--- a/olive/passes/pytorch/common.py
+++ b/olive/passes/pytorch/common.py
@@ -95,7 +95,6 @@ def inherit_pytorch_from_hf(
         model_file_format=model_file_format,
         io_config=io_config,
         model_attributes={**model.model_attributes, **extra_attributes},
-        generative=model.generative,
     )
 
 

--- a/test/unit_test/cli/test_base.py
+++ b/test/unit_test/cli/test_base.py
@@ -15,7 +15,6 @@ from olive.cli.base import get_input_model_config
     (
         "model_name_or_path",
         "trust_remote_code",
-        "is_generative_model",
         "task",
         "model_script",
         "script_dir",
@@ -27,7 +26,6 @@ from olive.cli.base import get_input_model_config
         (
             None,  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             None,  # task
             "model.py",  # model_script
             "scripts",  # script_dir
@@ -38,14 +36,12 @@ from olive.cli.base import get_input_model_config
                 "script_dir": "scripts",
                 "model_loader": "_model_loader",
                 "dummy_inputs_func": "_dummy_inputs",
-                "generative": False,
             },
         ),
         # AML registry model test
         (
             "azureml://registries/my_registry/models/my_model/versions/1",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -53,7 +49,6 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
-                "generative": False,
                 "model_path": {
                     "type": "azureml_registry_model",
                     "registry_name": "my_registry",
@@ -70,7 +65,6 @@ from olive.cli.base import get_input_model_config
         (
             "https://huggingface.co/my_model/my_model",  # model_name_or_path
             True,  # trust_remote_code
-            False,  # is_generative_model
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -78,7 +72,6 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
-                "generative": False,
                 "model_path": "my_model/my_model",
                 "load_kwargs": {
                     "trust_remote_code": True,
@@ -90,7 +83,6 @@ from olive.cli.base import get_input_model_config
         (
             "azureml:my_model:1",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             None,  # task
             "model.py",  # model_script
             "scripts",  # script_dir
@@ -100,7 +92,6 @@ from olive.cli.base import get_input_model_config
                 "model_script": "model.py",
                 "script_dir": "scripts",
                 "io_config": "_io_config",
-                "generative": False,
                 "model_path": {"type": "azureml_model", "name": "my_model", "version": "1"},
             },
         ),
@@ -108,7 +99,6 @@ from olive.cli.base import get_input_model_config
         (
             "hf_model",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -116,7 +106,6 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
-                "generative": False,
                 "model_path": "hf_model",
                 "load_kwargs": {
                     "trust_remote_code": False,
@@ -128,7 +117,6 @@ from olive.cli.base import get_input_model_config
         (
             "model.pt",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             None,  # task
             "model.py",  # model_script
             None,  # script_dir
@@ -138,13 +126,11 @@ from olive.cli.base import get_input_model_config
                 "model_script": "model.py",
                 "io_config": "_io_config",
                 "model_path": "model.pt",
-                "generative": False,
             },
         ),
         (
             "model.pt",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             None,  # task
             "model.py",  # model_script
             None,  # script_dir
@@ -155,14 +141,12 @@ from olive.cli.base import get_input_model_config
                 "model_loader": "_model_loader",
                 "io_config": "_io_config",
                 "model_path": "model.pt",
-                "generative": False,
             },
         ),
         # Local onnx model test
         (
             "model.onnx",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             None,  # task
             None,  # model_script
             None,  # script_dir
@@ -176,7 +160,6 @@ from olive.cli.base import get_input_model_config
         (
             "hf",  # model_name_or_path
             False,  # trust_remote_code
-            False,  # is_generative_model
             "task",  # task
             None,  # model_script
             None,  # script_dir
@@ -184,7 +167,6 @@ from olive.cli.base import get_input_model_config
             {  # expected config
                 "type": "HfModel",
                 "task": "task",
-                "generative": False,
                 "model_path": "hf",
                 "load_kwargs": {
                     "trust_remote_code": False,
@@ -199,7 +181,6 @@ def test_get_input_model_config(
     MockUserModuleLoader,
     model_name_or_path,
     trust_remote_code,
-    is_generative_model,
     task,
     model_script,
     script_dir,
@@ -211,7 +192,6 @@ def test_get_input_model_config(
     args = SimpleNamespace(
         model_name_or_path=model_name_or_path,
         trust_remote_code=trust_remote_code,
-        is_generative_model=is_generative_model,
         task=task,
         model_script=model_script,
         script_dir=script_dir,

--- a/test/unit_test/cli/test_cli.py
+++ b/test/unit_test/cli/test_cli.py
@@ -132,7 +132,6 @@ def test_workflow_run_command_with_overrides(mock_run, tmp_path):
             "input_model": {
                 "type": "HfModel",
                 "model_path": "hf-internal-testing/tiny-random-LlamaForCausalLM",
-                "generative": True,
                 "load_kwargs": {"attn_implementation": "eager", "trust_remote_code": False},
             },
             "engine": {},


### PR DESCRIPTION
## Describe your changes
Remove "generative" flag from input_model and "is_generative" command line option.

Check GenerationConfig to see if HF model is generative or not.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
