### PR TITLE
ModelOptimizer: Remove fuse_transpose_qat and patch_unsupported_argmax_operator

### DIFF
--- a/olive/passes/onnx/peephole_optimizer.py
+++ b/olive/passes/onnx/peephole_optimizer.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import numpy as np
 import onnx
-from google.protobuf.message import Message
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
@@ -26,181 +25,6 @@ class ModelOptimizer:
     def __init__(self, source_model_path):
         self.source_model_path = str(source_model_path)
         self.model = onnx.load(self.source_model_path)
-
-    def fuse_transpose_qat(self):
-        # DequantizeLinear -> Transpose = Dequantize Linear with transposed initializer
-        # Might need to check if this is performant for EPs like DML
-        # Very limited use case, assumes a lot of things about the model
-        # probably better to remove this or create a more general solution
-        from onnxruntime.transformers.onnx_model import OnnxModel as TransformersOnnxModel
-
-        onnx_model = TransformersOnnxModel(self.model)
-        graph = onnx_model.graph()
-
-        node_name2module = {}
-        for node_idx, node in enumerate(graph.node):
-            if node.name == "":
-                node.name = str(node.op_type) + str(node_idx)
-            node_name2module[node.name] = [node, node_idx]
-
-        num_changed = 0
-        for module in node_name2module.values():
-            node = module[0]
-            node_index = module[1]
-            if node.op_type == "Transpose" and "DequantizeLinear" in node.input[0]:
-                dequant_node_name = node.input[0][:-9]
-                new_dequant_node_output = node.output[0]
-                dequant_node = node_name2module[dequant_node_name][0]
-                x_node = node_name2module[dequant_node.input[0][:-9]][0]
-                x_scale_node = node_name2module[dequant_node.input[1][:-9]][0]
-                x_zero_point_node = node_name2module[dequant_node.input[2][:-9]][0]
-
-                x_val = onnx_model.get_constant_value(dequant_node.input[0])
-                new_x_val = np.transpose(x_val, axes=(1, 0))
-                x_scale_val = onnx_model.get_constant_value(dequant_node.input[1])
-                x_zero_point_val = onnx_model.get_constant_value(dequant_node.input[2])
-
-                self.remove_nodes(graph, [node, dequant_node, x_node, x_scale_node, x_zero_point_node])
-                new_dequant, x, x_scale, x_zero_point = self.create_dequantizelinear_node(
-                    new_x_val, x_scale_val, x_zero_point_val, new_dequant_node_output, node_index
-                )
-                self.add_nodes(graph, [new_dequant, x, x_scale, x_zero_point], node_index)
-                num_changed += 1
-
-        if num_changed > 0:
-            logger.debug(
-                "Converted %d Transpose -> DequantizeLinear to DequantizeLinear with transposed initializer",
-                num_changed,
-            )
-            onnx_model.topological_sort()
-
-    def create_dequantizelinear_node(self, x_val, x_scale_val, x_zero_point_val, outputs, node_name_suffix):
-        x_tensor = onnx.helper.make_tensor(
-            name="const_tensor",
-            data_type=onnx.TensorProto.DataType.INT8,
-            dims=x_val.shape,
-            vals=x_val.flatten().tobytes(),
-            raw=True,
-        )
-
-        x_scale_tensor = onnx.helper.make_tensor(
-            name="const_tensor",
-            data_type=onnx.TensorProto.DataType.FLOAT,
-            dims=[1],
-            vals=x_scale_val.tobytes(),
-            raw=True,
-        )
-
-        x_zero_point_tensor = onnx.helper.make_tensor(
-            name="const_tensor",
-            data_type=onnx.TensorProto.DataType.INT8,
-            dims=[1],
-            vals=x_zero_point_val.tobytes(),
-            raw=True,
-        )
-
-        x = onnx.helper.make_node("Constant", inputs=[], outputs=["x_" + str(node_name_suffix)], value=x_tensor)
-        x_scale = onnx.helper.make_node(
-            "Constant", inputs=[], outputs=["x_scale_" + str(node_name_suffix)], value=x_scale_tensor
-        )
-        x_zero_point = onnx.helper.make_node(
-            "Constant", inputs=[], outputs=["x_zero_point_" + str(node_name_suffix)], value=x_zero_point_tensor
-        )
-
-        dequant_node = onnx.helper.make_node(
-            "DequantizeLinear",
-            inputs=[
-                "x_" + str(node_name_suffix),
-                "x_scale_" + str(node_name_suffix),
-                "x_zero_point_" + str(node_name_suffix),
-            ],
-            outputs=[outputs],
-        )
-        return dequant_node, x, x_scale, x_zero_point
-
-    def remove_nodes(self, graph, nodes_list):
-        for node in nodes_list:
-            graph.node.remove(node)
-
-    def add_nodes(self, graph, nodes_list, node_index):
-        for node in nodes_list:
-            graph.node.insert(node_index, node)
-
-    @staticmethod
-    def _create_node_name(nodes: dict[str, Message], op_type: str, prefix_a: str, prefix_b: str):
-        prefix: str = ""
-        last_slash: int = -1
-        for i in range(min(len(prefix_a), len(prefix_b))):
-            if prefix_a[i] == prefix_b[i]:
-                prefix += prefix_a[i]
-                if prefix_a[i] == "/":
-                    last_slash = i
-            else:
-                break
-
-        if last_slash > 0:
-            prefix = prefix[: last_slash + 1]
-
-        if not prefix.endswith("/"):
-            prefix += "/"
-        prefix += op_type
-
-        suffix: int = 0
-        node_name: str = prefix
-        while True:
-            if node_name not in nodes:
-                return node_name
-
-            node_name = f"{prefix}_{suffix}"
-            suffix += 1
-
-    def patch_unsupported_argmax_operator(self):
-        # ORT<1.20 doesn't support int64 input for ArgMax operator on CPU EP.
-        # CUDA EP also falls back to CPU EP for non float inputs.
-        # Add a cast node to convert int64 input to int32.
-        from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
-        from onnxruntime.transformers.onnx_model import OnnxModel as TransformersOnnxModel
-
-        o_model = TransformersOnnxModel(self.model)
-        o_model.topological_sort()  # Prerequisite for SymbolicShapeInference to succeed
-
-        try:
-            model_proto = SymbolicShapeInference.infer_shapes(o_model.model, auto_merge=True, guess_output_rank=True)
-            s_model = TransformersOnnxModel(model_proto) if model_proto is not None else o_model
-        except Exception as e:
-            logger.debug("Shape inference failed. Will try to continue without it. Error: %s", e)
-            s_model = o_model
-
-        o_nodes_by_name = {n.name: n for n in o_model.nodes()}
-        s_value_info_by_name = {v.name: v for v in s_model.model.graph.value_info}
-        s_value_info_by_name.update({n.name: n for n in s_model.model.graph.input})
-
-        num_changed = 0
-        for s_argmax_node in s_model.get_nodes_by_op_type("ArgMax"):
-            if (s_value_info := s_value_info_by_name.get(s_argmax_node.input[0])) is None:
-                # there is no value info for the input, so we can't determine the type
-                continue
-            if s_value_info.type.tensor_type.HasField("elem_type") and (
-                s_value_info.type.tensor_type.elem_type == onnx.TensorProto.INT64
-            ):
-                cast_node_name = ModelOptimizer._create_node_name(
-                    o_nodes_by_name, "Cast", s_argmax_node.input[0], s_argmax_node.name
-                )
-                cast_output_name = cast_node_name + "_output_0"
-                cast_node = onnx.helper.make_node(
-                    "Cast", [s_argmax_node.input[0]], [cast_output_name], name=cast_node_name, to=onnx.TensorProto.INT32
-                )
-
-                o_argmax_node = o_nodes_by_name[s_argmax_node.name]
-                o_argmax_node.input[0] = cast_output_name
-                o_model.add_node(cast_node)
-                o_nodes_by_name[cast_node_name] = cast_node
-
-                num_changed += 1
-
-        if num_changed > 0:
-            logger.debug("Patched %d ArgMax operators with Cast operators", num_changed)
-            o_model.topological_sort()
 
     def fuse_reshape_operations(self):
         # Remove unnecessary Reshape operator. Consecutive Reshape operators with latter's input being "[-1]"
@@ -276,8 +100,6 @@ class OnnxPeepholeOptimizer(Pass):
         peephole_optimizer = ModelOptimizer(model.model_path)
         peephole_optimizer.onnxscript_optimize()
         peephole_optimizer.onnxoptimizer_optimize()
-        peephole_optimizer.fuse_transpose_qat()
-        peephole_optimizer.patch_unsupported_argmax_operator()
         peephole_optimizer.fuse_reshape_operations()
 
         # save the model to the output path and return the model

--- a/test/unit_test/passes/onnx/test_peephole_optimizer.py
+++ b/test/unit_test/passes/onnx/test_peephole_optimizer.py
@@ -3,20 +3,16 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
 from onnx import TensorProto, helper
 
-from olive.hardware import DEFAULT_CPU_ACCELERATOR, DEFAULT_GPU_CUDA_ACCELERATOR
+from olive.hardware import DEFAULT_CPU_ACCELERATOR
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.common import model_proto_to_olive_model
 from olive.passes.onnx.peephole_optimizer import OnnxPeepholeOptimizer
 from test.unit_test.utils import get_onnx_model
-
-if TYPE_CHECKING:
-    from olive.model import ONNXModelHandler
 
 
 @pytest.fixture(name="external_data_config")
@@ -38,93 +34,6 @@ def test_onnx_peephole_optimizer_pass(tmp_path):
 
     # execute
     p.run(input_model, output_folder)
-
-
-def _make_model_for_patch_unsupported_argmax_operator(
-    data_type: TensorProto.DataType, filepath: str, config: dict[str, Any]
-) -> "ONNXModelHandler":
-    X = helper.make_tensor_value_info("X", data_type, [None, None])  # noqa: N806
-    Y = helper.make_tensor_value_info("Y", data_type, [None])  # noqa: N806
-    node_def = helper.make_node("ArgMax", ["X"], ["Y"], domain="com.microsoft")
-    graph_def = helper.make_graph(
-        [node_def],
-        "g",
-        [X],
-        [Y],
-    )
-    opset_imports = [
-        helper.make_operatorsetid("", 18),
-        helper.make_operatorsetid("com.microsoft", 1),
-    ]
-    model = helper.make_model(
-        graph_def,
-        producer_name="From test_peephole_optimizer.py",
-        opset_imports=opset_imports,
-    )
-
-    return model_proto_to_olive_model(model, filepath, config)
-
-
-@patch("onnxoptimizer.optimize")
-@patch("onnxscript.optimizer.optimize")
-def test_onnx_peephole_optimizer_pass_patch_unsupported_argmax_operator_modified(
-    mock_onnxscript, mock_onnxoptimizer, tmp_path, external_data_config
-):
-    m = _make_model_for_patch_unsupported_argmax_operator(
-        TensorProto.INT64, str(tmp_path / "input.onnx"), external_data_config
-    )
-    p = create_pass_from_dict(
-        OnnxPeepholeOptimizer, external_data_config, disable_search=True, accelerator_spec=DEFAULT_GPU_CUDA_ACCELERATOR
-    )
-    mock_onnxscript.return_value = m.load_model()
-    mock_onnxoptimizer.return_value = m.load_model()
-
-    actual_model = p.run(m, str(tmp_path / "onnx"))
-    assert Path(actual_model.model_path).exists()
-
-    actual_model = actual_model.load_model()
-    assert len(actual_model.graph.node) == 2
-
-    argmax_op_count = 0
-    cast_op_count = 0
-    others_op_count = 0
-    for node in actual_model.graph.node:
-        if node.op_type == "ArgMax":
-            argmax_op_count += 1
-        elif node.op_type == "Cast":
-            cast_op_count += 1
-        else:
-            others_op_count += 1
-
-    assert argmax_op_count == 1
-    assert cast_op_count == 1
-    assert others_op_count == 0
-
-
-def test_onnx_peephole_optimizer_pass_patch_unsupported_argmax_operator_unmodified(tmp_path, external_data_config):
-    m = _make_model_for_patch_unsupported_argmax_operator(
-        TensorProto.INT32, str(tmp_path / "input.onnx"), external_data_config
-    )
-    p = create_pass_from_dict(
-        OnnxPeepholeOptimizer, external_data_config, disable_search=True, accelerator_spec=DEFAULT_GPU_CUDA_ACCELERATOR
-    )
-
-    actual_model = p.run(m, str(tmp_path / "onnx"))
-    assert Path(actual_model.model_path).exists()
-
-    actual_model = actual_model.load_model()
-    assert len(actual_model.graph.node) == 1
-
-    argmax_op_count = 0
-    others_op_count = 0
-    for node in actual_model.graph.node:
-        if node.op_type == "ArgMax":
-            argmax_op_count += 1
-        else:
-            others_op_count += 1
-
-    assert argmax_op_count == 1
-    assert others_op_count == 0
 
 
 # TODO(team): this test will creat an unnecessary intermediate model file. Need to optimize it.


### PR DESCRIPTION
## Describe your changes
- `fuse_transpose_qat` is not used at all and is not generic. Assumes all int types to be int8
- `patch_unsupported_argmax_operator` was supported since ort<1.20 did not support int64 for argmax op. This is almost two years old.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
