### PR TITLE
Gptq: Enable `desc_act` for per-channel quantization

### DIFF
--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -20,7 +20,6 @@ from olive.common.utils import tensor_data_to_device
 from olive.constants import PrecisionBits
 from olive.data.config import DataConfig
 from olive.data.template import huggingface_data_config_template
-from olive.hardware.accelerator import AcceleratorSpec
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf

--- a/olive/passes/pytorch/gptq.py
+++ b/olive/passes/pytorch/gptq.py
@@ -2,10 +2,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging
 import math
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 
@@ -19,13 +21,17 @@ from olive.constants import PrecisionBits
 from olive.data.config import DataConfig
 from olive.data.template import huggingface_data_config_template
 from olive.hardware.accelerator import AcceleratorSpec
-from olive.model import HfModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf
 from olive.passes.pytorch.train_utils import (
     load_hf_base_model,
 )
+
+if TYPE_CHECKING:
+    from olive.hardware.accelerator import AcceleratorSpec
+    from olive.model import HfModelHandler
+
 
 logger = logging.getLogger(__name__)
 
@@ -263,7 +269,7 @@ class Gptq(Pass):
         layer_args: list[tuple],
         layer_kwargs: list[dict],
         return_output: bool = False,
-    ) -> Optional[list[torch.Tensor]]:
+    ) -> list[torch.Tensor] | None:
         """Run a layer with the given inputs.
 
         Args:
@@ -502,7 +508,7 @@ class Gptq(Pass):
         return dataset
 
     @staticmethod
-    def get_calibration_data_config(model_name_or_path: str, trust_remote_code: Optional[bool] = None) -> DataConfig:
+    def get_calibration_data_config(model_name_or_path: str, trust_remote_code: bool | None = None) -> DataConfig:
         """Get default calibration data configuration for GPTQ quantization.
 
         Args:
@@ -550,6 +556,6 @@ class QuantInfo:
     """
 
     quantizer: WeightQuantizer
-    scales: Optional[torch.Tensor] = None
-    zero_points: Optional[torch.Tensor] = None
-    data: Optional[dict] = None
+    scales: torch.Tensor | None = None
+    zero_points: torch.Tensor | None = None
+    data: dict | None = None


### PR DESCRIPTION
## Describe your changes
- Enable act-order scheme for per-channel cases (`group_size=-1`).
- Blockwise quantization with act-order requires g_idx. It is not compatible with QDQ. Supported my MatMulNBits but the kernel is not as efficient.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
