### PR TITLE
feat: add components_to_skip to OnnxBlockWiseRtnQuantization

### DIFF
--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -179,6 +179,11 @@ class MobiusBuilder(Pass):
         # Determine which package components to export.
         all_keys = list(pkg.keys())
         if config.components_to_export is not None:
+            if len(config.components_to_export) == 0:
+                raise ValueError(
+                    "MobiusBuilder: components_to_export cannot be empty. "
+                    "Pass None to export all components, or specify at least one component name."
+                )
             requested = set(config.components_to_export)
             unknown = requested - set(all_keys)
             if unknown:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -107,6 +107,19 @@ class MobiusBuilder(Pass):
                     "configs alongside the ONNX models. 'none' to skip."
                 ),
             ),
+            "components_to_export": PassConfigParam(
+                type_=list,
+                required=False,
+                default_value=None,
+                description=(
+                    "Optional list of component names to export from a multi-component model "
+                    "(e.g. ['vision', 'embedding'] to skip the decoder). "
+                    "When set, only the named components are saved and returned; "
+                    "all others are discarded after the mobius build step. "
+                    "When not set, all components are exported (default, backward compatible). "
+                    "Has no effect on single-component models."
+                ),
+            ),
         }
 
     def _run_for_config(
@@ -163,10 +176,31 @@ class MobiusBuilder(Pass):
             trust_remote_code=trust_remote_code,
         )
 
+        # Determine which package components to export.
+        all_keys = list(pkg.keys())
+        if config.components_to_export:
+            requested = set(config.components_to_export)
+            unknown = requested - set(all_keys)
+            if unknown:
+                raise ValueError(
+                    f"MobiusBuilder: components_to_export contains unknown component(s): {sorted(unknown)}. "
+                    f"Available components from this model: {sorted(all_keys)}"
+                )
+            package_keys = [k for k in all_keys if k in requested]
+            logger.info(
+                "MobiusBuilder: exporting subset of components %s (skipping %s)",
+                package_keys,
+                [k for k in all_keys if k not in requested],
+            )
+            components_filter = lambda name: name in requested  # noqa: E731
+        else:
+            package_keys = all_keys
+            components_filter = None
+
         # ModelPackage.save() handles both single and multi-component layouts:
         #   single component  → <output_dir>/model.onnx
         #   multi-component   → <output_dir>/<name>/model.onnx  for each key
-        pkg.save(str(output_dir))
+        pkg.save(str(output_dir), components=components_filter)
 
         # Generate ORT GenAI config artifacts (genai_config.json, tokenizer
         # files, processor configs) when runtime is set to ort-genai.
@@ -174,10 +208,12 @@ class MobiusBuilder(Pass):
         if config.runtime == self.MobiusRuntime.ORT_GENAI:
             genai_artifacts = self._write_genai_config(pkg, str(output_dir), model_id, ep_str)
 
-        package_keys = list(pkg.keys())
         logger.info("MobiusBuilder: saved components %s to '%s'", package_keys, output_dir)
 
-        if len(package_keys) == 1:
+        # Use the single-component (root layout) path only when the model is
+        # architecturally single-component.  A multi-component model filtered
+        # down to one component still uses component sub-directories on disk.
+        if len(all_keys) == 1:
             # Single-component model (most LLMs): return a plain ONNXModelHandler.
             onnx_path = output_dir / "model.onnx"
             if not onnx_path.exists():

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -108,7 +108,7 @@ class MobiusBuilder(Pass):
                 ),
             ),
             "components_to_export": PassConfigParam(
-                type_=list,
+                type_=list[str],
                 required=False,
                 default_value=None,
                 description=(
@@ -116,8 +116,8 @@ class MobiusBuilder(Pass):
                     "(e.g. ['vision', 'embedding'] to skip the decoder). "
                     "When set, only the named components are saved and returned; "
                     "all others are discarded after the mobius build step. "
-                    "When not set, all components are exported (default, backward compatible). "
-                    "Has no effect on single-component models."
+                    "When not set (None), all components are exported (default, backward compatible). "
+                    "Raises ValueError if any specified name is not found in the model's components."
                 ),
             ),
         }
@@ -178,7 +178,7 @@ class MobiusBuilder(Pass):
 
         # Determine which package components to export.
         all_keys = list(pkg.keys())
-        if config.components_to_export:
+        if config.components_to_export is not None:
             requested = set(config.components_to_export)
             unknown = requested - set(all_keys)
             if unknown:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -192,6 +192,7 @@ class MobiusBuilder(Pass):
                 package_keys,
                 [k for k in all_keys if k not in requested],
             )
+
             def components_filter(name: str) -> bool:
                 return name in requested
         else:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -192,7 +192,8 @@ class MobiusBuilder(Pass):
                 package_keys,
                 [k for k in all_keys if k not in requested],
             )
-            components_filter = lambda name: name in requested  # noqa: E731
+            def components_filter(name: str) -> bool:
+                return name in requested
         else:
             package_keys = all_keys
             components_filter = None

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -128,6 +128,11 @@ class OnnxBlockWiseRtnQuantization(Pass):
                     onnx_file_name=component_model.onnx_file_name,
                     model_attributes=component_model.model_attributes,
                 )
+                # Mirror what the base run() does for each individual component.
+                output_component.model_attributes = (
+                    output_component.model_attributes or component_model.model_attributes
+                )
+                Pass._carry_forward_additional_files(component_model, output_component)
             else:
                 output_component = self.run(component_model, str(component_output_path))
             components.append(output_component)

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -71,7 +71,7 @@ class OnnxBlockWiseRtnQuantization(Pass):
                 description="List of node names to include in quantization.",
             ),
             "components_to_skip": PassConfigParam(
-                type_=list,
+                type_=list[str],
                 default_value=None,
                 description=(
                     "Optional list of component names to skip quantization for "
@@ -93,13 +93,27 @@ class OnnxBlockWiseRtnQuantization(Pass):
         output path unchanged instead of being quantized.
         """
         from olive.model import CompositeModelHandler
-        from olive.model.handler.onnx import ONNXModelHandler as OnnxHandler
 
         components_to_skip: set[str] = set(self.config.components_to_skip or [])
         if not components_to_skip or not isinstance(model, CompositeModelHandler):
             return super().run(model, output_model_path)
 
-        # Mirror the initialization guard from the base class run().
+        # Warn about component names that won't match anything — misspellings are
+        # silently ignored otherwise since skipping is non-fatal.
+        all_component_names = {name for name, _ in model.get_model_components()}
+        unknown_skips = components_to_skip - all_component_names
+        if unknown_skips:
+            logger.warning(
+                "OnnxBlockWiseRtnQuantization: components_to_skip contains name(s) not found "
+                "in this composite model: %s. Available components: %s",
+                sorted(unknown_skips),
+                sorted(all_component_names),
+            )
+
+        # Mirror the _initialized guard from the base Pass.run() implementation.
+        # Pass.run() checks and sets self._initialized before calling _run_for_config;
+        # since we bypass super().run() for composite models, we must replicate it here
+        # so lazy initialization (e.g. loading config, setting up hardware state) still runs.
         if not self._initialized:
             self._initialize()
             self._initialized = True
@@ -123,14 +137,10 @@ class OnnxBlockWiseRtnQuantization(Pass):
                     if component_output_path.exists():
                         shutil.rmtree(str(component_output_path))
                     shutil.copytree(str(src_dir), str(component_output_path))
-                output_component = OnnxHandler(
+                output_component = ONNXModelHandler(
                     model_path=str(component_output_path),
                     onnx_file_name=component_model.onnx_file_name,
                     model_attributes=component_model.model_attributes,
-                )
-                # Mirror what the base run() does for each individual component.
-                output_component.model_attributes = (
-                    output_component.model_attributes or component_model.model_attributes
                 )
                 Pass._carry_forward_additional_files(component_model, output_component)
             else:

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -99,6 +99,11 @@ class OnnxBlockWiseRtnQuantization(Pass):
         if not components_to_skip or not isinstance(model, CompositeModelHandler):
             return super().run(model, output_model_path)
 
+        # Mirror the initialization guard from the base class run().
+        if not self._initialized:
+            self._initialize()
+            self._initialized = True
+
         model_dir = Path(output_model_path).with_suffix("")
         model_dir.mkdir(parents=True, exist_ok=True)
 

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -5,7 +5,7 @@
 import logging
 import shutil
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -72,7 +72,6 @@ class OnnxBlockWiseRtnQuantization(Pass):
             ),
             "components_to_skip": PassConfigParam(
                 type_=list,
-                required=False,
                 default_value=None,
                 description=(
                     "Optional list of component names to skip quantization for "

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -3,8 +3,9 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+import shutil
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -69,8 +70,69 @@ class OnnxBlockWiseRtnQuantization(Pass):
                 default_value=None,
                 description="List of node names to include in quantization.",
             ),
+            "components_to_skip": PassConfigParam(
+                type_=list,
+                required=False,
+                default_value=None,
+                description=(
+                    "Optional list of component names to skip quantization for "
+                    "(e.g. ['embedding'] to pass the embedding model through unchanged). "
+                    "When a composite model component's name matches an entry in this list, "
+                    "its files are copied to the output path without modification. "
+                    "When not set, all components are quantized (default, backward compatible). "
+                    "Has no effect on single-component (non-composite) models."
+                ),
+            ),
             **get_external_data_config(),
         }
+
+    def run(self, model, output_model_path: str):
+        """Run quantization, skipping components listed in components_to_skip.
+
+        Overrides the base Pass.run() to intercept CompositeModelHandler processing.
+        Components whose names appear in config.components_to_skip are copied to the
+        output path unchanged instead of being quantized.
+        """
+        from olive.model import CompositeModelHandler
+        from olive.model.handler.onnx import ONNXModelHandler as OnnxHandler
+
+        components_to_skip: set[str] = set(self.config.components_to_skip or [])
+        if not components_to_skip or not isinstance(model, CompositeModelHandler):
+            return super().run(model, output_model_path)
+
+        model_dir = Path(output_model_path).with_suffix("")
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        components = []
+        component_names = []
+        for component_name, component_model in model.get_model_components():
+            component_output_path = model_dir / component_name
+            if component_name in components_to_skip:
+                logger.info(
+                    "OnnxBlockWiseRtnQuantization: skipping quantization for component '%s'.",
+                    component_name,
+                )
+                src = Path(component_model.model_path)
+                # model_path may point to the .onnx file rather than its parent dir
+                src_dir = src.parent if src.is_file() else src
+                if src_dir != component_output_path:
+                    if component_output_path.exists():
+                        shutil.rmtree(str(component_output_path))
+                    shutil.copytree(str(src_dir), str(component_output_path))
+                output_component = OnnxHandler(
+                    model_path=str(component_output_path),
+                    onnx_file_name=component_model.onnx_file_name,
+                    model_attributes=component_model.model_attributes,
+                )
+            else:
+                output_component = self.run(component_model, str(component_output_path))
+            components.append(output_component)
+            component_names.append(component_name)
+
+        output_model = CompositeModelHandler(components, component_names, model_path=model_dir)
+        output_model.model_attributes = output_model.model_attributes or model.model_attributes
+        Pass._carry_forward_additional_files(model, output_model)
+        return output_model
 
     def _run_for_config(
         self, model: ONNXModelHandler, config: type[BasePassConfig], output_model_path: str

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -74,9 +74,13 @@ def _make_pass(ep: str = ExecutionProvider.CPUExecutionProvider) -> MobiusBuilde
 
 
 def _fake_pkg(keys: list[str], _output_dir: Path) -> MagicMock:
-    """Create a fake ModelPackage that writes dummy .onnx files when .save() is called."""
+    """Create a fake ModelPackage that writes dummy .onnx files when .save() is called.
 
-    def _save(directory: str, **_kwargs):
+    Respects the optional ``components`` filter kwarg passed to ``save()``: only writes
+    files for components for which ``components(name)`` returns True (or all if None).
+    """
+
+    def _save(directory: str, components=None, **_kwargs):
         out = Path(directory)
         if len(keys) == 1:
             # Single-component: saved as <dir>/model.onnx
@@ -84,8 +88,9 @@ def _fake_pkg(keys: list[str], _output_dir: Path) -> MagicMock:
         else:
             # Multi-component: saved as <dir>/<key>/model.onnx
             for k in keys:
-                (out / k).mkdir(parents=True, exist_ok=True)
-                (out / k / "model.onnx").write_text("dummy")
+                if components is None or components(k):
+                    (out / k).mkdir(parents=True, exist_ok=True)
+                    (out / k / "model.onnx").write_text("dummy")
 
     pkg = MagicMock()
     pkg.keys.return_value = keys
@@ -467,7 +472,9 @@ def test_components_to_export_filters_subset(tmp_path):
     keys = ["decoder", "vision_encoder", "embedding"]
     pkg = _fake_pkg(keys, out)
 
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     p = create_pass_from_dict(
         MobiusBuilder,
         {"precision": "fp16", "components_to_export": ["vision_encoder", "embedding"]},
@@ -480,6 +487,7 @@ def test_components_to_export_filters_subset(tmp_path):
 
     assert isinstance(result, CompositeModelHandler)
     assert result.model_component_names == ["vision_encoder", "embedding"]
+
     # pkg.save must have been called with a components filter that excludes decoder
     save_kwargs = pkg.save.call_args.kwargs
     components_filter = save_kwargs.get("components")
@@ -487,6 +495,11 @@ def test_components_to_export_filters_subset(tmp_path):
     assert components_filter("vision_encoder") is True
     assert components_filter("embedding") is True
     assert components_filter("decoder") is False
+
+    # Verify skipped component directory is absent from disk
+    assert (out / "vision_encoder" / "model.onnx").exists(), "vision_encoder should be on disk"
+    assert (out / "embedding" / "model.onnx").exists(), "embedding should be on disk"
+    assert not (out / "decoder").exists(), "decoder directory should not exist on disk (was skipped)"
 
 
 def test_components_to_export_none_exports_all(tmp_path):
@@ -516,7 +529,9 @@ def test_components_to_export_single_component_via_filter(tmp_path):
     keys = ["decoder", "vision_encoder", "embedding"]
     pkg = _fake_pkg(keys, out)
 
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     p = create_pass_from_dict(
         MobiusBuilder,
         {"precision": "fp16", "components_to_export": ["decoder"]},
@@ -538,7 +553,9 @@ def test_components_to_export_unknown_component_raises(tmp_path):
     keys = ["decoder", "vision_encoder"]
     pkg = _fake_pkg(keys, out)
 
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     p = create_pass_from_dict(
         MobiusBuilder,
         {"precision": "fp16", "components_to_export": ["nonexistent"]},
@@ -552,7 +569,9 @@ def test_components_to_export_unknown_component_raises(tmp_path):
 
 def test_components_to_export_in_default_config():
     """components_to_export parameter must appear in _default_config with None default."""
-    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
     config = MobiusBuilder._default_config(accelerator_spec)  # pylint: disable=protected-access
     assert "components_to_export" in config
     assert config["components_to_export"].default_value is None

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -454,3 +454,106 @@ def test_no_warning_when_trust_remote_code_false(tmp_path):
 
     warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
     assert not any("trust_remote_code" in msg for msg in warning_messages)
+
+
+# ---------------------------------------------------------------------------
+# components_to_export filter tests
+# ---------------------------------------------------------------------------
+
+
+def test_components_to_export_filters_subset(tmp_path):
+    """Only requested components are saved and returned when components_to_export is set."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder", "embedding"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": ["vision_encoder", "embedding"]},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg):
+        result = p.run(_make_hf_model("org/vlm"), out)
+
+    assert isinstance(result, CompositeModelHandler)
+    assert result.model_component_names == ["vision_encoder", "embedding"]
+    # pkg.save must have been called with a components filter that excludes decoder
+    save_kwargs = pkg.save.call_args.kwargs
+    components_filter = save_kwargs.get("components")
+    assert components_filter is not None
+    assert components_filter("vision_encoder") is True
+    assert components_filter("embedding") is True
+    assert components_filter("decoder") is False
+
+
+def test_components_to_export_none_exports_all(tmp_path):
+    """All components are exported when components_to_export is None (default)."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder", "embedding"]
+    pkg = _fake_pkg(keys, out)
+
+    with _patch_build(pkg):
+        result = _make_pass().run(_make_hf_model("org/vlm"), out)
+
+    assert isinstance(result, CompositeModelHandler)
+    assert result.model_component_names == keys
+    # pkg.save must have been called without a filter (components=None)
+    save_kwargs = pkg.save.call_args.kwargs
+    assert save_kwargs.get("components") is None
+
+
+def test_components_to_export_single_component_via_filter(tmp_path):
+    """Filtering a multi-component model to one component returns CompositeModelHandler with one component.
+
+    Unlike an architecturally single-component model (which uses root layout), a
+    filtered multi-component model still uses the component sub-directory layout,
+    so we always return CompositeModelHandler for multi-component packages.
+    """
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder", "embedding"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": ["decoder"]},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg):
+        result = p.run(_make_hf_model("org/vlm"), out)
+
+    # Multi-component model filtered to 1 → still CompositeModelHandler (component sub-dir layout)
+    assert isinstance(result, CompositeModelHandler)
+    assert result.model_component_names == ["decoder"]
+
+
+def test_components_to_export_unknown_component_raises(tmp_path):
+    """ValueError when components_to_export names a component not in the package."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": ["nonexistent"]},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg), pytest.raises(ValueError, match="unknown component"):
+        p.run(_make_hf_model("org/vlm"), out)
+
+
+def test_components_to_export_in_default_config():
+    """components_to_export parameter must appear in _default_config with None default."""
+    accelerator_spec = AcceleratorSpec(accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider)
+    config = MobiusBuilder._default_config(accelerator_spec)  # pylint: disable=protected-access
+    assert "components_to_export" in config
+    assert config["components_to_export"].default_value is None
+    assert config["components_to_export"].required is False

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -567,6 +567,26 @@ def test_components_to_export_unknown_component_raises(tmp_path):
         p.run(_make_hf_model("org/vlm"), out)
 
 
+def test_components_to_export_empty_list_raises(tmp_path):
+    """components_to_export=[] must raise ValueError — empty list is always a mistake."""
+    out = tmp_path / "out"
+    keys = ["decoder", "vision_encoder"]
+    pkg = _fake_pkg(keys, out)
+
+    accelerator_spec = AcceleratorSpec(
+        accelerator_type=Device.CPU, execution_provider=ExecutionProvider.CPUExecutionProvider
+    )
+    p = create_pass_from_dict(
+        MobiusBuilder,
+        {"precision": "fp16", "components_to_export": []},
+        disable_search=True,
+        accelerator_spec=accelerator_spec,
+    )
+
+    with _patch_build(pkg), pytest.raises(ValueError, match="cannot be empty"):
+        p.run(_make_hf_model("org/vlm"), out)
+
+
 def test_components_to_export_in_default_config():
     """components_to_export parameter must appear in _default_config with None default."""
     accelerator_spec = AcceleratorSpec(

--- a/test/passes/onnx/test_rtn_quantization.py
+++ b/test/passes/onnx/test_rtn_quantization.py
@@ -541,3 +541,35 @@ class TestRTNQuantizationComponentsToSkip:
         assert "components_to_skip" in config
         assert config["components_to_skip"].default_value is None
         assert config["components_to_skip"].required is False
+
+    def test_components_to_skip_unknown_name_warns(self, tmp_path):
+        """Misspelled or missing component names in components_to_skip must log a warning."""
+        from olive.model.handler.composite import CompositeModelHandler
+
+        decoder = self._make_matmul_model(tmp_path / "src", "decoder")
+        vision = self._make_matmul_model(tmp_path / "src", "vision")
+        composite = CompositeModelHandler(
+            model_components=[decoder, vision],
+            model_component_names=["decoder", "vision"],
+        )
+
+        p = self._make_pass(components_to_skip=["typo_component"])
+
+        import logging
+
+        records = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        rtn_logger = logging.getLogger("olive.passes.onnx.rtn_quantization")
+        rtn_logger.addHandler(_Handler())
+        try:
+            p.run(composite, str(tmp_path / "out"))
+        finally:
+            rtn_logger.handlers = [h for h in rtn_logger.handlers if not isinstance(h, _Handler)]
+
+        assert any("typo_component" in msg for msg in records), (
+            f"Expected warning about unknown component name 'typo_component', got: {records}"
+        )

--- a/test/passes/onnx/test_rtn_quantization.py
+++ b/test/passes/onnx/test_rtn_quantization.py
@@ -427,3 +427,110 @@ class TestRTNQuantization:
         assert "weight" not in init_names, (
             f"Original FP32 'weight' initializer should have been removed, found: {init_names}"
         )
+
+
+class TestRTNQuantizationComponentsToSkip:
+    """Tests for the components_to_skip parameter on OnnxBlockWiseRtnQuantization."""
+
+    @staticmethod
+    def _make_matmul_model(tmp_path, name: str) -> ONNXModelHandler:
+        """Create a tiny MatMul ONNX model and return an ONNXModelHandler."""
+        weight = np.random.randn(64, 128).astype(np.float32)
+        inp = onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 64])
+        out = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 128])
+        weight_init = onnx.helper.make_tensor(name="weight", data_type=onnx.TensorProto.FLOAT, dims=[64, 128], vals=weight.flatten().tolist())
+        node = onnx.helper.make_node("MatMul", ["input", "weight"], ["output"], name="MatMul_Node")
+        graph = onnx.helper.make_graph([node], "g", [inp], [out], initializer=[weight_init])
+        model_def = onnx.helper.make_model(graph, producer_name="test")
+        model_def.opset_import[0].version = 13
+
+        model_dir = tmp_path / name
+        model_dir.mkdir(parents=True, exist_ok=True)
+        onnx.save(model_def, str(model_dir / "model.onnx"))
+        return ONNXModelHandler(model_path=str(model_dir), onnx_file_name="model.onnx")
+
+    @staticmethod
+    def _make_pass(components_to_skip=None) -> OnnxBlockWiseRtnQuantization:
+        from olive.hardware.accelerator import AcceleratorSpec
+        accelerator_spec = AcceleratorSpec(accelerator_type="CPU", execution_provider="CPUExecutionProvider")
+        config = {"bits": 4, "block_size": 128, "axis": 0, "is_symmetric": True}
+        if components_to_skip is not None:
+            config["components_to_skip"] = components_to_skip
+        return create_pass_from_dict(OnnxBlockWiseRtnQuantization, config, disable_search=True, accelerator_spec=accelerator_spec)
+
+    def test_components_to_skip_passes_component_through_unchanged(self, tmp_path):
+        """Skipped component's model files are copied without quantization."""
+        from olive.model.handler.composite import CompositeModelHandler
+
+        decoder = self._make_matmul_model(tmp_path / "src", "decoder")
+        embedding = self._make_matmul_model(tmp_path / "src", "embedding")
+
+        composite = CompositeModelHandler(
+            model_components=[decoder, embedding],
+            model_component_names=["decoder", "embedding"],
+            model_path=str(tmp_path / "src"),
+        )
+
+        p = self._make_pass(components_to_skip=["embedding"])
+        result = p.run(composite, str(tmp_path / "out"))
+
+        assert isinstance(result, CompositeModelHandler)
+        assert result.model_component_names == ["decoder", "embedding"]
+
+        # decoder should be quantized (MatMulNBits present)
+        decoder_out = next(m for name, m in result.get_model_components() if name == "decoder")
+        decoder_ir = ir.load(decoder_out.model_path)
+        assert any(n.op_type == str(OpType.MatMulNBits) for n in decoder_ir.graph.all_nodes()), (
+            "decoder should be quantized (MatMulNBits expected)"
+        )
+
+        # embedding should be unchanged (original MatMul still present)
+        emb_out = next(m for name, m in result.get_model_components() if name == "embedding")
+        emb_ir = ir.load(emb_out.model_path)
+        has_matmul = any(n.op_type == str(OpType.MatMul) for n in emb_ir.graph.all_nodes())
+        has_nbits = any(n.op_type == str(OpType.MatMulNBits) for n in emb_ir.graph.all_nodes())
+        assert has_matmul and not has_nbits, "embedding should be passed through unchanged (no MatMulNBits)"
+
+    def test_components_to_skip_none_quantizes_all(self, tmp_path):
+        """When components_to_skip is not set, all composite components are quantized."""
+        from olive.model.handler.composite import CompositeModelHandler
+
+        decoder = self._make_matmul_model(tmp_path / "src", "decoder")
+        embedding = self._make_matmul_model(tmp_path / "src", "embedding")
+
+        composite = CompositeModelHandler(
+            model_components=[decoder, embedding],
+            model_component_names=["decoder", "embedding"],
+            model_path=str(tmp_path / "src"),
+        )
+
+        p = self._make_pass(components_to_skip=None)
+        result = p.run(composite, str(tmp_path / "out"))
+
+        assert isinstance(result, CompositeModelHandler)
+
+        for name, component in result.get_model_components():
+            component_ir = ir.load(component.model_path)
+            assert any(n.op_type == str(OpType.MatMulNBits) for n in component_ir.graph.all_nodes()), (
+                f"component '{name}' should be quantized when components_to_skip is None"
+            )
+
+    def test_components_to_skip_does_not_affect_single_model(self, tmp_path):
+        """components_to_skip has no effect on non-composite (single) models."""
+        model = self._make_matmul_model(tmp_path, "single")
+        p = self._make_pass(components_to_skip=["single"])
+        result = p.run(model, str(tmp_path / "out"))
+
+        # Single model should still be quantized despite its path matching the skip list
+        result_ir = ir.load(result.model_path)
+        assert any(n.op_type == str(OpType.MatMulNBits) for n in result_ir.graph.all_nodes()), (
+            "Single-component model should be quantized even when components_to_skip is set"
+        )
+
+    def test_components_to_skip_in_default_config(self):
+        """components_to_skip must appear in _default_config with None as default."""
+        accelerator_spec = AcceleratorSpec(accelerator_type="CPU", execution_provider="CPUExecutionProvider")
+        config = OnnxBlockWiseRtnQuantization._default_config(accelerator_spec)  # pylint: disable=protected-access
+        assert "components_to_skip" in config
+        assert config["components_to_skip"].default_value is None
+        assert config["components_to_skip"].required is False

--- a/test/passes/onnx/test_rtn_quantization.py
+++ b/test/passes/onnx/test_rtn_quantization.py
@@ -438,7 +438,12 @@ class TestRTNQuantizationComponentsToSkip:
         weight = np.random.randn(64, 128).astype(np.float32)
         inp = onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 64])
         out = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 128])
-        weight_init = onnx.helper.make_tensor(name="weight", data_type=onnx.TensorProto.FLOAT, dims=[64, 128], vals=weight.flatten().tolist())
+        weight_init = onnx.helper.make_tensor(
+            name="weight",
+            data_type=onnx.TensorProto.FLOAT,
+            dims=[64, 128],
+            vals=weight.flatten().tolist(),
+        )
         node = onnx.helper.make_node("MatMul", ["input", "weight"], ["output"], name="MatMul_Node")
         graph = onnx.helper.make_graph([node], "g", [inp], [out], initializer=[weight_init])
         model_def = onnx.helper.make_model(graph, producer_name="test")
@@ -451,12 +456,13 @@ class TestRTNQuantizationComponentsToSkip:
 
     @staticmethod
     def _make_pass(components_to_skip=None) -> OnnxBlockWiseRtnQuantization:
-        from olive.hardware.accelerator import AcceleratorSpec
         accelerator_spec = AcceleratorSpec(accelerator_type="CPU", execution_provider="CPUExecutionProvider")
         config = {"bits": 4, "block_size": 128, "axis": 0, "is_symmetric": True}
         if components_to_skip is not None:
             config["components_to_skip"] = components_to_skip
-        return create_pass_from_dict(OnnxBlockWiseRtnQuantization, config, disable_search=True, accelerator_spec=accelerator_spec)
+        return create_pass_from_dict(
+            OnnxBlockWiseRtnQuantization, config, disable_search=True, accelerator_spec=accelerator_spec
+        )
 
     def test_components_to_skip_passes_component_through_unchanged(self, tmp_path):
         """Skipped component's model files are copied without quantization."""
@@ -489,7 +495,8 @@ class TestRTNQuantizationComponentsToSkip:
         emb_ir = ir.load(emb_out.model_path)
         has_matmul = any(n.op_type == str(OpType.MatMul) for n in emb_ir.graph.all_nodes())
         has_nbits = any(n.op_type == str(OpType.MatMulNBits) for n in emb_ir.graph.all_nodes())
-        assert has_matmul and not has_nbits, "embedding should be passed through unchanged (no MatMulNBits)"
+        assert has_matmul, "embedding should still contain the original MatMul op"
+        assert not has_nbits, "embedding should not be quantized (no MatMulNBits expected)"
 
     def test_components_to_skip_none_quantizes_all(self, tmp_path):
         """When components_to_skip is not set, all composite components are quantized."""


### PR DESCRIPTION
## Summary

Add optional `components_to_skip` parameter to the `OnnxBlockWiseRtnQuantization` pass. When set to a list of component names (e.g. `['embedding']`), those components in a `CompositeModelHandler` are copied to the output path unchanged instead of being quantized. Non-listed components are quantized as usual. When not set (default `None`), all components are quantized (fully backward compatible).

## Motivation

When quantizing large multi-component models (e.g. Mistral-3 with decoder + vision + embedding), users may want to skip RTN quantization for specific components such as the embedding model — which may already be in an acceptable format or should be kept in higher precision.

## Changes

- **`olive/passes/onnx/rtn_quantization.py`**:
  - Add `components_to_skip: list[str] | None` `PassConfigParam` (default `None`)
  - Override `run()` to intercept `CompositeModelHandler` processing: copy skipped components via `shutil.copytree`, quantize the rest via recursive `self.run()`
  - Log a warning when a name in `components_to_skip` is not found in the composite model's components (misspellings are non-fatal but should be surfaced)
  - Non-composite (single) models are unaffected by this parameter

- **`test/passes/onnx/test_rtn_quantization.py`**:
  - New `TestRTNQuantizationComponentsToSkip` class with 5 tests:
    - Skipped component passes through unchanged (no MatMulNBits)
    - Non-skipped components are still quantized
    - `components_to_skip=None` quantizes all (backward compat)
    - Single-model (non-composite) is unaffected
    - Unknown component name in `components_to_skip` logs a warning
    - Parameter exists in `_default_config` with `None` default

## Testing

All 16 tests pass:

```
python3 -m pytest test/passes/onnx/test_rtn_quantization.py -v
```

## Dependencies

Rebased onto #2454 (`feat/mobius-builder-components-filter`) to pick up `list[str]` type annotation convention.
