### PR TITLE
[MatMulNBitsQDQ] Avoid duplicate names between outputs of MatMulNBits and new MatMul

### DIFF
--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -252,6 +252,10 @@ class MatMulNBitsToQDQ(Pass):
 
             # MatMul
             matmul_name = self._get_new_node_name(dag, node_name, "MatMul")
+            suffix_for_mutmul = "/Q4"
+            if "MatMulNBits" in node_name:
+                suffix_for_mutmul = "/NBits"
+            matmul_name = matmul_name + suffix_for_mutmul
             matmul_output = f"{matmul_name}/output_0"
             new_nodes.append(
                 onnx.helper.make_node("MatMul", [node_inputs[0], matmul_input], [matmul_output], name=matmul_name)


### PR DESCRIPTION
## Describe your changes

- On running the MatMulNBitsQDQ  conversion pass with Phi3 example, observed following error:      _“ValueError: Output /model/layers.0/attn/q_proj/MatMul/output_0 is already connected to another node.”_
- This error appears to be resulting from common/matching name between output of existing MatMulNBits node and output of new MatMul node.
- With this change, adding a suffix to the name of new matmul node - this will make the output name of new matmul node different/unique. 
- With this change, the MatMulNBitsQDQ  passed without this error.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
