### PR TITLE
Add MTEBEvaluator for embedding model evaluation

### DIFF
--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -8,6 +8,7 @@ Mirrors the pattern in ``lmeval_ort.py``: thin adapters that bridge an
 exported ONNX (or ORT-GenAI) model into the interface expected by the
 evaluation library — in this case MTEB's ``EncoderProtocol``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -54,6 +55,10 @@ class MTEBOnnxBase(ABC):
 
     def encode(self, inputs, *, task_metadata=None, hf_split=None, hf_subset=None, prompt_type=None, **kwargs):
         """Encode sentences into embeddings — MTEB ``EncoderProtocol.encode``."""
+        # Handle string input (single sentence)
+        if isinstance(inputs, str):
+            inputs = [inputs]
+
         # Flatten DataLoader batches into a plain list of strings
         sentences: list[str] = []
         for batch in inputs:
@@ -118,6 +123,7 @@ class MTEBOnnxBase(ABC):
 
         Returns:
             Embeddings array of shape ``[batch, embed_dim]``.
+
         """
         raise NotImplementedError
 
@@ -158,10 +164,8 @@ class MTEBORTEvaluator(MTEBOnnxBase):
 
         feeds = {"input_ids": input_ids.astype(np.int64), "attention_mask": attention_mask.astype(np.int64)}
         # Some models also accept token_type_ids
-        if "token_type_ids" in [inp for inp in self.io_config["input_names"]]:
-            feeds["token_type_ids"] = encoded_input.get(
-                "token_type_ids", np.zeros_like(input_ids, dtype=np.int64)
-            )
+        if "token_type_ids" in list(self.io_config["input_names"]):
+            feeds["token_type_ids"] = encoded_input.get("token_type_ids", np.zeros_like(input_ids, dtype=np.int64))
 
         outputs = self.session.run(None, feeds)
 
@@ -244,16 +248,11 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
                 embed_dim = hidden_states.shape[-1]
                 hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
             return self._mean_pool(hidden_states, attention_mask)
-        except Exception:
-            logger.debug("hidden_states output not available, trying logits-based approach")
-
-        # Fallback: get logits and use them as-is (not ideal for embeddings)
-        logits = generator.get_output("logits")
-        logits = np.array(logits, copy=False)
-        if logits.ndim == 2:
-            embed_dim = logits.shape[-1]
-            logits = logits.reshape(batch_size, -1, embed_dim)
-        return self._mean_pool(logits, attention_mask)
+        except Exception as e:
+            raise RuntimeError(
+                "hidden_states output not available from GenAI model. "
+                "Ensure the model was built with include_hidden_states=1 in ModelBuilder."
+            ) from e
 
     @staticmethod
     def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -1,0 +1,264 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""MTEB-compatible wrappers for ONNX Runtime embedding models.
+
+Mirrors the pattern in ``lmeval_ort.py``: thin adapters that bridge an
+exported ONNX (or ORT-GenAI) model into the interface expected by the
+evaluation library — in this case MTEB's ``EncoderProtocol``.
+"""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+
+from olive.common.onnx_io import get_io_config
+
+try:
+    import onnxruntime_genai as og
+except ImportError:
+    og = None
+
+logger = logging.getLogger(__name__)
+
+
+class MTEBOnnxBase(ABC):
+    """Base class for MTEB-compatible ONNX embedding model wrappers.
+
+    Subclasses must implement :meth:`_encode_batch` which takes tokenised
+    inputs and returns a numpy embedding matrix.
+    """
+
+    def __init__(self, tokenizer_path: str, batch_size: int = 32, max_length: int | None = None):
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+        self.batch_size = batch_size
+        self._max_length = max_length
+
+    @property
+    def max_length(self) -> int:
+        if self._max_length:
+            return self._max_length
+        if hasattr(self.tokenizer, "model_max_length") and self.tokenizer.model_max_length < 1_000_000:
+            return self.tokenizer.model_max_length
+        return 512
+
+    # ------------------------------------------------------------------
+    # MTEB EncoderProtocol interface
+    # ------------------------------------------------------------------
+
+    def encode(self, inputs, *, task_metadata=None, hf_split=None, hf_subset=None, prompt_type=None, **kwargs):
+        """Encode sentences into embeddings — MTEB ``EncoderProtocol.encode``."""
+        # Flatten DataLoader batches into a plain list of strings
+        sentences: list[str] = []
+        for batch in inputs:
+            if isinstance(batch, dict) and "text" in batch:
+                sentences.extend(batch["text"])
+            elif isinstance(batch, (list, tuple)):
+                sentences.extend(batch)
+            elif isinstance(batch, str):
+                sentences.append(batch)
+            else:
+                sentences.extend(list(batch))
+
+        all_embeddings: list[np.ndarray] = []
+        for start in range(0, len(sentences), self.batch_size):
+            batch_sentences = sentences[start : start + self.batch_size]
+            encoded = self.tokenizer(
+                batch_sentences,
+                padding=True,
+                truncation=True,
+                max_length=self.max_length,
+                return_tensors="np",
+            )
+            embeddings = self._encode_batch(encoded)
+            all_embeddings.append(embeddings)
+
+        return np.concatenate(all_embeddings, axis=0)
+
+    @staticmethod
+    def similarity(embeddings1, embeddings2):
+        """Cosine similarity — default for MTEB."""
+        if isinstance(embeddings1, np.ndarray):
+            embeddings1 = torch.from_numpy(embeddings1)
+        if isinstance(embeddings2, np.ndarray):
+            embeddings2 = torch.from_numpy(embeddings2)
+        embeddings1 = torch.nn.functional.normalize(embeddings1.float(), p=2, dim=-1)
+        embeddings2 = torch.nn.functional.normalize(embeddings2.float(), p=2, dim=-1)
+        return embeddings1 @ embeddings2.T
+
+    @staticmethod
+    def similarity_pairwise(embeddings1, embeddings2):
+        if isinstance(embeddings1, np.ndarray):
+            embeddings1 = torch.from_numpy(embeddings1)
+        if isinstance(embeddings2, np.ndarray):
+            embeddings2 = torch.from_numpy(embeddings2)
+        embeddings1 = torch.nn.functional.normalize(embeddings1.float(), p=2, dim=-1)
+        embeddings2 = torch.nn.functional.normalize(embeddings2.float(), p=2, dim=-1)
+        return (embeddings1 * embeddings2).sum(dim=-1)
+
+    @property
+    def mteb_model_meta(self):
+        from mteb.models.model_meta import ModelMeta
+
+        return ModelMeta.create_empty()
+
+    @abstractmethod
+    def _encode_batch(self, encoded_input: dict) -> np.ndarray:
+        """Run model inference on a tokenised batch and return embeddings.
+
+        Args:
+            encoded_input: Dictionary with at least ``input_ids`` and
+                ``attention_mask`` as numpy arrays of shape ``[batch, seqlen]``.
+
+        Returns:
+            Embeddings array of shape ``[batch, embed_dim]``.
+        """
+        raise NotImplementedError
+
+
+# ------------------------------------------------------------------
+# ORT (plain ONNX) variant
+# ------------------------------------------------------------------
+
+
+class MTEBORTEvaluator(MTEBOnnxBase):
+    """MTEB wrapper for a plain ONNX embedding model run via ORT."""
+
+    def __init__(
+        self,
+        model_path: str,
+        batch_size: int = 32,
+        max_length: int | None = None,
+        ep: str | None = None,
+        ep_options: dict | None = None,
+    ):
+        import onnxruntime as ort
+
+        model_dir = str(Path(model_path).parent)
+        super().__init__(tokenizer_path=model_dir, batch_size=batch_size, max_length=max_length)
+
+        providers = []
+        if ep:
+            providers.append((ep, ep_options or {}))
+        providers.append(("CPUExecutionProvider", {}))
+
+        self.session = ort.InferenceSession(model_path, providers=providers)
+        self.io_config = get_io_config(model_path)
+        self._output_names = self.io_config["output_names"]
+
+    def _encode_batch(self, encoded_input: dict) -> np.ndarray:
+        input_ids = encoded_input["input_ids"]
+        attention_mask = encoded_input["attention_mask"]
+
+        feeds = {"input_ids": input_ids.astype(np.int64), "attention_mask": attention_mask.astype(np.int64)}
+        # Some models also accept token_type_ids
+        if "token_type_ids" in [inp for inp in self.io_config["input_names"]]:
+            feeds["token_type_ids"] = encoded_input.get(
+                "token_type_ids", np.zeros_like(input_ids, dtype=np.int64)
+            )
+
+        outputs = self.session.run(None, feeds)
+
+        # Determine which output contains the embeddings.
+        # Common patterns: "last_hidden_state" (index 0) or a dedicated "sentence_embedding" output.
+        if len(outputs) == 1:
+            hidden_states = outputs[0]
+        else:
+            # Try to find a sentence-level output first
+            for i, name in enumerate(self._output_names):
+                if "sentence" in name.lower() or "pooler" in name.lower() or "embedding" in name.lower():
+                    return outputs[i]  # Already pooled
+            # Fall back to the first output (last_hidden_state)
+            hidden_states = outputs[0]
+
+        # Mean pooling over the sequence dimension, masked by attention_mask
+        return self._mean_pool(hidden_states, attention_mask)
+
+    @staticmethod
+    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Mean pooling: average token embeddings weighted by attention mask."""
+        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
+        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
+        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
+        return sum_embeddings / sum_mask
+
+
+# ------------------------------------------------------------------
+# ORT-GenAI variant  (for models built with ModelBuilder)
+# ------------------------------------------------------------------
+
+
+class MTEBORTGenAIEvaluator(MTEBOnnxBase):
+    """MTEB wrapper for an ORT-GenAI embedding model (ModelBuilder output)."""
+
+    def __init__(
+        self,
+        pretrained: str,
+        batch_size: int = 32,
+        max_length: int | None = None,
+        ep: str = "follow_config",
+        ep_options: dict | None = None,
+    ):
+        if og is None:
+            raise ImportError("onnxruntime-genai is not installed.")
+
+        super().__init__(tokenizer_path=pretrained, batch_size=batch_size, max_length=max_length)
+
+        self.config = og.Config(pretrained)
+        if ep != "follow_config":
+            ep_clean = ep.lower().replace("executionprovider", "")
+            self.config.clear_providers()
+            if ep_clean != "cpu":
+                self.config.append_provider(ep_clean)
+            for key, value in (ep_options or {}).items():
+                self.config.set_provider_option(ep_clean, key, value)
+
+        self.model = og.Model(self.config)
+        self.og_tokenizer = og.Tokenizer(self.model)
+        self.pretrained = pretrained
+
+    def _encode_batch(self, encoded_input: dict) -> np.ndarray:
+        input_ids = encoded_input["input_ids"].astype(np.int64)
+        attention_mask = encoded_input["attention_mask"].astype(np.int64)
+
+        # Use the GeneratorParams / Generator API to get hidden states
+        batch_size, seq_len = input_ids.shape
+        params = og.GeneratorParams(self.model)
+        params.set_search_options(max_length=seq_len + 1, past_present_share_buffer=False, batch_size=batch_size)
+
+        generator = og.Generator(self.model, params)
+        generator.append_tokens(input_ids.tolist())
+
+        # Try to get hidden_states output (enabled via include_hidden_states=1)
+        try:
+            hidden_states = generator.get_output("hidden_states")
+            hidden_states = np.array(hidden_states, copy=False)
+            if hidden_states.ndim == 2:
+                # Shape might be [batch*seq, dim] — reshape
+                embed_dim = hidden_states.shape[-1]
+                hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
+            return self._mean_pool(hidden_states, attention_mask)
+        except Exception:
+            logger.debug("hidden_states output not available, trying logits-based approach")
+
+        # Fallback: get logits and use them as-is (not ideal for embeddings)
+        logits = generator.get_output("logits")
+        logits = np.array(logits, copy=False)
+        if logits.ndim == 2:
+            embed_dim = logits.shape[-1]
+            logits = logits.reshape(batch_size, -1, embed_dim)
+        return self._mean_pool(logits, attention_mask)
+
+    @staticmethod
+    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Mean pooling: average token embeddings weighted by attention mask."""
+        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
+        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
+        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
+        return sum_embeddings / sum_mask

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1180,7 +1180,11 @@ class MTEBEvaluator(OliveEvaluator):
                 genai_config = Path(model.model_path).parent / "genai_config.json"
                 model_class = "ortgenai" if genai_config.exists() else "ort"
             else:
-                model_class = "ortgenai"
+                raise ValueError(
+                    "Unable to auto-detect model_class for MTEBEvaluator from model handler "
+                    f"{type(model).__name__}. Please set model_class explicitly to one of "
+                    "'hf', 'ort', or 'ortgenai'."
+                )
 
         logger.info(
             "Running MTEB evaluation with model_class=%s, tasks=%s", model_class, self.tasks
@@ -1190,7 +1194,8 @@ class MTEBEvaluator(OliveEvaluator):
         if model_class == "hf":
             from sentence_transformers import SentenceTransformer
 
-            mteb_model = SentenceTransformer(model.model_name_or_path)
+            sentence_transformer_device = device.value if isinstance(device, Device) else str(device)
+            mteb_model = SentenceTransformer(model.model_name_or_path, device=sentence_transformer_device)
         elif model_class == "ort":
             mteb_model = MTEBORTEvaluator(
                 model_path=model.model_path,

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1168,7 +1168,6 @@ class MTEBEvaluator(OliveEvaluator):
     ) -> MetricResult:
         import mteb
 
-        import olive.evaluator.mteb_ort  # noqa: F401 # pylint: disable=unused-import
         from olive.evaluator.mteb_ort import MTEBORTEvaluator, MTEBORTGenAIEvaluator
 
         # Auto-detect model class from the model handler

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1186,9 +1186,7 @@ class MTEBEvaluator(OliveEvaluator):
                     "'hf', 'ort', or 'ortgenai'."
                 )
 
-        logger.info(
-            "Running MTEB evaluation with model_class=%s, tasks=%s", model_class, self.tasks
-        )
+        logger.info("Running MTEB evaluation with model_class=%s, tasks=%s", model_class, self.tasks)
 
         # Build the MTEB-compatible model wrapper
         if model_class == "hf":
@@ -1201,7 +1199,8 @@ class MTEBEvaluator(OliveEvaluator):
                 model_path=model.model_path,
                 batch_size=self.batch_size,
                 max_length=self.max_length,
-                ep=self.ep or (execution_providers[0] if isinstance(execution_providers, list) else execution_providers),
+                ep=self.ep
+                or (execution_providers[0] if isinstance(execution_providers, list) else execution_providers),
                 ep_options=self.ep_options,
             )
         elif model_class == "ortgenai":
@@ -1209,7 +1208,8 @@ class MTEBEvaluator(OliveEvaluator):
                 pretrained=str(Path(model.model_path).parent),
                 batch_size=self.batch_size,
                 max_length=self.max_length,
-                ep=self.ep or (execution_providers[0] if isinstance(execution_providers, list) else execution_providers)
+                ep=self.ep
+                or (execution_providers[0] if isinstance(execution_providers, list) else execution_providers)
                 or "follow_config",
                 ep_options=self.ep_options,
             )
@@ -1239,9 +1239,7 @@ class MTEBEvaluator(OliveEvaluator):
         for task_result in task_results:
             task_name = task_result.task_name
             task_metrics = {
-                "main_score": SubMetricResult(
-                    value=task_result.main_score, priority=-1, higher_is_better=True
-                ),
+                "main_score": SubMetricResult(value=task_result.main_score, priority=-1, higher_is_better=True),
             }
             for split_name, split_scores in task_result.scores.items():
                 for lang_score in split_scores:

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1125,6 +1125,134 @@ class LMEvaluator(OliveEvaluator):
         return flatten_metric_result(metrics)
 
 
+@Registry.register("MTEBEvaluator")
+class MTEBEvaluator(OliveEvaluator):
+    """Evaluator for embedding models using the MTEB (Massive Text Embedding Benchmark) library.
+
+    Supports three model classes, mirroring :class:`LMEvaluator`:
+
+    - ``"hf"`` — evaluates a HuggingFace model via sentence-transformers
+    - ``"ort"`` — evaluates a plain ONNX model via ORT inference session
+    - ``"ortgenai"`` — evaluates an ORT-GenAI model (ModelBuilder output)
+
+    Example recipe config::
+
+        "evaluators": {
+            "evaluator": {
+                "type": "MTEBEvaluator",
+                "tasks": ["STS17"],
+                "batch_size": 32
+            }
+        },
+        "evaluator": "evaluator"
+    """
+
+    def __init__(self, tasks: list[str], **kwargs):
+        super().__init__(**kwargs)
+        self.tasks = tasks
+        self.batch_size = kwargs.get("batch_size", 32)
+        self.max_length = kwargs.get("max_length")
+        self.model_class = kwargs.get("model_class")
+        self.ep = kwargs.get("execution_provider")
+        self.ep_options = kwargs.get("provider_options")
+        self.eval_splits = kwargs.get("eval_splits")
+        self.eval_subsets = kwargs.get("eval_subsets")
+        self.output_folder = kwargs.get("output_folder")
+
+    def evaluate(
+        self,
+        model: "OliveModelHandler",
+        metrics: list[Metric],
+        device: Device = Device.CPU,
+        execution_providers: Optional[Union[str, list[str]]] = None,
+    ) -> MetricResult:
+        import mteb
+
+        import olive.evaluator.mteb_ort  # noqa: F401 # pylint: disable=unused-import
+        from olive.evaluator.mteb_ort import MTEBORTEvaluator, MTEBORTGenAIEvaluator
+
+        # Auto-detect model class from the model handler
+        model_class = self.model_class
+        if not model_class:
+            if isinstance(model, HfModelHandler):
+                model_class = "hf"
+            elif isinstance(model, ONNXModelHandler):
+                # ModelBuilder outputs ONNXModelHandler but with genai_config.json
+                genai_config = Path(model.model_path).parent / "genai_config.json"
+                model_class = "ortgenai" if genai_config.exists() else "ort"
+            else:
+                model_class = "ortgenai"
+
+        logger.info(
+            "Running MTEB evaluation with model_class=%s, tasks=%s", model_class, self.tasks
+        )
+
+        # Build the MTEB-compatible model wrapper
+        if model_class == "hf":
+            from sentence_transformers import SentenceTransformer
+
+            mteb_model = SentenceTransformer(model.model_name_or_path)
+        elif model_class == "ort":
+            mteb_model = MTEBORTEvaluator(
+                model_path=model.model_path,
+                batch_size=self.batch_size,
+                max_length=self.max_length,
+                ep=self.ep or (execution_providers[0] if isinstance(execution_providers, list) else execution_providers),
+                ep_options=self.ep_options,
+            )
+        elif model_class == "ortgenai":
+            mteb_model = MTEBORTGenAIEvaluator(
+                pretrained=str(Path(model.model_path).parent),
+                batch_size=self.batch_size,
+                max_length=self.max_length,
+                ep=self.ep or (execution_providers[0] if isinstance(execution_providers, list) else execution_providers)
+                or "follow_config",
+                ep_options=self.ep_options,
+            )
+        else:
+            raise ValueError(f"Unknown model class for MTEBEvaluator: {model_class}")
+
+        # Run MTEB evaluation
+        mteb_tasks = mteb.get_tasks(tasks=self.tasks)
+        evaluation = mteb.MTEB(tasks=mteb_tasks)
+
+        run_kwargs = {}
+        if self.eval_splits:
+            run_kwargs["eval_splits"] = self.eval_splits
+        if self.eval_subsets:
+            run_kwargs["eval_subsets"] = self.eval_subsets
+
+        task_results = evaluation.run(
+            mteb_model,
+            output_folder=self.output_folder,
+            overwrite_results=True,
+            verbosity=0,
+            **run_kwargs,
+        )
+
+        # Convert MTEB results into Olive MetricResult
+        metrics_dict = {}
+        for task_result in task_results:
+            task_name = task_result.task_name
+            task_metrics = {
+                "main_score": SubMetricResult(
+                    value=task_result.main_score, priority=-1, higher_is_better=True
+                ),
+            }
+            for split_name, split_scores in task_result.scores.items():
+                for lang_score in split_scores:
+                    subset = lang_score.get("hf_subset", "")
+                    score_key = f"{split_name}_{subset}" if subset else split_name
+                    task_metrics[score_key] = SubMetricResult(
+                        value=lang_score.get("main_score", 0.0),
+                        priority=-1,
+                        higher_is_better=True,
+                    )
+            metrics_dict[task_name] = MetricResult.model_validate(task_metrics)
+
+        return flatten_metric_result(metrics_dict)
+
+
 class OliveEvaluatorConfig(NestedConfig):
     _nested_field_name: ClassVar[str] = "type_args"
 


### PR DESCRIPTION
## Summary

Add a built-in MTEB (Massive Text Embedding Benchmark) evaluator to Olive, following the same architecture as `LMEvaluator`/`lmeval_ort.py`.

## Changes

### `olive/evaluator/olive_evaluator.py`
- New `MTEBEvaluator` class registered in the evaluator registry
- Supports three model classes: `hf` (SentenceTransformer), `ort` (ONNX via ORT), `ortgenai` (GenAI with hidden_states)
- Auto-detects model class from handler type, including GenAI detection via `genai_config.json`

### `olive/evaluator/mteb_ort.py` (new)
- `MTEBOnnxBase`: abstract base implementing MTEB's EncoderProtocol with mean pooling
- `MTEBORTEvaluator`: wraps plain ONNX models via `ort.InferenceSession`
- `MTEBORTGenAIEvaluator`: wraps GenAI models using `og.Generator` + `hidden_states` output

## Usage

```json
"evaluators": {
    "mteb": {
        "type": "MTEBEvaluator",
        "tasks": ["STS17"],
        "batch_size": 32
    }
},
"evaluator": "mteb"
```

## Testing

Tested end-to-end with Qwen3-Embedding-0.6B CPU recipe — ModelBuilder export + MTEB STS17 evaluation on both input HF model and exported GenAI model.