### PR TITLE
Update tie-word embedding surgery

### DIFF
--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -1924,11 +1924,18 @@ class TieWordEmbeddings(ProtoSurgeon):
     def __call__(self, model: onnx.ModelProto):
         dag = OnnxDAG(model)
 
-        if not dag.is_input("input_ids") or not dag.is_output("logits"):
+        # support both "input_ids" and "input_embeds" as input names
+        input_name = None
+        for candidate in ("input_ids", "input_embeds"):
+            if candidate in dag.ios and dag.is_input(candidate):
+                input_name = candidate
+                break
+
+        if input_name is None or "logits" not in dag.ios or not dag.is_output("logits"):
             return dag.model
 
         embed_name, embed_op_type = self.get_name_op_type(
-            dag, dag.get_consumers("input_ids"), ["Gather", "GatherBlockQuantized"], 0
+            dag, dag.get_consumers(input_name), ["Gather", "GatherBlockQuantized"], 0
         )
         if embed_name is None:
             return dag.model


### PR DESCRIPTION
This pull request updates the `TieWordEmbeddings` class in `olive/passes/onnx/graph_surgeries.py` to improve input handling for ONNX models. The main change is that the class now supports both `"input_ids"` and `"input_embeds"` as valid input names, instead of requiring only `"input_ids"`. This makes the code more flexible when processing models with different input conventions.

**Improvements to input handling:**

* Updated the logic in `TieWordEmbeddings.__call__` to accept either `"input_ids"` or `"input_embeds"` as the model input, increasing compatibility with a wider range of ONNX models.