### PR TITLE
Static Quantization: Always patch `MinMaxCalibrator`

### DIFF
--- a/olive/passes/onnx/quantization.py
+++ b/olive/passes/onnx/quantization.py
@@ -250,7 +250,7 @@ _param_extra_options_mapping = {
 }
 
 
-def maybe_patch_min_max_calibrater():
+def patch_min_max_calibrater():
     from onnxruntime.quantization.calibrate import MinMaxCalibrater
 
     original_augment_graph = MinMaxCalibrater.augment_graph
@@ -486,7 +486,7 @@ class OnnxQuantization(Pass):
 
         if is_static:
             run_config = self.get_static_run_config(model, config, run_config, ort_less_than_1_21)
-            maybe_patch_min_max_calibrater()
+            patch_min_max_calibrater()
             try:
                 quantize_static(
                     model_input=model.model_path,


### PR DESCRIPTION
## Describe your changes
Always patch minmax calibrator since this patch saves additional compute if the lm head doesn't need to calibrated.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
