### PR TITLE
Replace TRANSFORMERS_CACHE with HF_HUB_CACHE

### DIFF
--- a/olive/cli/extract_adapters.py
+++ b/olive/cli/extract_adapters.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 from argparse import ArgumentParser
 
-from transformers.utils import TRANSFORMERS_CACHE
+from huggingface_hub.constants import HF_HUB_CACHE
 
 from olive.cli.base import BaseOliveCLICommand, add_logging_options
 from olive.common.utils import WeightsFileFormat, save_weights
@@ -50,7 +50,7 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
         sub_parser.add_argument(
             "--cache_dir",
             type=str,
-            default=TRANSFORMERS_CACHE,
+            default=HF_HUB_CACHE,
             help="Cache dir to store temporary files in. Default is Hugging Face's default cache dir.",
         )
         add_logging_options(sub_parser)

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar, Union
 
 import onnx
 import torch
-import transformers
+from huggingface_hub.constants import HF_HUB_CACHE
 from packaging import version
 
 from olive.constants import Precision
@@ -263,7 +263,7 @@ class ModelBuilder(Pass):
                 execution_provider=target_execution_provider,
                 # model builder uses the cache_dir both as hf cache and also to store intermediate files
                 # not ideal, but we can't change this without changing the model builder
-                cache_dir=transformers.utils.TRANSFORMERS_CACHE,
+                cache_dir=HF_HUB_CACHE,
                 **extra_args,
             )
 
@@ -281,7 +281,7 @@ class ModelBuilder(Pass):
                 onnx.save(model_proto, output_model_filepath)
         except Exception:
             # if model building fails, clean up the intermediate files in the cache_dir
-            cache_dir = Path(transformers.utils.TRANSFORMERS_CACHE)
+            cache_dir = Path(HF_HUB_CACHE)
             if cache_dir.is_dir():
                 for file in cache_dir.iterdir():
                     if file.suffix == ".bin":


### PR DESCRIPTION
## Describe your changes

`TRANSFORMERS_CACHE ` will be deprecated in transformers v5. Replaced it by `HF_HUB_CACHE`

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
