### PR TITLE
Gptq: Fix implementation

### DIFF
--- a/olive/common/quant/linear.py
+++ b/olive/common/quant/linear.py
@@ -128,6 +128,9 @@ class QuantLinear(nn.Module):
         # compute quantization parameters if not provided
         if scales is None:
             scales, zero_points = qlinear.quantizer.find_qparams(linear.weight)
+        else:
+            scales = scales.to(qlinear.device)
+            zero_points = zero_points.to(qlinear.device)
 
         # quantize weights
         qweight = qlinear.quantizer.quantize(linear.weight, scales, zero_points)


### PR DESCRIPTION
## Describe your changes
- `q` was incorrectly computed as quantized weight instead of fake quantized weight
- `Q` not assigned to the module's weight data

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
