### PR TITLE
OnnxDAG: Allow duplicate vi addition

### DIFF
--- a/olive/passes/onnx/onnx_dag.py
+++ b/olive/passes/onnx/onnx_dag.py
@@ -278,9 +278,9 @@ class OnnxDAG:
             self.ios[name] = OnnxIO(proto=[value_info], graph_idx=graph_idx)
             return
 
-        assert overwrite or not self.ios[name].proto, (
-            f"Value info for {name} already exists in the graph but overwrite is False."
-        )
+        assert (
+            overwrite or not self.ios[name].proto or self.ios[name].proto[0] == value_info
+        ), f"Value info for {name} already exists in the graph but overwrite is False."
         self.ios[name].proto = [value_info]
 
     def is_io(self, io_name: str) -> bool:

--- a/olive/passes/onnx/onnx_dag.py
+++ b/olive/passes/onnx/onnx_dag.py
@@ -278,9 +278,9 @@ class OnnxDAG:
             self.ios[name] = OnnxIO(proto=[value_info], graph_idx=graph_idx)
             return
 
-        assert (
-            overwrite or not self.ios[name].proto or self.ios[name].proto[0] == value_info
-        ), f"Value info for {name} already exists in the graph but overwrite is False."
+        assert overwrite or not self.ios[name].proto or self.ios[name].proto[0] == value_info, (
+            f"Value info for {name} already exists in the graph but overwrite is False."
+        )
         self.ios[name].proto = [value_info]
 
     def is_io(self, io_name: str) -> bool:


### PR DESCRIPTION
## Describe your changes
When composing split models, there are some DequantizeLinear nodes that are duplicated between splits to maintain QDQ structure. This causes failure due to duplicate value info when composing split models.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
