### PR TITLE
Fix version switcher issues on GH docs page

### DIFF
--- a/docs/source/_static/versions.json
+++ b/docs/source/_static/versions.json
@@ -1,6 +1,8 @@
 [
     { "name": "dev (main)", "version": "main", "url": "https://microsoft.github.io/Olive/" },
-    { "name": "0.10.1 (latest)", "version": "0.10.1", "url": "https://microsoft.github.io/Olive/0.10.1/" },
+    { "name": "0.12.1 (latest)", "version": "0.12.1", "url": "https://microsoft.github.io/Olive/0.12.1/" },
+    { "name": "0.12.0", "version": "0.12.0", "url": "https://microsoft.github.io/Olive/0.12.0/" },
+    { "name": "0.10.1", "version": "0.10.1", "url": "https://microsoft.github.io/Olive/0.10.1/" },
     { "name": "0.10.0", "version": "0.10.0", "url": "https://microsoft.github.io/Olive/0.10.0/" },
     { "name": "0.9.3", "version": "0.9.3", "url": "https://microsoft.github.io/Olive/0.9.3/" },
     { "name": "0.9.2", "version": "0.9.2", "url": "https://microsoft.github.io/Olive/0.9.2/" },

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ html_theme_options = {
         "**": ["page-toc"],
     },
     "switcher": {
-        "json_url": "https://microsoft.github.io/Olive/_static/versions.json",
+        "json_url": "./_static/versions.json",
         "version_match": version,
     },
 }


### PR DESCRIPTION
## Fix version switcher issues on GH docs page

Root cause: versions.json was modified on release branch and the automation script even updated the local versions file to add the new version, however, the build configuration wasn't using the local file. The build was configured to use the file from last released version on GH.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
