### PR TITLE
Fix input model cache issue

### DIFF
--- a/olive/model/config/model_config.py
+++ b/olive/model/config/model_config.py
@@ -57,6 +57,7 @@ class ModelConfig(NestedConfig):
 
     def get_model_identifier(self):
         model_path = self.config.get("model_path")
+        hash_list = []
         if model_path:
             model_path_resource_path = create_resource_path(model_path)
             if (
@@ -77,10 +78,12 @@ class ModelConfig(NestedConfig):
 
             if model_path_resource_path.is_azureml_resource():
                 return model_path_resource_path.get_path()
+            hash_list.append(model_path)
 
         file_hashes = self._get_model_files_hash(self.config)
         sorted_file_hashes = sorted(file_hashes)
-        return hash_string("".join(sorted_file_hashes))
+        hash_list.extend(sorted_file_hashes)
+        return hash_string("".join(hash_list))
 
     def _get_model_files_hash(self, config: dict):
         keys = ["model_path", "adapter_path", "model_script", "script_dir"]


### PR DESCRIPTION
## Describe your changes

Fix input model cache issue by including model_path in the hash calculation, to handle cases where multiple config files share the same model script.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
https://github.com/microsoft/Olive/issues/1936
