### PR TITLE
[DO NOT MERGE] Copy of 2292

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+hf-xet
 numpy
 onnx
 onnx_ir>=0.1.2


### PR DESCRIPTION
add the hf_xet package to avoid the warning when downloading models from HuggingFace.

I checked the repo and would need some opinion of developers where to put the fix: there are 2 places:

requirements.txt contains the base dependencies that are always installed olive/olive_config.json contains extra_dependencies for optional features that users can install as needed (like pip install olive-ai[gpu], pip install olive-ai[lora], etc.) Since the warning occurs during the getting started example (a basic use case), and hf_xet improves download performance from HuggingFace for models with Xet Storage, it makes sense to add it as a base dependency in requirements.txt.

Proposed change:
Add hf_xet to the requirements.txt

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
