### PR TITLE
Support int4-is-symmetric and int4-algo-config extra-options in model-builder pass

### DIFF
--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -82,6 +82,16 @@ class ModelBuilder(Pass):
                 required=False,
                 description="Specify the minimum accuracy level for activation of MatMul in int4 quantization.",
             ),
+            "int4_algo_config": PassConfigParam(
+                type_=str,
+                required=False,
+                description="Specify the INT4 quantization algorithm to use in GenAI Model Builder",
+            ),
+            "int4_is_symmetric": PassConfigParam(
+                type_=bool,
+                required=False,
+                description="Specify whether symmetric or asymmetric INT4 quantization needs to be used.",
+            ),
             "int4_op_types_to_quantize": PassConfigParam(
                 type_=list[str],
                 required=False,
@@ -206,6 +216,12 @@ class ModelBuilder(Pass):
 
         if config.int4_op_types_to_quantize:
             extra_args["int4_op_types_to_quantize"] = config.int4_op_types_to_quantize
+
+        if config.int4_algo_config:
+            extra_args["int4_algo_config"] = config.int4_algo_config
+
+        if config.int4_is_symmetric is not None:
+            extra_args["int4_is_symmetric"] = config.int4_is_symmetric
 
         # args that are only checked for presence, not value
         for arg in ["exclude_embeds", "exclude_lm_head"]:


### PR DESCRIPTION
## Describe your changes

- Currently, only "default" algo is picked up when running GenAI Model-Builder through Olive's Model-Builder pass.
- With this change, hooking up the int4-algo-config and int4-is-symmetric model-builder options in Olive's Model-Builder pass. 
- This should enable different quantization recipes through "Olive->GenAI-Model-Builder" workflow.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
