### PR TITLE
QNN recipes: Pin AOT ort-qnn version to 1.22.2

### DIFF
--- a/examples/phi3_5/README.md
+++ b/examples/phi3_5/README.md
@@ -154,7 +154,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 ```bash
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [qnn_config.json](qnn_config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:
@@ -202,9 +202,7 @@ The optimized model can be used for inference using ONNX Runtime QNNExecutionPro
 Open ARM64 Native Tools Command Prompt for VS2022 and run the following commands:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
-pip install "onnxruntime-genai>=0.7.0"
+pip install "onnxruntime-qnn>=1.22.2" "onnxruntime-genai>=0.7.0"
 ```
 
 #### **Run Console-Based Chat Interface**

--- a/examples/phi3_5/requirements.txt
+++ b/examples/phi3_5/requirements.txt
@@ -1,2 +1,4 @@
 datasets
 optimum
+# newer transformers might have incompatibility with gptq passes
+transformers==4.53.2


### PR DESCRIPTION
## Describe your changes
- Use a stable version of onnxruntime-qnn for context binary generation. the QNN SDK version on latest nightly keeps getting updated. Don't want to compile a model that cannot run with stable releases of winml or ort-qnn

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
