### PR TITLE
SelectiveMixedPrecision: Sensitivity score based algorithms

### DIFF
--- a/olive/common/quant/hf_utils.py
+++ b/olive/common/quant/hf_utils.py
@@ -105,7 +105,7 @@ class OliveHfQuantizationConfig(QuantizationConfigMixin):
                 cleaned_override = {k: v for k, v in override.__dict__.items() if v is not None and v != output[k]}
                 if cleaned_override:
                     overrides[module_name] = cleaned_override
-            output["overrides"] = overrides or None
+            output["overrides"] = sort_layers_by_name(overrides) or None
         else:
             output["overrides"] = None
         return output
@@ -128,6 +128,15 @@ class OliveHfQuantizationConfig(QuantizationConfigMixin):
         if override := self.overrides.get(module_name):
             init_args.update({k: v for k, v in override.__dict__.items() if v is not None})
         return init_args
+
+
+def sort_layers_by_name(layers_dict) -> dict:
+    """Sort layers dictionary by layer names in natural order."""
+
+    def sort_key(name: str) -> tuple:
+        return [int(part) if part.isdigit() else part for part in name.split(".")]
+
+    return dict(sorted(layers_dict.items(), key=lambda item: sort_key(item[0])))
 
 
 class OliveHfQuantizer(HfQuantizer):

--- a/olive/common/quant/utils.py
+++ b/olive/common/quant/utils.py
@@ -138,18 +138,22 @@ class WeightQuantizer:
         tensor = (q_tensor - zero_points.unsqueeze(-1)) * scales.unsqueeze(-1)
         return tensor.reshape(shape)
 
-    def fake_quantize(self, tensor: torch.Tensor, scales: torch.Tensor, zero_points: torch.Tensor) -> torch.Tensor:
+    def fake_quantize(
+        self, tensor: torch.Tensor, scales: torch.Tensor | None = None, zero_points: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Fake quantize the given tensor using the provided scales and zero points.
 
         Args:
             tensor: The tensor to quantize. Expected to be 2D with shape (out_features, in_features).
-            scales: The scales for quantization.
-            zero_points: The zero points for quantization.
+            scales: The scales for quantization. If None, scales will be computed from the tensor.
+            zero_points: The zero points for quantization. If None, zero points will be computed from the tensor.
 
         Returns:
             The fake quantized tensor.
 
         """
+        if scales is None or zero_points is None:
+            scales, zero_points = self.find_qparams(tensor)
         q_tensor = self.quantize(tensor, scales, zero_points)
         return self.dequantize(q_tensor, scales, zero_points)
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1051,6 +1051,11 @@ class LMEvaluator(OliveEvaluator):
         else:
             raise ValueError(f"Unknown model class: {self.model_class}")
 
+        logger.debug(
+            "Running LM evaluation with model class: %s and device/ep args: %s",
+            self.model_class,
+            {k: v for k, v in init_args.items() if k in ["device", "ep", "ep_options"]},
+        )
         lmmodel = get_model(self.model_class)(**init_args, batch_size=self.batch_size, max_length=self.max_length)
 
         results = simple_evaluate(

--- a/olive/passes/pytorch/autogptq.py
+++ b/olive/passes/pytorch/autogptq.py
@@ -2,31 +2,33 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from __future__ import annotations
+
 import json
 import logging
 from argparse import Namespace
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 import torch
 from packaging import version
 from transformers import PreTrainedModel
 
-from olive.common.config_utils import validate_config
 from olive.common.hf.wrapper import ModelWrapper
 from olive.common.utils import get_attr
 from olive.constants import PrecisionBits
 from olive.data.config import DataConfig
-from olive.data.template import huggingface_data_config_template
-from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.model.utils.path_utils import normalize_path_suffix
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf, inherit_pytorch_from_pytorch
-from olive.passes.pytorch.train_utils import load_hf_base_model
+from olive.passes.pytorch.train_utils import get_calibration_dataset, load_hf_base_model
+
+if TYPE_CHECKING:
+    from olive.hardware.accelerator import AcceleratorSpec
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +108,7 @@ class GptqQuantizer(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: type[BasePassConfig], output_model_path: str
+        self, model: HfModelHandler | PyTorchModelHandler, config: type[BasePassConfig], output_model_path: str
     ) -> PyTorchModelHandler:
         from auto_gptq import BaseQuantizeConfig, __version__
         from auto_gptq.modeling import BaseGPTQForCausalLM
@@ -117,7 +119,7 @@ class GptqQuantizer(Pass):
             # will move each block(layer) to cuda before quantization and move back to cpu when finished.
             raise ValueError("Please use GPU to run gptq quantization.")
 
-        dataset = self.get_dataset(model, config)
+        dataset = get_calibration_dataset(model, config.data_config)
 
         adapter_path = None
         if isinstance(model, HfModelHandler) and model.adapter_path:
@@ -233,35 +235,6 @@ class GptqQuantizer(Pass):
             new_load_kwargs["extra_args"]["use_safetensors"] = True
         return inherit_hf_from_hf(model, output_model_path, adapter_path=adapter_path, load_kwargs=new_load_kwargs)
 
-    def get_dataset(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: dict[str, Any]
-    ) -> list[dict[str, Any]]:
-        """Get the dataset for quantization."""
-        data_config = config.data_config
-        if not data_config and isinstance(model, HfModelHandler):
-            data_config = self.get_calibration_data_config(
-                model.model_name_or_path, trust_remote_code=model.get_load_kwargs().get("trust_remote_code", None)
-            )
-        elif not data_config:
-            raise ValueError("Data config is required for PyTorch model.")
-        data_config = validate_config(data_config, DataConfig)
-        dataloader = data_config.to_data_container().create_dataloader()
-        # each batch consists of (input_data, labels)
-        dataset = [data[0] for data in dataloader]
-
-        if (
-            not dataset
-            or not isinstance(dataset, list)
-            or not isinstance(dataset[0], dict)
-            or ("input_ids" not in dataset[0] or "attention_mask" not in dataset[0])
-        ):
-            raise ValueError(
-                "Provided dataset is invalid. The returned datasets is a list of tokenized data "
-                "(e.g. [{ 'input_ids': [[ 1, 100, 15, ... ]],'attention_mask': [[ 1, 1, 1, ... ]]},...])"
-            )
-
-        return dataset
-
     @staticmethod
     def get_gptq_info(model_wrapper: ModelWrapper, name: str) -> list[str]:
         """Get the GPTQ info from the model wrapper."""
@@ -279,27 +252,6 @@ class GptqQuantizer(Pass):
             return model_wrapper.get_layers()[1]
 
         raise ValueError(f"Unknown key {name}")
-
-    @staticmethod
-    def get_calibration_data_config(model_name_or_path: str, trust_remote_code: Optional[bool] = None):
-        return huggingface_data_config_template(
-            model_name=model_name_or_path,
-            task="text-generation",
-            load_dataset_config={
-                "data_name": "wikitext",
-                "subset": "wikitext-2-raw-v1",
-                # only require 128 samples for calibration
-                "split": "train[:1000]",
-                "trust_remote_code": trust_remote_code,
-            },
-            pre_process_data_config={
-                # should we randomize the data?
-                "add_special_tokens": False,
-                "max_seq_len": 2048,
-                "max_samples": 128,
-                "trust_remote_code": trust_remote_code,
-            },
-        )
 
     @contextmanager
     def _maybe_patch_gptq_model(self, gptq_model):

--- a/olive/passes/pytorch/gptqmodel.py
+++ b/olive/passes/pytorch/gptqmodel.py
@@ -2,24 +2,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from __future__ import annotations
+
 import json
 import logging
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 
-from olive.common.config_utils import validate_config
 from olive.common.hf.utils import get_tokenizer
 from olive.constants import PrecisionBits
 from olive.data.config import DataConfig
-from olive.data.template import huggingface_data_config_template
-from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf
+from olive.passes.pytorch.train_utils import get_calibration_dataset
+
+if TYPE_CHECKING:
+    from olive.hardware.accelerator import AcceleratorSpec
+
 
 logger = logging.getLogger(__name__)
 
@@ -107,12 +111,12 @@ class GptqModel(Pass):
 
     @torch.no_grad()
     def _run_for_config(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: type[BasePassConfig], output_model_path: str
+        self, model: HfModelHandler | PyTorchModelHandler, config: type[BasePassConfig], output_model_path: str
     ) -> PyTorchModelHandler:
         from gptqmodel import QuantizeConfig
         from gptqmodel.models.auto import MODEL_MAP, BaseGPTQModel
 
-        dataset = self.get_dataset(model, config)
+        dataset = get_calibration_dataset(model, config.data_config)
 
         adapter_path = None
         if isinstance(model, HfModelHandler) and model.adapter_path:
@@ -175,52 +179,3 @@ class GptqModel(Pass):
         if new_load_kwargs.get("extra_args") and new_load_kwargs["extra_args"].get("use_safetensors") is False:
             new_load_kwargs["extra_args"]["use_safetensors"] = True
         return inherit_hf_from_hf(model, output_model_path, adapter_path=adapter_path, load_kwargs=new_load_kwargs)
-
-    def get_dataset(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: dict[str, Any]
-    ) -> list[dict[str, Any]]:
-        """Get the dataset for quantization."""
-        data_config = config.data_config
-        if not data_config and isinstance(model, HfModelHandler):
-            data_config = self.get_calibration_data_config(
-                model.model_name_or_path, trust_remote_code=model.get_load_kwargs().get("trust_remote_code", None)
-            )
-        elif not data_config:
-            raise ValueError("Data config is required for PyTorch model.")
-        data_config = validate_config(data_config, DataConfig)
-        dataloader = data_config.to_data_container().create_dataloader()
-        # each batch consists of (input_data, labels)
-        dataset = [data[0] for data in dataloader]
-        if (
-            not dataset
-            or not isinstance(dataset, list)
-            or not isinstance(dataset[0], dict)
-            or ("input_ids" not in dataset[0] or "attention_mask" not in dataset[0])
-        ):
-            raise ValueError(
-                "Provided dataset is invalid. The returned datasets is a list of tokenized data "
-                "(e.g. [{ 'input_ids': [[ 1, 100, 15, ... ]],'attention_mask': [[ 1, 1, 1, ... ]]},...])"
-            )
-
-        return dataset
-
-    @staticmethod
-    def get_calibration_data_config(model_name_or_path: str, trust_remote_code: Optional[bool] = None):
-        return huggingface_data_config_template(
-            model_name=model_name_or_path,
-            task="text-generation",
-            load_dataset_config={
-                "data_name": "wikitext",
-                "subset": "wikitext-2-raw-v1",
-                # only require 128 samples for calibration
-                "split": "train[:1000]",
-                "trust_remote_code": trust_remote_code,
-            },
-            pre_process_data_config={
-                # should we randomize the data?
-                "add_special_tokens": False,
-                "max_seq_len": 2048,
-                "max_samples": 128,
-                "trust_remote_code": trust_remote_code,
-            },
-        )

--- a/olive/passes/pytorch/selective_mixed_precision.py
+++ b/olive/passes/pytorch/selective_mixed_precision.py
@@ -2,16 +2,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging
+import math
 from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import torch
 
 from olive.common.hf.wrapper import ModelWrapper
-from olive.common.utils import StrEnumBase
+from olive.common.quant.hf_utils import replace_matching_submodules, sort_layers_by_name
+from olive.common.quant.utils import WeightQuantizer
+from olive.common.utils import StrEnumBase, get_attr
 from olive.constants import PrecisionBits
-from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import HfModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
+from olive.passes.pytorch.train_utils import get_calibration_dataset, kl_div_loss, load_hf_base_model
+
+if TYPE_CHECKING:
+    from olive.hardware.accelerator import AcceleratorSpec
+
 
 logger = logging.getLogger(__name__)
 
@@ -22,15 +34,31 @@ class SelectiveMixedPrecision(Pass):
     This pass is used to annotate the model with mixed precision information, which can be used by other passes
     to quantize the model. The pass will add a model attribute `mixed_precision_info` that contains
     information about the default precision along with overrides for specific layers.
+
+    The supported algorithms are:
+    - Layer id based heuristic:
+        - k_quant_last: LM head in high precision.
+        - k_quant_down: LM head + Down projection from first 1/8 and last 1/8 layers, and every 3rd layer in between in high precision.
+        - k_quant_mixed: LM head + QKV and Down projection from first 1/8 and last 1/8 layers, and every 3rd layer in between in high precision.
+    - Sensitivity score based:
+        - snr: Signal-to-Noise Ratio based selection.
+        - snr_relative: Relative SNR (between low and high precision) based selection.
+        - iqe: Inverse of Integer Quantization Error based selection.
+        - iqe_relative: Relative IQE (between low and high precision) based selection.
+        - kld_gradient: KL Divergence gradient based selection.
     """
 
     class Algorithm(StrEnumBase):
         """The algorithm to use for mixed precision."""
 
+        IQE = "iqe"
+        IQE_RELATIVE = "iqe_relative"
         K_QUANT_DOWN = "k_quant_down"
         K_QUANT_MIXED = "k_quant_mixed"
         K_QUANT_LAST = "k_quant_last"
-        # TODO(jambayk): add other heuristic/algorithms
+        KLD_GRADIENT = "kld_gradient"
+        SNR = "snr"
+        SNR_RELATIVE = "snr_relative"
 
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> dict[str, PassConfigParam]:
@@ -40,12 +68,69 @@ class SelectiveMixedPrecision(Pass):
                 required=True,
                 description="The algorithm to use for mixed precision.",
             ),
-            "keep_tied_word_embeddings": PassConfigParam(
+            "bits": PassConfigParam(
+                type_=PrecisionBits,
+                default_value=PrecisionBits.BITS4,
+                description="The default precision bits.",
+            ),
+            "group_size": PassConfigParam(
+                type_=int,
+                default_value=128,
+                description="The default group size. Only used for snr, iqe and kld_gradient algorithms.",
+            ),
+            "sym": PassConfigParam(
                 type_=bool,
-                default_value=True,
-                description="Keep word embeddings in the same precision if they are tied.",
+                default_value=False,
+                description=(
+                    "Whether to use symmetric quantization by default. Only used for snr, iqe and kld_gradient"
+                    " algorithms."
+                ),
+            ),
+            "high_bits": PassConfigParam(
+                type_=PrecisionBits,
+                default_value=PrecisionBits.BITS8,
+                description="The high precision bits for selected layers.",
+            ),
+            "high_group_size": PassConfigParam(
+                type_=int,
+                default_value=None,
+                description=(
+                    "The group size for high precision layers. Only used for snr, iqe and kld_gradient algorithms. If"
+                    " None, use group_size."
+                ),
+            ),
+            "high_sym": PassConfigParam(
+                type_=bool,
+                default_value=None,
+                description=(
+                    "Whether to use symmetric quantization for high precision layers. Only used for snr, iqe and"
+                    " kld_gradient algorithms. If None, use sym."
+                ),
+            ),
+            "ratio": PassConfigParam(
+                type_=float,
+                default_value=None,
+                description=(
+                    "The ratio of default precision parameters to total parameters. Only used for snr, iqe and"
+                    " kld_gradient algorithms. Must be provided when using these algorithms."
+                ),
             ),
         }
+
+    @classmethod
+    def validate_config(
+        cls,
+        config: type[BasePassConfig],
+        accelerator_spec: AcceleratorSpec,
+    ) -> bool:
+        if not super().validate_config(config, accelerator_spec):
+            return False
+
+        if not config.algorithm.startswith("k_quant") and (config.ratio is None or not (0 < config.ratio < 1)):
+            logger.error("When using %s algorithm, ratio must be provided and between 0 and 1.", config.algorithm)
+            return False
+
+        return True
 
     def _run_for_config(
         self, model: HfModelHandler, config: type[BasePassConfig], output_model_path: str
@@ -54,15 +139,55 @@ class SelectiveMixedPrecision(Pass):
         if not isinstance(model, HfModelHandler):
             raise ValueError("SelectiveMixedPrecision pass currently only supports HfModelHandler.")
 
-        model_wrapper = ModelWrapper.from_model(model.load_model(cache_model=False))
+        # clear cached model
+        model.model = None
+        model_wrapper = ModelWrapper.from_model(load_hf_base_model(model))
 
-        # TODO(jambayk): make this configurable
-        override_config = {"bits": PrecisionBits.BITS8}
+        if config.algorithm.startswith("k_quant"):
+            default, overrides = self.get_k_quant_config(model_wrapper, config.algorithm, config.bits, config.high_bits)
+        else:
+            default, overrides = self.get_scored_config(
+                model,
+                model_wrapper,
+                config.algorithm,
+                config.bits,
+                config.group_size,
+                config.sym,
+                config.high_bits,
+                config.high_group_size if config.high_group_size is not None else config.group_size,
+                config.high_sym if config.high_sym is not None else config.sym,
+                config.ratio,
+            )
+
+        lm_head_name = model_wrapper.get_lm_head()[1]
+        if model_wrapper.config.tie_word_embeddings and lm_head_name in overrides:
+            overrides[model_wrapper.get_embeds()[1][0]] = overrides[lm_head_name]
+
+        # sort the overrides for better readability
+        overrides = sort_layers_by_name(overrides)
+
+        # Create output model with mixed precision info as model attribute
+        # deepcopy is okay since loaded model is not cached
+        output_model = deepcopy(model)
+        output_model.model_attributes = output_model.model_attributes or {}
+        output_model.model_attributes["mixed_precision_info"] = {
+            "default": default,
+            "overrides": overrides,
+        }
+        return output_model
+
+    @staticmethod
+    def get_k_quant_config(
+        model_wrapper: ModelWrapper,
+        algorithm: SelectiveMixedPrecision.Algorithm,
+        bits: PrecisionBits,
+        high_bits: PrecisionBits,
+    ) -> tuple[dict, dict[str, dict]]:
+        """Get mixed precision config for k-quant algorithms."""
+        override_config = {"bits": high_bits}
         overrides = {model_wrapper.get_lm_head()[1]: override_config}
-        if config.keep_tied_word_embeddings and model_wrapper.config.tie_word_embeddings:
-            overrides[model_wrapper.get_embeds()[1][0]] = override_config
 
-        if config.algorithm != SelectiveMixedPrecision.Algorithm.K_QUANT_LAST:
+        if algorithm != SelectiveMixedPrecision.Algorithm.K_QUANT_LAST:
             layer_prefix = model_wrapper.get_layers()[1]
             num_layers = model_wrapper.num_hidden_layers
             for layer_idx, layer_wrapper in enumerate(model_wrapper.get_layer_wrappers()):
@@ -74,7 +199,7 @@ class SelectiveMixedPrecision(Pass):
                     continue
 
                 # Add qkv
-                if config.algorithm == SelectiveMixedPrecision.Algorithm.K_QUANT_MIXED:
+                if algorithm == SelectiveMixedPrecision.Algorithm.K_QUANT_MIXED:
                     for attn_input_name in layer_wrapper.get_attention_inputs(return_name=True)[1]:
                         overrides[f"{layer_prefix}.{layer_idx}.{attn_input_name}"] = override_config
 
@@ -82,11 +207,223 @@ class SelectiveMixedPrecision(Pass):
                 for attn_output_name in layer_wrapper.get_mlp_outputs(return_name=True)[1]:
                     overrides[f"{layer_prefix}.{layer_idx}.{attn_output_name}"] = override_config
 
-        # Create output model with mixed precision info as model attribute
-        output_model = deepcopy(model)
-        output_model.model_attributes = output_model.model_attributes or {}
-        output_model.model_attributes["mixed_precision_info"] = {
-            "default": {"bits": PrecisionBits.BITS4},
-            "overrides": overrides,
-        }
-        return output_model
+        return {"bits": bits}, overrides
+
+    @staticmethod
+    def get_scored_config(
+        handler: HfModelHandler,
+        model_wrapper: ModelWrapper,
+        algorithm: SelectiveMixedPrecision.Algorithm,
+        bits: PrecisionBits,
+        group_size: int,
+        symmetric: bool,
+        high_bits: PrecisionBits,
+        high_group_size: int,
+        high_symmetric: bool,
+        ratio: float,
+    ):
+        """Get mixed precision config based on sensitivity scores."""
+        quantizer = WeightQuantizer(bits=bits, group_size=group_size, symmetric=symmetric)
+        high_quantizer = WeightQuantizer(
+            bits=high_bits,
+            group_size=high_group_size,
+            symmetric=high_symmetric,
+        )
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        algo_func = (
+            SelectiveMixedPrecision.get_kld_scores
+            if algorithm == SelectiveMixedPrecision.Algorithm.KLD_GRADIENT
+            else SelectiveMixedPrecision.get_snr_iqe_scores
+        )
+        module_numels, module_scores = algo_func(
+            handler,
+            model_wrapper.model,
+            algorithm,
+            quantizer,
+            high_quantizer,
+            device,
+        )
+
+        threshold = sum(module_numels.values()) * (1 - ratio)
+        # ascending order, lower score means more sensitive and should be in higher precision
+        sorted_modules = sorted(module_scores, key=lambda item: module_scores[item], reverse=False)
+        overrides = {}
+        high_override_config = {"bits": high_bits, "group_size": high_group_size, "symmetric": high_symmetric}
+        total = 0
+        for module_name in sorted_modules:
+            total += module_numels[module_name]
+            overrides[module_name] = high_override_config
+            if total >= threshold:
+                break
+        logger.info(
+            "Selected %d modules for high precision out of %d modules. Ratio of low precision: %.4f",
+            len(overrides),
+            len(module_numels),
+            1 - total / sum(module_numels.values()),
+        )
+
+        return {"bits": bits, "group_size": group_size, "symmetric": symmetric}, overrides
+
+    @staticmethod
+    def get_snr_iqe_scores(
+        handler: HfModelHandler,
+        model: torch.nn.Module,
+        algorithm: SelectiveMixedPrecision.Algorithm,
+        quantizer: WeightQuantizer,
+        high_quantizer: WeightQuantizer,
+        device: str,
+    ) -> tuple[dict[str, int], dict[str, float]]:
+        """Compute SNR or IQE based sensitivity scores."""
+        score_func = (
+            SelectiveMixedPrecision.compute_snr if algorithm.startswith("snr") else SelectiveMixedPrecision.compute_iqe
+        )
+
+        module_numels = {}
+        module_scores = {}
+
+        def should_include(module, _):
+            return isinstance(module, torch.nn.Linear)
+
+        @torch.no_grad()
+        def process_module(module, module_name):
+            module_numels[module_name] = module.weight.numel()
+            module.to(device)
+
+            score = score_func(module.weight, quantizer.fake_quantize(module.weight))
+            if algorithm.endswith("_relative"):
+                high_score = score_func(module.weight, high_quantizer.fake_quantize(module.weight))
+                if algorithm.startswith("snr"):
+                    # SNR is in dB, so we subtract
+                    score -= high_score
+                else:
+                    # IQE is inverted, so we divide
+                    score /= high_score
+            module_scores[module_name] = score
+            return module.cpu()
+
+        replace_matching_submodules(model, should_include, process_module, description="Computing SNR/IQE scores")
+        return module_numels, module_scores
+
+    @staticmethod
+    def get_kld_scores(
+        handler: HfModelHandler,
+        model: torch.nn.Module,
+        algorithm: SelectiveMixedPrecision.Algorithm,
+        quantizer: WeightQuantizer,
+        high_quantizer: WeightQuantizer,
+        device: str,
+    ) -> tuple[dict[str, int], dict[str, float]]:
+        """Compute KL Divergence gradient based sensitivity scores.
+
+        The gradients are computed using a calibration dataset and the KL Divergence loss between
+        the outputs of the original model and the fake quantized model.
+        """
+        # based on mlx-lm implementation at https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/quant/dynamic_quant.py
+        from tqdm.auto import tqdm
+
+        # TODO(jambayk): make data_config configurable
+        data = get_calibration_dataset(handler, max_seq_len=512, max_samples=256)
+
+        model.to(device).eval()
+        q_model = deepcopy(model).to(device).eval()
+
+        # freeze all parameters
+        for param in q_model.parameters():
+            param.requires_grad = False
+        # enable gradient checkpointing
+        q_model.gradient_checkpointing_enable()
+
+        # replace the weights in qmodel with low-bit quantized weights
+        module_numels = {}
+        q_layers: dict[str, torch.nn.Module] = {}
+        grad_accum: dict[str, torch.Tensor] = {}
+
+        def should_include(module, _):
+            return isinstance(module, torch.nn.Linear)
+
+        @torch.no_grad()
+        def process_module(module, module_name):
+            module_numels[module_name] = module.weight.numel()
+            low_w = quantizer.fake_quantize(module.weight.data)
+            module.weight.data = low_w
+            module.weight.requires_grad = True
+            q_layers[module_name] = module
+            grad_accum[module_name] = torch.zeros_like(module.weight.data, dtype=torch.float32)
+            return module
+
+        replace_matching_submodules(
+            q_model, should_include, process_module, description="Preparing for sensitivity estimation"
+        )
+
+        for batch in tqdm(data, desc="Estimating sensitivities"):
+            inputs = {k: v.to(device) for k, v in batch.items()}
+
+            with torch.no_grad():
+                teacher_logits = model(**inputs).logits
+
+            student_logits = q_model(**inputs).logits
+            loss = kl_div_loss(student_logits, teacher_logits).mean()
+            loss.backward()
+
+            # accumulate gradients
+            for name, layer in q_layers.items():
+                grad_accum[name] += layer.weight.grad.data.detach().float()
+
+            # zero grads
+            q_model.zero_grad()
+
+        @torch.no_grad()
+        def compute_sensitivity(module_name: str) -> torch.Tensor:
+            grad = grad_accum[module_name] / len(data)  # average gradient
+
+            # high-precision quantization baseline
+            high_w = high_quantizer.fake_quantize(get_attr(model, module_name).weight.data)
+
+            # get sensitivity
+            param_size_m = module_numels[module_name] / 1e6
+            alignment = (grad * (q_layers[module_name].weight.data - high_w)).sum().item()
+            return alignment / param_size_m
+
+        # negative sensitivity because lower is more sensitive
+        return module_numels, {name: -compute_sensitivity(name) for name in q_layers}
+
+    @staticmethod
+    def compute_snr(x: torch.Tensor, y: torch.Tensor, eps: float = 1e-12) -> float:
+        """Compute signal-to-noise ratio in dB.
+
+        Args:
+            x (torch.Tensor): Original tensor.
+            y (torch.Tensor): Quantized tensor.
+            eps (float): Small value to avoid division by zero.
+
+        Returns:
+            float: SNR value in dB.
+
+        """
+        x = x.flatten().float()
+        y = y.flatten().float()
+        signal_norm = max(torch.norm(x).item(), eps)
+        noise_norm = max(torch.norm(x - y).item(), eps)
+        return 20 * math.log10(signal_norm / noise_norm)
+
+    @staticmethod
+    def compute_iqe(x: torch.Tensor, y: torch.Tensor, eps: float = 1e-12) -> float:
+        """Compute the inverse of integer quantization error.
+
+        Error is computed as max(mean((x - y)^2)) over the last dimension.
+
+        Args:
+            x (torch.Tensor): Original tensor.
+            y (torch.Tensor): Quantized tensor.
+            eps (float): Small value to avoid division by zero.
+
+        Returns:
+            float: Inverse of IQE score.
+
+        """
+        # based on nncf implementation at
+        # https://github.com/openvinotoolkit/nncf/blob/develop/src/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+        iqe = torch.pow(x.float() - y.float(), 2).mean(-1).max().item()
+        # invert so that lower score means more sensitive
+        return 1 / (iqe + eps)

--- a/olive/passes/pytorch/train_utils.py
+++ b/olive/passes/pytorch/train_utils.py
@@ -7,22 +7,23 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+import torch
 import transformers
 from packaging import version
 from transformers import __version__ as transformers_version
 
-from olive.common.config_utils import NestedConfig
+from olive.common.config_utils import NestedConfig, validate_config
 from olive.common.pydantic_v1 import Field, validator
 from olive.common.utils import cleanup_memory
 from olive.data.config import DataConfig
-from olive.model import HfModelHandler
+from olive.data.template import huggingface_data_config_template
+from olive.model import HfModelHandler, PyTorchModelHandler
 from olive.model.config.hf_config import HfLoadKwargs
 
 logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    import torch
     from transformers import PreTrainedModel
 
 
@@ -240,3 +241,108 @@ DEFAULT_DEEPSPEED_CONFIG = {
     "gradient_accumulation_steps": "auto",
     "gradient_clipping": "auto",
 }
+
+
+def get_calibration_dataset(
+    model: HfModelHandler | PyTorchModelHandler,
+    data_config: DataConfig | dict | None = None,
+    split: str = "train[:1000]",
+    batch_size: int = 1,
+    max_seq_len: int = 2048,
+    max_samples: int = 128,
+) -> list[dict[str, Any]]:
+    """Get the dataset for quantization calibration.
+
+    Args:
+        model: The HuggingFace or PyTorch model to get dataset for.
+        data_config: Configuration object or dictionary containing data settings.
+        split: The dataset split to use for default data config. Default is 'train[:1000]'.
+        batch_size: The batch size to use for default data config. Default is 1.
+        max_seq_len: Maximum sequence length for default data config. Default is 2048.
+        max_samples: Maximum number of samples for default data config. Default is 128.
+
+    Returns:
+        List of tokenized data dictionaries for calibration.
+
+    Raises:
+        ValueError: If the dataset format is invalid.
+
+    """
+    if not data_config and isinstance(model, HfModelHandler):
+        data_config = get_calibration_data_config(
+            model.model_name_or_path,
+            trust_remote_code=model.get_load_kwargs().get("trust_remote_code", None),
+            split=split,
+            batch_size=batch_size,
+            max_seq_len=max_seq_len,
+            max_samples=max_samples,
+        )
+    elif not data_config:
+        raise ValueError("Data config is required for PyTorch model.")
+    data_config = validate_config(data_config, DataConfig)
+    dataloader = data_config.to_data_container().create_dataloader()
+    # each batch consists of (input_data, labels)
+    dataset = [data[0] for data in dataloader]
+
+    if (
+        not dataset
+        or not isinstance(dataset, list)
+        or not isinstance(dataset[0], dict)
+        or ("input_ids" not in dataset[0] or "attention_mask" not in dataset[0])
+    ):
+        raise ValueError(
+            "Provided dataset is invalid. The returned datasets is a list of tokenized data "
+            "(e.g. [{ 'input_ids': [[ 1, 100, 15, ... ]],'attention_mask': [[ 1, 1, 1, ... ]]},...])"
+        )
+
+    return dataset
+
+
+def get_calibration_data_config(
+    model_name_or_path: str,
+    trust_remote_code: bool | None = None,
+    split: str = "train[:1000]",
+    batch_size: int = 1,
+    max_seq_len: int = 2048,
+    max_samples: int = 128,
+) -> DataConfig:
+    """Get default calibration data configuration for GPTQ quantization.
+
+    Args:
+        model_name_or_path: Name or path of the model.
+        trust_remote_code: Whether to trust remote code when loading data.
+        split: The dataset split to use. Default is 'train[:1000]'.
+        batch_size: The batch size to use. Default is 1.
+        max_seq_len: Maximum sequence length. Default is 2048.
+        max_samples: Maximum number of samples. Default is 128.
+
+    Returns:
+        DataConfig object for calibration data.
+
+    """
+    return huggingface_data_config_template(
+        model_name=model_name_or_path,
+        task="text-generation",
+        load_dataset_config={
+            "data_name": "wikitext",
+            "subset": "wikitext-2-raw-v1",
+            "split": split,
+            "trust_remote_code": trust_remote_code,
+        },
+        pre_process_data_config={
+            # should we randomize the data?
+            "add_special_tokens": False,
+            "max_seq_len": max_seq_len,
+            "max_samples": max_samples,
+            "trust_remote_code": trust_remote_code,
+        },
+        dataloader_config={"batch_size": batch_size},
+    )
+
+
+def kl_div_loss(student_logits: torch.Tensor, teacher_logits: torch.Tensor) -> torch.Tensor:
+    """Compute the KL divergence loss between student and teacher logits."""
+    student_log_probs = torch.nn.functional.log_softmax(student_logits, dim=-1)
+    teacher_probs = torch.nn.functional.softmax(teacher_logits, dim=-1)
+    kl = torch.nn.functional.kl_div(student_log_probs, teacher_probs, reduction="none")
+    return kl.sum(-1)

--- a/test/passes/pytorch/test_rotate.py
+++ b/test/passes/pytorch/test_rotate.py
@@ -44,7 +44,7 @@ def test_quarot(tmp_path, model_path, rotate_mode):
     common_test_rotate(QuaRot, tmp_path, model_path, rotate_mode, 1e-5)
 
 
-def get_patched_data_config(model_name_or_path, trust_remote_code):
+def get_patched_data_config(model_name_or_path, trust_remote_code, **kwargs):
     return huggingface_data_config_template(
         model_name=model_name_or_path,
         task="text-generation",
@@ -66,7 +66,7 @@ def get_patched_data_config(model_name_or_path, trust_remote_code):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires a GPU")
 @pytest.mark.parametrize("model_path", ["tiny-phi3", "tiny-llama"])
 @pytest.mark.parametrize("rotate_mode", ["hadamard", "random"])
-@patch("olive.passes.pytorch.rotate.SpinQuant.get_train_data_config", side_effect=get_patched_data_config)
+@patch("olive.passes.pytorch.rotate.get_calibration_data_config", side_effect=get_patched_data_config)
 def test_spinquant(_, tmp_path, model_path, rotate_mode):
     common_test_rotate(
         SpinQuant,


### PR DESCRIPTION
## Describe your changes
- New selective mixed precision algorithms added that select the layers to put in higher precision based on sensitivity scores and a ratio.
- The sensitivity scores are signal-to-noise ratio, integer quantization error and kl divergence gradient. Refer to the pass docstring for more information on the scores.
- Some refactoring to reuse the default quantization calibration data between the passes.

Average improvement of the various algorithms across different (block_size, symmetric) settings compared with the full int4 model. 
- Ratios were selected to match the model size of the score-based algorithms to that of the `k_quant_down` heuristic.
- `kld_gradient` often performs among the top algorithms. However, it requires GPU resources for efficient computation because it is data-dependent and requires both forward and backward passes.

<img width="550" height="859" alt="image" src="https://github.com/user-attachments/assets/eb08d195-daba-47f5-b7cd-74f8dd68687f" />



## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
