### PR TITLE
CI: Use hf auth login

### DIFF
--- a/.azure_pipelines/job_templates/huggingface-login-template.yaml
+++ b/.azure_pipelines/job_templates/huggingface-login-template.yaml
@@ -2,5 +2,5 @@ parameters:
   hf_token: 'huggingface_token'
 
 steps:
-- script: huggingface-cli login --token ${{ parameters.hf_token }}
+- script: hf auth login --token ${{ parameters.hf_token }}
   displayName: 'Hugging Face Login'

--- a/.azure_pipelines/scripts/run_test.sh
+++ b/.azure_pipelines/scripts/run_test.sh
@@ -31,7 +31,7 @@ pip install -r "$4"
 
 # Set HF Token
 pip install huggingface-hub
-huggingface-cli login --token "$7"
+hf auth login --token "$7"
 
 # Step 4: Run tests with or without coverage tracking
 XML_PATH="/logs/TestOlive.xml"


### PR DESCRIPTION
## Describe your changes
`huggingface-cli login` is deprecated. Printing the deprecation message fails on Windows causing our CI to fail as well. 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
