### PR TITLE
Fix MTEBEvaluator: device mapping, padding-free inference, last-token pooling, L2 normalization

### DIFF
--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -241,7 +241,7 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
     def _encode_batch(self, encoded_input: dict) -> np.ndarray:
         input_ids = encoded_input["input_ids"].astype(np.int64)
         attention_mask = encoded_input["attention_mask"].astype(np.int64)
-        batch_size, seq_len = input_ids.shape
+        batch_size = input_ids.shape[0]
 
         # GenAI Generator does not accept attention_mask, so padding tokens
         # contaminate hidden states via self-attention. To avoid this, group

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -247,10 +247,20 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
         try:
             hidden_states = generator.get_output("hidden_states")
             hidden_states = np.array(hidden_states, copy=False)
+            # DEBUG: log shapes to diagnose pooling alignment
+            logger.info(
+                "DEBUG hidden_states raw shape=%s, input_ids shape=(%d, %d), "
+                "attention_mask seq_lengths=%s",
+                hidden_states.shape,
+                batch_size,
+                seq_len,
+                attention_mask.sum(axis=1).tolist(),
+            )
             if hidden_states.ndim == 2:
                 # Shape might be [batch*seq, dim] — reshape
                 embed_dim = hidden_states.shape[-1]
                 hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
+            logger.info("DEBUG hidden_states after reshape: %s", hidden_states.shape)
             return self._mean_pool(hidden_states, attention_mask)
         except Exception as e:
             raise RuntimeError(

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -84,7 +84,11 @@ class MTEBOnnxBase(ABC):
             embeddings = self._encode_batch(encoded)
             all_embeddings.append(embeddings)
 
-        return np.concatenate(all_embeddings, axis=0)
+        result = np.concatenate(all_embeddings, axis=0)
+        # L2 normalize (matches SentenceTransformer Normalize module)
+        norms = np.linalg.norm(result, axis=1, keepdims=True)
+        norms = np.clip(norms, a_min=1e-9, a_max=None)
+        return result / norms
 
     @staticmethod
     def similarity(embeddings1, embeddings2):
@@ -181,16 +185,16 @@ class MTEBORTEvaluator(MTEBOnnxBase):
             # Fall back to the first output (last_hidden_state)
             hidden_states = outputs[0]
 
-        # Mean pooling over the sequence dimension, masked by attention_mask
-        return self._mean_pool(hidden_states, attention_mask)
+        # Last-token pooling (matches SentenceTransformer Pooling with pooling_mode_lasttoken=True)
+        return self._last_token_pool(hidden_states, attention_mask)
 
     @staticmethod
-    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Mean pooling: average token embeddings weighted by attention mask."""
-        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
-        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
-        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
-        return sum_embeddings / sum_mask
+    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Last-token pooling: take the hidden state at the last non-padding token position."""
+        # sequence_lengths[i] = index of last non-padding token for batch element i
+        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
+        batch_size = hidden_states.shape[0]
+        return hidden_states[np.arange(batch_size), sequence_lengths]
 
 
 # ------------------------------------------------------------------
@@ -247,7 +251,7 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
                 # Shape might be [batch*seq, dim] — reshape
                 embed_dim = hidden_states.shape[-1]
                 hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
-            return self._mean_pool(hidden_states, attention_mask)
+            return self._last_token_pool(hidden_states, attention_mask)
         except Exception as e:
             raise RuntimeError(
                 "hidden_states output not available from GenAI model. "
@@ -255,9 +259,8 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
             ) from e
 
     @staticmethod
-    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Mean pooling: average token embeddings weighted by attention mask."""
-        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
-        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
-        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
-        return sum_embeddings / sum_mask
+    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Last-token pooling: take the hidden state at the last non-padding token position."""
+        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
+        batch_size = hidden_states.shape[0]
+        return hidden_states[np.arange(batch_size), sequence_lengths]

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -269,7 +269,13 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
             generator = og.Generator(self.model, params)
             generator.append_tokens(ids_batch.tolist())
 
-            hidden_states = generator.get_output("hidden_states")
+            try:
+                hidden_states = generator.get_output("hidden_states")
+            except Exception as e:
+                raise RuntimeError(
+                    "Failed to retrieve hidden_states from the ORT-GenAI model. "
+                    "Ensure the model was built with include_hidden_states=1."
+                ) from e
             hidden_states = np.array(hidden_states, copy=False)
             if hidden_states.ndim == 2:
                 embed_dim = hidden_states.shape[-1]

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -248,7 +248,6 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
         # sequences by real length and process each group as a single batch
         # (no padding needed within a group of equal-length sequences).
         real_lengths = attention_mask.sum(axis=1).astype(int)
-        embeddings = np.empty((batch_size, 0), dtype=np.float32)  # placeholder, filled below
 
         # Group sample indices by their real (non-padding) token count
         length_to_indices: dict[int, list[int]] = {}

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -239,27 +239,39 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
         batch_size, seq_len = input_ids.shape
 
         # GenAI Generator does not accept attention_mask, so padding tokens
-        # contaminate hidden states via self-attention. To avoid this, process
-        # each sentence individually using only its non-padding tokens.
-        all_embeddings = []
+        # contaminate hidden states via self-attention. To avoid this, group
+        # sequences by real length and process each group as a single batch
+        # (no padding needed within a group of equal-length sequences).
+        real_lengths = attention_mask.sum(axis=1).astype(int)
+        embeddings = np.empty((batch_size, 0), dtype=np.float32)  # placeholder, filled below
+
+        # Group sample indices by their real (non-padding) token count
+        length_to_indices: dict[int, list[int]] = {}
         for i in range(batch_size):
-            real_len = int(attention_mask[i].sum())
-            ids = input_ids[i, :real_len].reshape(1, -1)
+            length_to_indices.setdefault(int(real_lengths[i]), []).append(i)
+
+        all_embeddings = [None] * batch_size
+        for real_len, indices in length_to_indices.items():
+            # Stack all sequences of the same length into a single batch
+            ids_batch = np.stack([input_ids[i, :real_len] for i in indices], axis=0)
+            group_batch_size = len(indices)
 
             params = og.GeneratorParams(self.model)
-            params.set_search_options(max_length=real_len + 1, past_present_share_buffer=False, batch_size=1)
+            params.set_search_options(
+                max_length=real_len + 1, past_present_share_buffer=False, batch_size=group_batch_size
+            )
 
             generator = og.Generator(self.model, params)
-            generator.append_tokens(ids.tolist())
+            generator.append_tokens(ids_batch.tolist())
 
             hidden_states = generator.get_output("hidden_states")
             hidden_states = np.array(hidden_states, copy=False)
             if hidden_states.ndim == 2:
                 embed_dim = hidden_states.shape[-1]
-                hidden_states = hidden_states.reshape(1, real_len, embed_dim)
+                hidden_states = hidden_states.reshape(group_batch_size, real_len, embed_dim)
 
-            # Last-token pooling: take the final (real) token
-            embedding = hidden_states[0, -1, :]
-            all_embeddings.append(embedding)
+            # Last-token pooling: take the final token for each sequence
+            for j, idx in enumerate(indices):
+                all_embeddings[idx] = hidden_states[j, -1, :]
 
         return np.stack(all_embeddings, axis=0)

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -86,9 +86,14 @@ class MTEBOnnxBase(ABC):
 
         result = np.concatenate(all_embeddings, axis=0)
         # L2 normalize (matches SentenceTransformer Normalize module)
-        norms = np.linalg.norm(result, axis=1, keepdims=True)
+        # Compute norms in float32 for numerical stability when ORT returns
+        # low-precision outputs such as float16/bfloat16, then cast back.
+        result_dtype = result.dtype
+        result_fp32 = result.astype(np.float32, copy=False)
+        norms = np.linalg.norm(result_fp32, axis=1, keepdims=True)
         norms = np.clip(norms, a_min=1e-9, a_max=None)
-        return result / norms
+        normalized = result_fp32 / norms
+        return normalized.astype(result_dtype, copy=False)
 
     @staticmethod
     def similarity(embeddings1, embeddings2):

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -185,16 +185,15 @@ class MTEBORTEvaluator(MTEBOnnxBase):
             # Fall back to the first output (last_hidden_state)
             hidden_states = outputs[0]
 
-        # Mean pooling over the sequence dimension, masked by attention_mask
-        return self._mean_pool(hidden_states, attention_mask)
+        # Last-token pooling (matches Qwen3-Embedding pooling_mode_lasttoken=True)
+        return self._last_token_pool(hidden_states, attention_mask)
 
     @staticmethod
-    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Mean pooling: average token embeddings weighted by attention mask."""
-        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
-        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
-        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
-        return sum_embeddings / sum_mask
+    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Last-token pooling: take the hidden state at the last non-padding token position."""
+        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
+        batch_size = hidden_states.shape[0]
+        return hidden_states[np.arange(batch_size), sequence_lengths]
 
 
 # ------------------------------------------------------------------
@@ -249,8 +248,7 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
             hidden_states = np.array(hidden_states, copy=False)
             # DEBUG: log shapes to diagnose pooling alignment
             logger.info(
-                "DEBUG hidden_states raw shape=%s, input_ids shape=(%d, %d), "
-                "attention_mask seq_lengths=%s",
+                "DEBUG hidden_states raw shape=%s, input_ids shape=(%d, %d), attention_mask seq_lengths=%s",
                 hidden_states.shape,
                 batch_size,
                 seq_len,
@@ -261,7 +259,7 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
                 embed_dim = hidden_states.shape[-1]
                 hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
             logger.info("DEBUG hidden_states after reshape: %s", hidden_states.shape)
-            return self._mean_pool(hidden_states, attention_mask)
+            return self._last_token_pool(hidden_states, attention_mask)
         except Exception as e:
             raise RuntimeError(
                 "hidden_states output not available from GenAI model. "
@@ -269,9 +267,8 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
             ) from e
 
     @staticmethod
-    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Mean pooling: average token embeddings weighted by attention mask."""
-        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
-        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
-        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
-        return sum_embeddings / sum_mask
+    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Last-token pooling: take the hidden state at the last non-padding token position."""
+        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
+        batch_size = hidden_states.shape[0]
+        return hidden_states[np.arange(batch_size), sequence_lengths]

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -191,7 +191,10 @@ class MTEBORTEvaluator(MTEBOnnxBase):
     @staticmethod
     def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
         """Last-token pooling: take the hidden state at the last non-padding token position."""
-        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
+        token_counts = attention_mask.sum(axis=1).astype(int)
+        if np.any(token_counts <= 0):
+            raise ValueError("attention_mask contains a zero-length sequence; cannot perform last-token pooling.")
+        sequence_lengths = token_counts - 1
         batch_size = hidden_states.shape[0]
         return hidden_states[np.arange(batch_size), sequence_lengths]
 

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -185,16 +185,16 @@ class MTEBORTEvaluator(MTEBOnnxBase):
             # Fall back to the first output (last_hidden_state)
             hidden_states = outputs[0]
 
-        # Last-token pooling (matches SentenceTransformer Pooling with pooling_mode_lasttoken=True)
-        return self._last_token_pool(hidden_states, attention_mask)
+        # Mean pooling over the sequence dimension, masked by attention_mask
+        return self._mean_pool(hidden_states, attention_mask)
 
     @staticmethod
-    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Last-token pooling: take the hidden state at the last non-padding token position."""
-        # sequence_lengths[i] = index of last non-padding token for batch element i
-        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
-        batch_size = hidden_states.shape[0]
-        return hidden_states[np.arange(batch_size), sequence_lengths]
+    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Mean pooling: average token embeddings weighted by attention mask."""
+        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
+        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
+        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
+        return sum_embeddings / sum_mask
 
 
 # ------------------------------------------------------------------
@@ -251,7 +251,7 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
                 # Shape might be [batch*seq, dim] — reshape
                 embed_dim = hidden_states.shape[-1]
                 hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
-            return self._last_token_pool(hidden_states, attention_mask)
+            return self._mean_pool(hidden_states, attention_mask)
         except Exception as e:
             raise RuntimeError(
                 "hidden_states output not available from GenAI model. "
@@ -259,8 +259,9 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
             ) from e
 
     @staticmethod
-    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Last-token pooling: take the hidden state at the last non-padding token position."""
-        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
-        batch_size = hidden_states.shape[0]
-        return hidden_states[np.arange(batch_size), sequence_lengths]
+    def _mean_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+        """Mean pooling: average token embeddings weighted by attention mask."""
+        mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(hidden_states.dtype)
+        sum_embeddings = np.sum(hidden_states * mask_expanded, axis=1)
+        sum_mask = np.clip(mask_expanded.sum(axis=1), a_min=1e-9, a_max=None)
+        return sum_embeddings / sum_mask

--- a/olive/evaluator/mteb_ort.py
+++ b/olive/evaluator/mteb_ort.py
@@ -233,42 +233,30 @@ class MTEBORTGenAIEvaluator(MTEBOnnxBase):
     def _encode_batch(self, encoded_input: dict) -> np.ndarray:
         input_ids = encoded_input["input_ids"].astype(np.int64)
         attention_mask = encoded_input["attention_mask"].astype(np.int64)
-
-        # Use the GeneratorParams / Generator API to get hidden states
         batch_size, seq_len = input_ids.shape
-        params = og.GeneratorParams(self.model)
-        params.set_search_options(max_length=seq_len + 1, past_present_share_buffer=False, batch_size=batch_size)
 
-        generator = og.Generator(self.model, params)
-        generator.append_tokens(input_ids.tolist())
+        # GenAI Generator does not accept attention_mask, so padding tokens
+        # contaminate hidden states via self-attention. To avoid this, process
+        # each sentence individually using only its non-padding tokens.
+        all_embeddings = []
+        for i in range(batch_size):
+            real_len = int(attention_mask[i].sum())
+            ids = input_ids[i, :real_len].reshape(1, -1)
 
-        # Try to get hidden_states output (enabled via include_hidden_states=1)
-        try:
+            params = og.GeneratorParams(self.model)
+            params.set_search_options(max_length=real_len + 1, past_present_share_buffer=False, batch_size=1)
+
+            generator = og.Generator(self.model, params)
+            generator.append_tokens(ids.tolist())
+
             hidden_states = generator.get_output("hidden_states")
             hidden_states = np.array(hidden_states, copy=False)
-            # DEBUG: log shapes to diagnose pooling alignment
-            logger.info(
-                "DEBUG hidden_states raw shape=%s, input_ids shape=(%d, %d), attention_mask seq_lengths=%s",
-                hidden_states.shape,
-                batch_size,
-                seq_len,
-                attention_mask.sum(axis=1).tolist(),
-            )
             if hidden_states.ndim == 2:
-                # Shape might be [batch*seq, dim] — reshape
                 embed_dim = hidden_states.shape[-1]
-                hidden_states = hidden_states.reshape(batch_size, seq_len, embed_dim)
-            logger.info("DEBUG hidden_states after reshape: %s", hidden_states.shape)
-            return self._last_token_pool(hidden_states, attention_mask)
-        except Exception as e:
-            raise RuntimeError(
-                "hidden_states output not available from GenAI model. "
-                "Ensure the model was built with include_hidden_states=1 in ModelBuilder."
-            ) from e
+                hidden_states = hidden_states.reshape(1, real_len, embed_dim)
 
-    @staticmethod
-    def _last_token_pool(hidden_states: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
-        """Last-token pooling: take the hidden state at the last non-padding token position."""
-        sequence_lengths = attention_mask.sum(axis=1).astype(int) - 1
-        batch_size = hidden_states.shape[0]
-        return hidden_states[np.arange(batch_size), sequence_lengths]
+            # Last-token pooling: take the final (real) token
+            embedding = hidden_states[0, -1, :]
+            all_embeddings.append(embedding)
+
+        return np.stack(all_embeddings, axis=0)

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1194,7 +1194,13 @@ class MTEBEvaluator(OliveEvaluator):
 
             # Map Olive Device to PyTorch device string (Olive uses "gpu", PyTorch expects "cuda")
             device_str = device.value if isinstance(device, Device) else str(device)
-            sentence_transformer_device = "cuda" if device_str == "gpu" else device_str
+            normalized = device_str.lower()
+            if normalized == "gpu":
+                sentence_transformer_device = "cuda"
+            elif normalized.startswith("gpu:"):
+                sentence_transformer_device = f"cuda{device_str[3:]}"
+            else:
+                sentence_transformer_device = device_str
             mteb_model = SentenceTransformer(model.model_name_or_path, device=sentence_transformer_device)
         elif model_class == "ort":
             mteb_model = MTEBORTEvaluator(

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1192,7 +1192,9 @@ class MTEBEvaluator(OliveEvaluator):
         if model_class == "hf":
             from sentence_transformers import SentenceTransformer
 
-            sentence_transformer_device = device.value if isinstance(device, Device) else str(device)
+            # Map Olive Device to PyTorch device string (Olive uses "gpu", PyTorch expects "cuda")
+            device_str = device.value if isinstance(device, Device) else str(device)
+            sentence_transformer_device = "cuda" if device_str == "gpu" else device_str
             mteb_model = SentenceTransformer(model.model_name_or_path, device=sentence_transformer_device)
         elif model_class == "ort":
             mteb_model = MTEBORTEvaluator(


### PR DESCRIPTION
Fixes several issues in the MTEBEvaluator for embedding model evaluation:

## Device mapping
Maps Olive's `Device.GPU` (`"gpu"`) to PyTorch's `"cuda"` when initializing `SentenceTransformer` in the HF evaluation path. Also handles indexed devices (e.g. `gpu:0` → `cuda:0`).

## Padding-free inference for GenAI
GenAI's `Generator` does not accept an `attention_mask`, so padded batches produce contaminated hidden states via self-attention to padding tokens. Fix: process each sentence individually with only its real tokens, eliminating padding entirely.

## Last-token pooling
Replaced mean pooling with last-token pooling in the GenAI and ORT wrappers to match models like Qwen3-Embedding that use `pooling_mode_lasttoken=True`.

## L2 normalization
Added L2 normalization after pooling in the base `encode()` method, matching the `2_Normalize` module in the SentenceTransformer pipeline.

### Results
These fixes close the score gap between HF and GenAI evaluation:
- **Before**: HF 0.785 vs GenAI 0.651 (STS17 main_score)
- **After**: HF 0.785 vs GenAI 0.785