### PR TITLE
Add chat-template hooks to LMEvalORTGenAIEvaluator

### DIFF
--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -498,10 +498,11 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
                 self.config.set_provider_option(ep, key, value)
         self.model = og.Model(self.config)
         self.tokenizer = og.Tokenizer(self.model)
-        # HF tokenizer kept solely to render `apply_chat_template`; generation
-        # still uses og.Tokenizer above.
+        # HF tokenizer is loaded lazily by `apply_chat_template` on first use,
+        # so callers that don't enable chat templating do not need HF tokenizer
+        # files (tokenizer_config.json, etc.) in the model directory.
         self._pretrained = str(pretrained)
-        self._hf_tokenizer = AutoTokenizer.from_pretrained(self._pretrained)
+        self._hf_tokenizer: AutoTokenizer | None = None
 
         # consider adding auto batch sizes
         self.batch_size = int(batch_size)
@@ -527,15 +528,25 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
 
     @property
     def tokenizer_name(self) -> str:
-        """Identifier used by lm-eval for chat-template-aware caching."""
-        return self._pretrained.replace("/", "__")
+        r"""Stable identifier used by lm-eval's chat-template-aware result cache.
+
+        Replace both POSIX and Windows path separators so the cache key does
+        not embed raw path separators (a Windows path like ``C:\models\foo``
+        and the POSIX form ``C:/models/foo`` produce the same identifier).
+        """
+        return self._pretrained.replace("\\", "__").replace("/", "__")
 
     def apply_chat_template(self, chat_history: list[dict], add_generation_prompt: bool = True) -> str:
-        """Render a chat history through the model's HF chat template.
+        """Render a chat history through the model's HuggingFace chat template.
 
-        Required by lm-eval when `apply_chat_template=True` is passed to
-        `simple_evaluate`; without it, lm-eval raises NotImplementedError.
+        Required by lm-eval when ``apply_chat_template=True`` is passed to
+        ``simple_evaluate``; without it, lm-eval raises ``NotImplementedError``
+        at task setup. The HF tokenizer is loaded on first call so callers that
+        never enable chat templating are not required to ship HF tokenizer
+        files alongside the ONNX model.
         """
+        if self._hf_tokenizer is None:
+            self._hf_tokenizer = AutoTokenizer.from_pretrained(self._pretrained)
         return self._hf_tokenizer.apply_chat_template(
             chat_history,
             tokenize=False,

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -498,9 +498,6 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
                 self.config.set_provider_option(ep, key, value)
         self.model = og.Model(self.config)
         self.tokenizer = og.Tokenizer(self.model)
-        # HF tokenizer is loaded lazily by `apply_chat_template` on first use,
-        # so callers that don't enable chat templating do not need HF tokenizer
-        # files (tokenizer_config.json, etc.) in the model directory.
         self._pretrained = str(pretrained)
         self._hf_tokenizer: AutoTokenizer | None = None
 
@@ -528,23 +525,9 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
 
     @property
     def tokenizer_name(self) -> str:
-        r"""Stable identifier used by lm-eval's chat-template-aware result cache.
-
-        Replace both POSIX and Windows path separators so the cache key does
-        not embed raw path separators (a Windows path like ``C:\models\foo``
-        and the POSIX form ``C:/models/foo`` produce the same identifier).
-        """
         return self._pretrained.replace("\\", "__").replace("/", "__")
 
     def apply_chat_template(self, chat_history: list[dict], add_generation_prompt: bool = True) -> str:
-        """Render a chat history through the model's HuggingFace chat template.
-
-        Required by lm-eval when ``apply_chat_template=True`` is passed to
-        ``simple_evaluate``; without it, lm-eval raises ``NotImplementedError``
-        at task setup. The HF tokenizer is loaded on first call so callers that
-        never enable chat templating are not required to ship HF tokenizer
-        files alongside the ONNX model.
-        """
         if self._hf_tokenizer is None:
             self._hf_tokenizer = AutoTokenizer.from_pretrained(self._pretrained)
         return self._hf_tokenizer.apply_chat_template(

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -498,6 +498,10 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
                 self.config.set_provider_option(ep, key, value)
         self.model = og.Model(self.config)
         self.tokenizer = og.Tokenizer(self.model)
+        # HF tokenizer kept solely to render `apply_chat_template`; generation
+        # still uses og.Tokenizer above.
+        self._pretrained = str(pretrained)
+        self._hf_tokenizer = AutoTokenizer.from_pretrained(self._pretrained)
 
         # consider adding auto batch sizes
         self.batch_size = int(batch_size)
@@ -520,6 +524,24 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
 
         self.device = device
         self._returns_full_logits = self._detect_full_logits()
+
+    @property
+    def tokenizer_name(self) -> str:
+        """Identifier used by lm-eval for chat-template-aware caching."""
+        return self._pretrained.replace("/", "__")
+
+    def apply_chat_template(self, chat_history: list[dict], add_generation_prompt: bool = True) -> str:
+        """Render a chat history through the model's HF chat template.
+
+        Required by lm-eval when `apply_chat_template=True` is passed to
+        `simple_evaluate`; without it, lm-eval raises NotImplementedError.
+        """
+        return self._hf_tokenizer.apply_chat_template(
+            chat_history,
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+            continue_final_message=not add_generation_prompt,
+        )
 
     def _detect_full_logits(self) -> bool:
         """Check if the model returns logits for all input positions or only the last."""

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -513,13 +513,6 @@ class TestLMEvaluatorModelClass:
 
 
 class TestLMEvalORTGenAIChatTemplate:
-    """Cover the chat-template hooks added to LMEvalORTGenAIEvaluator.
-
-    The hooks must work without instantiating the full evaluator (which requires
-    an ONNX model + onnxruntime-genai), so the tests skip ``__init__`` and
-    exercise the methods directly on a bare instance.
-    """
-
     def _bare_instance(self, pretrained: str):
         # pylint: disable=protected-access
         from olive.evaluator.lmeval_ort import LMEvalORTGenAIEvaluator
@@ -534,8 +527,6 @@ class TestLMEvalORTGenAIChatTemplate:
         [
             ("/models/lfm2-350m", "__models__lfm2-350m"),
             ("relative/path/model", "relative__path__model"),
-            # Windows-style separators must normalize identically to their POSIX form
-            # so the cache key is stable across platforms.
             ("C:\\models\\lfm2-350m", "C:__models__lfm2-350m"),
         ],
     )
@@ -551,11 +542,10 @@ class TestLMEvalORTGenAIChatTemplate:
 
         instance = self._bare_instance("/models/lfm2")
 
-        auto_tokenizer_mock.from_pretrained.assert_not_called()  # not loaded at construction
+        auto_tokenizer_mock.from_pretrained.assert_not_called()
         assert instance.apply_chat_template(chat_history) == "rendered prompt"
         auto_tokenizer_mock.from_pretrained.assert_called_once_with("/models/lfm2")
 
-        # Subsequent calls reuse the cached tokenizer rather than reloading it.
         instance.apply_chat_template(chat_history, add_generation_prompt=False)
         auto_tokenizer_mock.from_pretrained.assert_called_once()
         mock_tokenizer.apply_chat_template.assert_called_with(

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -510,3 +510,57 @@ class TestLMEvaluatorModelClass:
         evaluator.evaluate(model, metrics=[], device=Device.CPU, execution_providers=["CPUExecutionProvider"])
 
         get_model_mock.assert_called_once_with(model_class)
+
+
+class TestLMEvalORTGenAIChatTemplate:
+    """Cover the chat-template hooks added to LMEvalORTGenAIEvaluator.
+
+    The hooks must work without instantiating the full evaluator (which requires
+    an ONNX model + onnxruntime-genai), so the tests skip ``__init__`` and
+    exercise the methods directly on a bare instance.
+    """
+
+    def _bare_instance(self, pretrained: str):
+        # pylint: disable=protected-access
+        from olive.evaluator.lmeval_ort import LMEvalORTGenAIEvaluator
+
+        instance = LMEvalORTGenAIEvaluator.__new__(LMEvalORTGenAIEvaluator)
+        instance._pretrained = pretrained
+        instance._hf_tokenizer = None
+        return instance
+
+    @pytest.mark.parametrize(
+        ("pretrained", "expected"),
+        [
+            ("/models/lfm2-350m", "__models__lfm2-350m"),
+            ("relative/path/model", "relative__path__model"),
+            # Windows-style separators must normalize identically to their POSIX form
+            # so the cache key is stable across platforms.
+            ("C:\\models\\lfm2-350m", "C:__models__lfm2-350m"),
+        ],
+    )
+    def test_tokenizer_name_normalizes_separators(self, pretrained, expected):
+        assert self._bare_instance(pretrained).tokenizer_name == expected
+
+    @patch("olive.evaluator.lmeval_ort.AutoTokenizer")
+    def test_apply_chat_template_lazy_loads_hf_tokenizer(self, auto_tokenizer_mock):
+        chat_history = [{"role": "user", "content": "hello"}]
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "rendered prompt"
+        auto_tokenizer_mock.from_pretrained.return_value = mock_tokenizer
+
+        instance = self._bare_instance("/models/lfm2")
+
+        auto_tokenizer_mock.from_pretrained.assert_not_called()  # not loaded at construction
+        assert instance.apply_chat_template(chat_history) == "rendered prompt"
+        auto_tokenizer_mock.from_pretrained.assert_called_once_with("/models/lfm2")
+
+        # Subsequent calls reuse the cached tokenizer rather than reloading it.
+        instance.apply_chat_template(chat_history, add_generation_prompt=False)
+        auto_tokenizer_mock.from_pretrained.assert_called_once()
+        mock_tokenizer.apply_chat_template.assert_called_with(
+            chat_history,
+            tokenize=False,
+            add_generation_prompt=False,
+            continue_final_message=True,
+        )

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -517,7 +517,7 @@ class TestLMEvalORTGenAIChatTemplate:
         # pylint: disable=protected-access
         from olive.evaluator.lmeval_ort import LMEvalORTGenAIEvaluator
 
-        instance = LMEvalORTGenAIEvaluator.__new__(LMEvalORTGenAIEvaluator)
+        instance = object.__new__(LMEvalORTGenAIEvaluator)
         instance._pretrained = pretrained
         instance._hf_tokenizer = None
         return instance

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -512,6 +512,10 @@ class TestLMEvaluatorModelClass:
         get_model_mock.assert_called_once_with(model_class)
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("lm_eval") is None,
+    reason="lm_eval not installed",
+)
 class TestLMEvalORTGenAIChatTemplate:
     def _bare_instance(self, pretrained: str):
         # pylint: disable=protected-access


### PR DESCRIPTION
## Describe your changes

Implement `tokenizer_name` and `apply_chat_template` on `LMEvalORTGenAIEvaluator` so the backend supports `lm_eval.simple_evaluate(apply_chat_template=True)`. Without these, lm-eval raises `NotImplementedError` at task setup for any chat-formatted task.

Parity with the HuggingFace backend in `lm_eval/models/huggingface.py`. The HF tokenizer is loaded lazily on the first `apply_chat_template` call, so model directories without HF tokenizer files still work for non-chat evaluation. Generation continues to go through `og.Tokenizer`.

## Checklist before requesting a review

- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? Release note: *Enable `apply_chat_template=True` in lm-eval for ortgenai-backed evaluators.*

## (Optional) Issue link

N/A