### PR TITLE
Fix "Provider xxx has already been registered."

### DIFF
--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -84,6 +84,7 @@ def initialize_inference_session_options(
     # ep_device.ep_name and ep_device.device.type combinations, but we can only
     # call add_provider_for_devices once for each unique EP device combination.
     # Use a dictionary to deduplicate by (ep_name, device_type) key.
+    # Additionally, it can also happen when your device indeed has two identical graphics cards.
     unique_ep_devices = { (ep.ep_name, ep.device.type): ep for ep in ort.get_ep_devices() }
     for ep_device in unique_ep_devices.values():
         if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep:

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -78,10 +78,10 @@ def initialize_inference_session_options(
     provider_options = provider_options or []
     provider_options_by_ep = dict(zip(providers, provider_options))
     ort_device_type = get_ort_hardware_device_type(device)
-
-    # ort.get_ep_devices could return eps with same name like when we have multiple graphcards
-    # but in onnxruntime, for each ep name, could only add once https://github.com/microsoft/onnxruntime/blob/fb0f6c652be5db0a3182c424a995efecf792d41c/onnxruntime/core/framework/execution_providers.h#L75
-    added_ep_names = {}
+    
+    # ort.get_ep_devices may return ep_devices with the same name and device, for example when connecting remotely or when there are multiple graph cards.
+    # However, in onnxruntime, each EP name can only be added once. See: https://github.com/microsoft/onnxruntime/blob/fb0f6c652be5db0a3182c424a995efecf792d41c/onnxruntime/core/framework/execution_providers.h#L75
+    added_ep_names = set()
     for ep_device in ort.get_ep_devices():
         if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep and ep_device.ep_name not in added_ep_names:
             added_ep_names.add(ep_device.ep_name)

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -79,15 +79,12 @@ def initialize_inference_session_options(
     provider_options_by_ep = dict(zip(providers, provider_options))
     ort_device_type = get_ort_hardware_device_type(device)
 
-    # Remove duplicate EP devices to avoid conflicts
-    # In remote connection scenarios, ort.get_ep_devices() may return duplicate
-    # ep_device.ep_name and ep_device.device.type combinations, but we can only
-    # call add_provider_for_devices once for each unique EP device combination.
-    # Use a dictionary to deduplicate by (ep_name, device_type) key.
-    # Additionally, it can also happen when your device indeed has two identical graphics cards.
-    unique_ep_devices = { (ep.ep_name, ep.device.type): ep for ep in ort.get_ep_devices() }
-    for ep_device in unique_ep_devices.values():
-        if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep:
+    # ort.get_ep_devices could return eps with same name like when we have multiple graphcards
+    # but in onnxruntime, for each ep name, could only add once https://github.com/microsoft/onnxruntime/blob/fb0f6c652be5db0a3182c424a995efecf792d41c/onnxruntime/core/framework/execution_providers.h#L75
+    added_ep_names = {}
+    for ep_device in ort.get_ep_devices():
+        if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep and ep_device.ep_name not in added_ep_names:
+            added_ep_names.add(ep_device.ep_name)
             sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
 
     if provider_selection_policy:

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -78,14 +78,25 @@ def initialize_inference_session_options(
     provider_options = provider_options or []
     provider_options_by_ep = dict(zip(providers, provider_options))
     ort_device_type = get_ort_hardware_device_type(device)
-    
-    # ort.get_ep_devices may return ep_devices with the same name and device, for example when connecting remotely or when there are multiple graph cards.
+
+    # NOTE: In the current latest version 1.22.0:
+    # ort.get_ep_devices may return ep_devices with the same ep_name and device, for example when connecting remotely or when there are multiple graph cards.
     # However, in onnxruntime, each EP name can only be added once. See: https://github.com/microsoft/onnxruntime/blob/fb0f6c652be5db0a3182c424a995efecf792d41c/onnxruntime/core/framework/execution_providers.h#L75
-    added_ep_names = set()
-    for ep_device in ort.get_ep_devices():
-        if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep and ep_device.ep_name not in added_ep_names:
-            added_ep_names.add(ep_device.ep_name)
-            sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
+    if version.parse(ort.__version__) < version.parse("1.22.0"):
+        added_ep_names = set()
+        for ep_device in ort.get_ep_devices():
+            if (
+                ep_device.device.type == ort_device_type
+                and ep_device.ep_name in provider_options_by_ep
+                and ep_device.ep_name not in added_ep_names
+            ):
+                added_ep_names.add(ep_device.ep_name)
+                sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
+    else:
+        # In ort v1.22.0 and later, we can use add_provider_for_devices to add providers with options.
+        for ep_device in ort.get_ep_devices():
+            if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep:
+                sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
 
     if provider_selection_policy:
         provider_selection_policy = get_ort_execution_provider_device_policy(provider_selection_policy)


### PR DESCRIPTION
We observed that when connecting remotely to a device with a GPU, the `ort.get_ep_devices()` function returns duplicate GPU EP devices.

Execute the following code.
```
import onnxruntime as ort

ep_devices = ort.get_ep_devices()
for ep_device in ep_devices:
    print(f"{id(ep_device.device)} {ep_device.ep_name} {ep_device.device.type} {ep_device.device.device_id} {ep_device.device.vendor_id} {ep_device.device.vendor}")
```

The output contains duplicate GPU EP devices.
```
2157111435568 CPUExecutionProvider OrtHardwareDeviceType.CPU 0 32902 GenuineIntel
2157111435568 DmlExecutionProvider OrtHardwareDeviceType.GPU 9988 4318 NVIDIA
2157111435568 DmlExecutionProvider OrtHardwareDeviceType.GPU 9988 4318 NVIDIA
2157111435568 NvTensorRTRTXExecutionProvider OrtHardwareDeviceType.GPU 9988 4318 NVIDIA
2157111435568 NvTensorRTRTXExecutionProvider OrtHardwareDeviceType.GPU 9988 4318 NVIDIA
```

This result in the following error when creating session:

```
File "C:\Users\xx\AppData\Local\miniconda3\envs\xx\Lib\site-packages\onnxruntime\capi\onnxruntime_inference_collection.py", line 570, in _create_inference_session
    sess.initialize_session(providers, provider_options, disabled_optimizers)
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Provider NvTensorRTRTXExecutionProvider has already been registered.
```
https://github.com/microsoft/win-onnxruntime/blob/e46c0d86b9cd15fce1dd6d53fdf03a22edce1ff7/onnxruntime/core/framework/execution_providers.h#L77

Additionally, this error can also occur if your device has two identical graphics cards installed.
So we try to add only one device for each EP to resolve this error.

FYI:
https://microsoft.visualstudio.com/OS/_workitems/edit/57991508

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
