### PR TITLE
Examples: Update ort-genai to 0.9.0+ for LLM example inference

### DIFF
--- a/examples/deepseek/README.md
+++ b/examples/deepseek/README.md
@@ -9,5 +9,5 @@ Sample use cases of Olive to optimize a [DeepSeek R1 Distill](https://huggingfac
   - Run the workflow with `olive run --config qdq_config_vitis_ai.json -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -o models/deepseek-r1-vai`.
 - [PTQ + AOT Compilation for Qualcomm NPUs using QNN EP](../phi3_5/README.md):
   - Run the workflow with `olive run --config qnn_config.json -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -o models/deepseek-r1-qnn`.
-  - Run the inference with `python app.py -m models/deepseek-r1-qnn -c "<｜User｜>{input}<｜Assistant｜><think>"`.
+  - Run the inference with `python app.py -m models/deepseek-r1-qnn`.
 - [PTQ + AWQ ONNX OVIR Encapsulated 4-bit weight compression using Optimum OpenVINO](./openvino/)

--- a/examples/llama3/README.md
+++ b/examples/llama3/README.md
@@ -9,7 +9,7 @@ Sample use cases of Olive to optimize [meta-llama/Llama-3.2-1B-Instruct](https:/
   - Run the workflow with `olive run --config qdq_config_vitis_ai.json -m meta-llama/Llama-3.2-1B-Instruct -o models/llama3-vai`.
 - [PTQ + AOT Compilation for Qualcomm NPUs using QNN EP](../phi3_5/README.md):
   - Run the workflow with `olive run --config qnn_config.json -m meta-llama/Llama-3.2-1B-Instruct -o models/llama3-qnn`.
-  - Run the inference with `python app.py -m models/llama3-qnn -c "<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"`.
+  - Run the inference with `python app.py -m models/llama3-qnn`.
 - [PTQ + AWQ ONNX OVIR Encapsulated 4-bit weight compression using Optimum OpenVINO](./openvino/)
 
 **NOTE:**

--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -69,7 +69,9 @@ Quantization is resource-intensive and requires GPU acceleration. In an [x64 Pyt
 pip install -r requirements.txt
 
 # Install ONNX Runtime GPU packages
-# ort-genai 0.8.x has some issues, use 0.7.1 for now. Also not compatible with ort 1.22+
+# ort-genai 0.8.x has some issues
+# 0.9.0 adds a conflicting sliding_window option only handled correct in Olive main (after 0.9.2)
+# 0.7.1 not compatible with ort>=1.22
 pip install "onnxruntime-gpu==1.21.1" "onnxruntime-genai-cuda==0.7.1"
 
 # AutoGPTQ: Install from source (stable package may be slow for weight packing)
@@ -204,7 +206,9 @@ Open ARM64 Native Tools Command Prompt for VS2022 and run the following commands
 ```bash
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
 pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
-pip install "onnxruntime-genai>=0.7.0"
+# ort-genai 0.9.0 fixes bug with incorrect first token generation
+# backwards compatible with model generated with older ort-genai version
+pip install "onnxruntime-genai>=0.9.0"
 ```
 
 #### **Run Console-Based Chat Interface**

--- a/examples/phi3_5/app.py
+++ b/examples/phi3_5/app.py
@@ -12,13 +12,6 @@ parser.add_argument(
     default="models/phi3_5-qdq",
     help="Path to the folder containing the outputs of Olive run",
 )
-parser.add_argument(
-    "-c",
-    "--chat_template",
-    type=str,
-    default="<|user|>\n{input} <|end|>\n<|assistant|>",
-    help="Template for the chat input",
-)
 args = parser.parse_args()
 
 # Load the base model and tokenizer
@@ -42,7 +35,9 @@ while True:
         break
 
     # Generate prompt (prompt template + input)
-    prompt = f"{args.chat_template.format(input=text)}"
+    prompt = tokenizer.apply_chat_template(
+        messages=f"""[{{"role": "user", "content": "{text}"}}]""", add_generation_prompt=True
+    )
 
     # Encode the prompt using the tokenizer
     input_tokens = tokenizer.encode(prompt)

--- a/examples/qwen2_5/README.md
+++ b/examples/qwen2_5/README.md
@@ -8,7 +8,7 @@ Sample use cases of Olive to optimize a [Qwen/Qwen 2.5 1.5B Instruct](https://hu
   - Run the workflow with `olive run --config qdq_config_vitis_ai.json -m Qwen/Qwen2.5-1.5B-Instruct -o models/qwen2_5-vai`.
 - [PTQ + AOT Compilation for Qualcomm NPUs using QNN EP](../phi3_5/README.md):
   - Run the workflow with `olive run --config qnn_config.json -m Qwen/Qwen2.5-1.5B-Instruct -o models/qwen2_5-qnn`.
-  - Run the inference with `python app.py -m models/qwen2_5-qnn -c "<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n"`.
+  - Run the inference with `python app.py -m models/qwen2_5-qnn`.
 - [PTQ + AWQ ONNX OVIR Encapsulated 4-bit weight compression using Intel® Optimum OpenVINO](./openvino/)
 
 ## **Optimization and Quantization for AMD NPU**


### PR DESCRIPTION
## Describe your changes
- 0.9.0 fixes issue with first token generation
- app.py updated to remove manually provided chat template since it now supports `apply_chat_template`
- Model generation requirement is still pinned at 0.7.1 since 0.9.0 automatically adds a new option under `sliding_window` which conflicts with the static llm model run. It needs to be removed but the change is not in any Olive release yet

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
