### PR TITLE
Fix quantize CLI bits issue

### DIFF
--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -78,14 +78,14 @@ class QuantizeCommand(BaseOliveCLICommand):
             "--precision",
             type=str,
             default=Precision.INT8,
-            choices=list(Precision) + list(PrecisionBits),
+            choices=[p.value for p in Precision],
             help="The precision of the quantized model.",
         )
         sub_parser.add_argument(
             "--act_precision",
             type=str,
             default=Precision.INT8,
-            choices=list(Precision),
+            choices=[p.value for p in Precision],
             help="The precision of the activation quantization for static quantization.",
         )
         sub_parser.add_argument(

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -39,6 +39,16 @@ class ImplName(StrEnumBase):
     AUTOGPTQ = "autogptq"
 
 
+PRECISION_TO_BITS = {
+    Precision.INT4: 4,
+    Precision.INT8: 8,
+    Precision.INT16: 16,
+    Precision.UINT4: 4,
+    Precision.UINT8: 8,
+    Precision.UINT16: 16,
+}
+
+
 class QuantizeCommand(BaseOliveCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
@@ -150,8 +160,8 @@ class QuantizeCommand(BaseOliveCLICommand):
 
         # config options to add for a given option
         to_add = {
-            "AutoAWQQuantizer": {"bits": self.args.precision},
-            "GptqQuantizer": {"bits": self.args.precision},
+            "AutoAWQQuantizer": {"bits": PRECISION_TO_BITS[self.args.precision]},
+            "GptqQuantizer": {"bits": PRECISION_TO_BITS[self.args.precision]},
             "OnnxBnB4Quantization": {"precision": self.args.precision},
             "NVModelOptQuantization": {"precision": self.args.precision, "algorithm": self.args.algorithm},
             "OnnxDynamicQuantization": {"precision": self.args.precision, "quant_format": quant_format},

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -23,7 +23,7 @@ from olive.cli.base import (
     update_shared_cache_options,
 )
 from olive.common.utils import StrEnumBase, set_nested_dict_value
-from olive.constants import Precision, QuantAlgorithm
+from olive.constants import Precision, QuantAlgorithm, precision_bits_from_precision
 from olive.package_config import OlivePackageConfig
 
 
@@ -37,16 +37,6 @@ class ImplName(StrEnumBase):
     QUAROT = "quarot"
     AWQ = "awq"
     AUTOGPTQ = "autogptq"
-
-
-PRECISION_TO_BITS = {
-    Precision.INT4: 4,
-    Precision.INT8: 8,
-    Precision.INT16: 16,
-    Precision.UINT4: 4,
-    Precision.UINT8: 8,
-    Precision.UINT16: 16,
-}
 
 
 class QuantizeCommand(BaseOliveCLICommand):
@@ -160,8 +150,8 @@ class QuantizeCommand(BaseOliveCLICommand):
 
         # config options to add for a given option
         to_add = {
-            "AutoAWQQuantizer": {"bits": PRECISION_TO_BITS[self.args.precision]},
-            "GptqQuantizer": {"bits": PRECISION_TO_BITS[self.args.precision]},
+            "AutoAWQQuantizer": {"bits": precision_bits_from_precision(self.args.precision)},
+            "GptqQuantizer": {"bits": precision_bits_from_precision(self.args.precision)},
             "OnnxBnB4Quantization": {"precision": self.args.precision},
             "NVModelOptQuantization": {"precision": self.args.precision, "algorithm": self.args.algorithm},
             "OnnxDynamicQuantization": {"precision": self.args.precision, "quant_format": quant_format},
@@ -174,7 +164,7 @@ class QuantizeCommand(BaseOliveCLICommand):
             "OnnxBlockWiseRtnQuantization": {},
             "IncDynamicQuantization": {
                 "algorithm": self.args.algorithm,
-                "bits": PRECISION_TO_BITS[self.args.precision],
+                "bits": precision_bits_from_precision(self.args.precision),
             },
             "MatMulNBitsToQDQ": {},
         }

--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -23,7 +23,7 @@ from olive.cli.base import (
     update_shared_cache_options,
 )
 from olive.common.utils import StrEnumBase, set_nested_dict_value
-from olive.constants import Precision, PrecisionBits, QuantAlgorithm
+from olive.constants import Precision, QuantAlgorithm
 from olive.package_config import OlivePackageConfig
 
 
@@ -172,7 +172,10 @@ class QuantizeCommand(BaseOliveCLICommand):
                 "data_config": "default_data_config",
             },
             "OnnxBlockWiseRtnQuantization": {},
-            "IncDynamicQuantization": {"algorithm": self.args.algorithm, "bits": self.args.precision},
+            "IncDynamicQuantization": {
+                "algorithm": self.args.algorithm,
+                "bits": PRECISION_TO_BITS[self.args.precision],
+            },
             "MatMulNBitsToQDQ": {},
         }
 

--- a/olive/constants.py
+++ b/olive/constants.py
@@ -95,3 +95,17 @@ class AccuracyLevel(IntEnumBase):
     fp16 = 2
     bf16 = 3
     int8 = 4
+
+
+def precision_bits_from_precision(p):
+    mapping = {
+        Precision.INT4: PrecisionBits.BITS4,
+        Precision.INT8: PrecisionBits.BITS8,
+        Precision.INT16: PrecisionBits.BITS16,
+        Precision.INT32: PrecisionBits.BITS32,
+        Precision.UINT4: PrecisionBits.BITS4,
+        Precision.UINT8: PrecisionBits.BITS8,
+        Precision.UINT16: PrecisionBits.BITS16,
+        Precision.UINT32: PrecisionBits.BITS32,
+    }
+    return mapping.get(p)

--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -14,7 +14,7 @@ from packaging import version
 
 from olive.common.config_utils import validate_config
 from olive.common.utils import exclude_keys, hash_string
-from olive.constants import Precision, PrecisionBits
+from olive.constants import Precision
 from olive.data.config import DataConfig
 from olive.exception import OlivePassError
 from olive.hardware.accelerator import AcceleratorSpec
@@ -231,28 +231,6 @@ def quant_type_from_precision(p):
         Precision.UINT8: QuantType["QUInt8"],
         Precision.INT16: QuantType["QInt16"],
         Precision.UINT16: QuantType["QUInt16"],
-    }
-    return mapping.get(p)
-
-
-def bits_from_precision(p):
-    mapping = {
-        Precision.INT4: 4,
-        Precision.INT8: 8,
-    }
-    return mapping.get(p)
-
-
-def precision_bits_from_precision(p):
-    mapping = {
-        Precision.INT4: PrecisionBits.BITS4,
-        Precision.INT8: PrecisionBits.BITS8,
-        Precision.INT16: PrecisionBits.BITS16,
-        Precision.INT32: PrecisionBits.BITS32,
-        Precision.UINT4: PrecisionBits.BITS4,
-        Precision.UINT8: PrecisionBits.BITS8,
-        Precision.UINT16: PrecisionBits.BITS16,
-        Precision.UINT32: PrecisionBits.BITS32,
     }
     return mapping.get(p)
 


### PR DESCRIPTION
## Describe your changes

Fix quantize CLI bits issue. precision bit map was deleted in https://github.com/microsoft/Olive/pull/1808. Add precision bit map back and make the precision definition different from bits.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
https://github.com/microsoft/Olive/issues/1942