### PR TITLE
Add ORTGenAI backend option to benchmark CLI

### DIFF
--- a/olive/cli/benchmark.py
+++ b/olive/cli/benchmark.py
@@ -68,6 +68,14 @@ class BenchmarkCommand(BaseOliveCLICommand):
             help="Number (or percentage of dataset) of samples to use for evaluation.",
         )
 
+        lmeval_group.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "ort", "ortgenai"],
+            help="Backend for ONNX model evaluation. Use 'auto' to infer backend from model type.",
+        )
+
         add_logging_options(sub_parser)
         add_save_config_file_options(sub_parser)
         add_shared_cache_options(sub_parser)
@@ -88,6 +96,9 @@ class BenchmarkCommand(BaseOliveCLICommand):
             "onnxmodel",
         }, "Only HfModel, PyTorchModel and OnnxModel are supported in benchmark command."
 
+        if self.args.backend != "auto" and input_model_config["type"].lower() != "onnxmodel":
+            raise ValueError("--backend is only supported for ONNX input models.")
+
         to_replace = [
             ("input_model", input_model_config),
             ("output_dir", self.args.output_path),
@@ -101,8 +112,11 @@ class BenchmarkCommand(BaseOliveCLICommand):
             (("evaluators", "evaluator", "device"), self.args.device),
             (("evaluators", "evaluator", "batch_size"), self.args.batch_size),
             (("evaluators", "evaluator", "max_length"), self.args.max_length),
-            (("evaluators", "evaluator", "device"), self.args.device),
             (("evaluators", "evaluator", "limit"), self.args.limit),
+            (
+                ("evaluators", "evaluator", "model_class"),
+                None if self.args.backend == "auto" else self.args.backend,
+            ),
         ]
 
         for keys, value in to_replace:

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -688,3 +688,136 @@ def test_benchmark_command_onnxmodel(mock_run, tmp_path):
     assert config["evaluators"]["evaluator"]["max_length"] == 1024
     assert config["evaluators"]["evaluator"]["limit"] == 16
     assert mock_run.call_count == 1
+
+
+@patch("olive.workflows.run")
+def test_benchmark_command_onnxmodel_with_ort_backend(mock_run, tmp_path):
+    from test.utils import ONNX_MODEL_PATH
+
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        str(ONNX_MODEL_PATH),
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "ort",
+    ]
+
+    cli_main(command_args)
+
+    config = mock_run.call_args[0][0]
+    assert config["evaluators"]["evaluator"]["model_class"] == "ort"
+    assert mock_run.call_count == 1
+
+
+@patch("olive.workflows.run")
+def test_benchmark_command_onnxmodel_with_ortgenai_backend(mock_run, tmp_path):
+    from test.utils import ONNX_MODEL_PATH
+
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        str(ONNX_MODEL_PATH),
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "ortgenai",
+    ]
+
+    cli_main(command_args)
+
+    config = mock_run.call_args[0][0]
+    assert config["evaluators"]["evaluator"]["model_class"] == "ortgenai"
+    assert mock_run.call_count == 1
+
+
+@patch("huggingface_hub.repo_exists", return_value=True)
+def test_benchmark_command_non_onnx_model_with_backend_option_raises(_, tmp_path):
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        "dummy-model-id",
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "ortgenai",
+    ]
+
+    with pytest.raises(ValueError, match="--backend is only supported for ONNX input models"):
+        cli_main(command_args)
+
+
+@patch("huggingface_hub.repo_exists", return_value=True)
+def test_benchmark_command_non_onnx_model_with_ort_backend_raises(_, tmp_path):
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        "dummy-model-id",
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "ort",
+    ]
+
+    with pytest.raises(ValueError, match="--backend is only supported for ONNX input models"):
+        cli_main(command_args)
+
+
+@patch("olive.workflows.run")
+def test_benchmark_command_onnxmodel_with_auto_backend(mock_run, tmp_path):
+    from test.utils import ONNX_MODEL_PATH
+
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        str(ONNX_MODEL_PATH),
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "auto",
+    ]
+
+    cli_main(command_args)
+
+    config = mock_run.call_args[0][0]
+    assert "model_class" not in config["evaluators"]["evaluator"]
+    assert mock_run.call_count == 1
+
+
+@patch("olive.workflows.run")
+@patch("huggingface_hub.repo_exists", return_value=True)
+def test_benchmark_command_hfmodel_with_auto_backend(_, mock_run, tmp_path):
+    output_dir = tmp_path / "output_dir"
+    command_args = [
+        "benchmark",
+        "-m",
+        "dummy-model-id",
+        "--output_path",
+        str(output_dir),
+        "--tasks",
+        "arc_easy",
+        "--backend",
+        "auto",
+    ]
+
+    cli_main(command_args)
+
+    config = mock_run.call_args[0][0]
+    assert "model_class" not in config["evaluators"]["evaluator"]
+    assert mock_run.call_count == 1

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import importlib.util
 from functools import partial
 from types import FunctionType
 from typing import ClassVar
@@ -478,3 +479,34 @@ class TestOliveEvaluatorConfig:
             OliveEvaluatorConfig.from_json({"type": "test_evaluator"})
 
         registry_get_mock.assert_called_once_with("test_evaluator")
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("lm_eval") is None,
+    reason="lm_eval not installed",
+)
+class TestLMEvaluatorModelClass:
+    """Verify LMEvaluator dispatches to the lm-eval model backend matching model_class."""
+
+    @pytest.mark.parametrize("model_class", ["ort", "ortgenai"])
+    @patch("lm_eval.utils.setup_logging")
+    @patch("lm_eval.tasks.TaskManager")
+    @patch("lm_eval.simple_evaluate")
+    @patch("lm_eval.api.registry.get_model")
+    def test_lm_evaluator_dispatches_to_requested_backend(
+        self, get_model_mock, simple_evaluate_mock, _task_manager_mock, _setup_logging_mock, model_class
+    ):
+        from olive.evaluator.olive_evaluator import LMEvaluator
+        from olive.model.handler.onnx import ONNXModelHandler
+
+        simple_evaluate_mock.return_value = {"results": {}}
+        get_model_mock.return_value = MagicMock(return_value=MagicMock())
+
+        evaluator = LMEvaluator(tasks=["arc_easy"], model_class=model_class, batch_size=1, max_length=128)
+
+        model = MagicMock(spec=ONNXModelHandler)
+        model.model_path = "/tmp/model.onnx"
+
+        evaluator.evaluate(model, metrics=[], device=Device.CPU, execution_providers=["CPUExecutionProvider"])
+
+        get_model_mock.assert_called_once_with(model_class)


### PR DESCRIPTION
## Context
The benchmark command currently defaults to the ONNX Runtime lm-eval model path. Olive already has ORTGenAI lm-eval support in the evaluator layer, but benchmark CLI had no way to select it.

This PR exposes that capability through benchmark CLI while preserving existing defaults.

## What This Changes
- Adds a new benchmark CLI argument: `--backend` with choices:
  - `auto` (default)
  - `ort`
  - `ortgenai`
- Wires explicit backend selection into generated workflow config by setting evaluator `model_class` when backend is not `auto`.
- Keeps current behavior unchanged when `--backend auto` is used (or omitted).
- Adds validation: explicit `--backend` is only accepted for ONNX input models.

## Why This Approach
- Non-breaking by default: existing benchmark flows continue to infer model class automatically.
- Minimal change surface: only benchmark CLI config generation and tests are touched.
- Leverages existing evaluator support rather than introducing new runtime logic.

## User-Facing Behavior
Examples:
- Existing behavior (unchanged):
  - `olive benchmark -m <model> --tasks arc_easy`
- Explicit ORT:
  - `olive benchmark -m <onnx_model> --tasks arc_easy --backend ort`
- Explicit ORTGenAI:
  - `olive benchmark -m <onnx_model> --tasks arc_easy --backend ortgenai`

If `--backend` is provided for non-ONNX inputs, benchmark now raises a clear error.

## Tests Added/Updated
- Verifies ONNX benchmark accepts `--backend ortgenai` and writes evaluator `model_class=ortgenai`.
- Verifies non-ONNX model with explicit backend raises expected `ValueError`.
- Existing benchmark tests continue to pass.

## Validation
- `pip install -e .`
- `python -m olive --help`
- `python -m olive benchmark --help`
- `python -m pytest test/cli/test_cli.py -k benchmark_command -q`