### PR TITLE
perf: use get_logits() to avoid massive GPU→CPU logits copy in ortgenai evaluator

### DIFF
--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -551,11 +551,6 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
         self.params.set_search_options(batch_size=batch_size)
         generator = og.Generator(self.model, self.params)
 
-        if self._returns_full_logits:
-            generator.append_tokens(input_ids.tolist())
-            return torch.from_numpy(generator.get_output("logits")).to(self.device)
-
-        # Model only returns logits for the last appended position.
         if batch_size > 1 and cont_len > 1:
             raise ValueError(
                 "batch_size > 1 is not supported when the model returns single-position logits"
@@ -563,15 +558,18 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
                 " batch elements. Use batch_size=1 instead."
             )
 
-        # Bulk-append context tokens, then step through the last cont_len tokens
-        # one at a time to collect only the logits we actually need.
+        # Use incremental token appending with get_logits() to avoid copying
+        # the full logits tensor from GPU to CPU. get_output("logits") copies
+        # seq_len * vocab_size * 2 bytes (e.g. 472MB for 900 tokens with
+        # 262K vocab), while get_logits() copies only vocab_size * 4 bytes
+        # (~1MB) per position.
         n_logits = max(cont_len, 1)
         prefix_len = seq_len - n_logits
         generator.append_tokens(input_ids[:, : prefix_len + 1].tolist())
-        all_logits = [torch.from_numpy(generator.get_output("logits")).to(self.device)]
+        all_logits = [torch.from_numpy(generator.get_logits()).to(self.device)]
         for i in range(prefix_len + 1, seq_len):
             generator.append_tokens(input_ids[:, i : i + 1].tolist())
-            all_logits.append(torch.from_numpy(generator.get_output("logits")).to(self.device))
+            all_logits.append(torch.from_numpy(generator.get_logits()).to(self.device))
 
         # No need to pad to [batch, seq_len, vocab]. The slicing in _loglikelihood_tokens computes
         # ctx_len = inplen + (logits.shape[0] - padding_len_inp), which adjusts for the shorter

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -553,7 +553,7 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
 
         if batch_size > 1 and cont_len > 1:
             raise ValueError(
-                "batch_size > 1 is not supported when the model returns single-position logits"
+                "batch_size > 1 is not supported when using incremental get_logits() retrieval"
                 " and continuation length > 1. Right-padding misaligns continuation positions across"
                 " batch elements. Use batch_size=1 instead."
             )


### PR DESCRIPTION
## Summary

Replace `get_output('logits')` with `get_logits()` in the ortgenai evaluator to avoid copying the full logits tensor from GPU to CPU each call.

## Problem

`generator.get_output('logits')` copies the **entire** logits tensor (`[batch, seq_len, vocab_size]`) from GPU to CPU. For a 900-token prompt with 262K vocab, this is **472MB per call**, taking **~410ms** — more than the forward pass itself (289ms).

For loglikelihood evaluation, we only need logits at the continuation token positions (typically 1–20 positions out of 900). Copying all 900 positions is wasteful.

## Fix

Use `generator.get_logits()` which returns only the last position's logits (~1MB, ~2ms). The evaluator now always uses incremental token appending: bulk-prefill the context, then step through continuation tokens collecting logits at each position.

## Benchmark

Gemma4 E2B-IT, MMLU Pro limit=50, CUDA EP, H200:

| Metric | Before | After |
|--------|--------|-------|
| Time | 46.9s | **24.2s** |
| Throughput | 10.6 req/s | **20.7 req/s** |
| **Speedup** | — | **1.94×** |
| Accuracy | 16.0% | 16.0% ✅ |

### Per-call impact

| API | Copy size | Time |
|-----|----------|------|
| `get_output('logits')` | 472MB (all positions) | ~410ms |
| `get_logits()` | ~1MB (last position) | ~2ms |

Full analysis: [onnxruntime/mobius#285](https://github.com/onnxruntime/mobius/issues/285)