### PR TITLE
UT: Replace ptb_text_only with wikitext dataset

### DIFF
--- a/test/unit_test/passes/pytorch/test_lora.py
+++ b/test/unit_test/passes/pytorch/test_lora.py
@@ -9,38 +9,19 @@ import pytest
 import torch
 
 from olive.common.constants import OS
-from olive.data.template import huggingface_data_config_template
 from olive.model import HfModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.pytorch.lora import DoRA, LoftQ, LoHa, LoKr, LoRA, QLoRA
+from test.unit_test.utils import get_wikitext_data_config
 
 # pylint: disable=redefined-outer-name
 
 
 def get_pass_config(model_name, task, **kwargs):
-    dataset = {
-        "load_dataset_config": {
-            "params": {
-                "data_name": "ptb_text_only",
-                "subset": "penn_treebank",
-                "split": "train",
-                "trust_remote_code": True,
-            }
-        },
-        "pre_process_data_config": {
-            "params": {
-                "text_cols": ["sentence"],
-                "strategy": "line-by-line",
-                "max_seq_len": 512,
-                "max_samples": 10,
-                "pad_to_max_len": False,
-                "trust_remote_code": True,
-            }
-        },
-    }
-    data_config = huggingface_data_config_template(model_name=model_name, task=task, **dataset).to_json()
     return {
-        "train_data_config": data_config,
+        "train_data_config": get_wikitext_data_config(
+            model_name, strategy="line-by-line", max_seq_len=100, max_samples=10, pad_to_max_len=False
+        ),
         # hidden sizes are 4 or 16
         # will have invalid adapter weights since `in_features` and/or `out_features` say 64 (r) even though
         # the actual weights are 4 or 16. Bug not from our code, it's from peft

--- a/test/unit_test/passes/pytorch/test_sparsegpt.py
+++ b/test/unit_test/passes/pytorch/test_sparsegpt.py
@@ -2,10 +2,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from olive.data.template import huggingface_data_config_template
 from olive.model import HfModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.pytorch.sparsegpt import SparseGPT
+from test.unit_test.utils import get_wikitext_data_config
 
 
 def test_sparsegpt(tmp_path):
@@ -13,31 +13,7 @@ def test_sparsegpt(tmp_path):
     model_name = "sshleifer/tiny-gpt2"
     task = "text-generation"
     input_model = HfModelHandler(model_path=model_name, task=task)
-    component_configs = {
-        "load_dataset_config": {
-            "params": {
-                "data_name": "ptb_text_only",
-                "subset": "penn_treebank",
-                "split": "train",
-                "trust_remote_code": True,
-            }
-        },
-        "pre_process_data_config": {
-            "params": {
-                "text_cols": ["sentence"],
-                "strategy": "join-random",
-                "max_seq_len": 1024,
-                "max_samples": 1,
-                "random_seed": 42,
-                "trust_remote_code": True,
-            }
-        },
-    }
-    data_config = huggingface_data_config_template(model_name=model_name, task=task, **component_configs)
-    config = {
-        "sparsity": [2, 4],
-        "data_config": data_config,
-    }
+    config = {"sparsity": [2, 4], "data_config": get_wikitext_data_config(model_name)}
 
     p = create_pass_from_dict(SparseGPT, config, disable_search=True)
     output_folder = str(tmp_path / "sparse")

--- a/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
+++ b/test/unit_test/passes/pytorch/test_torch_trt_conversion.py
@@ -10,11 +10,11 @@ import torch
 
 from olive.common.hf.wrapper import ModelWrapper
 from olive.common.utils import get_attr
-from olive.data.template import huggingface_data_config_template
 from olive.model import HfModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.pytorch.sparsegpt_utils import get_layer_submodules
 from olive.passes.pytorch.torch_trt_conversion import TorchTRTConversion
+from test.unit_test.utils import get_wikitext_data_config
 
 # pylint: disable=abstract-method
 
@@ -53,30 +53,8 @@ def test_torch_trt_conversion_success(tmp_path):
             ModelWrapper.from_model(input_model.load_model()).get_layers(False)[0], submodule_types=[torch.nn.Linear]
         ).keys()
     )
-
-    dataset = {
-        "load_dataset_config": {
-            "params": {
-                "data_name": "ptb_text_only",
-                "subset": "penn_treebank",
-                "split": "train",
-                "trust_remote_code": True,
-            }
-        },
-        "pre_process_data_config": {
-            "params": {
-                "text_cols": ["sentence"],
-                "strategy": "join-random",
-                "max_seq_len": 100,
-                "max_samples": 1,
-                "random_seed": 42,
-                "trust_remote_code": True,
-            }
-        },
-    }
-    data_config = huggingface_data_config_template(model_name=model_name, task=task, **dataset)
     config = {
-        "data_config": data_config,
+        "data_config": get_wikitext_data_config(model_name, max_seq_len=100),
     }
 
     p = create_pass_from_dict(TorchTRTConversion, config, disable_search=True)

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -383,5 +383,6 @@ def get_wikitext_data_config(
             "max_seq_len": max_seq_len,
             "max_samples": max_samples,
             "pad_to_max_len": pad_to_max_len,
+            "random_seed": 42,
         },
     )

--- a/test/unit_test/utils.py
+++ b/test/unit_test/utils.py
@@ -14,6 +14,7 @@ from olive.common.config_utils import validate_config
 from olive.constants import Framework
 from olive.data.config import DataComponentConfig, DataConfig
 from olive.data.registry import Registry
+from olive.data.template import huggingface_data_config_template
 from olive.evaluator.metric import AccuracySubType, LatencySubType, Metric, MetricType
 from olive.evaluator.metric_config import MetricGoal
 from olive.model import HfModelHandler, ModelConfig, ONNXModelHandler, PyTorchModelHandler
@@ -363,4 +364,24 @@ def make_local_tiny_llama(save_path, model_type="hf"):
         HfModelHandler(model_path=save_path)
         if model_type == "hf"
         else ONNXModelHandler(model_path=save_path, onnx_file_name="model.onnx")
+    )
+
+
+def get_wikitext_data_config(
+    model_name_or_path, max_seq_len=1024, max_samples=1, strategy="join-random", pad_to_max_len=True
+):
+    return huggingface_data_config_template(
+        model_name=model_name_or_path,
+        task="text-generation",
+        load_dataset_config={
+            "data_name": "wikitext",
+            "subset": "wikitext-2-raw-v1",
+            "split": "train[:1000]",
+        },
+        pre_process_data_config={
+            "strategy": strategy,
+            "max_seq_len": max_seq_len,
+            "max_samples": max_samples,
+            "pad_to_max_len": pad_to_max_len,
+        },
     )


### PR DESCRIPTION
## Describe your changes
`ptb_text_only` dataset uses a script to generate the data. `datasets>=4.0.0` doesn't support that anymore.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
