### PR TITLE
Rename trt-rtx to NvTensorRtRtx

### DIFF
--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -52,7 +52,7 @@ class ModelBuilder(Pass):
         ExecutionProvider.DmlExecutionProvider: "dml",
         ExecutionProvider.WebGpuExecutionProvider: "webgpu",
         ExecutionProvider.JsExecutionProvider: "web",
-        ExecutionProvider.NvTensorRTRTXExecutionProvider: "trt-rtx",
+        ExecutionProvider.NvTensorRTRTXExecutionProvider: "NvTensorRtRtx",
     }
 
     @classmethod


### PR DESCRIPTION
As per the discussion with the GenAI team, we are moving the the NvtensorRtRtx user facing name

GenAI PR: https://github.com/microsoft/onnxruntime-genai/pull/1791