### PR TITLE
Update CalibrationDataReader to support strided data for onnx quantization

### DIFF
--- a/examples/phi3_5/qnn_config.json
+++ b/examples/phi3_5/qnn_config.json
@@ -73,7 +73,7 @@
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
             "save_as_external_data": true,
-            "extra_option": {"CalibStridedMinMax": 4}
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/examples/phi3_5/qnn_config.json
+++ b/examples/phi3_5/qnn_config.json
@@ -72,7 +72,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": {"CalibStridedMinMax": 4}
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -101,7 +101,7 @@ def default_calibration_dataloader(
             return batch
 
         def set_range(self, start_index, end_index):
-            self.start_index = start_index
+            self.curr_index = start_index
             self.end_index = end_index
 
         def rewind(self):

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -72,12 +72,20 @@ def default_calibration_dataloader(
             self.io_config = io_config
             self.kwargs = kwargs
             self.data_iter = iter(self.dataloader)
+            self.curr_index = 0
+            self.end_index = 0
+
+        def __len__(self):
+            return len(self.dataloader)
 
         def get_next(self):
+            if self.end_index > 0 and self.curr_index >= self.end_index:
+                return None
             if self.data_iter is None:
                 self.data_iter = iter(self.dataloader)
             try:
                 batch = next(self.data_iter)
+                self.curr_index += 1
             except StopIteration:
                 return None
             if isinstance(batch, (list, tuple)):
@@ -91,6 +99,10 @@ def default_calibration_dataloader(
             else:
                 batch = {k: v.detach().cpu().numpy() for k, v in batch.items()}
             return batch
+
+        def set_range(self, start_index, end_index):
+            self.start_index = start_index
+            self.end_index = end_index
 
         def rewind(self):
             self.data_iter = None


### PR DESCRIPTION
## Update CalibrationDataReader to support strided data for Onnx Quantization
Using CalibStridedMinMax option in onnx quantization, only stride amount of data is used and all results are merged in the end during the calibration process. This helps in better managing mem usage.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
