### PR TITLE
HfModelHandler: Check for tokenizer_config.json instead of try/else

### DIFF
--- a/olive/model/handler/mixin/hf.py
+++ b/olive/model/handler/mixin/hf.py
@@ -103,11 +103,8 @@ class HfMixin:
             saved_filepaths.append(str(generation_config_file_path))
 
         # save tokenizer, skip if it already exists
-        try:
-            get_tokenizer(output_dir)
-        except (OSError, TypeError):
+        if not (output_dir / "tokenizer_config.json").exists():
             # there is no tokenizer in the output_dir, save the tokenizer
-            # "TypeError: not a string" happens with transformers 4.52+
             tokenizer_filepaths = save_tokenizer(self.get_hf_tokenizer(), output_dir, **kwargs)
             saved_filepaths.extend([fp for fp in tokenizer_filepaths if Path(fp).exists()])
 


### PR DESCRIPTION
## Describe your changes
- the try/else solution is finicky. The errors when the tokenizer is not present depend on the versions as well as model.
- Better solution to check for `tokenizer_config.json` like we do for the other files.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
