### PR TITLE
OnnxFloatToFloat16: Add op_include_list and node_include_list

### DIFF
--- a/examples/phi3_5/qnn_config_fp16.json
+++ b/examples/phi3_5/qnn_config_fp16.json
@@ -1,0 +1,101 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "microsoft/Phi-3.5-mini-instruct" },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [ { "execution_providers": [ "QNNExecutionProvider" ] } ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "wikitext2_train_joined",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": {
+                "strategy": "join",
+                "add_special_tokens": false,
+                "max_seq_len": 4096,
+                "max_samples": 128
+            }
+        },
+        {
+            "name": "wikitext2_train_act",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": { "data_name": "wikitext", "subset": "wikitext-2-raw-v1", "split": "train" },
+            "pre_process_data_config": {
+                "strategy": "line-by-line",
+                "add_special_tokens": true,
+                "max_samples": 256,
+                "max_seq_len": 4096
+            }
+        }
+    ],
+    "passes": {
+        "q": { "type": "QuaRot" },
+        "g": {
+            "type": "GptqQuantizer",
+            "sym": true,
+            "group_size": -1,
+            "desc_act": true,
+            "data_config": "wikitext2_train_joined"
+        },
+        "cs": { "type": "CaptureSplitInfo", "num_splits": 4, "unique_embeds_lm_head_splits": true },
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_accuracy_level": 4,
+            "int4_op_types_to_quantize": [ "MatMul", "Gather" ]
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "nodes_to_exclude": [ "/lm_head/MatMul_Q4" ],
+            "save_as_external_data": true
+        },
+        "gs": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "AttentionMaskToSequenceLengths" },
+                { "surgeon": "SimplifiedLayerNormToL2Norm" }
+            ],
+            "save_as_external_data": true
+        },
+        "f16": {
+            "type": "OnnxFloatToFloat16",
+            "op_include_list": [ "GroupQueryAttention" ],
+            "keep_io_types": [ "logits" ],
+            "save_as_external_data": true
+        },
+        "sq": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "wikitext2_train_act",
+            "activation_type": "uint16",
+            "precision": "uint8",
+            "calibration_providers": [ "CUDAExecutionProvider" ],
+            "quant_preprocess": true,
+            "op_types_to_exclude": [ "Cast", "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
+            "save_as_external_data": true
+        },
+        "sp": { "type": "SplitModel" },
+        "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "target": "qnn_system",
+    "log_severity_level": 1,
+    "output_dir": "models/phi3_5-qnn",
+    "cache_dir": "cache",
+    "no_artifacts": true
+}

--- a/examples/phi3_5/qnn_config_fp16.json
+++ b/examples/phi3_5/qnn_config_fp16.json
@@ -78,7 +78,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "Cast", "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/olive/passes/onnx/float16_conversion.py
+++ b/olive/passes/onnx/float16_conversion.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 from pathlib import Path
+from typing import Union
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
 from olive.model.utils import resolve_onnx_path
 from olive.passes import Pass
 from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
+from olive.passes.onnx.onnx_dag import OnnxDAG
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 
@@ -28,7 +30,9 @@ class OnnxFloatToFloat16(Pass):
                 type_=float, default_value=1e4, description="Constant values will be clipped against this value"
             ),
             "keep_io_types": PassConfigParam(
-                type_=bool, default_value=False, description="Whether model inputs/outputs should be left as float32"
+                type_=Union[bool, list],
+                default_value=False,
+                description="Whether model inputs/outputs should be left as float32",
             ),
             "use_symbolic_shape_infer": PassConfigParam(
                 type_=bool,
@@ -38,8 +42,18 @@ class OnnxFloatToFloat16(Pass):
             "op_block_list": PassConfigParam(
                 type_=list[str], default_value=None, description="List of op types to leave as float32"
             ),
+            "op_include_list": PassConfigParam(
+                type_=list[str],
+                default_value=None,
+                description="List of op types to include as float16. Mutually exclusive with op_block_list.",
+            ),
             "node_block_list": PassConfigParam(
                 type_=list[str], default_value=None, description="List of node names to leave as float32"
+            ),
+            "node_include_list": PassConfigParam(
+                type_=list[str],
+                default_value=None,
+                description="List of node names to include as float16. Mutually exclusive with node_block_list.",
             ),
         }
         config.update(get_external_data_config())
@@ -52,22 +66,33 @@ class OnnxFloatToFloat16(Pass):
 
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
+        loaded_model = model.load_model()
+        dag = OnnxDAG(loaded_model)
+
+        op_block_list = config.op_block_list
+        if config.op_include_list:
+            if op_block_list is not None:
+                raise ValueError("op_include_list and op_block_list are mutually exclusive.")
+            op_block_list = [op_type for op_type in dag.get_node_op_types() if op_type not in config.op_include_list]
+        node_block_list = config.node_block_list
+        if config.node_include_list:
+            if node_block_list is not None:
+                raise ValueError("node_include_list and node_block_list are mutually exclusive.")
+            node_block_list = [
+                node_name for node_name in dag.get_node_names() if node_name not in config.node_include_list
+            ]
+
         # using the float16 converter from onnxruntime since it is regularly updated
         # and can handle large models (>2GB) as well as ort contrib ops
-        ort_onnx_model = OnnxModel(model.load_model())
+        ort_onnx_model = OnnxModel(loaded_model)
         config_dict = config.dict()
         ort_onnx_model.convert_float_to_float16(
+            op_block_list=op_block_list,
+            node_block_list=node_block_list,
             **{
                 key: config_dict[key]
-                for key in [
-                    "min_positive_val",
-                    "max_finite_val",
-                    "keep_io_types",
-                    "use_symbolic_shape_infer",
-                    "op_block_list",
-                    "node_block_list",
-                ]
-            }
+                for key in ["min_positive_val", "max_finite_val", "keep_io_types", "use_symbolic_shape_infer"]
+            },
         )
 
         # save the model to the output path and return the model


### PR DESCRIPTION
## Describe your changes
- `OnnxFloatToFloat16` now has two new options `op_include_list` and `node_include_list`. 
- Added `qnn_config_fp16.json` which uses fp16 GQA since it improves TPS. TIinyMMLU is 61 for fp16 vs 65 for fp32.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
- [ ] Is this PR including examples changes? If yes, please remember to update [example documentation](https://github.com/microsoft/Olive/blob/main/docs/source/examples.md) in a follow-up PR.

## (Optional) Issue link
