### PR TITLE
Quantization: Add AutoClip Pass

### DIFF
--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -28,6 +28,15 @@
             "dataset": "dataset_optional",
             "module_dependencies": [ "autoawq" ]
         },
+        "AutoClip": {
+            "module_path": "olive.passes.pytorch.autoclip.AutoClip",
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [  ],
+            "supported_algorithms": [  ],
+            "supported_quantization_encodings": [  ],
+            "dataset": "dataset_optional"
+        },
         "CaptureSplitInfo": {
             "module_path": "olive.passes.pytorch.capture_split_info.CaptureSplitInfo",
             "supported_providers": [ "*" ],

--- a/olive/passes/pytorch/autoclip.py
+++ b/olive/passes/pytorch/autoclip.py
@@ -1,3 +1,10 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+# Based on original implementation at
+# https://github.com/OpenBitSys/BitDistiller/blob/main/quantization/autoclip.py
+# --------------------------------------------------------------------------
 from __future__ import annotations
 
 import logging

--- a/olive/passes/pytorch/autoclip.py
+++ b/olive/passes/pytorch/autoclip.py
@@ -98,6 +98,8 @@ class AutoClip(Pass):
             include_lm_head=config.lm_head,
         )
 
+        # TODO(jambayk): explore whether we should tie the embedding with lm_head after lm_head is clipped
+
         wrapper.model.save_pretrained(output_model_path)
         model.save_metadata(output_model_path)
 

--- a/olive/passes/pytorch/clip.py
+++ b/olive/passes/pytorch/clip.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import TYPE_CHECKING, Union
+
+import torch
+
+from olive.data.config import DataConfig
+from olive.passes import Pass
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+from olive.passes.pytorch.common import inherit_hf_from_hf
+from olive.passes.pytorch.quant_utils import (
+    get_quantizer_config,
+    prepare_model,
+    run_layerwise_quantization,
+)
+
+if TYPE_CHECKING:
+    from olive.hardware.accelerator import AcceleratorSpec
+    from olive.model import HfModelHandler
+
+
+logger = logging.getLogger(__name__)
+
+
+class AutoClip(Pass):
+    """AutoClip quantization-aware clipping for weights."""
+
+    @classmethod
+    def _default_config(cls, accelerator_spec: AcceleratorSpec) -> dict[str, PassConfigParam]:
+        return {
+            **get_quantizer_config(),
+            "n_grid": PassConfigParam(
+                type_=int,
+                default_value=20,
+                description="Number of grid steps to search for clipping.",
+            ),
+            "max_shrink": PassConfigParam(
+                type_=float,
+                default_value=0.5,
+                description="Maximum shrink ratio for clip bounds.",
+            ),
+            "n_sample_token": PassConfigParam(
+                type_=int,
+                default_value=512,
+                description="Number of token samples for input feature selection.",
+            ),
+            "data_config": PassConfigParam(
+                type_=Union[DataConfig, dict],
+                default_value=None,
+                description=(
+                    "Data config for clipping calibration. If not provided, wikitest train data will be used for"
+                    " HfModels. Required for PyTorch models."
+                ),
+            ),
+        }
+
+    @classmethod
+    def validate_config(
+        cls,
+        config: type[BasePassConfig],
+        accelerator_spec: AcceleratorSpec,
+    ) -> bool:
+        if not super().validate_config(config, accelerator_spec):
+            return False
+
+        if config.group_size <= 0 and config.group_size != -1:
+            logger.info("group_size must be -1 or greater than 0")
+            return False
+
+        bits = config.bits.value if hasattr(config.bits, "value") else config.bits
+        if bits not in [2, 4, 8]:
+            logger.info("bits must be 2, 4, or 8")
+            return False
+
+        return True
+
+    @torch.no_grad()
+    def _run_for_config(
+        self, model: HfModelHandler, config: type[BasePassConfig], output_model_path: str
+    ) -> HfModelHandler:
+        wrapper, _, _ = prepare_model(model, config, exclude_attn_inputs=True)
+
+        process_module = partial(
+            self.process_module,
+            n_grid=config.n_grid,
+            max_shrink=config.max_shrink,
+            n_sample_token=config.n_sample_token,
+        )
+        run_layerwise_quantization(
+            model,
+            wrapper,
+            config.data_config,
+            input_hook=self.accumulate_inputs,
+            process_module=process_module,
+            update_before_process=True,
+            include_lm_head=config.lm_head,
+        )
+
+        wrapper.model.save_pretrained(output_model_path)
+        model.save_metadata(output_model_path)
+
+        return inherit_hf_from_hf(model, output_model_path, adapter_path=model.adapter_path)
+
+    @staticmethod
+    def _get_oc_batch_size(out_features: int) -> int:
+        for candidate in [256, 128, 64, 32, 16]:
+            if out_features % candidate == 0:
+                return candidate
+        return out_features
+
+    @staticmethod
+    def accumulate_inputs(module: torch.nn.Module, inputs: tuple, _: torch.Tensor) -> None:
+        if module.quant_info.data is None:
+            module.quant_info.data = {"inputs": []}
+        module.quant_info.data["inputs"].append(inputs[0].detach().cpu())
+
+    @classmethod
+    def process_module(
+        cls,
+        module: torch.nn.Module,
+        device: str,
+        n_grid: int,
+        max_shrink: float,
+        n_sample_token: int,
+    ) -> None:
+        if module.quant_info.data is None or not module.quant_info.data.get("inputs"):
+            raise ValueError(f"Module {module} does not have cached inputs initialized!")
+
+        input_feat = torch.cat(module.quant_info.data["inputs"], dim=0)
+        module.quant_info.data = None
+
+        module.to(device)
+        weight = module.weight.data
+        quantizer = module.quant_info.quantizer
+        max_val, min_val = cls._auto_clip_layer(
+            weight,
+            input_feat,
+            quantizer,
+            n_grid,
+            max_shrink,
+            n_sample_token,
+        )
+        cls._apply_clip(module, max_val, min_val)
+        module.to("cpu")
+
+    @staticmethod
+    def _apply_clip(module: torch.nn.Module, max_val: torch.Tensor, min_val: torch.Tensor) -> None:
+        weight = module.weight.data
+        original_shape = weight.shape
+        weight = weight.reshape(max_val.shape[0], max_val.shape[1], -1)
+        weight = torch.clamp(weight, min_val, max_val)
+        module.weight.data = weight.reshape(original_shape)
+
+    @classmethod
+    def _auto_clip_layer(
+        cls,
+        weight: torch.Tensor,
+        input_feat: torch.Tensor,
+        quantizer,
+        n_grid: int,
+        max_shrink: float,
+        n_sample_token: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if weight.dim() != 2:
+            raise ValueError("AutoClip expects a 2D linear weight tensor.")
+
+        group_size = getattr(quantizer, "group_size", 0)
+        effective_group_size = weight.shape[1] if group_size <= 0 else group_size
+        if weight.shape[1] % effective_group_size != 0:
+            raise ValueError("Weight in_features must be divisible by group_size.")
+
+        input_feat = input_feat.view(-1, input_feat.shape[-1])
+        if input_feat.shape[0] > n_sample_token:
+            step = max(1, input_feat.shape[0] // n_sample_token)
+            input_feat = input_feat[::step]
+        input_feat = input_feat.reshape(1, input_feat.shape[0], -1, effective_group_size)
+
+        weight = weight.reshape(weight.shape[0], 1, -1, effective_group_size)
+
+        oc_batch_size = cls._get_oc_batch_size(weight.shape[0])
+        best_max_val_all = []
+        best_min_val_all = []
+
+        input_feat = input_feat.to(weight.device)
+        for i_b in range(0, weight.shape[0], oc_batch_size):
+            w_block = weight[i_b : i_b + oc_batch_size]
+
+            org_max_val = w_block.amax(dim=-1, keepdim=True)
+            org_min_val = w_block.amin(dim=-1, keepdim=True)
+
+            best_max_val = org_max_val.clone()
+            best_min_val = org_min_val.clone()
+            min_errs = torch.full_like(org_max_val, 1e9)
+
+            org_out = (input_feat * w_block).sum(dim=-1)
+
+            for i_s_p in range(int(max_shrink * n_grid)):
+                max_val = org_max_val * (1 - i_s_p / n_grid)
+                for i_s_n in range(int(max_shrink * n_grid)):
+                    min_val = org_min_val * (1 - i_s_n / n_grid)
+                    cur_w = torch.clamp(w_block, min_val, max_val)
+                    q_w = quantizer.fake_quantize(cur_w.reshape(cur_w.shape[0], -1)).reshape(cur_w.shape)
+
+                    cur_out = (input_feat * q_w).sum(dim=-1)
+                    err = (cur_out - org_out).pow(2).mean(dim=1).reshape(min_errs.shape)
+
+                    cur_best = err < min_errs
+                    min_errs[cur_best] = err[cur_best]
+                    best_max_val[cur_best] = max_val[cur_best]
+                    best_min_val[cur_best] = min_val[cur_best]
+
+            best_max_val_all.append(best_max_val)
+            best_min_val_all.append(best_min_val)
+
+        best_max_val = torch.cat(best_max_val_all, dim=0).squeeze(1)
+        best_min_val = torch.cat(best_min_val_all, dim=0).squeeze(1)
+        return best_max_val, best_min_val

--- a/olive/passes/pytorch/quant_utils.py
+++ b/olive/passes/pytorch/quant_utils.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import torch
 
@@ -19,10 +19,11 @@ from olive.common.quant.hf_utils import (
 )
 from olive.common.quant.nn import QuantEmbedding, QuantLinear
 from olive.common.quant.utils import WeightQuantizer
+from olive.common.utils import tensor_data_to_device
 from olive.constants import PrecisionBits
 from olive.passes.pass_config import PassConfigParam
 from olive.passes.pytorch.common import inherit_hf_from_hf
-from olive.passes.pytorch.train_utils import load_hf_base_model
+from olive.passes.pytorch.train_utils import get_calibration_dataset, load_hf_base_model
 
 if TYPE_CHECKING:
     from olive.model import HfModelHandler
@@ -78,7 +79,10 @@ def get_quantizer_config(allow_embeds: bool = False) -> dict[str, PassConfigPara
 
 
 def prepare_model(
-    model: HfModelHandler, config: type[BasePassConfig], allow_quantized: bool = False
+    model: HfModelHandler,
+    config: type[BasePassConfig],
+    allow_quantized: bool = False,
+    exclude_attn_inputs: bool = False,
 ) -> tuple[ModelWrapper, OliveHfQuantizationConfig, bool]:
     """Prepare the model for quantization by adding quant_info to linear layers.
 
@@ -86,6 +90,7 @@ def prepare_model(
         model: The HuggingFace model to prepare.
         config: Configuration object containing quantization parameters.
         allow_quantized: Whether to allow already (partially) quantized models.
+        exclude_attn_inputs: Whether to exclude attention input projection layers from quantization.
 
     Returns:
         A tuple containing ModelWrapper with prepared model, the quantization configuration, and a boolean indicating if the word embeddings are eligible for tieing.
@@ -112,7 +117,18 @@ def prepare_model(
     embeds_name = wrapper.get_embeds()[1][0]
     new_qargs: dict[str, dict[str, int | bool]] = {}
 
+    excluded_attn_inputs: set[str] = set()
+    if exclude_attn_inputs:
+        for layer_wrapper in wrapper.get_layer_wrappers():
+            _, attn_input_names = layer_wrapper.get_attention_inputs()
+            if len(attn_input_names) == 1:
+                excluded_attn_inputs.add(attn_input_names[0])
+            else:
+                excluded_attn_inputs.update(attn_input_names[:2])
+
     def should_quantize(module: torch.nn.Module, name: str) -> bool:
+        if name in excluded_attn_inputs:
+            return False
         if isinstance(module, torch.nn.Linear):
             return name != lm_head_name or qcfg.lm_head
         if qcfg.embeds and isinstance(module, torch.nn.Embedding):
@@ -126,12 +142,7 @@ def prepare_model(
         new_qargs[name] = qargs
         return module
 
-    replace_matching_submodules(
-        wrapper.model,
-        should_quantize,
-        add_quant_info,
-        description="Preparing model for quantization",
-    )
+    replace_matching_submodules(wrapper.model, should_quantize, add_quant_info, description="Preparing model")
 
     # remove overrides for modules not being quantized
     for name in list(qcfg.overrides or {}):
@@ -212,6 +223,181 @@ class QuantInfo:
     scales: torch.Tensor | None = None
     zero_points: torch.Tensor | None = None
     data: dict | None = None
+
+
+@torch.no_grad()
+def get_layer_inputs_for_calibration(
+    model: HfModelHandler,
+    wrapper: ModelWrapper,
+    data_config,
+    device: str,
+) -> tuple[list[torch.Tensor], list[tuple], list[dict]]:
+    """Get initial layer inputs for calibration.
+
+    Args:
+        model: The HuggingFace model handler.
+        wrapper: ModelWrapper containing the model.
+        data_config: Data config used to build the calibration dataset.
+        device: Device to run calibration on.
+
+    Returns:
+        Tuple containing hidden states, layer args, and layer kwargs.
+
+    """
+    hidden_states, layer_args, layer_kwargs = [], [], []
+
+    pre_layer_modules = list(wrapper.get_embeds(return_name=False))
+    if rotary_embed := wrapper.get_rotary_embed(return_name=False):
+        pre_layer_modules.append(rotary_embed)
+    for module in pre_layer_modules:
+        module.to(device)
+
+    def store_input_hook(_, args: tuple, kwargs: dict) -> None:
+        if kwargs.get("hidden_states") is not None:
+            args = (kwargs.pop("hidden_states"), *args)
+        hidden_states.append(args[0])
+        layer_args.append(args[1:])
+        layer_kwargs.append(kwargs)
+        raise ValueError
+
+    first_layer = wrapper.get_layers(return_name=False)[0]
+    hook = first_layer.register_forward_pre_hook(store_input_hook, with_kwargs=True)
+
+    for data in get_calibration_dataset(model, data_config):
+        try:
+            wrapper.model(**tensor_data_to_device(data, device))
+        except ValueError:
+            pass
+
+    hook.remove()
+    for module in pre_layer_modules:
+        module.to("cpu")
+
+    return hidden_states, layer_args, layer_kwargs
+
+
+@torch.no_grad()
+def run_layer(
+    layer: torch.nn.Module,
+    hidden_states: list[torch.Tensor],
+    layer_args: list[tuple] | None = None,
+    layer_kwargs: list[dict] | None = None,
+    return_output: bool = False,
+) -> list[torch.Tensor] | None:
+    """Run a layer with the given inputs.
+
+    Args:
+        layer: The model layer to run.
+        hidden_states: List of hidden state tensors.
+        layer_args: List of additional positional arguments for each input.
+        layer_kwargs: List of keyword arguments for each input.
+        return_output: Whether to return the layer outputs.
+
+    Returns:
+        List of output tensors if return_output is True, otherwise None.
+
+    """
+    outputs = []
+    layer.to(hidden_states[0].device)
+
+    for i, hs in enumerate(hidden_states):
+        layer_output = layer(
+            hs,
+            *(layer_args[i] if layer_args else ()),
+            **(layer_kwargs[i] if layer_kwargs else {}),
+        )
+        if return_output:
+            if isinstance(layer_output, tuple):
+                layer_output = layer_output[0]
+            outputs.append(layer_output)
+
+    layer.to("cpu")
+    return outputs or None
+
+
+@torch.no_grad()
+def run_layerwise_quantization(
+    model: HfModelHandler,
+    wrapper: ModelWrapper,
+    data_config,
+    input_hook: Callable[[torch.nn.Module, tuple, torch.Tensor], None],
+    process_module: Callable[[torch.nn.Module, str], None],
+    update_before_process: bool,
+    include_lm_head: bool,
+    device: str | None = None,
+) -> str:
+    """Run a layerwise calibration + processing loop with configurable hook order.
+
+    Args:
+        model: The HuggingFace model handler.
+        wrapper: ModelWrapper containing the model.
+        data_config: Data config used to build the calibration dataset.
+        input_hook: Forward hook to collect calibration data for a module.
+        process_module: Callback to process a single module after hooks are collected.
+        update_before_process: Whether to run the layer forward to get next inputs before processing.
+        include_lm_head: Whether to process the lm_head similarly to other layers.
+        device: Device to run calibration on. If None, uses cuda when available.
+
+    Returns:
+        Device string used for calibration.
+
+    """
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    original_use_cache = getattr(wrapper.model.config, "use_cache", None)
+    if original_use_cache is not None:
+        wrapper.model.config.use_cache = False
+
+    hidden_states, layer_args, layer_kwargs = get_layer_inputs_for_calibration(model, wrapper, data_config, device)
+    if not hidden_states:
+        raise ValueError("Calibration data is empty. Provide a valid data_config.")
+
+    for layer in wrapper.get_layers(return_name=False):
+        quantizable_modules = [module for module in layer.modules() if hasattr(module, "quant_info")]
+        handles = [module.register_forward_hook(input_hook) for module in quantizable_modules]
+
+        if update_before_process:
+            hidden_states = run_layer(
+                layer,
+                hidden_states,
+                layer_args,
+                layer_kwargs,
+                return_output=True,
+            )
+        else:
+            run_layer(layer, hidden_states, layer_args, layer_kwargs)
+
+        for handle in handles:
+            handle.remove()
+
+        for module in quantizable_modules:
+            process_module(module, device)
+
+        if not update_before_process:
+            hidden_states = run_layer(
+                layer,
+                hidden_states,
+                layer_args,
+                layer_kwargs,
+                return_output=True,
+            )
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    if include_lm_head:
+        hidden_states = run_layer(wrapper.get_pre_head_layernorm(return_name=False), hidden_states, return_output=True)
+        lm_head = wrapper.get_lm_head(return_name=False)
+        handle = lm_head.register_forward_hook(input_hook)
+        run_layer(lm_head, hidden_states, return_output=True)
+        handle.remove()
+        process_module(lm_head, device)
+
+    if original_use_cache is not None:
+        wrapper.model.config.use_cache = original_use_cache
+
+    return device
 
 
 def finalize(

--- a/olive/passes/pytorch/train_utils.py
+++ b/olive/passes/pytorch/train_utils.py
@@ -301,6 +301,8 @@ def get_calibration_dataset(
 def get_calibration_data_config(
     model_name_or_path: str,
     trust_remote_code: bool | None = None,
+    data_name: str = "Salesforce/wikitext",
+    subset: str = "wikitext-2-raw-v1",
     split: str = "train[:1000]",
     batch_size: int = 1,
     max_seq_len: int = 2048,
@@ -311,6 +313,8 @@ def get_calibration_data_config(
     Args:
         model_name_or_path: Name or path of the model.
         trust_remote_code: Whether to trust remote code when loading data.
+        data_name: The name of the dataset to use from Hugging Face Datasets. Default is "Salesforce/wikitext".
+        subset: The subset of the dataset to use. Default is "wikitext-2-raw-v1".
         split: The dataset split to use. Default is 'train[:1000]'.
         batch_size: The batch size to use. Default is 1.
         max_seq_len: Maximum sequence length. Default is 2048.
@@ -324,8 +328,8 @@ def get_calibration_data_config(
         model_name=model_name_or_path,
         task="text-generation",
         load_dataset_config={
-            "data_name": "Salesforce/wikitext",
-            "subset": "wikitext-2-raw-v1",
+            "data_name": data_name,
+            "subset": subset,
             "split": split,
             "trust_remote_code": trust_remote_code,
         },

--- a/test/passes/pytorch/test_autoclip.py
+++ b/test/passes/pytorch/test_autoclip.py
@@ -11,7 +11,7 @@ from olive.hardware.accelerator import AcceleratorSpec, Device
 from olive.model import HfModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.pytorch.autoclip import AutoClip
-from test.utils import get_tiny_phi3, make_local_tiny_llama
+from test.utils import get_tiny_phi3, get_wikitext_data_config, make_local_tiny_llama
 
 
 # running on CPU takes time so will only run a subset of tests when GPU is not available
@@ -36,6 +36,9 @@ def test_autoclip(tmp_path: Path, model_path: str, expected_model_type: str, gro
             "lm_head": False,
             "sym": False,
             "overrides": {"model.layers.0.self_attn.o_proj": {"bits": 8}},
+            "data_config": get_wikitext_data_config(
+                input_model.model_name_or_path, strategy="line-by-line", max_seq_len=100, max_samples=2
+            ),
         },
         disable_search=True,
         accelerator_spec=AcceleratorSpec(accelerator_type=Device.GPU, execution_provider="CUDAExecutionProvider"),

--- a/test/passes/pytorch/test_autoclip.py
+++ b/test/passes/pytorch/test_autoclip.py
@@ -23,7 +23,7 @@ from test.utils import get_tiny_phi3, make_local_tiny_llama
     ],
 )
 @pytest.mark.parametrize("group_size", [-1, 16] if torch.cuda.is_available() else [16])
-def test_gptq(tmp_path: Path, model_path: str, expected_model_type: str, group_size: int):
+def test_autoclip(tmp_path: Path, model_path: str, expected_model_type: str, group_size: int):
     # setup
     if model_path == "tiny-llama":
         input_model = make_local_tiny_llama(tmp_path / "input_model")

--- a/test/passes/pytorch/test_autoclip.py
+++ b/test/passes/pytorch/test_autoclip.py
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from pathlib import Path
+
+import pytest
+import torch
+
+from olive.hardware.accelerator import AcceleratorSpec, Device
+from olive.model import HfModelHandler
+from olive.passes.olive_pass import create_pass_from_dict
+from olive.passes.pytorch.autoclip import AutoClip
+from test.utils import get_tiny_phi3, make_local_tiny_llama
+
+
+# running on CPU takes time so will only run a subset of tests when GPU is not available
+@pytest.mark.parametrize(
+    ("model_path", "expected_model_type"),
+    [
+        ("tiny-phi3", "Phi3ForCausalLM"),
+        ("tiny-llama", "LlamaForCausalLM"),
+    ],
+)
+@pytest.mark.parametrize("group_size", [-1, 16] if torch.cuda.is_available() else [16])
+def test_gptq(tmp_path: Path, model_path: str, expected_model_type: str, group_size: int):
+    # setup
+    if model_path == "tiny-llama":
+        input_model = make_local_tiny_llama(tmp_path / "input_model")
+    else:
+        input_model = get_tiny_phi3()
+    p = create_pass_from_dict(
+        AutoClip,
+        {
+            "group_size": group_size,
+            "lm_head": False,
+            "sym": False,
+            "overrides": {"model.layers.0.self_attn.o_proj": {"bits": 8}},
+        },
+        disable_search=True,
+        accelerator_spec=AcceleratorSpec(accelerator_type=Device.GPU, execution_provider="CUDAExecutionProvider"),
+    )
+    gptq_out_folder = str(tmp_path / "gptq")
+
+    # execute
+    out = p.run(input_model, gptq_out_folder)
+
+    # assert
+    assert isinstance(out, HfModelHandler)
+    loaded_model = out.load_model()
+    assert loaded_model.__class__.__name__ == expected_model_type


### PR DESCRIPTION
## Describe your changes
- Add `AutoClip` pass which conducts an automatic search for optimal clipping values for linear layers that will be quantized later.
- Based on [`BitDistiller`](https://arxiv.org/abs/2402.10631) paper.
- Model quality metrics will be provided in a follow up paper which adds the self-distillation part of the paper.
- Gptq pass and quant_utils refactored to share common code. These will also be useful later when adding AWQ pass which is similar to autoclip but does symmetric clipping and also optimizes scales. 

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
