### PR TITLE
Add Shape to ALLOWED_CONSUMER_OPS in ReplaceAttentionMaskValue surgery

### DIFF
--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -1318,7 +1318,7 @@ class ReplaceAttentionMaskValue(ProtoSurgeon):
     This surgery is useful if the default mask value does not quantize well due to numerical instability.
     """
 
-    ALLOWED_CONSUMER_OPS: ClassVar[set[str]] = {"Add", "Mul", "Expand", "Where"}
+    ALLOWED_CONSUMER_OPS: ClassVar[set[str]] = {"Add", "Mul", "Expand", "Where", "Shape"}
 
     def __init__(self, threshold: float = -3e30, replacement: float = -1e4):
         self.threshold = threshold


### PR DESCRIPTION
## Describe your changes
In [text_encoder](https://huggingface.co/openai/clip-vit-large-patch14) model, a ConstantOfShape op with -inf value is not getting replaced with the given replacement value in ReplaceAttentionMaskValue surgery as Shape node is one of the consumers of the ConstantOfShape node. Hence added Shape to ALLOWED_CONSUMER_OPS.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
