### PR TITLE
Add ORTGenAI backend option to benchmark CLI

### DIFF
--- a/olive/cli/benchmark.py
+++ b/olive/cli/benchmark.py
@@ -2,8 +2,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # -----------------------------------------------------------------------------
+import json
 from argparse import ArgumentParser
 from copy import deepcopy
+from pathlib import Path
 
 from olive.cli.base import (
     BaseOliveCLICommand,
@@ -17,6 +19,39 @@ from olive.cli.base import (
 )
 from olive.common.utils import set_nested_dict_value
 from olive.telemetry import action
+
+
+def _is_local_onnx_model(model_name_or_path) -> bool:
+    """Return True if model_name_or_path clearly points to a local ONNX model.
+
+    Resolves without any network calls. Covers:
+    - a local .onnx file
+    - a local directory containing one or more .onnx files
+    - a previous-command output directory whose model_config.json type is OnnxModel
+    """
+    if not model_name_or_path:
+        return False
+
+    model_path = Path(model_name_or_path)
+    if not model_path.exists():
+        return False
+
+    if model_path.is_file():
+        return model_path.suffix == ".onnx"
+
+    if not model_path.is_dir():
+        return False
+
+    model_config_path = model_path / "model_config.json"
+    if model_config_path.exists():
+        try:
+            with open(model_config_path) as f:
+                model_config = json.load(f)
+            return model_config.get("type", "").lower() == "onnxmodel"
+        except (OSError, ValueError):
+            return False
+
+    return any(model_path.glob("*.onnx"))
 
 
 class BenchmarkCommand(BaseOliveCLICommand):
@@ -88,6 +123,12 @@ class BenchmarkCommand(BaseOliveCLICommand):
 
     def _get_run_config(self, tempdir: str) -> dict:
         config = deepcopy(TEMPLATE)
+
+        # Short-circuit: validate --backend against local inputs before
+        # get_input_model_config, which may trigger a network call
+        # (hf_repo_exists) for unknown model ids.
+        if self.args.backend != "auto" and not _is_local_onnx_model(self.args.model_name_or_path):
+            raise ValueError("--backend is only supported for ONNX input models.")
 
         input_model_config = get_input_model_config(self.args)
         assert input_model_config["type"].lower() in {

--- a/olive/cli/benchmark.py
+++ b/olive/cli/benchmark.py
@@ -68,6 +68,14 @@ class BenchmarkCommand(BaseOliveCLICommand):
             help="Number (or percentage of dataset) of samples to use for evaluation.",
         )
 
+        lmeval_group.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "ort", "ortgenai"],
+            help="Backend for ONNX model evaluation. Use 'auto' to infer backend from model type.",
+        )
+
         add_logging_options(sub_parser)
         add_save_config_file_options(sub_parser)
         add_shared_cache_options(sub_parser)
@@ -88,6 +96,9 @@ class BenchmarkCommand(BaseOliveCLICommand):
             "onnxmodel",
         }, "Only HfModel, PyTorchModel and OnnxModel are supported in benchmark command."
 
+        if self.args.backend != "auto" and input_model_config["type"].lower() != "onnxmodel":
+            raise ValueError("--backend is only supported for ONNX input models.")
+
         to_replace = [
             ("input_model", input_model_config),
             ("output_dir", self.args.output_path),
@@ -103,6 +114,10 @@ class BenchmarkCommand(BaseOliveCLICommand):
             (("evaluators", "evaluator", "max_length"), self.args.max_length),
             (("evaluators", "evaluator", "device"), self.args.device),
             (("evaluators", "evaluator", "limit"), self.args.limit),
+            (
+                ("evaluators", "evaluator", "model_class"),
+                None if self.args.backend == "auto" else self.args.backend,
+            ),
         ]
 
         for keys, value in to_replace:

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -677,7 +677,7 @@ def test_benchmark_command_onnxmodel_with_ortgenai_backend(mock_run, tmp_path):
     assert mock_run.call_count == 1
 
 
-@patch("huggingface_hub.repo_exists", return_value=True)
+@patch("huggingface_hub.repo_exists", side_effect=AssertionError("should not hit HF hub"))
 def test_benchmark_command_non_onnx_model_with_backend_option_raises(_, tmp_path):
     output_dir = tmp_path / "output_dir"
     command_args = [

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -678,11 +678,14 @@ def test_benchmark_command_onnxmodel_with_ortgenai_backend(mock_run, tmp_path):
 
 
 @patch("huggingface_hub.repo_exists", return_value=True)
-def test_benchmark_command_non_onnx_model_with_backend_option_raises(_):
+def test_benchmark_command_non_onnx_model_with_backend_option_raises(_, tmp_path):
+    output_dir = tmp_path / "output_dir"
     command_args = [
         "benchmark",
         "-m",
         "dummy-model-id",
+        "--output_path",
+        str(output_dir),
         "--tasks",
         "arc_easy",
         "--backend",

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -651,3 +651,43 @@ def test_benchmark_command_onnxmodel(mock_run, tmp_path):
     assert config["evaluators"]["evaluator"]["max_length"] == 1024
     assert config["evaluators"]["evaluator"]["limit"] == 16
     assert mock_run.call_count == 1
+
+
+@patch("olive.workflows.run")
+def test_benchmark_command_onnxmodel_with_ortgenai_backend(mock_run, tmp_path):
+    from test.utils import ONNX_MODEL_PATH
+
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        str(ONNX_MODEL_PATH),
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "ortgenai",
+    ]
+
+    cli_main(command_args)
+
+    config = mock_run.call_args[0][0]
+    assert config["evaluators"]["evaluator"]["model_class"] == "ortgenai"
+    assert mock_run.call_count == 1
+
+
+@patch("huggingface_hub.repo_exists", return_value=True)
+def test_benchmark_command_non_onnx_model_with_backend_option_raises(_):
+    command_args = [
+        "benchmark",
+        "-m",
+        "dummy-model-id",
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "ortgenai",
+    ]
+
+    with pytest.raises(ValueError, match="--backend is only supported for ONNX input models"):
+        cli_main(command_args)


### PR DESCRIPTION
## Context
The benchmark command currently defaults to the ONNX Runtime lm-eval model path. Olive already has ORTGenAI lm-eval support in the evaluator layer, but benchmark CLI had no way to select it.

This PR exposes that capability through benchmark CLI while preserving existing defaults.

## What This Changes
- Adds a new benchmark CLI argument: `--backend` with choices:
  - `auto` (default)
  - `ort`
  - `ortgenai`
- Wires explicit backend selection into generated workflow config by setting evaluator `model_class` when backend is not `auto`.
- Keeps current behavior unchanged when `--backend auto` is used (or omitted).
- Adds validation: explicit `--backend` is only accepted for ONNX input models.

## Why This Approach
- Non-breaking by default: existing benchmark flows continue to infer model class automatically.
- Minimal change surface: only benchmark CLI config generation and tests are touched.
- Leverages existing evaluator support rather than introducing new runtime logic.

## User-Facing Behavior
Examples:
- Existing behavior (unchanged):
  - `olive benchmark -m <model> --tasks arc_easy`
- Explicit ORT:
  - `olive benchmark -m <onnx_model> --tasks arc_easy --backend ort`
- Explicit ORTGenAI:
  - `olive benchmark -m <onnx_model> --tasks arc_easy --backend ortgenai`

If `--backend` is provided for non-ONNX inputs, benchmark now raises a clear error.

## Tests Added/Updated
- Verifies ONNX benchmark accepts `--backend ortgenai` and writes evaluator `model_class=ortgenai`.
- Verifies non-ONNX model with explicit backend raises expected `ValueError`.
- Existing benchmark tests continue to pass.

## Validation
- `pip install -e .`
- `python -m olive --help`
- `python -m olive benchmark --help`
- `python -m pytest test/cli/test_cli.py -k benchmark_command -q`