### PR TITLE
Support multiple modes of ignored scopes simultaneously in Intel® OpenVINO weight compression and quantization passes

### DIFF
--- a/olive/passes/openvino/compression.py
+++ b/olive/passes/openvino/compression.py
@@ -176,20 +176,22 @@ class OpenVINOWeightCompression(Pass):
                 description="Data config for compression.",
             ),
             "ignored_scope": PassConfigParam(
-                type_=Union[str, list[str]],
+                type_=Union[list[str], list[list[str]]],
                 required=False,
                 default_value=None,
                 description=(
-                    "This parameter can be used to exclude some layers "
-                    "from the quantization process to preserve the model accuracy. Please refer to "
+                    "This parameter can be used to exclude some layers based on their names, types, and/or patterns "
+                    "from the compression process to preserve the model accuracy. Please refer to "
                     "https://docs.openvino.ai/2025/openvino-workflow/model-optimization-guide/quantizing-models-post-training/basic-quantization-flow.html#tune-quantization-parameters."
+                    "If multiple ignored_scope_types are provided, ignored_scope should be a list of lists, "
+                    "where each inner list corresponds to a specific ignored_scope_type in the same order."
                 ),
             ),
             "ignored_scope_type": PassConfigParam(
-                type_=IgnoreScopeTypeEnum,
+                type_=Union[IgnoreScopeTypeEnum, list[IgnoreScopeTypeEnum]],
                 required=False,
                 default_value=None,
-                description="Defines the type of the ignored scope. Supported values: 'names', 'types', 'patterns'.",
+                description="Defines the type(s) of the ignored scope. Supported values: 'names', 'types', 'patterns'.",
             ),
             "target_device": PassConfigParam(
                 type_=Device,
@@ -393,8 +395,33 @@ class OpenVINOWeightCompression(Pass):
                 else nncf.QuantizationPreset.MIXED
             )
         # target device is not needed for weight compression with NNCF
-        if config.ignored_scope:
-            kwargs = {config.ignored_scope_type: config.ignored_scope}
+        if (config.ignored_scope and not config.ignored_scope_type) or (
+            config.ignored_scope_type and not config.ignored_scope
+        ):
+            raise ValueError(
+                "Both 'ignored_scope' and 'ignored_scope_type' must be provided together for ignored scope configuration."
+            )
+        if config.ignored_scope and config.ignored_scope_type:
+            # Handle list of ignored_scope_types by zipping with ignored_scope.
+            # Ensure ignored_scope is a list of lists if ignored_scope_type is a list
+            # with number of elements in ignored_scope equalling number of elements in ignored_scope_type.
+            if isinstance(config.ignored_scope_type, list):
+                if isinstance(config.ignored_scope, list) and all(
+                    isinstance(item, list) for item in config.ignored_scope
+                ):
+                    if len(set(config.ignored_scope_type)) != len(config.ignored_scope_type):
+                        raise ValueError(
+                            "All values in ignored_scope_type must be unique to avoid overwriting in the ignored_scope dictionary."
+                        )
+                    if len(config.ignored_scope) != len(config.ignored_scope_type):
+                        raise ValueError(
+                            "Length of ignored_scope must match length of ignored_scope_type when both are lists."
+                        )
+                    kwargs = dict(zip(config.ignored_scope_type, config.ignored_scope))
+                else:
+                    raise ValueError("When ignored_scope_type is a list, ignored_scope must be a list of lists.")
+            else:
+                kwargs = {config.ignored_scope_type: config.ignored_scope}
             extra_params["ignored_scope"] = nncf.IgnoredScope(**kwargs)
 
         return extra_params

--- a/test/passes/openvino/test_openvino_compression.py
+++ b/test/passes/openvino/test_openvino_compression.py
@@ -91,6 +91,74 @@ def test_openvino_weight_compression_hf_to_openvino(tmp_path):
         shutil.rmtree(hf_to_ov_model.model_path)
 
 
+def test_openvino_weight_compression_hf_to_openvino_multi_ignore_scope(tmp_path):
+    # imports here
+    import numpy as np
+    from nncf.parameters import CompressWeightsMode, SensitivityMetric
+
+    # setup
+    input_hf_model = get_hf_model("hf-internal-testing/tiny-random-LlamaForCausalLM")
+
+    def custom_transform_func(data, tokenizer):
+        tokenized_text = tokenizer(data["text"], return_tensors="np")
+        input_ids = tokenized_text["input_ids"]
+        attention_mask = tokenized_text["attention_mask"]
+
+        inputs = {}
+        inputs["input_ids"] = input_ids
+        inputs["attention_mask"] = attention_mask
+        position_ids = np.cumsum(attention_mask, axis=1) - 1
+        position_ids[attention_mask == 0] = 1
+        inputs["position_ids"] = position_ids
+
+        batch_size = input_ids.shape[0]
+        inputs["beam_idx"] = np.arange(batch_size, dtype=int)
+
+        return inputs
+
+    openvino_weight_compression_config = {
+        "compress_config": {
+            "mode": CompressWeightsMode.INT4_SYM,
+            "ratio": 0.8,
+            "sensitivity_metric": SensitivityMetric.HESSIAN_INPUT_ACTIVATION,
+        },
+        "transform_fn": custom_transform_func,
+        "extra_args": {"tokenizer": True},
+        "data_config": DataConfig(
+            name="compress_data_config",
+            load_dataset_config=DataComponentConfig(type="wikitext_2_raw_v1_test"),
+        ),
+        "ignored_scope": [["Gather", "Add", "MatMul"], [".*Mul.*"]],
+        "ignored_scope_type": ["types", "patterns"],
+    }
+    p = create_pass_from_dict(
+        OpenVINOWeightCompression,
+        openvino_weight_compression_config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+
+    # create output folder
+    output_folder = str(Path(tmp_path) / "openvino_wc_hf_to_ov")
+
+    # execute
+    hf_to_ov_model = p.run(input_hf_model, output_folder)
+
+    # define the XML and bin files paths if openvino models are produced
+    xml_file = Path(hf_to_ov_model.model_path) / "openvino_model.xml"
+    bin_file = Path(hf_to_ov_model.model_path) / "openvino_model.bin"
+
+    # test if the model file is created
+    assert xml_file.exists()
+    assert xml_file.is_file()
+    assert bin_file.exists()
+    assert bin_file.is_file()
+
+    # cleanup
+    if Path(hf_to_ov_model.model_path).exists():
+        shutil.rmtree(hf_to_ov_model.model_path)
+
+
 @pytest.mark.skipif(
     version.parse(torch.__version__) >= version.parse("2.9.0"),
     reason="torch.onnx.export uses dynamo by default in torch 2.9.0+",
@@ -106,6 +174,50 @@ def test_openvino_weight_compression_hf_to_onnx(tmp_path):
         "extra_args": {"use_onnx": True, "advanced_compression_parameters": {"backend_params": {"external_dir": True}}},
         "ignored_scope": ["Gather"],
         "ignored_scope_type": "types",
+    }
+    p = create_pass_from_dict(
+        OpenVINOWeightCompression,
+        openvino_weight_compression_config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+
+    # create output folder
+    output_folder = str(Path(tmp_path) / "openvino_wc_hf_to_onnx")
+
+    # execute
+    hf_to_onnx_model = p.run(input_hf_model, output_folder)
+
+    # test if the model file is created
+    assert Path(hf_to_onnx_model.model_path).exists()
+    assert Path(hf_to_onnx_model.model_path).is_file()
+
+    # cleanup
+    if Path(hf_to_onnx_model.model_path).is_file():
+        q_dir = Path(hf_to_onnx_model.model_path).parent
+    else:
+        q_dir = Path(hf_to_onnx_model.model_path)
+    shutil.rmtree(q_dir)
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) >= version.parse("2.9.0"),
+    reason="torch.onnx.export uses dynamo by default in torch 2.9.0+",
+)
+def test_openvino_weight_compression_hf_to_onnx_multi_ignore_scope(tmp_path):
+    from nncf.parameters import CompressWeightsMode
+
+    # setup
+    input_hf_model = get_hf_model("hf-internal-testing/tiny-random-LlamaForCausalLM")
+
+    openvino_weight_compression_config = {
+        "compress_config": {"mode": CompressWeightsMode.INT4_SYM, "ratio": 1.0, "all_layers": True},
+        "extra_args": {"use_onnx": True, "advanced_compression_parameters": {"backend_params": {"external_dir": True}}},
+        "ignored_scope": [
+            ["Gather", "Add", "MatMul"],
+            ["/model/Mul_1", "/model/Mul_2", "/model/Mul_3", "/model/Mul_4"],
+        ],
+        "ignored_scope_type": ["types", "names"],
     }
     p = create_pass_from_dict(
         OpenVINOWeightCompression,
@@ -158,6 +270,62 @@ def test_openvino_weight_compression_onnx_to_onnx(tmp_path):
         "extra_args": {"use_onnx": True, "advanced_compression_parameters": {"backend_params": {"external_dir": True}}},
         "ignored_scope": ["Gather"],
         "ignored_scope_type": "types",
+    }
+    p = create_pass_from_dict(
+        OpenVINOWeightCompression,
+        openvino_weight_compression_config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+
+    # create output folder
+    output_folder = str(Path(tmp_path) / "openvino_wc_onnx_to_onnx")
+
+    # execute
+    onnx_to_onnx_model = p.run(input_onnx_model, output_folder)
+
+    # test if the model file is created
+    assert Path(onnx_to_onnx_model.model_path).exists()
+    assert Path(onnx_to_onnx_model.model_path).is_file()
+
+    # cleanup
+    shutil.rmtree(output_folder_optimum)
+    if Path(onnx_to_onnx_model.model_path).is_file():
+        q_dir = Path(onnx_to_onnx_model.model_path).parent
+    else:
+        q_dir = Path(onnx_to_onnx_model.model_path)
+    shutil.rmtree(q_dir)
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) >= version.parse("2.9.0"),
+    reason="torch.onnx.export uses dynamo by default in torch 2.9.0+",
+)
+def test_openvino_weight_compression_onnx_to_onnx_multi_ignore_scope(tmp_path):
+    from nncf.parameters import CompressWeightsMode
+
+    # setup
+    input_hf_model = get_hf_model("hf-internal-testing/tiny-random-LlamaForCausalLM")
+    optimum_conversion_config = {}
+    p_optimum = create_pass_from_dict(
+        OptimumConversion,
+        optimum_conversion_config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "CPUExecutionProvider"),
+    )
+
+    # create output folder
+    output_folder_optimum = str(Path(tmp_path) / "optimum_convert")
+    input_onnx_model = p_optimum.run(input_hf_model, output_folder_optimum)
+
+    openvino_weight_compression_config = {
+        "compress_config": {"mode": CompressWeightsMode.INT4_SYM, "ratio": 1.0, "all_layers": True},
+        "extra_args": {"use_onnx": True, "advanced_compression_parameters": {"backend_params": {"external_dir": True}}},
+        "ignored_scope": [
+            ["Gather", "Add", "MatMul"],
+            ["/model/Mul_1", "/model/Mul_2", "/model/Mul_3", "/model/Mul_4"],
+        ],
+        "ignored_scope_type": ["types", "names"],
     }
     p = create_pass_from_dict(
         OpenVINOWeightCompression,

--- a/test/passes/openvino/test_openvino_quantization.py
+++ b/test/passes/openvino/test_openvino_quantization.py
@@ -30,7 +30,7 @@ def cifar10_dataset(data_dir, **kwargs):
     # define the full CIFAR10 test set
     full_test_set = CIFAR10(root=data_dir, train=False, transform=ToTensor(), download=True)
 
-    # randomply sample n_test_samples from the full test set
+    # randomly sample n_test_samples from the full test set
     n_test_samples = 5
     random_indices = random.sample(range(len(full_test_set)), n_test_samples)
     return Subset(full_test_set, random_indices)
@@ -47,6 +47,41 @@ def test_openvino_quantization(tmp_path):
             load_dataset_config=DataComponentConfig(type="cifar10_dataset", params={"data_dir": str(data_dir)}),
             dataloader_config=DataComponentConfig(params={"shuffle": True}),
         )
+    }
+    p = create_pass_from_dict(
+        OpenVINOQuantization,
+        config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+    output_folder = str(tmp_path / "quantized")
+
+    # execute
+    quantized_model = p.run(ov_model, output_folder)
+
+    # assert
+    assert Path(quantized_model.model_path).exists()
+    assert (Path(quantized_model.model_path) / "ov_model_quant.bin").is_file()
+    assert (Path(quantized_model.model_path) / "ov_model_quant.xml").is_file()
+
+    # cleanup
+    shutil.rmtree(quantized_model.model_path)
+    shutil.rmtree(data_dir)
+
+
+def test_openvino_quantization_multi_ignore_scope(tmp_path):
+    # setup
+    ov_model = get_openvino_model(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    config = {
+        "data_config": DataConfig(
+            name="test_dc_config",
+            load_dataset_config=DataComponentConfig(type="cifar10_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(params={"shuffle": True}),
+        ),
+        "ignored_scope": [["Add", "MatMul"], [".*Mul.*"]],
+        "ignored_scope_type": ["types", "patterns"],
     }
     p = create_pass_from_dict(
         OpenVINOQuantization,
@@ -111,6 +146,50 @@ def test_openvino_quantization_onnx_input(tmp_path):
     shutil.rmtree(q_dir)
 
 
+def test_openvino_quantization_onnx_input_multi_ignore_scope(tmp_path):
+    # setup
+    onnx_model = get_cifar10_mv2_onnx_model(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+
+    def transform_to_np(data_item):
+        image, _ = data_item
+        return {"input": image.numpy()}
+
+    config = {
+        "data_config": DataConfig(
+            name="test_dc_config",
+            load_dataset_config=DataComponentConfig(type="cifar10_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(params={"shuffle": True}),
+        ),
+        "transform_fn": transform_to_np,
+        "ignored_scope": [["Add"], [".*Add.*"]],
+        "ignored_scope_type": ["types", "patterns"],
+    }
+    p = create_pass_from_dict(
+        OpenVINOQuantization,
+        config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+    output_folder = str(tmp_path / "quantized")
+
+    # execute
+    quantized_model = p.run(onnx_model, output_folder)
+
+    # assert
+    assert Path(quantized_model.model_path).exists()
+    assert Path(quantized_model.model_path).is_file()
+
+    # cleanup
+    shutil.rmtree(data_dir)
+    if Path(quantized_model.model_path).is_file():
+        q_dir = Path(quantized_model.model_path).parent
+    else:
+        q_dir = Path(quantized_model.model_path)
+    shutil.rmtree(q_dir)
+
+
 def test_openvino_quantization_with_accuracy(tmp_path):
     # setup
     ov_model = get_openvino_model(tmp_path)
@@ -122,6 +201,41 @@ def test_openvino_quantization_with_accuracy(tmp_path):
             load_dataset_config=DataComponentConfig(type="cifar10_dataset", params={"data_dir": str(data_dir)}),
             dataloader_config=DataComponentConfig(params={"shuffle": True}),
         )
+    }
+    p = create_pass_from_dict(
+        OpenVINOQuantizationWithAccuracy,
+        config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+    output_folder = str(tmp_path / "quantized")
+
+    # execute
+    quantized_model = p.run(ov_model, output_folder)
+
+    # assert
+    assert Path(quantized_model.model_path).exists()
+    assert (Path(quantized_model.model_path) / "ov_model_quant.bin").is_file()
+    assert (Path(quantized_model.model_path) / "ov_model_quant.xml").is_file()
+
+    # cleanup
+    shutil.rmtree(quantized_model.model_path)
+    shutil.rmtree(data_dir)
+
+
+def test_openvino_quantization_with_accuracy_multi_ignore_scope(tmp_path):
+    # setup
+    ov_model = get_openvino_model(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    config = {
+        "data_config": DataConfig(
+            name="test_dc_config",
+            load_dataset_config=DataComponentConfig(type="cifar10_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(params={"shuffle": True}),
+        ),
+        "ignored_scope": [["Add", "MatMul"], [".*Mul.*"]],
+        "ignored_scope_type": ["types", "patterns"],
     }
     p = create_pass_from_dict(
         OpenVINOQuantizationWithAccuracy,
@@ -164,6 +278,54 @@ def test_openvino_quantization_with_accuracy_onnx_input(tmp_path):
         ),
         "transform_fn": transform_to_np,
         "max_drop": np.inf,
+    }
+
+    p = create_pass_from_dict(
+        OpenVINOQuantizationWithAccuracy,
+        config,
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
+    )
+    output_folder = str(tmp_path / "quantized")
+
+    # execute
+    quantized_model = p.run(onnx_model, output_folder)
+
+    # assert
+    assert Path(quantized_model.model_path).exists()
+    assert Path(quantized_model.model_path).is_file()
+
+    # cleanup
+    shutil.rmtree(data_dir)
+    if Path(quantized_model.model_path).is_file():
+        q_dir = Path(quantized_model.model_path).parent
+    else:
+        q_dir = Path(quantized_model.model_path)
+    shutil.rmtree(q_dir)
+
+
+def test_openvino_quantization_with_accuracy_onnx_input_multi_ignore_scope(tmp_path):
+    import numpy as np
+
+    # setup
+    onnx_model = get_cifar10_mv2_onnx_model(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+
+    def transform_to_np(data_item):
+        image, _ = data_item
+        return {"input": image.numpy()}
+
+    config = {
+        "data_config": DataConfig(
+            name="test_dc_config",
+            load_dataset_config=DataComponentConfig(type="cifar10_dataset", params={"data_dir": str(data_dir)}),
+            dataloader_config=DataComponentConfig(params={"shuffle": True}),
+        ),
+        "transform_fn": transform_to_np,
+        "max_drop": np.inf,
+        "ignored_scope": [["Add"], [".*Add.*"]],
+        "ignored_scope_type": ["types", "patterns"],
     }
 
     p = create_pass_from_dict(


### PR DESCRIPTION
This commit aligns Olive behavior for quantizationa and compression
passes for ignored_scope with behavior of NNCF which supports multiple
modes of ignored scope simultaneously, which includes names, types and
patterns.

---------

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

## Describe your changes

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
