### PR TITLE
MatMulNBitsToQDQ: Avoid output name clashes

### DIFF
--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -253,6 +253,10 @@ class MatMulNBitsToQDQ(Pass):
             # MatMul
             matmul_name = self._get_new_node_name(dag, node_name, "MatMul")
             matmul_output = f"{matmul_name}/output_0"
+            if matmul_output == node_output:
+                # rename the node_output to avoid conflicts, want to keep the matmul_output for consistency
+                node_output = f"{node_output}_renamed"
+                dag.rename_node_output(node_name, matmul_output, node_output)
             new_nodes.append(
                 onnx.helper.make_node("MatMul", [node_inputs[0], matmul_input], [matmul_output], name=matmul_name)
             )


### PR DESCRIPTION
## Describe your changes
- Onnx quantizer uses the same output name for the quantized output as the float output.
- Avoid this by renaming the Mnb output. Keeping the DQ Matmul output name the same for consistency.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
