### PR TITLE
UT: Use same input pytorch model in openvino test

### DIFF
--- a/test/passes/openvino/test_openvino_quantization.py
+++ b/test/passes/openvino/test_openvino_quantization.py
@@ -379,6 +379,9 @@ def get_openvino_model(tmp_path, cifar10_mv2_model):
     )
     output_folder = str(tmp_path / "openvino")
 
+    # remove any cached loaded model
+    cifar10_mv2_model.model = None
+
     # execute
     return p.run(cifar10_mv2_model, output_folder)
 
@@ -392,4 +395,5 @@ def get_cifar10_mv2_onnx_model(tmp_path, cifar10_mv2_model):
         disable_search=True,
         accelerator_spec=AcceleratorSpec("cpu", "OpenVINOExecutionProvider"),
     )
+    cifar10_mv2_model.model = None
     return p.run(cifar10_mv2_model, str(onnx_model_path))


### PR DESCRIPTION
## Describe your changes
- It uses a new torch hub directory for each test case which leads to multiple downloads of the same model.
- This gets rate limited sometimes causing the test to fail.
- Use a common pytorch model that downloads into the same 

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
