### PR TITLE
Hf: Catch type error in tokenizer save

### DIFF
--- a/olive/model/handler/mixin/hf.py
+++ b/olive/model/handler/mixin/hf.py
@@ -105,7 +105,9 @@ class HfMixin:
         # save tokenizer, skip if it already exists
         try:
             get_tokenizer(output_dir)
-        except OSError:
+        except (OSError, TypeError):
+            # there is no tokenizer in the output_dir, save the tokenizer
+            # "TypeError: not a string" happens with transformers 4.52+
             tokenizer_filepaths = save_tokenizer(self.get_hf_tokenizer(), output_dir, **kwargs)
             saved_filepaths.extend([fp for fp in tokenizer_filepaths if Path(fp).exists()])
 


### PR DESCRIPTION
## Describe your changes
- In transformers 4.52+, when trying to load tokenizer from a directory with no tokenizer files, it raises `TypeError` instead of `OSError`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
