### PR TITLE
Enable QNN-GPU in Olive thorugh QNN-EP

### DIFF
--- a/olive/hardware/accelerator.py
+++ b/olive/hardware/accelerator.py
@@ -163,6 +163,8 @@ class AcceleratorLookup:
 
         if execution_providers == [ExecutionProvider.CPUExecutionProvider]:
             inferred_devices = ["cpu"]
+        elif execution_providers == [ExecutionProvider.QNNExecutionProvider]:
+            inferred_devices = ["npu"]
         else:
             inferred_devices = AcceleratorLookup.infer_devices_from_execution_providers(execution_providers)
             assert inferred_devices, (

--- a/olive/hardware/constants.py
+++ b/olive/hardware/constants.py
@@ -40,6 +40,7 @@ PROVIDER_PACKAGE_MAPPING = {
 DEVICE_TO_EXECUTION_PROVIDERS = {
     "cpu": {ExecutionProvider.CPUExecutionProvider, ExecutionProvider.OpenVINOExecutionProvider},
     "gpu": {
+        ExecutionProvider.QNNExecutionProvider,
         ExecutionProvider.DmlExecutionProvider,
         ExecutionProvider.CUDAExecutionProvider,
         ExecutionProvider.ROCMExecutionProvider,

--- a/olive/passes/onnx/static_llm.py
+++ b/olive/passes/onnx/static_llm.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import onnx
 
+from olive.hardware import Device
 from olive.hardware.accelerator import AcceleratorSpec
+from olive.hardware.constants import ExecutionProvider
 from olive.model import CompositeModelHandler, ONNXModelHandler
 from olive.passes import Pass
 from olive.passes.onnx.common import (
@@ -15,6 +17,7 @@ from olive.passes.onnx.common import (
     fix_dim_params,
     process_llm_pipeline,
     resave_model,
+    update_llm_pipeline_genai_config_gpu,
 )
 from olive.passes.onnx.onnx_dag import OnnxDAG
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
@@ -61,9 +64,18 @@ class StaticLLM(Pass):
             ),
         }
 
-    def _run_for_config(
-        self, model: CompositeModelHandler, config: type[BasePassConfig], output_model_path: str
-    ) -> CompositeModelHandler:
+    def _run_for_config(self, model, config: type[BasePassConfig], output_model_path: str):
+        if (
+            self.accelerator_spec.execution_provider == ExecutionProvider.QNNExecutionProvider
+            and self.accelerator_spec.accelerator_type == Device.GPU
+        ):
+            assert isinstance(model, ONNXModelHandler), "StaticLLM (qnn-gpu) requires a single ONNXModelHandler."
+            return self._run_qnn_gpu(model, config, output_model_path)
+
+        else:
+            return self._run_generic(model, config, output_model_path)
+
+    def _run_generic(self, model: CompositeModelHandler, config: type[BasePassConfig], output_model_path: str):
         assert isinstance(model, CompositeModelHandler), "StaticLLM pass only supports CompositeModelHandler"
         model_components = list(model.model_components)
         assert all(isinstance(m, ONNXModelHandler) for m in model_components), "All components must be ONNXModelHandler"
@@ -167,6 +179,60 @@ class StaticLLM(Pass):
             output_model_path,
             decoder_config_extra=decoder_config_extra,
             group_session_options=config.group_session_options,
+        )
+
+    def _run_qnn_gpu(self, model: ONNXModelHandler, config: type[BasePassConfig], output_model_path: Path):
+        output_model_dir = Path(output_model_path).with_suffix("")
+        model_path = Path(model.model_path)
+
+        # --- Step 1: Load model (handle both single and external data) ---
+        try:
+            model_proto = onnx.load(model_path, load_external_data=True)
+        except Exception as e:
+            raise RuntimeError(f"Failed to load ONNX model: {e}") from e
+
+        # --- Step 2: Fix symbolic dimensions ---
+        batch_size, sequence_length = OnnxDAG(model_proto).get_io_shape("input_ids")
+        if not (isinstance(batch_size, str) and isinstance(sequence_length, str)):
+            raise ValueError("Input dimensions must be symbolic before static shape fixing.")
+
+        param_mapping = {batch_size: config.batch_size, sequence_length: config.context_length}
+        self.fix_shape(model_proto, param_mapping)
+
+        # --- Step 3: Save model as external-data format ---
+        output_model_file = Path(output_model_dir) / "model.onnx"
+        external_data_file = Path(output_model_dir) / "model.onnx.data"
+
+        onnx.save(
+            model_proto,
+            str(output_model_file),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=external_data_file.name,
+            convert_attribute=False,
+        )
+
+        decoder_config_extra = {
+            "inputs": {
+                "past_sequence_length": "past_seq_len",
+                "total_sequence_length": "total_seq_len",
+            },
+            "sliding_window": {
+                "window_size": config.context_length,
+                "pad_value": 0,
+                "alignment": "left",
+                "slide_key_value_cache": False,
+            },
+        }
+
+        input_model_path = model.model_path
+        model_static = ONNXModelHandler(model_path=output_model_dir, onnx_file_name=output_model_file.name)
+
+        return update_llm_pipeline_genai_config_gpu(
+            model_static,
+            output_model_dir,
+            input_model_path,
+            decoder_config_extra,
         )
 
     @staticmethod


### PR DESCRIPTION
## Describe your changes
- Enable gpu in QNNExecutionProvider list
- Update StaticLLM pass for gpu
- Updat ContextBinaryGeneration pass for bin generation through QNN GPU
- Use npu as default for QNN-EP
- Added Olive-recipe for GPU under PR: https://github.com/microsoft/olive-recipes/pull/145 

Testing:
- Validated the following models on Olive through gpu
    - Qwen-Qwen2.5-1.5B-Instruct
    - deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B
    - meta-llama-Llama-3.2-1B-Instruct
    -microsoft-Phi-3.5-mini-instruct
- Validated HTP configs to make sure there are no regressions
