### PR TITLE
quantize: expose act precision

### DIFF
--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -60,6 +60,13 @@ class QuantizeCommand(BaseOliveCLICommand):
             help="The precision of the quantized model.",
         )
         sub_parser.add_argument(
+            "--act_precision",
+            type=str,
+            default="int8",
+            choices=list(Precision),
+            help="The precision of the activation quantization for static quantization.",
+        )
+        sub_parser.add_argument(
             "--implementation",
             type=str,
             help="The specific implementation of quantization algorithms to use.",
@@ -102,8 +109,9 @@ class QuantizeCommand(BaseOliveCLICommand):
             ):
                 if not self._check_data_name_arg(pinfo):
                     print(
-                        f"Warning: Quantization for {algo} {precision} {impl} implementation with QDQ {self.args.use_qdq_encoding}"
-                        " requires dataset. Please provide a dataset using --data_name option."
+                        f"Warning: Quantization for {algo} {precision} {impl} implementation with QDQ"
+                        f" {self.args.use_qdq_encoding} requires dataset. Please provide a dataset using --data_name"
+                        " option."
                     )
                 else:
                     pass_list.append(r["pass_type"])
@@ -128,6 +136,7 @@ class QuantizeCommand(BaseOliveCLICommand):
             "OnnxDynamicQuantization": {"precision": self.args.precision, "quant_format": quant_format},
             "OnnxStaticQuantization": {
                 "precision": self.args.precision,
+                "act_precision": self.args.act_precision,
                 "quant_format": quant_format,
                 "data_config": "default_data_config",
             },
@@ -202,6 +211,7 @@ TEMPLATE = {
 # Pass order in this mapping is important. More than one passes could be selected from this mapping.
 PT_QUANT_IMPLEMENTATION_MAPPING = [
     {"impl_name": "quarot", "pass_type": "QuaRot"},
+    # TODO(jambayk): consider exposing the activation bits through the act_precision argument
     {"impl_name": "spinquant", "pass_type": "SpinQuant"},
     {"impl_name": "awq", "pass_type": "AutoAWQQuantizer"},
     {"impl_name": "autogptq", "pass_type": "GptqQuantizer"},
@@ -215,6 +225,6 @@ ONNX_QUANT_IMPLEMENTATION_MAPPING = [
     {"impl_name": "ort", "pass_type": "OnnxStaticQuantization"},
     {"impl_name": "nvmo", "pass_type": "NVModelOptQuantization"},
     {"impl_name": "inc", "pass_type": "IncDynamicQuantization"},
-    {"pass_type": "OnnxHqqQuantization"},
+    {"impl_name": "olive", "pass_type": "OnnxHqqQuantization"},
     # "impl_name": "inc", "pass_type": "IncStaticQuantization"},
 ]


### PR DESCRIPTION
## Describe your changes
- We have multiple examples doing w8a16 static quantization. Exposing this option in the quantize cli

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
