### PR TITLE
Hf: Trigger registration of optimum onnx configs for model io

### DIFF
--- a/olive/common/hf/model_io.py
+++ b/olive/common/hf/model_io.py
@@ -44,6 +44,8 @@ def get_preprocessors(model_name: str, **kwargs) -> Optional[dict]:
 def get_export_config(model_name: str, task: str, **kwargs) -> Optional["OnnxConfig"]:
     """Get the export config for the model_name and task."""
     try:
+        # need this in optimum 1.27.0+ to trigger the registration of ONNX export configs
+        from optimum.exporters.onnx import model_configs as _  # noqa: F401 # pylint: disable=unused-import
         from optimum.exporters.tasks import TasksManager
     except ImportError:
         logger.debug("optimum is not installed. Cannot get export config")


### PR DESCRIPTION
## Describe your changes
Optimum 1.27.0 now registers the onnx export configs using a decorator. Need to import the relevant submodule to trigger the import.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
