### PR TITLE
Update pipeline Python version from 3.10 to 3.12

### DIFF
--- a/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
+++ b/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
@@ -9,6 +9,9 @@ ARG PYTHON_VERSION
 ARG TENSORRT_VERSION
 
 RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     python${PYTHON_VERSION} \
     python${PYTHON_VERSION}-dev \

--- a/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
+++ b/.azure_pipelines/dockerfiles/linux-gpu.dockerfile
@@ -8,6 +8,8 @@ FROM ${BASE_IMAGE}
 ARG PYTHON_VERSION
 ARG TENSORRT_VERSION
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \

--- a/.azure_pipelines/job_templates/olive-setup-template.yaml
+++ b/.azure_pipelines/job_templates/olive-setup-template.yaml
@@ -1,5 +1,5 @@
 parameters:
-  python_version: '3.10'
+  python_version: '3.12'
   onnxruntime: 'onnxruntime'
   onnxruntime_nightly: false
   torch: torch

--- a/.azure_pipelines/job_templates/olive-test-cpu-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-cpu-template.yaml
@@ -2,7 +2,7 @@ parameters:
   name: ''
   pool: ''
   windows: False
-  python_version: '3.10'
+  python_version: '3.12'
   onnxruntime: 'onnxruntime'
   onnxruntime_nightly: false
   torch: 'torch'

--- a/.azure_pipelines/job_templates/olive-test-linux-gpu-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-linux-gpu-template.yaml
@@ -7,7 +7,7 @@ parameters:
   docker_image: 'olive-pipeline:latest'
   base_image: 'mcr.microsoft.com/mirror/nvcr/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
   trt_version: '10.5.0.18-1+cuda12.6'
-  python_version: '3.10'
+  python_version: '3.12'
   onnxruntime: 'onnxruntime-gpu'
   torch: 'torch'
   requirements_file: 'requirements-test-gpu.txt'

--- a/.azure_pipelines/scripts/run_test.sh
+++ b/.azure_pipelines/scripts/run_test.sh
@@ -33,8 +33,10 @@ echo "Installing additional dependencies..."
 pip install pytest azure-identity azure-storage-blob tabulate
 pip install -r "$4"
 
-# Install auto-gptq from source (no Python 3.12 wheels on PyPI, disable CUDA extension build)
-BUILD_CUDA_EXT=0 pip install --no-build-isolation git+https://github.com/PanQiWei/AutoGPTQ.git
+# Install auto-gptq from source (no Python 3.12 wheels on PyPI, disable CUDA extension build).
+# Pin to an explicit ref so CI remains reproducible; update this value intentionally when upgrading AutoGPTQ.
+AUTOGPTQ_REF="v0.7.1"
+BUILD_CUDA_EXT=0 pip install --no-build-isolation "git+https://github.com/PanQiWei/AutoGPTQ.git@${AUTOGPTQ_REF}"
 
 # Set HF Token
 pip install huggingface-hub

--- a/.azure_pipelines/scripts/run_test.sh
+++ b/.azure_pipelines/scripts/run_test.sh
@@ -33,6 +33,9 @@ echo "Installing additional dependencies..."
 pip install pytest azure-identity azure-storage-blob tabulate
 pip install -r "$4"
 
+# Install auto-gptq from source (no Python 3.12 wheels on PyPI, disable CUDA extension build)
+BUILD_CUDA_EXT=0 pip install --no-build-isolation git+https://github.com/PanQiWei/AutoGPTQ.git
+
 # Set HF Token
 pip install huggingface-hub
 hf auth login --token "$7"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ on:
 
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.12"
 
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           # Version range or exact version of Python to use, using SemVer's version range syntax. Reads from .python-version if unset.
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install -r requirements-dev.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ If you need to run tests, install the appropriate dependencies from `test/requir
 - Prefer behavior-focused tests over implementation-focused tests.
 - Use the existing naming convention: `test_<method_or_function>_<expected_behavior>[_when_<condition>]`.
 
+## Pull requests
+
+- When creating PRs, use the template at `.github/pull_request_template.md` for the PR body.
+- Fill in the "Describe your changes" section with a clear summary of what changed and why.
+
 ## Security and environment notes
 
 - Do not commit secrets, caches, or generated model artifacts.

--- a/test/passes/pytorch/test_autogptq.py
+++ b/test/passes/pytorch/test_autogptq.py
@@ -31,8 +31,8 @@ test_gptq_dc_config = DataConfig(
 )
 
 
-# TODO(team): Fix auto-gptq compatibility with transformers>=4.57 (tensor size mismatch in apply_rotary_pos_emb)
-@pytest.mark.skip(reason="auto-gptq incompatible with transformers>=4.57, need fix")
+# TODO(team): auto-gptq is archived and has no Python 3.12 wheels. Consider replacing with gptqmodel.
+@pytest.mark.skip(reason="auto-gptq is archived, incompatible with Python 3.12 and transformers>=4.57")
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="gptq requires GPU.",

--- a/test/passes/pytorch/test_autogptq.py
+++ b/test/passes/pytorch/test_autogptq.py
@@ -31,8 +31,8 @@ test_gptq_dc_config = DataConfig(
 )
 
 
-# TODO(team): auto-gptq is archived and has no Python 3.12 wheels. Consider replacing with gptqmodel.
-@pytest.mark.skip(reason="auto-gptq is archived, incompatible with Python 3.12 and transformers>=4.57")
+# TODO(team): Fix auto-gptq compatibility with transformers>=4.57 (tensor size mismatch in apply_rotary_pos_emb)
+@pytest.mark.skip(reason="auto-gptq incompatible with transformers>=4.57, need fix")
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="gptq requires GPU.",

--- a/test/requirements-test-gpu.txt
+++ b/test/requirements-test-gpu.txt
@@ -1,5 +1,4 @@
 -r requirements-test.txt
-auto-gptq==0.7.1
 bitsandbytes
 onnxruntime-genai-cuda
 torch<2.11.0 # torch 2.11.0 is not compatible with CI v100 GPU

--- a/test/requirements-test-gpu.txt
+++ b/test/requirements-test-gpu.txt
@@ -3,3 +3,4 @@ bitsandbytes
 onnxruntime-genai-cuda
 torch<2.11.0 # torch 2.11.0 is not compatible with CI v100 GPU
 triton
+# auto-gptq: installed from source in run_test.sh (no Python 3.12 wheels on PyPI)


### PR DESCRIPTION
## Describe your changes

Update the default Python version used in CI/CD pipelines from 3.10 to 3.12.

Python 3.10 is reaching end-of-life and most core dependencies no longer produce Python 3.10 wheels. This caused CI to install older versions of those dependencies instead of the latest, reducing test coverage against current releases. This updates GitHub Actions workflows (lint, docs), Azure Pipelines job templates (setup, CPU test, Linux GPU test), and the GPU Dockerfile to support Python 3.12.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
