### PR TITLE
Phi3_5: Remove add metadata pass

### DIFF
--- a/examples/phi3_5/qdq_config.json
+++ b/examples/phi3_5/qdq_config.json
@@ -51,8 +51,7 @@
             "save_as_external_data": true
         },
         "sp": { "type": "SplitModel" },
-        "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },
-        "add_metadata": { "type": "AddOliveMetadata", "config": { "graph_name": "Phi-3.5-mini-instruct" } }
+        "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 }
     },
     "log_severity_level": 1,
     "output_dir": "models/phi3_5-qdq",

--- a/examples/phi3_5/qdq_config_vitis_ai.json
+++ b/examples/phi3_5/qdq_config_vitis_ai.json
@@ -67,8 +67,7 @@
                 "provider_options": [ { "VitisAI": {  } } ],
                 "graph_optimization_level": "ORT_ENABLE_ALL"
             }
-        },
-        "add_metadata": { "type": "AddOliveMetadata", "config": { "graph_name": "Phi-3.5-mini-instruct" } }
+        }
     },
     "log_severity_level": 1,
     "output_dir": "models/phi3_5-vai",

--- a/examples/phi3_5/qnn_config.json
+++ b/examples/phi3_5/qnn_config.json
@@ -3,7 +3,7 @@
     "systems": {
         "qnn_system": {
             "type": "PythonEnvironment",
-            "python_environment_path": "/path/to/qnn/env/bin",
+            "python_environment_path": "/datadisks/jambaykinley/conda/envs/qnn/bin",
             "accelerators": [ { "execution_providers": [ "QNNExecutionProvider" ] } ]
         }
     },
@@ -69,8 +69,7 @@
             "session_options": { "intra_op_num_threads": 2, "inter_op_num_threads": 1 },
             "weight_sharing": true
         },
-        "cp": { "type": "ComposeOnnxModels" },
-        "add_metadata": { "type": "AddOliveMetadata", "config": { "graph_name": "Phi-3.5-mini-instruct" } }
+        "cp": { "type": "ComposeOnnxModels" }
     },
     "target": "qnn_system",
     "log_severity_level": 1,

--- a/examples/phi3_5/qnn_config.json
+++ b/examples/phi3_5/qnn_config.json
@@ -3,7 +3,7 @@
     "systems": {
         "qnn_system": {
             "type": "PythonEnvironment",
-            "python_environment_path": "/datadisks/jambaykinley/conda/envs/qnn/bin",
+            "python_environment_path": "/path/to/qnn/env/bin",
             "accelerators": [ { "execution_providers": [ "QNNExecutionProvider" ] } ]
         }
     },


### PR DESCRIPTION
## Describe your changes
`AddOliveMetadata` does not work for static-llm models which have a special structure. Removing from the NPU recipes for now since these are important recipes. 
The metadata could be added before the static-llm pass and the later passes be updated to preserve the metadata in the components.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
