### PR TITLE
Remove redundant log for run cli

### DIFF
--- a/olive/cli/run.py
+++ b/olive/cli/run.py
@@ -65,9 +65,5 @@ class WorkflowRunCommand(BaseOliveCLICommand):
 
         if self.args.list_required_packages is True:
             print("Required packages listed!")
-        elif workflow_output.has_output_model():
-            print(f"Model is saved at {self.args.output_path}")
-        else:
-            print("No output model produced. Please check the log for details.")
 
         return workflow_output

--- a/olive/engine/engine.py
+++ b/olive/engine/engine.py
@@ -256,7 +256,7 @@ class Engine:
             if len(accelerator_output_dir_list) > 1 and self.skip_saving_artifacts:
                 [shutil.rmtree(folder) for folder in accelerator_output_dir_list if folder.exists()]
         else:
-            logger.warning("No output model")
+            logger.warning("No output model produced. Please check the log for details.")
 
         return workflow_output
 


### PR DESCRIPTION
## Describe your changes

Logs from WorkflowRunCommand is duplicated from Engine log.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
