### PR TITLE
remove backend_path in EPContextBinaryGenerator

### DIFF
--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -227,8 +227,8 @@ class EPContextBinaryGenerator(Pass):
         :param ignore_missing_cb_bin: Whether to ignore missing context binary files.
         :return: ONNXModelHandler for the generated context binary.
         """
-        from onnxruntime import __version__ as OrtVersion
         import onnxruntime as ort
+        from onnxruntime import __version__ as OrtVersion
 
         from olive.common.ort_inference import initialize_inference_session_options, ort_supports_ep_devices
 


### PR DESCRIPTION
## Describe your changes

After this PR in onnxruntime, this options is not needed anymore https://github.com/microsoft/onnxruntime/pull/24235/files

If someone is using ort less than 1.22, we can ask them to provide the backend_path as part of the pass’ provider_options config param

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
