### PR TITLE
Add hf-xet to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+hf-xet
 numpy
 onnx
 onnx_ir>=0.1.2


### PR DESCRIPTION
add the hf_xet package to avoid the warning when downloading models from HuggingFace.

I checked the repo and would need some opinion of developers where to put the fix: there are 2 places:

requirements.txt contains the base dependencies that are always installed olive/olive_config.json contains extra_dependencies for optional features that users can install as needed (like pip install olive-ai[gpu], pip install olive-ai[lora], etc.) Since the warning occurs during the getting started example (a basic use case), and hf_xet improves download performance from HuggingFace for models with Xet Storage, it makes sense to add it as a base dependency in requirements.txt.

Proposed change:
Add hf_xet to the requirements.txt

## Describe your changes
changes do not require unit test or doc update nor is it user-facing (there is no change, just avoiding a current warning

## Checklist before requesting a review
- [X] Add unit tests for this change.
- [X] Make sure all tests can pass.
- [X] Update documents if necessary.
- [X] Lint and apply fixes to your code by running `lintrunner -a`
- [X] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
fix for https://github.com/microsoft/Olive/issues/2288
