### PR TITLE
Mark auto-opt command as deprecated

### DIFF
--- a/olive/cli/auto_opt.py
+++ b/olive/cli/auto_opt.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import logging
 from argparse import ArgumentParser
 from collections import OrderedDict
 from copy import deepcopy
@@ -25,13 +26,19 @@ from olive.hardware.constants import ExecutionProvider
 from olive.package_config import OlivePackageConfig
 from olive.telemetry import action
 
+logger = logging.getLogger(__name__)
+
 
 class AutoOptCommand(BaseOliveCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         sub_parser = parser.add_parser(
             "auto-opt",
-            help="Automatically optimize the performance of the input model.",
+            help=(
+                "Automatically optimize the performance of the input model.\n"
+                "**** DEPRECATION WARNING ****\n"
+                '"auto-opt" command is deprecated in favor of "optimize".'
+            ),
         )
 
         # Model options
@@ -174,6 +181,11 @@ class AutoOptCommand(BaseOliveCLICommand):
 
     @action
     def run(self):
+        logger.warning(
+            "**** DEPRECATION WARNING ****\n"
+            '"auto-opt" command is deprecated in favor of "optimize". Please switch to using "optimize".\n'
+            "Deprecated commands will be removed entirely in future release."
+        )
         return self._run_workflow()
 
     def _get_run_config(self, tempdir) -> dict:


### PR DESCRIPTION
## Mark auto-opt command as deprecated

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
