### PR TITLE
Don't trust remote code explicitly

### DIFF
--- a/olive/cli/extract_adapters.py
+++ b/olive/cli/extract_adapters.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser
 
 from huggingface_hub.constants import HF_HUB_CACHE
 
-from olive.cli.base import BaseOliveCLICommand, add_logging_options, add_telemetry_options
+from olive.cli.base import BaseOliveCLICommand, add_input_model_options, add_logging_options, add_telemetry_options
 from olive.common.utils import WeightsFileFormat, get_attr, save_weights
 from olive.telemetry import action
 
@@ -16,14 +16,14 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
     def register_subcommand(parser: ArgumentParser):
         sub_parser = parser.add_parser(
             "extract-adapters",
-            help="Extract LoRAs from PyTorch model to separate files",
+            help="Extract LoRAs from PyTorch/HfModel model to separate files",
         )
-        sub_parser.add_argument(
-            "-m",
-            "--model_name_or_path",
-            type=str,
-            required=True,
-            help="Path to the PyTorch model. Can be a local folder or Hugging Face id.",
+        # model options
+        add_input_model_options(
+            sub_parser,
+            enable_hf=True,
+            enable_pt=True,
+            default_output_path="adapters",
         )
         sub_parser.add_argument(
             "-f",
@@ -32,14 +32,6 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
             choices=[el.value for el in WeightsFileFormat],
             required=True,
             help="Format to save the LoRAs in.",
-        )
-        sub_parser.add_argument(
-            "-o",
-            "--output",
-            type=str,
-            required=True,
-            default="adapters",
-            help="Output folder to save the LoRAs in the requested format.",
         )
         sub_parser.add_argument(
             "--dtype",
@@ -86,7 +78,7 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
 
         # Load LoRA config and LoRA model
         config = AutoConfig.from_pretrained(
-            self.args.model_name_or_path, cache_dir=self.args.cache_dir, trust_remote_code=True
+            self.args.model_name_or_path, cache_dir=self.args.cache_dir, trust_remote_code=self.args.trust_remote_code
         )
         if is_peft:
             # Peft model
@@ -95,7 +87,7 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
                 os.path.join(self.args.model_name_or_path, first_adapter_name),
                 adapter_name=first_adapter_name,
                 cache_dir=self.args.cache_dir,
-                trust_remote_code=True,
+                trust_remote_code=self.args.trust_remote_code,
             )
             for adapter_path in adapter_paths[1:]:
                 adapter_name = Path(adapter_path).name
@@ -103,7 +95,9 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
         else:
             # Transformers model
             peft_model = AutoModelForCausalLM.from_pretrained(
-                self.args.model_name_or_path, cache_dir=self.args.cache_dir, trust_remote_code=True
+                self.args.model_name_or_path,
+                cache_dir=self.args.cache_dir,
+                trust_remote_code=self.args.trust_remote_code,
             )
 
         head_size = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
@@ -168,5 +162,5 @@ class ExtractAdaptersCommand(BaseOliveCLICommand):
 
         # Save each LoRA set to disk
         for adapter_name, adapter_set in adapter_sets.items():
-            output_path = save_weights(adapter_set, os.path.join(self.args.output, adapter_name), self.args.format)
+            output_path = save_weights(adapter_set, os.path.join(self.args.output_path, adapter_name), self.args.format)
             print(f"Exported {adapter_name} adapter weights to {output_path}")

--- a/olive/data/component/sd_lora/auto_caption.py
+++ b/olive/data/component/sd_lora/auto_caption.py
@@ -77,6 +77,7 @@ def auto_caption(
     device: str = "cuda",
     overwrite: bool = False,
     trigger_word: Optional[str] = None,
+    trust_remote_code: Optional[bool] = False,
     **kwargs,
 ):
     """Auto-generate captions for images using vision-language models.
@@ -123,6 +124,7 @@ def auto_caption(
             device=device,
             overwrite=overwrite,
             prefix=prefix,
+            trust_remote_code=trust_remote_code,
             **kwargs,
         )
     else:
@@ -253,6 +255,7 @@ def florence2_caption(
     prefix: str = "",
     suffix: str = "",
     use_fp16: bool = True,
+    trust_remote_code: bool = False,
     **kwargs,
 ):
     """Generate captions using Florence-2 model.
@@ -275,6 +278,7 @@ def florence2_caption(
         prefix: Prefix to add to all generated captions.
         suffix: Suffix to add to all generated captions.
         use_fp16: Whether to use FP16 for inference.
+        trust_remote_code: Trust remote code when loading a huggingface model.
         **kwargs: Additional generation arguments.
 
     Returns:
@@ -288,8 +292,12 @@ def florence2_caption(
     logger.info("Loading Florence-2 model: %s", model_name)
 
     dtype = torch.float16 if use_fp16 and device == "cuda" else torch.float32
-    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
-    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=dtype, trust_remote_code=True).to(device)
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=dtype,
+        trust_remote_code=trust_remote_code,
+    ).to(device)
     model.eval()
 
     # Check if dataset supports in-memory caption storage

--- a/olive/passes/onnx/nvmo_quantization.py
+++ b/olive/passes/onnx/nvmo_quantization.py
@@ -6,7 +6,7 @@ import logging
 import os
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import onnxruntime as ort
 import torch
@@ -131,6 +131,11 @@ class NVModelOptQuantization(Pass):
                 When specified, automatically enables mixed precision quantization.
                 It will override the default mixed quant strategy.
                 """,
+            ),
+            "trust_remote_code": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="[Torch] Trust remote code from HuggingFace",
             ),
         }
 
@@ -393,10 +398,10 @@ class NVModelOptQuantization(Pass):
         # Access transformers and datasets from the instance variables
 
         config = AutoConfig.from_pretrained(
-            model_name, use_auth_token=True, cache_dir=cache_dir, trust_remote_code=True
+            model_name, token=True, cache_dir=cache_dir, trust_remote_code=self.config.trust_remote_code
         )
         tokenizer = AutoTokenizer.from_pretrained(
-            model_name, use_auth_token=True, cache_dir=cache_dir, trust_remote_code=True
+            model_name, token=True, cache_dir=cache_dir, trust_remote_code=self.config.trust_remote_code
         )
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         tokenizer.pad_token = tokenizer.eos_token

--- a/olive/passes/pytorch/autoclip.py
+++ b/olive/passes/pytorch/autoclip.py
@@ -92,7 +92,7 @@ class AutoClip(Pass):
 
         data_config = config.data_config or get_calibration_data_config(
             model.model_name_or_path,
-            trust_remote_code=model.get_load_kwargs().get("trust_remote_code", None),
+            trust_remote_code=model.get_load_kwargs().get("trust_remote_code", False),
             data_name="mit-han-lab/pile-val-backup",
             subset=None,
             split="validation[:1000]",

--- a/olive/passes/pytorch/gptqmodel.py
+++ b/olive/passes/pytorch/gptqmodel.py
@@ -119,6 +119,7 @@ class GptqModel(Pass):
         dataset = get_calibration_dataset(model, config.data_config)
 
         adapter_path = None
+        trust_remote_code = False
         if isinstance(model, HfModelHandler) and model.adapter_path:
             logger.info(
                 "Model has adapters but GPTQ does not support adapters. Quantizing without adapters. The original"
@@ -126,6 +127,7 @@ class GptqModel(Pass):
             )
             # TODO(jambayk): should we copy the adapter? what about non-local adapters?
             adapter_path = model.adapter_path
+            trust_remote_code = model.get_load_kwargs().get("trust_remote_code", False)
 
             # create a new input model with the adapter path removed
             model.model = None
@@ -153,7 +155,11 @@ class GptqModel(Pass):
 
         model_class = MODEL_MAP.get(model_type, BaseGPTQModel)
         quantized_model: BaseGPTQModel = model_class(
-            pytorch_model, False, quantize_config, trust_remote_code=True, model_local_path=model.model_path
+            pytorch_model,
+            False,
+            quantize_config,
+            trust_remote_code=trust_remote_code,
+            model_local_path=model.model_path,
         )
 
         # quantize the model

--- a/olive/passes/pytorch/rotate.py
+++ b/olive/passes/pytorch/rotate.py
@@ -355,7 +355,7 @@ class SpinQuant(RotateBase):
             train_dataset = get_training_dataset(
                 get_calibration_data_config(
                     model.model_name_or_path,
-                    trust_remote_code=model.get_load_kwargs().get("trust_remote_code", None),
+                    trust_remote_code=model.get_load_kwargs().get("trust_remote_code", False),
                     split="train",
                     max_seq_len=2048,
                     max_samples=800,

--- a/olive/passes/pytorch/train_utils.py
+++ b/olive/passes/pytorch/train_utils.py
@@ -280,7 +280,7 @@ def get_calibration_dataset(
     if not data_config and isinstance(model, HfModelHandler):
         data_config = get_calibration_data_config(
             model.model_name_or_path,
-            trust_remote_code=model.get_load_kwargs().get("trust_remote_code", None),
+            trust_remote_code=model.get_load_kwargs().get("trust_remote_code", False),
             split=split,
             batch_size=batch_size,
             max_seq_len=max_seq_len,
@@ -309,7 +309,7 @@ def get_calibration_dataset(
 
 def get_calibration_data_config(
     model_name_or_path: str,
-    trust_remote_code: bool | None = None,
+    trust_remote_code: bool = False,
     data_name: str = "Salesforce/wikitext",
     subset: str = "wikitext-2-raw-v1",
     split: str = "train[:1000]",


### PR DESCRIPTION
## Don't trust remote code explicitly

## Pull request overview

This PR reduces implicit trust of Hugging Face “remote code” by replacing hard-coded `trust_remote_code=True` with configurable/propagated values across several model-loading call sites.

**Changes:**
- Propagate or parameterize `trust_remote_code` instead of always enabling it when loading HF models/tokenizers/processors.
- Add a new pass config option in NVMO quantization to control `trust_remote_code`.
- Update adapter extraction CLI to use shared input-model options and pass through `trust_remote_code`.

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 9 comments.

| File | Description |
| ---- | ----------- |
| `olive/passes/pytorch/gptqmodel.py` | Stops forcing `trust_remote_code=True` during GPTQ model construction; attempts to propagate from model load kwargs. |
| `olive/passes/onnx/nvmo_quantization.py` | Adds `trust_remote_code` knob to pass config and uses it in `from_pretrained` calls. |
| `olive/data/component/sd_lora/auto_caption.py` | Adds `trust_remote_code` parameter and threads it through Florence-2 processor/model loading. |
| `olive/cli/extract_adapters.py` | Switches to shared model CLI options and uses CLI-provided `trust_remote_code` in `from_pretrained`. |

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
