### PR TITLE
Add option to override genai_config.json property OV models

### DIFF
--- a/olive/passes/openvino/encapsulation.py
+++ b/olive/passes/openvino/encapsulation.py
@@ -3,18 +3,20 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import os
+import logging
 from pathlib import Path
 from typing import ClassVar, Union
 
 import onnx.helper as helper
 from onnx import TensorProto, save
-
+from typing import Any, Mapping, MutableMapping
+import numbers
 from olive.common.utils import hardlink_copy_dir, hardlink_copy_file
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import ONNXModelHandler, OpenVINOModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
-
+logger = logging.getLogger(__name__)
 
 class OpenVINOEncapsulation(Pass):
     """Encapsulates OpenVINO models with onnx context nodes."""
@@ -96,6 +98,14 @@ class OpenVINOEncapsulation(Pass):
                 default_value=False,
                 required=False,
                 description=("Reuse cache of previous passes to reduce storage footprint."),
+            ),
+            "genai_config_override": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                required=False,
+                description=(
+                    "Configuration overrides for genai_config.json generation. "
+                )
             ),
         }
 
@@ -252,6 +262,45 @@ def extract_shape_list(shape, config, prefix: str = "input_0_") -> list:
     return shape_list
 
 
+def _compatible_type(default_val: Any, new_val: Any) -> bool:
+    """Loose type check: allow ints for floats, bool as bool, etc."""
+    if default_val is None:
+        return True
+    if isinstance(default_val, bool):
+        return isinstance(new_val, bool)
+    if isinstance(default_val, numbers.Real) and not isinstance(default_val, bool):
+        return isinstance(new_val, numbers.Real) and not isinstance(new_val, bool)
+    if isinstance(default_val, str):
+        return isinstance(new_val, str)
+    if isinstance(default_val, (list, tuple)):
+        return isinstance(new_val, (list, tuple))
+    if isinstance(default_val, Mapping):
+        return isinstance(new_val, Mapping)
+    return True  # fall back to permissive
+
+def apply_genai_overrides(defaults: MutableMapping[str, Any], overrides: Mapping[str, Any], *, path: str = "") -> MutableMapping[str, Any]:
+    """
+    Recursively merge `overrides` into `defaults`.
+    """
+    for k, v in overrides.items():
+        here = f"{path}.{k}" if path else k
+        if k not in defaults:
+            continue
+
+        dv = defaults[k]
+
+        # Recurse for dicts
+        if isinstance(dv, Mapping) and isinstance(v, Mapping):
+            apply_genai_overrides(dv, v, path=here)
+            continue
+
+        # Replace lists/tuples and scalars
+        if not _compatible_type(dv, v):
+            logger.warning(f"Type mismatch at {here}: default={type(dv).__name__}, new={type(v).__name__}. Using new anyway.")
+        defaults[k] = v
+    return defaults
+
+
 def create_genai_config(model_name: str, output_path: str, config: type[BasePassConfig]) -> None:
     """Generate the genai_config.json from the model config files.
 
@@ -370,6 +419,9 @@ def create_genai_config(model_name: str, output_path: str, config: type[BasePass
     genai_config["model"]["vocab_size"] = src_config.get("vocab_size", -1)
 
     genai_config["search"]["max_length"] = src_config.get("max_position_embeddings", -1)
+
+    if isinstance(config.genai_config_override, dict):
+        apply_genai_overrides(genai_config, config.genai_config_override)
 
     # Step 2: Write to JSON file
     output_genai_config = Path(output_path) / "genai_config.json"

--- a/olive/passes/openvino/encapsulation.py
+++ b/olive/passes/openvino/encapsulation.py
@@ -2,21 +2,24 @@
 # Copyright (c) Intel Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import os
 import logging
+import numbers
+import os
+from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import ClassVar, Union
+from typing import Any, ClassVar, Union
 
 import onnx.helper as helper
 from onnx import TensorProto, save
-from typing import Any, Mapping, MutableMapping
-import numbers
+
 from olive.common.utils import hardlink_copy_dir, hardlink_copy_file
 from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import ONNXModelHandler, OpenVINOModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
 logger = logging.getLogger(__name__)
+
 
 class OpenVINOEncapsulation(Pass):
     """Encapsulates OpenVINO models with onnx context nodes."""
@@ -103,9 +106,7 @@ class OpenVINOEncapsulation(Pass):
                 type_=dict,
                 default_value=None,
                 required=False,
-                description=(
-                    "Configuration overrides for genai_config.json generation. "
-                )
+                description=("Configuration overrides for genai_config.json generation. "),
             ),
         }
 
@@ -278,9 +279,11 @@ def _compatible_type(default_val: Any, new_val: Any) -> bool:
         return isinstance(new_val, Mapping)
     return True  # fall back to permissive
 
-def apply_genai_overrides(defaults: MutableMapping[str, Any], overrides: Mapping[str, Any], *, path: str = "") -> MutableMapping[str, Any]:
-    """
-    Recursively merge `overrides` into `defaults`.
+
+def apply_genai_overrides(
+    defaults: MutableMapping[str, Any], overrides: Mapping[str, Any], *, path: str = ""
+) -> MutableMapping[str, Any]:
+    """Recursively merge `overrides` into `defaults`.
     """
     for k, v in overrides.items():
         here = f"{path}.{k}" if path else k
@@ -296,7 +299,9 @@ def apply_genai_overrides(defaults: MutableMapping[str, Any], overrides: Mapping
 
         # Replace lists/tuples and scalars
         if not _compatible_type(dv, v):
-            logger.warning(f"Type mismatch at {here}: default={type(dv).__name__}, new={type(v).__name__}. Using new anyway.")
+            logger.warning(
+                f"Type mismatch at {here}: default={type(dv).__name__}, new={type(v).__name__}. Using new anyway."
+            )
         defaults[k] = v
     return defaults
 

--- a/olive/passes/openvino/encapsulation.py
+++ b/olive/passes/openvino/encapsulation.py
@@ -283,8 +283,7 @@ def _compatible_type(default_val: Any, new_val: Any) -> bool:
 def apply_genai_overrides(
     defaults: MutableMapping[str, Any], overrides: Mapping[str, Any], *, path: str = ""
 ) -> MutableMapping[str, Any]:
-    """Recursively merge `overrides` into `defaults`.
-    """
+    """Recursively merge `overrides` into `defaults`."""
     for k, v in overrides.items():
         here = f"{path}.{k}" if path else k
         if k not in defaults:
@@ -299,9 +298,7 @@ def apply_genai_overrides(
 
         # Replace lists/tuples and scalars
         if not _compatible_type(dv, v):
-            logger.warning(
-                f"Type mismatch at {here}: default={type(dv).__name__}, new={type(v).__name__}. Using new anyway."
-            )
+            logger.warning("Type mismatch at %s", here)
         defaults[k] = v
     return defaults
 


### PR DESCRIPTION
## Describe your changes
Adds capability in OV encapsulation pass to parse optional configs to use as override in the resulting genai_config.json

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
