### PR TITLE
Add MIGraphX execution provider mapping

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -187,7 +187,10 @@ class AutoOptCommand(BaseOliveCLICommand):
             self.args.device = "gpu"
         elif self.args.provider in [ExecutionProvider.QNNExecutionProvider, ExecutionProvider.VitisAIExecutionProvider]:
             self.args.device = "npu"
-        elif self.args.provider == ExecutionProvider.CUDAExecutionProvider:
+        elif self.args.provider in [
+            ExecutionProvider.CUDAExecutionProvider,
+            ExecutionProvider.MIGraphXExecutionProvider,
+        ]:
             self.args.device = "gpu"
 
         # _get_passes_config requires input_model to be set

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -53,6 +53,7 @@ class ModelBuilder(Pass):
         ExecutionProvider.CPUExecutionProvider: "cpu",
         ExecutionProvider.CUDAExecutionProvider: "cuda",
         ExecutionProvider.DmlExecutionProvider: "dml",
+        ExecutionProvider.MIGraphXExecutionProvider: "migraphx",
         ExecutionProvider.WebGpuExecutionProvider: "webgpu",
         ExecutionProvider.JsExecutionProvider: "web",
         ExecutionProvider.NvTensorRTRTXExecutionProvider: "NvTensorRtRtx",


### PR DESCRIPTION
## Summary

  Add MIGraphXExecutionProvider to the EP_MAP in ModelBuilder pass, enabling model conversion for AMD GPUs via ONNX Runtime GenAI.

  [MIGraphX](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX) is AMD's graph inference engine for optimizing and running models on AMD GPUs. This enables Olive users to convert models targeting AMD GPUs.

  ## Related PR

  - OGA ModelBuilder support: [microsoft/onnxruntime-genai#2086](https://github.com/microsoft/onnxruntime-genai/pull/2086)