### PR TITLE
Update unit tests to specify group size fallback

### DIFF
--- a/test/passes/openvino/test_openvino_compression.py
+++ b/test/passes/openvino/test_openvino_compression.py
@@ -29,6 +29,7 @@ def test_openvino_weight_compression_hf_to_openvino(tmp_path):
     # imports here
     import numpy as np
     from nncf.parameters import CompressWeightsMode, SensitivityMetric
+    from nncf.quantization.advanced_parameters import GroupSizeFallbackMode
 
     # setup
     input_hf_model = get_hf_model("hf-internal-testing/tiny-random-LlamaForCausalLM")
@@ -57,7 +58,12 @@ def test_openvino_weight_compression_hf_to_openvino(tmp_path):
             "sensitivity_metric": SensitivityMetric.HESSIAN_INPUT_ACTIVATION,
         },
         "transform_fn": custom_transform_func,
-        "extra_args": {"tokenizer": True},
+        "extra_args": {
+            "tokenizer": True,
+            "advanced_compression_parameters": {
+                "group_size_fallback_mode": GroupSizeFallbackMode.IGNORE,
+            },
+        },
         "data_config": DataConfig(
             name="compress_data_config",
             load_dataset_config=DataComponentConfig(type="wikitext_2_raw_v1_test"),
@@ -165,13 +171,20 @@ def test_openvino_weight_compression_hf_to_openvino_multi_ignore_scope(tmp_path)
 )
 def test_openvino_weight_compression_hf_to_onnx(tmp_path):
     from nncf.parameters import CompressWeightsMode
+    from nncf.quantization.advanced_parameters import GroupSizeFallbackMode
 
     # setup
     input_hf_model = get_hf_model("hf-internal-testing/tiny-random-LlamaForCausalLM")
 
     openvino_weight_compression_config = {
         "compress_config": {"mode": CompressWeightsMode.INT4_SYM, "ratio": 1.0, "all_layers": True},
-        "extra_args": {"use_onnx": True, "advanced_compression_parameters": {"backend_params": {"external_dir": True}}},
+        "extra_args": {
+            "use_onnx": True,
+            "advanced_compression_parameters": {
+                "backend_params": {"external_dir": True},
+                "group_size_fallback_mode": GroupSizeFallbackMode.IGNORE,
+            },
+        },
         "ignored_scope": ["Gather"],
         "ignored_scope_type": "types",
     }
@@ -250,6 +263,7 @@ def test_openvino_weight_compression_hf_to_onnx_multi_ignore_scope(tmp_path):
 )
 def test_openvino_weight_compression_onnx_to_onnx(tmp_path):
     from nncf.parameters import CompressWeightsMode
+    from nncf.quantization.advanced_parameters import GroupSizeFallbackMode
 
     # setup
     input_hf_model = get_hf_model("hf-internal-testing/tiny-random-LlamaForCausalLM")
@@ -267,7 +281,13 @@ def test_openvino_weight_compression_onnx_to_onnx(tmp_path):
 
     openvino_weight_compression_config = {
         "compress_config": {"mode": CompressWeightsMode.INT4_SYM, "ratio": 1.0, "all_layers": True},
-        "extra_args": {"use_onnx": True, "advanced_compression_parameters": {"backend_params": {"external_dir": True}}},
+        "extra_args": {
+            "use_onnx": True,
+            "advanced_compression_parameters": {
+                "backend_params": {"external_dir": True},
+                "group_size_fallback_mode": GroupSizeFallbackMode.IGNORE,
+            },
+        },
         "ignored_scope": ["Gather"],
         "ignored_scope_type": "types",
     }


### PR DESCRIPTION
With newer NNCF, it is necessary to specify group size fallback in advanced compression parameters, which is reflected in a few unit tests that fail due to InvalidGroupSizeError.
Also updated the Intel® NNCF Compression pass in Olive OpenVINO passes to accurately handle advanced parameters in both enum and string forms

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
