### PR TITLE
Phi3.5: pin ort-genai to 0.7.1

### DIFF
--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -69,7 +69,7 @@ Quantization is resource-intensive and requires GPU acceleration. In an [x64 Pyt
 pip install -r requirements.txt
 
 # Install ONNX Runtime GPU packages
-pip install "onnxruntime-gpu>=1.21.0" "onnxruntime-genai-cuda>=0.6.0"
+pip install "onnxruntime-gpu>=1.21.0" "onnxruntime-genai-cuda==0.7.1"
 
 # AutoGPTQ: Install from source (stable package may be slow for weight packing)
 # Disable CUDA extension build (not required)
@@ -195,7 +195,7 @@ Open ARM64 Native Tools Command Prompt for VS2022 and run the following commands
 ```bash
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
 pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
-pip install "onnxruntime-genai>=0.7.0rc2"
+pip install "onnxruntime-genai==0.7.1"
 ```
 
 #### **Run Console-Based Chat Interface**

--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -69,7 +69,8 @@ Quantization is resource-intensive and requires GPU acceleration. In an [x64 Pyt
 pip install -r requirements.txt
 
 # Install ONNX Runtime GPU packages
-pip install "onnxruntime-gpu>=1.21.0" "onnxruntime-genai-cuda==0.7.1"
+# ort-genai 0.8.x has some issues, use 0.7.1 for now. Also not compatible with ort 1.22+
+pip install "onnxruntime-gpu==1.21.1" "onnxruntime-genai-cuda==0.7.1"
 
 # AutoGPTQ: Install from source (stable package may be slow for weight packing)
 # Disable CUDA extension build (not required)
@@ -195,7 +196,7 @@ Open ARM64 Native Tools Command Prompt for VS2022 and run the following commands
 ```bash
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
 pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
-pip install "onnxruntime-genai==0.7.1"
+pip install "onnxruntime-genai>=0.7.0"
 ```
 
 #### **Run Console-Based Chat Interface**


### PR DESCRIPTION
## Describe your changes
Pin the onnxruntime-genai version for NPU llm examples to 0.7.1. There are some issues (such as #1912) with 0.8.x releases which need more investigation. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
Fixes #1912