### PR TITLE
Remove DefaultAzureCredential from codebase

### DIFF
--- a/docs/source/features/azure-ai/azure-ai.md
+++ b/docs/source/features/azure-ai/azure-ai.md
@@ -31,7 +31,6 @@ Where:
 - `max_operation_retries: [int]` The maximum number of retries for Azure ML operations like resource creation and download.
 The default value is 3. User can increase if there are network issues and the operations fail.
 - `operation_retry_interval: [int]` The initial interval in seconds between retries for Azure ML operations like resource creation and download. The interval doubles after each retry. The default value is 5. User can increase if there are network issues and the operations fail.
-- `default_auth_params: Dict[str, Any]` Default auth parameters for AzureML client. Please refer to [azure DefaultAzureCredential](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python#parameters) for more details. For example, if you want to exclude managed identity credential, you can set the following:
 
 ### Using AzureML registered model
 You can run Olive workflow with your AML workspace registered model. In the input model section, define the model config as:

--- a/docs/source/reference/options.md
+++ b/docs/source/reference/options.md
@@ -54,17 +54,6 @@ more details.
 - `max_operation_retries: [int]` The maximum number of retries for Azure ML operations like resource creation and download.
 The default value is 3. User can increase if there are network issues and the operations fail.
 - `operation_retry_interval: [int]` The initial interval in seconds between retries for Azure ML operations like resource creation and download. The interval doubles after each retry. The default value is 5. User can increase if there are network issues and the operations fail.
-- `default_auth_params: Dict[str, Any]` Default auth parameters for AzureML client. Please refer to [azure DefaultAzureCredential](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python#parameters) for more details. For example, if you want to exclude managed identity credential, you can set the following:
-
-    ```json
-    "azureml_client": {
-        // ...
-        "default_auth_params": {
-            "exclude_managed_identity_credential": true
-        }
-    }
-    ```
-
 - `keyvault_name: [str]` The keyvault name to retrieve secrets.
 
 ### Example

--- a/olive/azureml/azureml_client.py
+++ b/olive/azureml/azureml_client.py
@@ -5,7 +5,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from olive.common.config_utils import ConfigBase
 from olive.common.pydantic_v1 import Field, validator
@@ -42,18 +42,6 @@ class AzureMLClientConfig(ConfigBase):
         description=(
             "Initial interval in seconds between retries for AzureML operations like resource creation or download. The"
             " interval doubles after each retry."
-        ),
-    )
-    # as the DefaultAzureCredential is used by default, we need to provide the default auth config for it.
-    # but DefaultAzureCredential accept kwargs as parameters, it is hard to validate the config.
-    # so we just provide a dict here and let the user to provide the correct config following the doc.
-    default_auth_params: Optional[dict[str, Any]] = Field(
-        None,
-        description=(
-            "Default auth config for AzureML client. Please refer to"
-            " https://learn.microsoft.com/en-us/python/api/azure-identity/"
-            "azure.identity.defaultazurecredential?view=azure-python#parameters"
-            " for more details."
         ),
     )
     keyvault_name: Optional[str] = Field(
@@ -98,7 +86,7 @@ class AzureMLClientConfig(ConfigBase):
             if self.workspace_name is None:
                 raise ValueError("workspace_name must be provided if aml_config_path is not provided")
             return MLClient(
-                credential=get_credentials(self.default_auth_params),
+                credential=get_credentials(),
                 subscription_id=self.subscription_id,
                 resource_group_name=self.resource_group,
                 workspace_name=self.workspace_name,
@@ -106,7 +94,7 @@ class AzureMLClientConfig(ConfigBase):
             )
         else:
             return MLClient.from_config(
-                credential=get_credentials(self.default_auth_params),
+                credential=get_credentials(),
                 path=self.aml_config_path,
                 read_timeout=self.read_timeout,
             )
@@ -117,7 +105,7 @@ class AzureMLClientConfig(ConfigBase):
 
         set_azure_logging_if_noset()
 
-        return MLClient(credential=get_credentials(self.default_auth_params), registry_name=registry_name)
+        return MLClient(credential=get_credentials(), registry_name=registry_name)
 
 
 def set_azure_logging_if_noset():

--- a/olive/common/hf/login.py
+++ b/olive/common/hf/login.py
@@ -5,6 +5,8 @@
 import logging
 import os
 
+from olive.common.utils import get_credentials
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,13 +19,12 @@ def huggingface_login(token: str):
 def aml_runner_hf_login():
     hf_login = os.environ.get("HF_LOGIN")
     if hf_login:
-        from azure.identity import DefaultAzureCredential
         from azure.keyvault.secrets import SecretClient
 
         keyvault_name = os.environ.get("KEYVAULT_NAME")
         logger.debug("Getting token from keyvault %s", keyvault_name)
 
-        credential = DefaultAzureCredential()
+        credential = get_credentials()
         secret_client = SecretClient(vault_url=f"https://{keyvault_name}.vault.azure.net/", credential=credential)
         token = secret_client.get_secret("hf-token").value
         huggingface_login(token)

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -531,27 +531,29 @@ def find_first_matched_value(original, keys: Union[str, tuple, list[str]], raise
     return None
 
 
-def get_credentials(default_auth_params: dict = None):
+def get_credentials():
     """Get credentials for MLClient.
 
     Order of credential providers:
     1. Azure CLI
-    2. DefaultAzureCredential
     3. InteractiveBrowserCredential
     """
-    from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential
+    try:
+        from azure.identity import AzureCliCredential, InteractiveBrowserCredential
+    except ImportError:
+        raise ImportError(
+            "azure-identity is not installed. Please install azure-identity packages to use this command."
+        ) from None
 
     logger.debug("Getting credentials for MLClient")
     try:
-        default_auth_params = default_auth_params or {}
-        credential = DefaultAzureCredential(**default_auth_params)
-        # Check if given credential can get token successfully.
+        credential = AzureCliCredential()
         credential.get_token("https://management.azure.com/.default")
-        logger.debug("Using DefaultAzureCredential")
+        logger.debug("Using AzureCliCredential")
     except Exception:
-        logger.warning("Using InteractiveBrowserCredential since of default credential errors", exc_info=True)
-        # Fall back to InteractiveBrowserCredential in case DefaultAzureCredential not work
+        logger.warning("Using InteractiveBrowserCredential since of AzureCliCredential errors", exc_info=True)
         credential = InteractiveBrowserCredential()
+        logger.debug("Using InteractiveBrowserCredential")
 
     return credential
 


### PR DESCRIPTION
## Describe your changes

Remove DefaultAzureCredential from codebase. Based on new Azure policy, `DefaultAzureCredential` can only be used for developing and testing. So remove `DefaultAzureCredential` and use `AzureCliCredential` as the default.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
