### PR TITLE
fix: handle list eos_token_id in ortgenai evaluator

### DIFF
--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -511,8 +511,10 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
                 self.max_length = genai_config["search"]["max_length"]
             eot = genai_config["model"]["eos_token_id"]
             # eos_token_id can be a list (e.g. [1, 106] for Gemma4) or a scalar.
-            # Use the first element for loglikelihood evaluation.
-            self._eot_token_id = eot[0] if isinstance(eot, list) else eot
+            # Store all EOS IDs for generate_until stop detection,
+            # and first/scalar for loglikelihood (TemplateLM.eot_token_id expects int).
+            self._eos_token_ids = list(eot) if isinstance(eot, list) else [eot]
+            self._eot_token_id = self._eos_token_ids[0]
         self.params = og.GeneratorParams(self.model)
         self.params.set_search_options(max_length=self.max_length, past_present_share_buffer=False)
 
@@ -618,7 +620,7 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
             generator = og.Generator(self.model, params)
             generator.append_tokens([input_ids])
 
-            eos_ids = self._eot_token_id if isinstance(self._eot_token_id, (list, tuple)) else [self._eot_token_id]
+            eos_ids = self._eos_token_ids
 
             generated_ids = []
             # Decode periodically to check for stop sequences

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -509,7 +509,10 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
                 self.max_length = max_length
             else:
                 self.max_length = genai_config["search"]["max_length"]
-            self._eot_token_id = genai_config["model"]["eos_token_id"]
+            eot = genai_config["model"]["eos_token_id"]
+            # eos_token_id can be a list (e.g. [1, 106] for Gemma4) or a scalar.
+            # Use the first element for loglikelihood evaluation.
+            self._eot_token_id = eot[0] if isinstance(eot, list) else eot
         self.params = og.GeneratorParams(self.model)
         self.params.set_search_options(max_length=self.max_length, past_present_share_buffer=False)
 
@@ -575,3 +578,70 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
 
     def complete(self):
         pass
+
+    def generate_until(self, requests, disable_tqdm: bool = False) -> list[str]:
+        """Generate text until a stop sequence is reached.
+
+        Used by benchmarks like MMLU Pro (CoT variant) that score by generating
+        chain-of-thought text and extracting the answer with a regex filter.
+        """
+        results = []
+        for request in tqdm(requests, disable=disable_tqdm, desc="Running generate_until requests"):
+            context = request.args[0]
+            gen_kwargs = request.args[1]
+
+            until = gen_kwargs.get("until", [])
+            max_gen_toks = gen_kwargs.get("max_gen_toks", 256)
+            if isinstance(until, str):
+                until = [until]
+
+            input_ids = self.tok_encode(context)
+            max_new_tokens = min(max_gen_toks, self.max_length - len(input_ids))
+            if max_new_tokens <= 0:
+                results.append("")
+                continue
+
+            params = og.GeneratorParams(self.model)
+            params.set_search_options(
+                max_length=len(input_ids) + max_new_tokens,
+                past_present_share_buffer=False,
+                batch_size=1,
+            )
+            if gen_kwargs.get("temperature", 0.0) == 0.0:
+                params.set_search_options(do_sample=False)
+            else:
+                params.set_search_options(
+                    do_sample=True,
+                    temperature=gen_kwargs["temperature"],
+                )
+
+            generator = og.Generator(self.model, params)
+            generator.append_tokens([input_ids])
+
+            eos_ids = self._eot_token_id if isinstance(self._eot_token_id, (list, tuple)) else [self._eot_token_id]
+
+            generated_ids = []
+            # Decode periodically to check for stop sequences
+            decode_interval = 16
+            while not generator.is_done():
+                generator.generate_next_token()
+                token_id = generator.get_next_tokens()[0]
+                generated_ids.append(token_id)
+                if token_id in eos_ids:
+                    break
+                # Check stop sequences periodically by decoding
+                if until and len(generated_ids) % decode_interval == 0:
+                    partial_text = self.tokenizer.decode(generated_ids)
+                    if any(stop_seq in partial_text for stop_seq in until):
+                        break
+
+            generated_text = self.tokenizer.decode(generated_ids)
+
+            # Truncate at the first stop sequence
+            for stop_seq in until:
+                idx = generated_text.find(stop_seq)
+                if idx != -1:
+                    generated_text = generated_text[:idx]
+
+            results.append(generated_text)
+        return results


### PR DESCRIPTION
## Summary

Fix `_detect_full_logits` in `LMEvalORTGenAIEvaluator` incorrectly detecting single-position logits when `eos_token_id` is a list.

## Problem

When `genai_config.json` has `"eos_token_id": [1, 106]` (e.g. Gemma4), the detection probe creates `[[[1,106],[1,106],[1,106]]]` — a nested list with 6 flattened tokens instead of 3 scalar tokens. The shape check `logits.shape[1] == 3` gets `6 != 3` → returns `False`, forcing the model into the slower token-by-token stepping path even though it supports full-sequence logits.

## Fix

- Store all EOS token IDs in `_eos_token_ids: list[int]` for `generate_until` stop detection
- Store first EOS ID in `_eot_token_id: int` for the `TemplateLM` interface and `_detect_full_logits` probe
- Simplify `generate_until` to use `_eos_token_ids` directly instead of runtime isinstance check

## Benchmark

Tested on Gemma4 E2B-IT F16 (MMLU Pro, limit=50, CUDA):

| Metric | Before | After |
|--------|--------|-------|
| `_returns_full_logits` | `False` ❌ | `True` ✅ |
| Time (499 requests) | 51.5s | 45.4s |
| Throughput | 9.7 req/s | 11.0 req/s |
| Speedup | — | **1.13×** |

The speedup is modest for MMLU Pro (short answer continuations), but the fix is critical for correctness: without it, tasks with multi-token continuations (e.g. CoT generation scoring) would perform N extra sequential inference steps per request.

## Root cause context

Full analysis in [onnxruntime/mobius#285](https://github.com/onnxruntime/mobius/issues/285#issuecomment-4401474030). The dominant performance gap (12× raw forward pass) is architectural (GenAI multimodal model loading overhead), but this bug fix eliminates the secondary source of unnecessary work.