### PR TITLE
remove version check when add_provider_for_devices

### DIFF
--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -80,24 +80,17 @@ def initialize_inference_session_options(
     provider_options_by_ep = dict(zip(providers, provider_options))
     ort_device_type = get_ort_hardware_device_type(device)
 
-    # NOTE: In the current latest version 1.22.0:
     # ort.get_ep_devices may return ep_devices with the same ep_name and device, for example when connecting remotely or when there are multiple graph cards.
     # However, in onnxruntime, each EP name can only be added once. See: https://github.com/microsoft/onnxruntime/blob/fb0f6c652be5db0a3182c424a995efecf792d41c/onnxruntime/core/framework/execution_providers.h#L75
-    if version.parse(ort.__version__) < version.parse("1.22.0"):
-        added_ep_names = set()
-        for ep_device in ort.get_ep_devices():
-            if (
-                ep_device.device.type == ort_device_type
-                and ep_device.ep_name in provider_options_by_ep
-                and ep_device.ep_name not in added_ep_names
-            ):
-                added_ep_names.add(ep_device.ep_name)
-                sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
-    else:
-        # In ort v1.22.0 and later, we can use add_provider_for_devices to add providers with options.
-        for ep_device in ort.get_ep_devices():
-            if ep_device.device.type == ort_device_type and ep_device.ep_name in provider_options_by_ep:
-                sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
+    added_ep_names = set()
+    for ep_device in ort.get_ep_devices():
+        if (
+            ep_device.device.type == ort_device_type
+            and ep_device.ep_name in provider_options_by_ep
+            and ep_device.ep_name not in added_ep_names
+        ):
+            added_ep_names.add(ep_device.ep_name)
+            sess_options.add_provider_for_devices([ep_device], provider_options_by_ep.get(ep_device.ep_name) or {})
 
     if provider_selection_policy:
         provider_selection_policy = get_ort_execution_provider_device_policy(provider_selection_policy)


### PR DESCRIPTION
## 
Based on @skottmckay 's explanation, it is reasonable to filter out duplicate EPs. Given this, the version detection logic appears to be redundant and can be safely removed. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
