### PR TITLE
Fix legacy ONNX export crash with transformers >= 5.0

### DIFF
--- a/olive/passes/onnx/conversion.py
+++ b/olive/passes/onnx/conversion.py
@@ -189,6 +189,11 @@ def _patch_model_if_necessary(pytorch_model: torch.nn.Module):
     if transformers_version < version.parse("4.45"):
         return
 
+    # from_legacy_cache / to_legacy_cache were removed in transformers 5.0.
+    # This patch is only needed for transformers 4.45 <= version < 5.0.
+    if transformers_version >= version.parse("5.0"):
+        return
+
     orig_forward_name = "forward" if hasattr(pytorch_model, "forward") else "call"
     orig_forward = getattr(pytorch_model, orig_forward_name)
     signature = inspect.signature(orig_forward)
@@ -712,6 +717,26 @@ class OnnxConversion(Pass):
         # load the model
         pytorch_model = model.load_model(cache_model=False)
         pytorch_model.eval()
+
+        # Check transformers >= 5.0 compatibility with legacy ONNX export.
+        # transformers 5.0 removed DynamicCache.from_legacy_cache() and changed the cache API
+        # (e.g., past_key_values must be a Cache object, not a list of tuples), making the
+        # legacy (non-dynamo) ONNX export path incompatible for models with KV cache.
+        if (
+            not config.use_dynamo_exporter
+            and version.parse(transformers.__version__) >= version.parse("5.0")
+            and isinstance(model, HfModelHandler)
+        ):
+            raise RuntimeError(
+                f"Legacy ONNX export (use_dynamo_exporter=False) is not compatible with "
+                f"transformers {transformers.__version__}. transformers >= 5.0 changed the "
+                "DynamicCache API, which breaks the non-dynamo export path for models with "
+                "KV cache. Please use one of the following options:\n"
+                "  1. Add --use_model_builder --use_ort_genai to use the model builder (recommended)\n"
+                "  2. Add --use_dynamo_exporter to use the dynamo-based ONNX export\n"
+                "  3. Downgrade transformers below 5.0\n"
+                "Example: olive auto-opt --model_name_or_path <model> --use_model_builder --use_ort_genai ..."
+            )
 
         # get dummy inputs
         dummy_inputs = _get_dummy_inputs(model, config)


### PR DESCRIPTION
## Summary

Fix `olive auto-opt` crash when using the default (non-dynamo) ONNX export path with `transformers >= 5.0`.

**Root cause:** `transformers 5.0` removed `DynamicCache.from_legacy_cache()` / `.to_legacy_cache()` and changed the cache API so that `past_key_values` must be a `Cache` object (not a list of tuples). The legacy ONNX export path passes list-format `past_key_values` via `merge_kv_cache_to_tuple_hook`, which causes `AttributeError` during model tracing.

**Fix:**
1. Add an early check in `_convert_model_on_device`: when `transformers >= 5.0` and `use_dynamo_exporter=False`, raise a clear `RuntimeError` directing users to `--use_model_builder --use_ort_genai` (recommended) or `--use_dynamo_exporter`.
2. Guard `_patch_model_if_necessary` to skip on `transformers >= 5.0` (the `from_legacy_cache` / `to_legacy_cache` calls are only valid for `4.45 <= transformers < 5.0`).

Fixes #2335

<details>
<summary>Before (cryptic crash)</summary>

```
$ python -m olive auto-opt \
  --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
  --output_path /tmp/test/qwen-cpu-int4 \
  --device cpu --provider CPUExecutionProvider --precision int4 --log_level 1

Loading HuggingFace model from Qwen/Qwen2.5-0.5B-Instruct
[INFO] Running workflow default_workflow
[INFO] Running pass conversion:onnxconversion

...full traceback...

  File ".../transformers/masking_utils.py", line 846, in _preprocess_mask_arguments
    q_offset = past_key_values.get_seq_length()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get_seq_length'
```

</details>

<details>
<summary>After (clear error message)</summary>

```
$ python -m olive auto-opt \
  --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
  --output_path /tmp/test/qwen-cpu-int4 \
  --device cpu --provider CPUExecutionProvider --precision int4 --log_level 1

RuntimeError: Legacy ONNX export (use_dynamo_exporter=False) is not compatible with
transformers 5.5.0. transformers >= 5.0 changed the DynamicCache API, which breaks
the non-dynamo export path for models with KV cache. Please use one of the following options:
  1. Add --use_model_builder --use_ort_genai to use the model builder (recommended)
  2. Add --use_dynamo_exporter to use the dynamo-based ONNX export
  3. Downgrade transformers below 5.0
Example: olive auto-opt --model_name_or_path <model> --use_model_builder --use_ort_genai ...
```

</details>

<details>
<summary>After (with recommended --use_model_builder flag, succeeds)</summary>

```
$ python -m olive auto-opt \
  --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
  --output_path /tmp/test/qwen-cpu-int4 \
  --device cpu --provider CPUExecutionProvider \
  --use_model_builder --use_ort_genai --precision int4 --log_level 1

Loading HuggingFace model from Qwen/Qwen2.5-0.5B-Instruct
[INFO] Running workflow default_workflow
[INFO] Running pass model_builder:modelbuilder
Saving processing files in .olive-cache/.../models for GenAI
[INFO] Pass model_builder:modelbuilder finished in 32.39 seconds
[INFO] Pass extract_adapters:extractadapters finished in 0.04 seconds
[INFO] Saved output model to /tmp/test/qwen-cpu-int4
Model is saved at /tmp/test/qwen-cpu-int4
```

</details>

## Test plan
- [x] Reproduce original crash with `transformers 5.5.0` + `torch 2.11.0`
- [x] Verify clear error message is shown on legacy export path
- [x] Verify `--use_model_builder --use_ort_genai` workaround succeeds
- [ ] Existing unit tests pass