### PR TITLE
qauntize cli: Add gptq as supported implementation

### DIFF
--- a/olive/cli/quantize.py
+++ b/olive/cli/quantize.py
@@ -133,7 +133,7 @@ class QuantizeCommand(BaseOliveCLICommand):
 
         if not pass_list:
             raise ValueError(
-                f"Quantiation for precision {precision}, algorithm {algo} and implementation {impl} "
+                f"Quantization for precision {precision}, algorithm {algo} and implementation {impl} "
                 f"with QDQ {self.args.use_qdq_encoding} is not supported"
             )
 
@@ -237,6 +237,7 @@ PT_QUANT_IMPLEMENTATION_MAPPING = [
     # TODO(jambayk): consider exposing the activation bits through the act_precision argument
     {"impl_name": ImplName.SPINQUANT, "pass_type": "SpinQuant"},
     {"impl_name": ImplName.AWQ, "pass_type": "AutoAWQQuantizer"},
+    {"impl_name": ImplName.OLIVE, "pass_type": "Gptq"},
     {"impl_name": ImplName.AUTOGPTQ, "pass_type": "GptqQuantizer"},
 ]
 

--- a/olive/common/ort_inference.py
+++ b/olive/common/ort_inference.py
@@ -37,10 +37,14 @@ def ort_supports_ep_devices() -> bool:
 
 def maybe_register_ep_libraries(ep_paths: dict[str, str]):
     """Register execution provider libraries if onnxruntime supports it."""
-    if not ort_supports_ep_devices():
+    try:
+        import onnxruntime as ort
+    except ImportError:
+        logger.debug("Skipping EP registration since onnxruntime is not installed")
         return
 
-    import onnxruntime as ort
+    if not ort_supports_ep_devices():
+        return
 
     # providers that ort was built with such as CUDA, QNN, VitisAI but need registration
     for provider in set(ort.get_available_providers()):


### PR DESCRIPTION
## Describe your changes
- Add the olive native `Gptq` pass as supported implementation in the `quantize` cli
- `maybe_register_ep_libraries`: skip registration if ort is not installed. This util is called everytime a system is created but onnxruntime is not always required. For instance, like when running only pytorch passes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
