### PR TITLE
QNN: Use `desc_act` in gptq, MatMulNBitsToQDQ: Use correct bias input

### DIFF
--- a/examples/phi3_5/qnn_config.json
+++ b/examples/phi3_5/qnn_config.json
@@ -9,20 +9,37 @@
     },
     "data_configs": [
         {
-            "name": "wikitext2_train",
+            "name": "wikitext2_train_joined",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": {
+                "strategy": "join",
+                "add_special_tokens": false,
+                "max_seq_len": 4096,
+                "max_samples": 128
+            }
+        },
+        {
+            "name": "wikitext2_train_act",
             "type": "HuggingfaceContainer",
             "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
             "pre_process_data_config": {
                 "strategy": "line-by-line",
-                "add_special_tokens": false,
-                "max_samples": 128,
-                "max_seq_len": 512
+                "add_special_tokens": true,
+                "max_samples": 256,
+                "max_seq_len": 4096
             }
         }
     ],
     "passes": {
         "q": { "type": "QuaRot" },
-        "g": { "type": "GptqQuantizer", "sym": true, "group_size": -1 },
+        "g": {
+            "type": "GptqQuantizer",
+            "sym": true,
+            "group_size": -1,
+            "desc_act": true,
+            "data_config": "wikitext2_train_joined"
+        },
         "cs": { "type": "CaptureSplitInfo", "num_splits": 4, "unique_embeds_lm_head_splits": true },
         "mb": {
             "type": "ModelBuilder",
@@ -49,7 +66,7 @@
         },
         "sq": {
             "type": "OnnxStaticQuantization",
-            "data_config": "wikitext2_train",
+            "data_config": "wikitext2_train_act",
             "activation_type": "uint16",
             "precision": "uint8",
             "calibration_providers": [ "CUDAExecutionProvider" ],

--- a/examples/phi3_5/qnn_docker.json
+++ b/examples/phi3_5/qnn_docker.json
@@ -17,20 +17,37 @@
     },
     "data_configs": [
         {
-            "name": "wikitext2_train",
+            "name": "wikitext2_train_joined",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": {
+                "strategy": "join",
+                "add_special_tokens": false,
+                "max_seq_len": 4096,
+                "max_samples": 128
+            }
+        },
+        {
+            "name": "wikitext2_train_act",
             "type": "HuggingfaceContainer",
             "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
             "pre_process_data_config": {
                 "strategy": "line-by-line",
-                "add_special_tokens": false,
-                "max_samples": 32,
-                "max_seq_len": 256
+                "add_special_tokens": true,
+                "max_samples": 256,
+                "max_seq_len": 4096
             }
         }
     ],
     "passes": {
         "q": { "type": "QuaRot" },
-        "g": { "type": "GptqQuantizer", "sym": true, "group_size": -1 },
+        "g": {
+            "type": "GptqQuantizer",
+            "sym": true,
+            "group_size": -1,
+            "desc_act": true,
+            "data_config": "wikitext2_train_joined"
+        },
         "cs": { "type": "CaptureSplitInfo", "num_splits": 4, "unique_embeds_lm_head_splits": true },
         "mb": {
             "type": "ModelBuilder",
@@ -57,7 +74,7 @@
         },
         "sq": {
             "type": "OnnxStaticQuantization",
-            "data_config": "wikitext2_train",
+            "data_config": "wikitext2_train_act",
             "activation_type": "uint16",
             "precision": "uint8",
             "calibration_providers": [ "CUDAExecutionProvider" ],

--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -274,10 +274,10 @@ class MatMulNBitsToQDQ(Pass):
                 # it has bias
                 bias_i_name = node_inputs[5]
                 new_bias_i_name = bias_i_name.replace("MatMulNBits", "MatMul")
-                bias_initiaizer = onnx.numpy_helper.from_array(
+                bias_initializer = onnx.numpy_helper.from_array(
                     dag.get_initializer_np_array(bias_i_name), name=new_bias_i_name
                 )
-                dag.add_initializer(bias_initiaizer, graph_idx)
+                dag.add_initializer(bias_initializer, graph_idx)
 
                 bias_name = self._get_new_node_name(dag, node_name, "Add")
                 bias_output = f"{bias_name}/output_0"

--- a/olive/passes/onnx/mnb_to_qdq.py
+++ b/olive/passes/onnx/mnb_to_qdq.py
@@ -269,10 +269,10 @@ class MatMulNBitsToQDQ(Pass):
             final_name = matmul_name
             final_output = matmul_output
 
-            if len(node_inputs) >= 5 and node_inputs[4]:
+            if len(node_inputs) >= 6 and node_inputs[5]:
                 # Bias Add
                 # it has bias
-                bias_i_name = node_inputs[4]
+                bias_i_name = node_inputs[5]
                 new_bias_i_name = bias_i_name.replace("MatMulNBits", "MatMul")
                 bias_initiaizer = onnx.numpy_helper.from_array(
                     dag.get_initializer_np_array(bias_i_name), name=new_bias_i_name


### PR DESCRIPTION
## Describe your changes
- `desc_act=True` is compatible with per-channel quantization since there is only one group. No need to worry about non-trivial `g_idx`. Emperically found to improve MMLU score for phi-3.5
- Updated data configs
- Fix bug in `MatMulNBitsToQDQ` where the incorrect input was taken as the bias. Was not caught since no model so far has used bias.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
