### PR TITLE
Updates to QNN clip olive example recipes

### DIFF
--- a/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_fp32.json
+++ b/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_fp32.json
@@ -20,26 +20,14 @@
     },
     "data_configs": [
         {
-            "name": "quant_data_config",
-            "user_script": "user_script.py",
-            "load_dataset_config": {
-                "type": "clip_dataset",
-                "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
-                "dataset_name": "nlphuji/flickr30k",
-                "start": 0,
-                "end": 10
-            },
-            "dataloader_config": { "type": "no_auto_batch_dataloader" }
-        },
-        {
             "name": "metric_data_config",
             "user_script": "user_script.py",
             "load_dataset_config": {
                 "type": "clip_dataset",
                 "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }

--- a/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_fp32_ctx.json
+++ b/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_fp32_ctx.json
@@ -20,26 +20,14 @@
     },
     "data_configs": [
         {
-            "name": "quant_data_config",
-            "user_script": "user_script.py",
-            "load_dataset_config": {
-                "type": "clip_dataset",
-                "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
-                "dataset_name": "nlphuji/flickr30k",
-                "start": 0,
-                "end": 10
-            },
-            "dataloader_config": { "type": "no_auto_batch_dataloader" }
-        },
-        {
             "name": "metric_data_config",
             "user_script": "user_script.py",
             "load_dataset_config": {
                 "type": "clip_dataset",
                 "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }

--- a/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq.json
+++ b/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq.json
@@ -27,7 +27,7 @@
                 "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
                 "dataset_name": "nlphuji/flickr30k",
                 "start": 0,
-                "end": 10
+                "end": 100
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         },
@@ -38,8 +38,8 @@
                 "type": "clip_dataset",
                 "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -164,7 +164,10 @@
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
         "surgery": {
             "type": "GraphSurgeries",
-            "surgeries": [ { "surgeon": "MatMulAddToGemm" }, { "surgeon": "ReplaceAttentionMaskValue" } ]
+            "surgeries": [
+                { "surgeon": "MatMulAddToGemm" },
+                { "surgeon": "ReplaceAttentionMaskValue", "replacement": -50.0 }
+            ]
         },
         "quantization": {
             "type": "OnnxStaticQuantization",

--- a/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq_ctx.json
+++ b/examples/clip/qnn/laion_CLIP-ViT-B-32-laion2B-s34B-b79K_ptq_qnn_qdq_ctx.json
@@ -27,7 +27,7 @@
                 "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
                 "dataset_name": "nlphuji/flickr30k",
                 "start": 0,
-                "end": 10
+                "end": 100
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         },
@@ -38,8 +38,8 @@
                 "type": "clip_dataset",
                 "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -132,7 +132,10 @@
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
         "surgery": {
             "type": "GraphSurgeries",
-            "surgeries": [ { "surgeon": "MatMulAddToGemm" }, { "surgeon": "ReplaceAttentionMaskValue" } ]
+            "surgeries": [
+                { "surgeon": "MatMulAddToGemm" },
+                { "surgeon": "ReplaceAttentionMaskValue", "replacement": -50.0 }
+            ]
         },
         "quantization": {
             "type": "OnnxStaticQuantization",

--- a/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_fp32.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_fp32.json
@@ -26,8 +26,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch16",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -45,11 +45,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -85,11 +80,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -124,11 +114,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -156,6 +141,7 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "MatMulAddToGemm" } ] },
         "add_metadata": { "type": "AddOliveMetadata", "graph_name": "clip-vit-base-patch16" }
     },
     "evaluator": "common_evaluator",

--- a/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_fp32_ctx.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_fp32_ctx.json
@@ -26,8 +26,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch16",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -45,11 +45,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -75,11 +70,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -101,11 +91,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -124,10 +109,10 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "MatMulAddToGemm" } ] },
         "cb": {
             "type": "EPContextBinaryGenerator",
-            "provider_options": { "htp_graph_finalization_optimization_mode": "3", "enable_htp_fp16_precision": "1" },
-            "session_options": { "optimization.disable_specified_optimizers": "MatMulAddFusion" }
+            "provider_options": { "htp_graph_finalization_optimization_mode": "3", "enable_htp_fp16_precision": "1" }
         },
         "add_metadata": { "type": "AddOliveMetadata", "graph_name": "clip-vit-base-patch16" }
     },

--- a/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_qdq.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_qdq.json
@@ -27,7 +27,7 @@
                 "model_name": "openai/clip-vit-base-patch16",
                 "dataset_name": "nlphuji/flickr30k",
                 "start": 0,
-                "end": 10
+                "end": 100
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         },
@@ -38,8 +38,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch16",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -57,11 +57,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -97,11 +92,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -136,11 +126,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -168,7 +153,13 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
-        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "surgery": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "MatMulAddToGemm" },
+                { "surgeon": "ReplaceAttentionMaskValue", "replacement": -50.0 }
+            ]
+        },
         "quantization": {
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,

--- a/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_qdq_ctx.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch16_ptq_qnn_qdq_ctx.json
@@ -27,7 +27,7 @@
                 "model_name": "openai/clip-vit-base-patch16",
                 "dataset_name": "nlphuji/flickr30k",
                 "start": 0,
-                "end": 10
+                "end": 100
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         },
@@ -38,8 +38,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch16",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -57,11 +57,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -87,11 +82,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -113,11 +103,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -136,7 +121,13 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
-        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "surgery": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "MatMulAddToGemm" },
+                { "surgeon": "ReplaceAttentionMaskValue", "replacement": -50.0 }
+            ]
+        },
         "quantization": {
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
@@ -150,8 +141,7 @@
             "provider_options": {
                 "htp_graph_finalization_optimization_mode": "3",
                 "offload_graph_io_quantization": "0"
-            },
-            "session_options": { "optimization.disable_specified_optimizers": "MatMulAddFusion" }
+            }
         },
         "add_metadata": { "type": "AddOliveMetadata", "graph_name": "clip-vit-base-patch16" }
     },

--- a/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_fp32.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_fp32.json
@@ -26,8 +26,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch32",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -45,11 +45,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -85,11 +80,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -124,11 +114,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -156,6 +141,7 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "MatMulAddToGemm" } ] },
         "add_metadata": { "type": "AddOliveMetadata", "graph_name": "clip-vit-base-patch32" }
     },
     "evaluator": "common_evaluator",

--- a/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_fp32_ctx.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_fp32_ctx.json
@@ -26,8 +26,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch32",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -45,11 +45,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -75,11 +70,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -101,11 +91,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -124,10 +109,10 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
+        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "MatMulAddToGemm" } ] },
         "cb": {
             "type": "EPContextBinaryGenerator",
-            "provider_options": { "htp_graph_finalization_optimization_mode": "3", "enable_htp_fp16_precision": "1" },
-            "session_options": { "optimization.disable_specified_optimizers": "MatMulAddFusion" }
+            "provider_options": { "htp_graph_finalization_optimization_mode": "3", "enable_htp_fp16_precision": "1" }
         },
         "add_metadata": { "type": "AddOliveMetadata", "graph_name": "clip-vit-base-patch32" }
     },

--- a/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_qdq.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_qdq.json
@@ -27,7 +27,7 @@
                 "model_name": "openai/clip-vit-base-patch32",
                 "dataset_name": "nlphuji/flickr30k",
                 "start": 0,
-                "end": 10
+                "end": 100
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         },
@@ -38,8 +38,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch32",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -57,11 +57,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -97,11 +92,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -136,11 +126,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -168,7 +153,13 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
-        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "surgery": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "MatMulAddToGemm" },
+                { "surgeon": "ReplaceAttentionMaskValue", "replacement": -50.0 }
+            ]
+        },
         "quantization": {
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,

--- a/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_qdq_ctx.json
+++ b/examples/clip/qnn/openai_clip-vit-base-patch32_ptq_qnn_qdq_ctx.json
@@ -27,7 +27,7 @@
                 "model_name": "openai/clip-vit-base-patch32",
                 "dataset_name": "nlphuji/flickr30k",
                 "start": 0,
-                "end": 10
+                "end": 100
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" }
         },
@@ -38,8 +38,8 @@
                 "type": "clip_dataset",
                 "model_name": "openai/clip-vit-base-patch32",
                 "dataset_name": "nlphuji/flickr30k",
-                "start": 10,
-                "end": 20
+                "start": 100,
+                "end": 200
             },
             "dataloader_config": { "type": "no_auto_batch_dataloader" },
             "post_process_data_config": { "type": "clip_post_process" }
@@ -57,11 +57,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -87,11 +82,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -113,11 +103,6 @@
                     "user_config": {
                         "inference_settings": {
                             "onnx": {
-                                "session_options": {
-                                    "extra_session_config": {
-                                        "optimization.disable_specified_optimizers": "MatMulAddFusion"
-                                    }
-                                },
                                 "execution_provider": "QNNExecutionProvider",
                                 "provider_options": [
                                     {
@@ -136,7 +121,13 @@
     },
     "passes": {
         "conversion": { "type": "OnnxConversion", "target_opset": 20 },
-        "surgery": { "type": "GraphSurgeries", "surgeries": [ { "surgeon": "ReplaceAttentionMaskValue" } ] },
+        "surgery": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "MatMulAddToGemm" },
+                { "surgeon": "ReplaceAttentionMaskValue", "replacement": -50.0 }
+            ]
+        },
         "quantization": {
             "type": "OnnxStaticQuantization",
             "quant_preprocess": true,
@@ -150,8 +141,7 @@
             "provider_options": {
                 "htp_graph_finalization_optimization_mode": "3",
                 "offload_graph_io_quantization": "0"
-            },
-            "session_options": { "optimization.disable_specified_optimizers": "MatMulAddFusion" }
+            }
         },
         "add_metadata": { "type": "AddOliveMetadata", "graph_name": "clip-vit-base-patch32" }
     },


### PR DESCRIPTION
## Describe your changes
Updates to QNN clip olive example recipes for Accuracy and Performance improvement

- Increased number of samples used for quantization
- Updated ReplaceAttentionMaskValue to -50
- Removed disabling of MatMulAddFusion
- Added MatMulAddToGemm graph surgery

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
