### PR TITLE
Load external ONNX tensor data before transforming models

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -655,6 +655,7 @@ class OnnxOpVersionConversion(Pass):
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path)
         model_ir = model.load_ir_model()
+        ir.external_data.load_to_model(model_ir)
         version_converter.convert_version(model_ir, config.target_opset, fallback=True)
         return ir_model_to_olive_model(model_ir, output_model_path, config)
 

--- a/olive/passes/onnx/hqq_quantization.py
+++ b/olive/passes/onnx/hqq_quantization.py
@@ -72,6 +72,7 @@ class OnnxHqqQuantization(Pass):
             return model
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
         ir_model = model.load_ir_model()
+        ir.external_data.load_to_model(ir_model)
         ir_model.graph.opset_imports[MSFT_DOMAIN] = 1
         self._quantize_model(
             ir_model,

--- a/olive/passes/onnx/onnxscript_fusion.py
+++ b/olive/passes/onnx/onnxscript_fusion.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 
 from onnxscript.rewriter import ort_fusions
+import onnx_ir as ir
 
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler
@@ -30,7 +31,8 @@ class OnnxScriptFusion(Pass):
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
 
         model_ir = model.load_ir_model()
-
+        ir.external_data.load_to_model(model_ir)
+        
         # TODO(exporter team): Different fusions support different devices
         model_ir, function_stats = ort_fusions.optimize_for_ort(model_ir)
         logger.debug("Function stats: %s", function_stats)

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -77,6 +77,7 @@ class OnnxBlockWiseRtnQuantization(Pass):
     ) -> ONNXModelHandler:
         output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
         ir_model = model.load_ir_model()
+        ir.external_data.load_to_model(ir_model)
         ir_model.graph.opset_imports[MSFT_DOMAIN] = 1
         self._quantize_model(
             ir_model,


### PR DESCRIPTION
Ensure every ONNX pass hydrates external tensor data after loading the IR model. This avoids writing broken references when saving quantized or converted models with external weights, restoring the behavior seen in v0.9.1.

## Describe your changes
- load external tensor data into the in-memory IR model for conversion, HQQ and RTN quantization
- hydrate external data before running ONNXScript fusions so the passes can safely rewrite the graph
- restores the ability to emit valid quantized models with external weights after the IR migration

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
Fixes https://github.com/microsoft/Olive/issues/2223