### PR TITLE
Update MatMulAddToGemm Graph Surgery when ReLU is present after Add

### DIFF
--- a/docs/source/features/onnx-transformations.md
+++ b/docs/source/features/onnx-transformations.md
@@ -1097,7 +1097,7 @@ Transformed model graph:
 
 Replace MatMul + Add with Gemm.
 
-Second MatMul input must be a 2D tensor and the other input of the Add node must be a 1D tensor. If the first MatMul input is more than 2D and the shapes are static, it is reshaped to 2D before the Gemm node and reshaped back to the original shape after the Gemm node.
+Second MatMul input must be a 2D tensor and the other input of the Add node must be a 1D tensor. If the first MatMul input is more than 2D and the shapes are static, it is reshaped to 2D before the Gemm node and reshaped back to the original shape after the Gemm node. If a Relu is present after the Add operation and reshaping is required, the post-reshape will be added after the Relu operation.
 
 #### Example
 
@@ -1115,6 +1115,12 @@ Static shaped input:
                  |             |
                  v             v
 [N-D Input] --> MatMul -----> Add
+
+Static shaped input and ReLU post Add:
+             [2D weight]    [1D bias]
+                 |             |
+                 v             v
+[N-D Input] --> MatMul -----> Add -----> Relu
 ```
 
 After applying:
@@ -1148,6 +1154,15 @@ Static shaped inputs:
                               |
                               v
 [N-D Input] --> Reshape --> Gemm (alpha=1.0, beta=1.0) --> Reshape
+                              ^
+                              |
+                          [1D bias]
+
+Static shaped inputs and ReLU post Add:
+                          [2D weight]
+                              |
+                              v
+[N-D Input] --> Reshape --> Gemm (alpha=1.0, beta=1.0) --> ReLU --> Reshape
                               ^
                               |
                           [1D bias]

--- a/test/passes/onnx/test_graph_surgeries.py
+++ b/test/passes/onnx/test_graph_surgeries.py
@@ -808,7 +808,7 @@ def test_matmul_add_to_gemm(tmp_path):
     expected_num_nodes = 4
     dag = OnnxDAG.from_model_path(output_model.model_path)
     assert len(dag.nodes) == expected_num_nodes
-    assert "matmul" not in dag.get_node_op_types()
+    assert "MatMul" not in dag.get_node_op_types()
 
     # assert
     onnx.checker.check_model(output_model.load_model())
@@ -821,6 +821,77 @@ def test_matmul_add_to_gemm(tmp_path):
 
     matmul_output = np.matmul(input_data, constant1_data)
     expected_output = matmul_output + constant2_data
+    assert np.allclose(outputs[0], expected_output)
+
+
+def test_matmul_add_to_gemm_with_relu(tmp_path):
+    # setup input and output tensors
+    input_tensor = helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 3, 3])
+    output_tensor = helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 3, 3])
+
+    constant1_data = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
+    constant2_data = np.array([1, 2, 3], dtype=np.float32)
+    # Create constant tensors
+    initializers = [
+        helper.make_tensor("constant1", TensorProto.FLOAT, [3, 3], constant1_data),
+        helper.make_tensor("constant2", TensorProto.FLOAT, [3], constant2_data),
+    ]
+
+    nodes = [
+        helper.make_node("MatMul", inputs=["input", "constant1"], outputs=["matmul_output"]),
+        helper.make_node("Add", inputs=["matmul_output", "constant2"], outputs=["add_output"]),
+        helper.make_node("Relu", inputs=["add_output"], outputs=["relu_output"]),
+        helper.make_node("Identity", inputs=["relu_output"], outputs=["output"]),
+    ]
+
+    graph = helper.make_graph(
+        nodes=nodes,
+        name="TestGraph",
+        inputs=[input_tensor],
+        outputs=[output_tensor],
+        initializer=initializers,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 20)])
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    model_path = tmp_path / "model.onnx"
+    onnx.save(model, model_path)
+    input_model = ONNXModelHandler(model_path=str(model_path))
+
+    output_folder = str(tmp_path / "onnx")
+    p = create_pass_from_dict(
+        GraphSurgeries,
+        {"surgeries": [{"surgeon": "MatMulAddToGemm"}]},
+        disable_search=True,
+    )
+
+    output_model = p.run(input_model, output_folder)
+
+    # Matmul->Add->Relu->Identity will be replaced with Reshape->Gemm->Relu->Reshape->Identity
+    expected_num_nodes = 5
+    dag = OnnxDAG.from_model_path(output_model.model_path)
+    assert len(dag.nodes) == expected_num_nodes
+    assert "MatMul" not in dag.get_node_op_types()
+    gemm_node = None
+    for node_name in dag.get_node_names():
+        if dag.get_node_op_type(node_name) == "Gemm":
+            gemm_node = node_name
+            break
+    assert dag.get_node_op_type(dag.get_consumers(gemm_node)[0]) == "Relu"
+
+    # assert
+    onnx.checker.check_model(output_model.load_model())
+    output_session = output_model.prepare_session()
+
+    # Define the input data
+    input_data = np.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]], dtype=np.float32)
+
+    outputs = output_session.run(None, {"input": input_data})
+
+    matmul_output = np.matmul(input_data, constant1_data)
+    add_output = matmul_output + constant2_data
+    expected_output = np.maximum(add_output, 0)
     assert np.allclose(outputs[0], expected_output)
 
 


### PR DESCRIPTION
## Describe your changes
If Relu is present after the Add operation and reshaping is required, the post-reshape will be added after the Relu operation. So, the Gemm operation will be followed by ReLU and then Reshape.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
