### PR TITLE
Rename QuickGeluToSigmoid to DecomposeQuickGelu

### DIFF
--- a/docs/source/features/onnx-transformations.md
+++ b/docs/source/features/onnx-transformations.md
@@ -745,7 +745,7 @@ graph {
 }
 ```
 
-### `QuickGeluToSigmoid`
+### `DecomposeQuickGelu`
 
 #### Description
 
@@ -779,7 +779,7 @@ After applying:
     "type": "GraphSurgeries",
     "surgeries": [
         {
-            "surgeon": "QuickGeluToSigmoid"
+            "surgeon": "DecomposeQuickGelu"
         }
     ]
 }

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -452,7 +452,7 @@ class ExposeQuantizedOutput(ProtoSurgeon):
         return self._add_zero_point(model, zero_point_value, zero_point_onnx_dtype, zero_point_np_dtype)
 
 
-class QuickGeluToSigmoid(Surgeon):
+class DecomposeQuickGelu(Surgeon):
     """Lower QuickGelu operator to standard ONNX operators.
 
     QuickGelu pattern:

--- a/test/unit_test/passes/onnx/test_graph_surgeries.py
+++ b/test/unit_test/passes/onnx/test_graph_surgeries.py
@@ -1716,7 +1716,7 @@ def test_quickgelu_to_sigmoid(tmp_path):
     output_folder = str(tmp_path / "onnx")
     p = create_pass_from_dict(
         GraphSurgeries,
-        {"surgeries": [{"surgeon": "QuickGeluToSigmoid"}]},
+        {"surgeries": [{"surgeon": "DecomposeQuickGelu"}]},
         disable_search=True,
     )
 


### PR DESCRIPTION
## Describe your changes

Unify the naming convention for graph surgery by using the combination of Decompose and contrib op names to identify lowering operations.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
