### PR TITLE
Disable lmhead during prefill phase in genai config

### DIFF
--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -760,6 +760,8 @@ def update_llm_pipeline_genai_config(
                 pipeline_config[name]["session_options"] = group_session_options
             pipeline_config[name][f"run_on_{dont_run_on}"] = False
 
+    pipeline_config[llm_pipeline["lm_head"]]["is_lm_head"] = True
+
     decoder_config["pipeline"] = [pipeline_config]
 
     # save the updated genai_config


### PR DESCRIPTION
## Describe your changes
Set `"is_lm_head": true` in the genai_config json file so that lm head model is not run for all but the last window during the prefill phase. Corresponding changes [here](https://github.com/microsoft/onnxruntime-genai/pull/1762).

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
