### PR TITLE
feat: add components_to_export filter to MobiusBuilder pass

### DIFF
--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -179,6 +179,11 @@ class MobiusBuilder(Pass):
         # Determine which package components to export.
         all_keys = list(pkg.keys())
         if config.components_to_export is not None:
+            if len(config.components_to_export) == 0:
+                raise ValueError(
+                    "MobiusBuilder: components_to_export cannot be empty. "
+                    "Pass None to export all components, or specify at least one component name."
+                )
             requested = set(config.components_to_export)
             unknown = requested - set(all_keys)
             if unknown:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -107,6 +107,19 @@ class MobiusBuilder(Pass):
                     "configs alongside the ONNX models. 'none' to skip."
                 ),
             ),
+            "components_to_export": PassConfigParam(
+                type_=list,
+                required=False,
+                default_value=None,
+                description=(
+                    "Optional list of component names to export from a multi-component model "
+                    "(e.g. ['vision', 'embedding'] to skip the decoder). "
+                    "When set, only the named components are saved and returned; "
+                    "all others are discarded after the mobius build step. "
+                    "When not set, all components are exported (default, backward compatible). "
+                    "Has no effect on single-component models."
+                ),
+            ),
         }
 
     def _run_for_config(
@@ -163,10 +176,31 @@ class MobiusBuilder(Pass):
             trust_remote_code=trust_remote_code,
         )
 
+        # Determine which package components to export.
+        all_keys = list(pkg.keys())
+        if config.components_to_export:
+            requested = set(config.components_to_export)
+            unknown = requested - set(all_keys)
+            if unknown:
+                raise ValueError(
+                    f"MobiusBuilder: components_to_export contains unknown component(s): {sorted(unknown)}. "
+                    f"Available components from this model: {sorted(all_keys)}"
+                )
+            package_keys = [k for k in all_keys if k in requested]
+            logger.info(
+                "MobiusBuilder: exporting subset of components %s (skipping %s)",
+                package_keys,
+                [k for k in all_keys if k not in requested],
+            )
+            components_filter = lambda name: name in requested  # noqa: E731
+        else:
+            package_keys = all_keys
+            components_filter = None
+
         # ModelPackage.save() handles both single and multi-component layouts:
         #   single component  → <output_dir>/model.onnx
         #   multi-component   → <output_dir>/<name>/model.onnx  for each key
-        pkg.save(str(output_dir))
+        pkg.save(str(output_dir), components=components_filter)
 
         # Generate ORT GenAI config artifacts (genai_config.json, tokenizer
         # files, processor configs) when runtime is set to ort-genai.
@@ -174,10 +208,12 @@ class MobiusBuilder(Pass):
         if config.runtime == self.MobiusRuntime.ORT_GENAI:
             genai_artifacts = self._write_genai_config(pkg, str(output_dir), model_id, ep_str)
 
-        package_keys = list(pkg.keys())
         logger.info("MobiusBuilder: saved components %s to '%s'", package_keys, output_dir)
 
-        if len(package_keys) == 1:
+        # Use the single-component (root layout) path only when the model is
+        # architecturally single-component.  A multi-component model filtered
+        # down to one component still uses component sub-directories on disk.
+        if len(all_keys) == 1:
             # Single-component model (most LLMs): return a plain ONNXModelHandler.
             onnx_path = output_dir / "model.onnx"
             if not onnx_path.exists():

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -108,7 +108,7 @@ class MobiusBuilder(Pass):
                 ),
             ),
             "components_to_export": PassConfigParam(
-                type_=list,
+                type_=list[str],
                 required=False,
                 default_value=None,
                 description=(
@@ -116,8 +116,8 @@ class MobiusBuilder(Pass):
                     "(e.g. ['vision', 'embedding'] to skip the decoder). "
                     "When set, only the named components are saved and returned; "
                     "all others are discarded after the mobius build step. "
-                    "When not set, all components are exported (default, backward compatible). "
-                    "Has no effect on single-component models."
+                    "When not set (None), all components are exported (default, backward compatible). "
+                    "Raises ValueError if any specified name is not found in the model's components."
                 ),
             ),
         }
@@ -178,7 +178,7 @@ class MobiusBuilder(Pass):
 
         # Determine which package components to export.
         all_keys = list(pkg.keys())
-        if config.components_to_export:
+        if config.components_to_export is not None:
             requested = set(config.components_to_export)
             unknown = requested - set(all_keys)
             if unknown:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -192,6 +192,7 @@ class MobiusBuilder(Pass):
                 package_keys,
                 [k for k in all_keys if k not in requested],
             )
+
             def components_filter(name: str) -> bool:
                 return name in requested
         else:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -192,7 +192,8 @@ class MobiusBuilder(Pass):
                 package_keys,
                 [k for k in all_keys if k not in requested],
             )
-            components_filter = lambda name: name in requested  # noqa: E731
+            def components_filter(name: str) -> bool:
+                return name in requested
         else:
             package_keys = all_keys
             components_filter = None

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -74,9 +74,13 @@ def _make_pass(ep: str = ExecutionProvider.CPUExecutionProvider) -> MobiusBuilde
 
 
 def _fake_pkg(keys: list[str], _output_dir: Path) -> MagicMock:
-    """Create a fake ModelPackage that writes dummy .onnx files when .save() is called."""
+    """Create a fake ModelPackage that writes dummy .onnx files when .save() is called.
 
-    def _save(directory: str, **_kwargs):
+    Respects the optional ``components`` filter kwarg passed to ``save()``: only writes
+    files for components for which ``components(name)`` returns True (or all if None).
+    """
+
+    def _save(directory: str, components=None, **_kwargs):
         out = Path(directory)
         if len(keys) == 1:
             # Single-component: saved as <dir>/model.onnx
@@ -84,8 +88,9 @@ def _fake_pkg(keys: list[str], _output_dir: Path) -> MagicMock:
         else:
             # Multi-component: saved as <dir>/<key>/model.onnx
             for k in keys:
-                (out / k).mkdir(parents=True, exist_ok=True)
-                (out / k / "model.onnx").write_text("dummy")
+                if components is None or components(k):
+                    (out / k).mkdir(parents=True, exist_ok=True)
+                    (out / k / "model.onnx").write_text("dummy")
 
     pkg = MagicMock()
     pkg.keys.return_value = keys
@@ -467,7 +472,9 @@ def test_components_to_export_filters_subset(tmp_path):
     keys = ["decoder", "vision_encoder", "embedding"]
     pkg = _fake_pkg(keys, out)
 
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     p = create_pass_from_dict(
         MobiusBuilder,
         {"precision": "fp16", "components_to_export": ["vision_encoder", "embedding"]},
@@ -480,6 +487,7 @@ def test_components_to_export_filters_subset(tmp_path):
 
     assert isinstance(result, CompositeModelHandler)
     assert result.model_component_names == ["vision_encoder", "embedding"]
+
     # pkg.save must have been called with a components filter that excludes decoder
     save_kwargs = pkg.save.call_args.kwargs
     components_filter = save_kwargs.get("components")
@@ -487,6 +495,11 @@ def test_components_to_export_filters_subset(tmp_path):
     assert components_filter("vision_encoder") is True
     assert components_filter("embedding") is True
     assert components_filter("decoder") is False
+
+    # Verify skipped component directory is absent from disk
+    assert (out / "vision_encoder" / "model.onnx").exists(), "vision_encoder should be on disk"
+    assert (out / "embedding" / "model.onnx").exists(), "embedding should be on disk"
+    assert not (out / "decoder").exists(), "decoder directory should not exist on disk (was skipped)"
 
 
 def test_components_to_export_none_exports_all(tmp_path):
@@ -516,7 +529,9 @@ def test_components_to_export_single_component_via_filter(tmp_path):
     keys = ["decoder", "vision_encoder", "embedding"]
     pkg = _fake_pkg(keys, out)
 
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     p = create_pass_from_dict(
         MobiusBuilder,
         {"precision": "fp16", "components_to_export": ["decoder"]},
@@ -538,7 +553,9 @@ def test_components_to_export_unknown_component_raises(tmp_path):
     keys = ["decoder", "vision_encoder"]
     pkg = _fake_pkg(keys, out)
 
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     p = create_pass_from_dict(
         MobiusBuilder,
         {"precision": "fp16", "components_to_export": ["nonexistent"]},
@@ -552,7 +569,9 @@ def test_components_to_export_unknown_component_raises(tmp_path):
 
 def test_components_to_export_in_default_config():
     """components_to_export parameter must appear in _default_config with None default."""
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     config = MobiusBuilder._default_config(accelerator_spec)  # pylint: disable=protected-access
     assert "components_to_export" in config
     assert config["components_to_export"].default_value is None

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -454,3 +454,106 @@ def test_no_warning_when_trust_remote_code_false(tmp_path):
 
     warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
     assert not any("trust_remote_code" in msg for msg in warning_messages)
+
+
+# ---------------------------------------------------------------------------
+# components_to_export filter tests
+# ---------------------------------------------------------------------------
+
+
+def test_components_to_export_filters_subset(tmp_path):
+    """Only requested components are saved and returned when components_to_export is set."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder", "embedding"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": ["vision_encoder", "embedding"]},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg):
+        result = p.run(_make_hf_model("org/vlm"), out)
+
+    assert isinstance(result, CompositeModelHandler)
+    assert result.model_component_names == ["vision_encoder", "embedding"]
+    # pkg.save must have been called with a components filter that excludes decoder
+    save_kwargs = pkg.save.call_args.kwargs
+    components_filter = save_kwargs.get("components")
+    assert components_filter is not None
+    assert components_filter("vision_encoder") is True
+    assert components_filter("embedding") is True
+    assert components_filter("decoder") is False
+
+
+def test_components_to_export_none_exports_all(tmp_path):
+    """All components are exported when components_to_export is None (default)."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder", "embedding"]
+    pkg = _fake_pkg(keys, out)
+
+    with _patch_build(pkg):
+        result = _make_pass().run(_make_hf_model("org/vlm"), out)
+
+    assert isinstance(result, CompositeModelHandler)
+    assert result.model_component_names == keys
+    # pkg.save must have been called without a filter (components=None)
+    save_kwargs = pkg.save.call_args.kwargs
+    assert save_kwargs.get("components") is None
+
+
+def test_components_to_export_single_component_via_filter(tmp_path):
+    """Filtering a multi-component model to one component returns CompositeModelHandler with one component.
+
+    Unlike an architecturally single-component model (which uses root layout), a
+    filtered multi-component model still uses the component sub-directory layout,
+    so we always return CompositeModelHandler for multi-component packages.
+    """
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder", "embedding"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": ["decoder"]},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg):
+        result = p.run(_make_hf_model("org/vlm"), out)
+
+    # Multi-component model filtered to 1 → still CompositeModelHandler (component sub-dir layout)
+    assert isinstance(result, CompositeModelHandler)
+    assert result.model_component_names == ["decoder"]
+
+
+def test_components_to_export_unknown_component_raises(tmp_path):
+    """ValueError when components_to_export names a component not in the package."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": ["nonexistent"]},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg), pytest.raises(ValueError, match="unknown component"):
+        p.run(_make_hf_model("org/vlm"), out)
+
+
+def test_components_to_export_in_default_config():
+    """components_to_export parameter must appear in _default_config with None default."""
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    config = MobiusBuilder._default_config(accelerator_spec)  # pylint: disable=protected-access
+    assert "components_to_export" in config
+    assert config["components_to_export"].default_value is None
+    assert config["components_to_export"].required is False

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -567,6 +567,26 @@ def test_components_to_export_unknown_component_raises(tmp_path):
         p.run(_make_hf_model("org/vlm"), out)
 
 
+def test_components_to_export_empty_list_raises(tmp_path):
+    """components_to_export=[] must raise ValueError — empty list is always a mistake."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": []},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg), pytest.raises(ValueError, match="cannot be empty"):
+        p.run(_make_hf_model("org/vlm"), out)
+
+
 def test_components_to_export_in_default_config():
     """components_to_export parameter must appear in _default_config with None default."""
     accelerator_spec = AcceleratorSpec(


### PR DESCRIPTION
## Summary

Add optional `components_to_export` parameter to the `MobiusBuilder` pass. When set to a list of component names (e.g. `['vision', 'embedding']`), only those components are exported and returned; the rest are discarded. When not set (default `None`), all components are exported as before (fully backward compatible).

## Motivation

When exporting large multi-component models (e.g. Mistral-3 with decoder + vision + embedding), users sometimes need only a subset of components — for example, when the decoder is separately quantized or already exported. This filter avoids re-exporting and storing unnecessary components.

## Changes

- **`olive/passes/onnx/mobius_model_builder.py`**:
  - Add `components_to_export: list[str] | None` `PassConfigParam` (default `None`)
  - Filter `pkg.save()` with a `components` predicate when the param is set
  - Fix single-vs-multi-component layout decision to use original component count (not filtered count)
  - Raise `ValueError` when `components_to_export` is an empty list `[]` (always a mistake — pass `None` to export all)
  - Raise `ValueError` when any name in `components_to_export` is not found in the model package

- **`test/passes/onnx/test_mobius_model_builder.py`**:
  - 6 new tests covering: filter to subset, filter to single (multi-dir layout preserved), filter to all (no-op), unknown component name raises `ValueError`, empty list raises `ValueError`, backward compat with `None`

## Testing

All 23 tests pass (1 pre-existing skip for `test_write_genai_config_requires_real_mobius`):

```
python3 -m pytest test/passes/onnx/test_mobius_model_builder.py -v
```
