### PR TITLE
`run`: Allow run_config dicts

### DIFF
--- a/olive/cli/run.py
+++ b/olive/cli/run.py
@@ -43,7 +43,10 @@ class WorkflowRunCommand(BaseOliveCLICommand):
         from olive.common.config_utils import load_config_file
         from olive.workflows import run as olive_run
 
-        run_config = load_config_file(self.args.run_config)
+        # allow the run_config to be a dict already (for api use)
+        run_config = self.args.run_config
+        if not isinstance(run_config, dict):
+            run_config = load_config_file(run_config)
         if input_model_config := get_input_model_config(self.args, required=False):
             print("Replacing input model config in run config")
             run_config["input_model"] = input_model_config


### PR DESCRIPTION
## Describe your changes
- `olive.run` python api uses `WorkflowRunCommand`. 
- Let the run_config be dict so that the user can just do `olive.run(run_config_dict)`.
- This was possible before when `olive.run` used `olive.workflows.run` instead.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
