### PR TITLE
Add QuantizeEmbeddingInt8 and ShareEmbeddingLmHead graph surgeries for INT8 embedding quantization

### DIFF
--- a/olive/common/onnx_io.py
+++ b/olive/common/onnx_io.py
@@ -89,19 +89,24 @@ def get_kv_info(io_config: dict) -> dict | None:
     if kv_format is None:
         return None
 
-    # find the number of layers
-    num_layers = 0
+    # find the actual layer indices (may be non-contiguous after pruning)
+    layer_indices = []
     for i_name in io_config["input_names"]:
-        num_layers += int(re.match(kv_format, i_name) is not None)
+        m = re.match(kv_format, i_name)
+        if m:
+            idx = int(m.group(1))
+            if idx not in layer_indices:
+                layer_indices.append(idx)
+    layer_indices.sort()
 
     past_names = []
     present_to_past = {}
     for k in ["key", "value"]:
-        past_names.extend([kv_options[kv_format][f"past_{k}"] % i for i in range(num_layers)])
+        past_names.extend([kv_options[kv_format][f"past_{k}"] % i for i in layer_indices])
         present_to_past.update(
             {
                 kv_options[kv_format][f"present_{k}"] % i: kv_options[kv_format][f"past_{k}"] % i
-                for i in range(num_layers)
+                for i in layer_indices
             }
         )
 

--- a/olive/common/onnx_io.py
+++ b/olive/common/onnx_io.py
@@ -90,14 +90,12 @@ def get_kv_info(io_config: dict) -> dict | None:
         return None
 
     # find the actual layer indices (may be non-contiguous after pruning)
-    layer_indices = []
+    layer_indices = set()
     for i_name in io_config["input_names"]:
         m = re.match(kv_format, i_name)
         if m:
-            idx = int(m.group(1))
-            if idx not in layer_indices:
-                layer_indices.append(idx)
-    layer_indices.sort()
+            layer_indices.add(int(m.group(1)))
+    layer_indices = sorted(layer_indices)
 
     past_names = []
     present_to_past = {}

--- a/olive/common/onnx_io.py
+++ b/olive/common/onnx_io.py
@@ -104,10 +104,7 @@ def get_kv_info(io_config: dict) -> dict | None:
     for k in ["key", "value"]:
         past_names.extend([kv_options[kv_format][f"past_{k}"] % i for i in layer_indices])
         present_to_past.update(
-            {
-                kv_options[kv_format][f"present_{k}"] % i: kv_options[kv_format][f"past_{k}"] % i
-                for i in layer_indices
-            }
+            {kv_options[kv_format][f"present_{k}"] % i: kv_options[kv_format][f"past_{k}"] % i for i in layer_indices}
         )
 
     past_shape = io_config["input_shapes"][io_config["input_names"].index(past_names[0])]

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -293,6 +293,28 @@ class Prefill:
         if self.kv_info is None:
             raise ValueError("Invalid io_config: kv_info not found")
 
+        # detect position_ids rank (e.g. 3 for mRoPE models like Qwen3.5)
+        self.position_ids_rank = 2
+        if "position_ids" in self.io_config["input_names"]:
+            idx = self.io_config["input_names"].index("position_ids")
+            self.position_ids_rank = len(self.io_config["input_shapes"][idx])
+
+        # detect hybrid state inputs (conv_state, recurrent_state for linear attention layers)
+        self.hybrid_states = {}
+        for idx, name in enumerate(self.io_config["input_names"]):
+            if "conv_state" in name or "recurrent_state" in name:
+                shape = self.io_config["input_shapes"][idx]
+                dtype = self.io_config["input_types"][idx]
+                self.hybrid_states[name] = {"shape": shape, "dtype": dtype}
+
+        # detect hybrid state outputs
+        self.hybrid_state_outputs = {}
+        for idx, name in enumerate(self.io_config["output_names"]):
+            if "conv_state" in name or "recurrent_state" in name:
+                shape = self.io_config["output_shapes"][idx]
+                dtype = self.io_config["output_types"][idx]
+                self.hybrid_state_outputs[name] = {"shape": shape, "dtype": dtype}
+
         self._session = None
         self._batch_size = None
         self._buffers = None
@@ -331,17 +353,29 @@ class Prefill:
             inputs_to_bind[name] = (self._buffers["inputs"][name], self.io_dtypes[name], shape)
         if "position_ids" in self._buffers["inputs"]:
             # need to reallocate since the position_ids tensor may be sliced
-            inputs_to_bind["position_ids"] = (
-                self._buffers["inputs"]["position_ids"][:batch_size, :seqlen].contiguous(),
-                self.io_dtypes["position_ids"],
-                (batch_size, seqlen),
-            )
+            if self.position_ids_rank == 3:
+                inputs_to_bind["position_ids"] = (
+                    self._buffers["inputs"]["position_ids"][:, :batch_size, :seqlen].contiguous(),
+                    self.io_dtypes["position_ids"],
+                    (self._buffers["inputs"]["position_ids"].shape[0], batch_size, seqlen),
+                )
+            else:
+                inputs_to_bind["position_ids"] = (
+                    self._buffers["inputs"]["position_ids"][:batch_size, :seqlen].contiguous(),
+                    self.io_dtypes["position_ids"],
+                    (batch_size, seqlen),
+                )
         for name in self._buffers["kv_inputs"]:
             inputs_to_bind[name] = (
                 self._buffers["kv_inputs"][name],
                 self.kv_info["dtype"],
                 (batch_size, self.kv_info["num_kv_heads"], 0, self.kv_info["head_size"]),
             )
+        # hybrid state inputs (conv_state, recurrent_state)
+        for name, buf in self._buffers["hybrid_inputs"].items():
+            shape = list(buf.shape)
+            shape[0] = batch_size
+            inputs_to_bind[name] = (buf, self.hybrid_states[name]["dtype"], tuple(shape))
         for name, (buffer, dtype, shape) in inputs_to_bind.items():
             io_binding.bind_input(
                 name,
@@ -363,6 +397,11 @@ class Prefill:
                 self.kv_info["dtype"],
                 (batch_size, self.kv_info["num_kv_heads"], seqlen, self.kv_info["head_size"]),
             )
+        # hybrid state outputs (conv_state, recurrent_state)
+        for name, buf in self._buffers["hybrid_outputs"].items():
+            shape = list(buf.shape)
+            shape[0] = batch_size
+            outputs_to_bind[name] = (buf, self.hybrid_state_outputs[name]["dtype"], tuple(shape))
         for name, (buffer, dtype, shape) in outputs_to_bind.items():
             io_binding.bind_output(
                 name,
@@ -418,11 +457,18 @@ class Prefill:
             )
         }
         if self.io_dtypes.get("position_ids") is not None:
-            inputs["position_ids"] = (
+            pos_ids = (
                 torch.arange(max_length, dtype=getattr(torch, self.io_dtypes["position_ids"]), device=self.device)
                 .unsqueeze(0)
                 .expand(batch_size, -1)
             )
+            if self.position_ids_rank == 3:
+                # mRoPE: expand to [mrope_sections, batch_size, seq_len]
+                mrope_sections = self.io_config["input_shapes"][
+                    self.io_config["input_names"].index("position_ids")
+                ][0]
+                pos_ids = pos_ids.unsqueeze(0).expand(mrope_sections, -1, -1)
+            inputs["position_ids"] = pos_ids
         if self.io_dtypes.get("past_seq_len") is not None:
             inputs["past_seq_len"] = (
                 torch.tensor(max_length - 1, dtype=getattr(torch, self.io_dtypes["past_seq_len"]), device=self.device)
@@ -457,6 +503,24 @@ class Prefill:
         }
 
         self._buffers = {"inputs": inputs, "outputs": outputs, "kv_inputs": kv_inputs, "kv_outputs": kv_outputs}
+
+        # hybrid state buffers (conv_state, recurrent_state) - zero-initialized
+        hybrid_inputs = {}
+        for name, info in self.hybrid_states.items():
+            # Replace symbolic 'batch_size' with actual batch_size
+            shape = [batch_size if s == "batch_size" else s for s in info["shape"]]
+            hybrid_inputs[name] = torch.zeros(
+                shape, dtype=getattr(torch, info["dtype"]), device=self.device
+            )
+        hybrid_outputs = {}
+        for name, info in self.hybrid_state_outputs.items():
+            shape = [batch_size if s == "batch_size" else s for s in info["shape"]]
+            hybrid_outputs[name] = torch.zeros(
+                shape, dtype=getattr(torch, info["dtype"]), device=self.device
+            )
+        self._buffers["hybrid_inputs"] = hybrid_inputs
+        self._buffers["hybrid_outputs"] = hybrid_outputs
+
         self._batch_size = batch_size
 
 

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -464,9 +464,7 @@ class Prefill:
             )
             if self.position_ids_rank == 3:
                 # mRoPE: expand to [mrope_sections, batch_size, seq_len]
-                mrope_sections = self.io_config["input_shapes"][
-                    self.io_config["input_names"].index("position_ids")
-                ][0]
+                mrope_sections = self.io_config["input_shapes"][self.io_config["input_names"].index("position_ids")][0]
                 pos_ids = pos_ids.unsqueeze(0).expand(mrope_sections, -1, -1)
             inputs["position_ids"] = pos_ids
         if self.io_dtypes.get("past_seq_len") is not None:
@@ -509,15 +507,11 @@ class Prefill:
         for name, info in self.hybrid_states.items():
             # Replace symbolic 'batch_size' with actual batch_size
             shape = [batch_size if s == "batch_size" else s for s in info["shape"]]
-            hybrid_inputs[name] = torch.zeros(
-                shape, dtype=getattr(torch, info["dtype"]), device=self.device
-            )
+            hybrid_inputs[name] = torch.zeros(shape, dtype=getattr(torch, info["dtype"]), device=self.device)
         hybrid_outputs = {}
         for name, info in self.hybrid_state_outputs.items():
             shape = [batch_size if s == "batch_size" else s for s in info["shape"]]
-            hybrid_outputs[name] = torch.zeros(
-                shape, dtype=getattr(torch, info["dtype"]), device=self.device
-            )
+            hybrid_outputs[name] = torch.zeros(shape, dtype=getattr(torch, info["dtype"]), device=self.device)
         self._buffers["hybrid_inputs"] = hybrid_inputs
         self._buffers["hybrid_outputs"] = hybrid_outputs
 
@@ -603,7 +597,7 @@ class LMEvalORTGenAIEvaluator(LMEvalOnnxBase):
     def eot_token_id(self):
         return self._eot_token_id
 
-    def tok_encode(self, string: str, **kwargs) -> list[int]:
+    def tok_encode(self, string: str, add_special_tokens: bool | None = None, **kwargs) -> list[int]:
         """Tokenize a string using the model's tokenizer and return a list of token IDs."""
         return self.tokenizer.encode(string).tolist()
 

--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -293,27 +293,20 @@ class Prefill:
         if self.kv_info is None:
             raise ValueError("Invalid io_config: kv_info not found")
 
-        # detect position_ids rank (e.g. 3 for mRoPE models like Qwen3.5)
+        # detect position_ids rank, hybrid state inputs and outputs in a single pass
         self.position_ids_rank = 2
-        if "position_ids" in self.io_config["input_names"]:
-            idx = self.io_config["input_names"].index("position_ids")
-            self.position_ids_rank = len(self.io_config["input_shapes"][idx])
-
-        # detect hybrid state inputs (conv_state, recurrent_state for linear attention layers)
         self.hybrid_states = {}
-        for idx, name in enumerate(self.io_config["input_names"]):
-            if "conv_state" in name or "recurrent_state" in name:
-                shape = self.io_config["input_shapes"][idx]
-                dtype = self.io_config["input_types"][idx]
-                self.hybrid_states[name] = {"shape": shape, "dtype": dtype}
-
-        # detect hybrid state outputs
         self.hybrid_state_outputs = {}
-        for idx, name in enumerate(self.io_config["output_names"]):
-            if "conv_state" in name or "recurrent_state" in name:
-                shape = self.io_config["output_shapes"][idx]
-                dtype = self.io_config["output_types"][idx]
-                self.hybrid_state_outputs[name] = {"shape": shape, "dtype": dtype}
+        for prefix in ("input", "output"):
+            names = self.io_config[f"{prefix}_names"]
+            shapes = self.io_config[f"{prefix}_shapes"]
+            types = self.io_config[f"{prefix}_types"]
+            target = self.hybrid_states if prefix == "input" else self.hybrid_state_outputs
+            for idx, name in enumerate(names):
+                if name == "position_ids":
+                    self.position_ids_rank = len(shapes[idx])
+                elif "conv_state" in name or "recurrent_state" in name:
+                    target[name] = {"shape": shapes[idx], "dtype": types[idx]}
 
         self._session = None
         self._batch_size = None

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1115,10 +1115,16 @@ class LMEvaluator(OliveEvaluator):
 
                 task_metrics = {}
                 for mf, v in metric_items:
-                    if mf != "alias":
+                    if mf == "alias":
+                        continue
+                    if not isinstance(v, (int, float)):
+                        continue
+                    if "," in mf:
                         m, _ = mf.split(",", 1)
-                        if not m.endswith("_stderr"):
-                            task_metrics[m] = SubMetricResult(value=v, priority=-1, higher_is_better=True)
+                    else:
+                        m = mf
+                    if not m.endswith("_stderr"):
+                        task_metrics[m] = SubMetricResult(value=v, priority=-1, higher_is_better=True)
 
                 metrics[task_name] = MetricResult.model_validate(task_metrics)
 

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -1924,11 +1924,18 @@ class TieWordEmbeddings(ProtoSurgeon):
     def __call__(self, model: onnx.ModelProto):
         dag = OnnxDAG(model)
 
-        if not dag.is_input("input_ids") or not dag.is_output("logits"):
+        # support both "input_ids" and "input_embeds" as input names
+        input_name = None
+        for candidate in ("input_ids", "input_embeds"):
+            if candidate in dag.ios and dag.is_input(candidate):
+                input_name = candidate
+                break
+
+        if input_name is None or "logits" not in dag.ios or not dag.is_output("logits"):
             return dag.model
 
         embed_name, embed_op_type = self.get_name_op_type(
-            dag, dag.get_consumers("input_ids"), ["Gather", "GatherBlockQuantized"], 0
+            dag, dag.get_consumers(input_name), ["Gather", "GatherBlockQuantized"], 0
         )
         if embed_name is None:
             return dag.model

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -106,6 +106,14 @@ class ProtoSurgeon(Surgeon):
         return None
 
     @staticmethod
+    def find_node(dag: OnnxDAG, op_type: str, name_substr: str) -> str | None:
+        """Find the first node matching an op_type and name substring."""
+        for name in dag.get_node_names():
+            if dag.get_node_op_type(name) == op_type and name_substr in name:
+                return name
+        return None
+
+    @staticmethod
     def create_new_name(name: str, old_op: str, new_op: str) -> str:
         return name.replace(old_op, new_op) if old_op in name else f"{name}_{new_op}"
 
@@ -2371,49 +2379,6 @@ class TieWordEmbeddings(ProtoSurgeon):
         return np.array_equal(arr0.ravel(), arr1.ravel())
 
 
-def _find_embed_node(model, op_type, label):
-    """Find the embed_tokens node of the given op_type and its index."""
-    for i, node in enumerate(model.graph.node):
-        if node.op_type == op_type and "embed_tokens" in node.name:
-            return node, i
-    logger.warning("No embed_tokens %s node found, skipping %s", op_type, label)
-    return None, None
-
-
-def _find_lm_head_node(model):
-    """Find the lm_head MatMulNBits node and its index."""
-    for i, node in enumerate(model.graph.node):
-        if node.op_type == "MatMulNBits" and "lm_head" in node.name:
-            return node, i
-    logger.warning("No lm_head MatMulNBits found")
-    return None, None
-
-
-def _find_initializer(model, name):
-    """Find an initializer by name."""
-    for init in model.graph.initializer:
-        if init.name == name:
-            return init
-    return None
-
-
-def _get_node_attrs(node, *attr_names):
-    """Extract integer attributes from a node by name."""
-    result = {}
-    for attr in node.attribute:
-        if attr.name in attr_names:
-            result[attr.name] = attr.i
-    return result
-
-
-def _ensure_msft_opset(model):
-    """Ensure com.microsoft opset import is present in the model."""
-    for opset in model.opset_import:
-        if opset.domain == "com.microsoft":
-            return
-    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
-
-
 class QuantizeEmbeddingInt8(ProtoSurgeon):
     """Quantize FP16 embedding to INT8 using GatherBlockQuantized.
 
@@ -2424,23 +2389,27 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
     def __call__(self, model: onnx.ModelProto):
         from onnx import numpy_helper
 
-        # Find embedding Gather node and weight
-        gather_node, gather_idx = _find_embed_node(model, "Gather", "QuantizeEmbeddingInt8")
-        if gather_node is None:
+        dag = OnnxDAG(model)
+
+        # Find embedding Gather node
+        gather_name = self.find_node(dag, "Gather", "embed_tokens")
+        if gather_name is None:
+            logger.warning("No embed_tokens Gather node found, skipping QuantizeEmbeddingInt8")
             return model
 
-        embed_init = _find_initializer(model, gather_node.input[0])
-
-        if embed_init is None:
+        embed_weight_name = dag.get_node_inputs(gather_name)[0]
+        if not dag.is_initializer(embed_weight_name):
             logger.warning("Embedding weight initializer not found, skipping QuantizeEmbeddingInt8")
             return model
+
+        embed_init = dag.get_initializer_proto(embed_weight_name)
 
         # Check if already quantized
         if embed_init.data_type not in (onnx.TensorProto.FLOAT16, onnx.TensorProto.FLOAT):
             logger.info("Embedding is not FP16/FP32, skipping QuantizeEmbeddingInt8")
             return model
 
-        embed = numpy_helper.to_array(embed_init).astype(np.float32)
+        embed = dag.get_initializer_np_array(embed_weight_name).astype(np.float32)
         vocab_size, hidden_size = embed.shape
         block_size = 32
 
@@ -2456,7 +2425,7 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
 
         logger.info(
             "Quantizing embedding %s (%dx%d) from %s to INT8 (block_size=%d)",
-            embed_init.name,
+            embed_weight_name,
             vocab_size,
             hidden_size,
             "FP16" if scales_dtype == np.float16 else "FP32",
@@ -2482,39 +2451,46 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
             "Embedding: %.0f MB -> %.0f MB (saved %.0f MB)", old_size_mb, new_size_mb, old_size_mb - new_size_mb
         )
 
+        graph_idx = dag.get_graph_idx(gather_name)
+
         # Create new initializers
-        qweight_name = embed_init.name + "_Q8"
-        scales_name = embed_init.name + "_scales"
-        zp_name = embed_init.name + "_zp"
-        model.graph.initializer.append(numpy_helper.from_array(q_flat, name=qweight_name))
-        model.graph.initializer.append(numpy_helper.from_array(scales, name=scales_name))
-        model.graph.initializer.append(numpy_helper.from_array(zero_points, name=zp_name))
+        qweight_name = embed_weight_name + "_Q8"
+        scales_name = embed_weight_name + "_scales"
+        zp_name = embed_weight_name + "_zp"
+        dag.add_initializer(numpy_helper.from_array(q_flat, name=qweight_name), graph_idx)
+        dag.add_initializer(numpy_helper.from_array(scales, name=scales_name), graph_idx)
+        dag.add_initializer(numpy_helper.from_array(zero_points, name=zp_name), graph_idx)
 
         # Ensure com.microsoft opset is declared
-        _ensure_msft_opset(model)
+        dag.set_opset_import("com.microsoft", 1)
 
         # Create GatherBlockQuantized node
+        gather_inputs = dag.get_node_inputs(gather_name)
+        gather_output = dag.get_node_outputs(gather_name)[0]
+        gbq_output = gather_output + "_gbq"
+        gbq_name = gather_name.replace("Gather", "GatherBlockQuantized")
         gbq_node = onnx.helper.make_node(
             "GatherBlockQuantized",
-            inputs=[qweight_name, gather_node.input[1], scales_name, zp_name],
-            outputs=gather_node.output,
-            name=gather_node.name.replace("Gather", "GatherBlockQuantized"),
+            inputs=[qweight_name, gather_inputs[1], scales_name, zp_name],
+            outputs=[gbq_output],
+            name=gbq_name,
             domain="com.microsoft",
             bits=8,
             block_size=block_size,
             gather_axis=0,
             quantize_axis=1,
         )
+        dag.add_node(gbq_node, graph_idx)
 
-        # Replace Gather with GatherBlockQuantized
-        model.graph.node.remove(gather_node)
-        model.graph.node.insert(gather_idx, gbq_node)
-
-        # Remove old FP16 embedding weight
-        model.graph.initializer.remove(embed_init)
+        # Rewire consumers from old Gather output to new GBQ output and remove old node
+        for consumer in dag.get_consumers(gather_output):
+            dag.replace_node_input(consumer, gather_output, gbq_output)
+        dag.remove_node(gather_name)
+        # Old FP16 embedding weight is auto-cleaned by update() since no consumers remain
 
         logger.info("Replaced Gather with GatherBlockQuantized (INT8)")
-        return model
+        dag.update()
+        return dag.model
 
 
 class ShareEmbeddingLmHead(ProtoSurgeon):
@@ -2528,12 +2504,15 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
     def __call__(self, model: onnx.ModelProto):
         from onnx import numpy_helper
 
+        dag = OnnxDAG(model)
+
         # Find embedding GatherBlockQuantized
-        gbq_node, _ = _find_embed_node(model, "GatherBlockQuantized", "ShareEmbeddingLmHead")
-        if gbq_node is None:
+        gbq_name = self.find_node(dag, "GatherBlockQuantized", "embed_tokens")
+        if gbq_name is None:
+            logger.warning("No embed_tokens GatherBlockQuantized node found, skipping ShareEmbeddingLmHead")
             return model
 
-        attrs = _get_node_attrs(gbq_node, "bits", "block_size")
+        attrs = dag.get_node_attributes(gbq_name)
         gbq_bits = attrs.get("bits", 8)
         gbq_block_size = attrs.get("block_size", 32)
 
@@ -2542,34 +2521,36 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
             return model
 
         # Get embedding weight, scales, zero_points names
-        embed_weight_name = gbq_node.input[0]
-        embed_scales_name = gbq_node.input[2]
-        embed_zp_name = gbq_node.input[3] if len(gbq_node.input) > 3 else None
+        gbq_inputs = dag.get_node_inputs(gbq_name)
+        embed_weight_name = gbq_inputs[0]
+        embed_scales_name = gbq_inputs[2]
+        embed_zp_name = gbq_inputs[3] if len(gbq_inputs) > 3 else None
 
         # Get embedding weight shape to determine K and N
-        embed_weight_init = _find_initializer(model, embed_weight_name)
-        if embed_weight_init is None:
+        if not dag.is_initializer(embed_weight_name):
             logger.warning("Could not find embedding weight initializer")
             return model
 
-        embed_weight = numpy_helper.to_array(embed_weight_init)
+        embed_weight = dag.get_initializer_np_array(embed_weight_name)
 
         vocab_size, hidden_size = embed_weight.shape  # [V, H] for INT8
         num_blocks = hidden_size // gbq_block_size
 
         # Find lm_head MatMulNBits node
-        lm_head_node, lm_head_idx = _find_lm_head_node(model)
-        if lm_head_node is None:
+        lm_head_name = self.find_node(dag, "MatMulNBits", "lm_head")
+        if lm_head_name is None:
+            logger.warning("No lm_head MatMulNBits found")
             return model
 
+        lm_head_inputs = dag.get_node_inputs(lm_head_name)
+
         # Check if already shared (idempotency): lm_head weight input references embedding weight
-        lm_head_weight_input = lm_head_node.input[1]
-        if embed_weight_name in lm_head_weight_input or lm_head_node.input[2] == embed_scales_name:
+        if embed_weight_name in lm_head_inputs[1] or lm_head_inputs[2] == embed_scales_name:
             logger.info("lm_head already shares weights with embedding, skipping ShareEmbeddingLmHead")
             return model
 
         # Get old lm_head attributes
-        old_attrs = _get_node_attrs(lm_head_node, "K", "N", "bits", "block_size")
+        old_attrs = dag.get_node_attributes(lm_head_name)
 
         logger.info(
             "Sharing embedding with lm_head: lm_head INT%d (%dx%d, bs=%d) -> INT8 (shared with embedding)",
@@ -2579,17 +2560,13 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
             old_attrs.get("block_size", 0),
         )
 
-        # Remove old lm_head weight initializers
-        old_init_names = set(lm_head_node.input[1:])  # weight, scales, [zp], [g_idx]
-        to_remove = [init for init in model.graph.initializer if init.name in old_init_names]
-        for init in to_remove:
-            model.graph.initializer.remove(init)
+        graph_idx = dag.get_graph_idx(lm_head_name)
 
         # MatMulNBits needs [N, K_blocks, block_size] but GBQ weight is [V, H].
         # Add a Reshape node to convert, referencing the SAME embedding weight.
         reshape_shape_name = "lm_head.MatMulNBits.reshape_shape"
         reshape_shape = np.array([vocab_size, num_blocks, gbq_block_size], dtype=np.int64)
-        model.graph.initializer.append(numpy_helper.from_array(reshape_shape, name=reshape_shape_name))
+        dag.add_initializer(numpy_helper.from_array(reshape_shape, name=reshape_shape_name), graph_idx)
 
         reshape_output = "lm_head.MatMulNBits.reshaped_weight"
         reshape_node = onnx.helper.make_node(
@@ -2598,22 +2575,26 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
             outputs=[reshape_output],
             name="lm_head/Reshape_shared_weight",
         )
-        model.graph.node.insert(lm_head_idx, reshape_node)
+        dag.add_node(reshape_node, graph_idx)
 
         # Scales and zp: reuse embedding's directly
-        inputs = [lm_head_node.input[0], reshape_output, embed_scales_name]
+        inputs = [lm_head_inputs[0], reshape_output, embed_scales_name]
         if embed_zp_name:
             inputs.append(embed_zp_name)
 
         # Ensure com.microsoft opset is declared
-        _ensure_msft_opset(model)
+        dag.set_opset_import("com.microsoft", 1)
 
         # Create new INT8 MatMulNBits node
+        lm_head_output = dag.get_node_outputs(lm_head_name)[0]
+        new_lm_head_output = lm_head_output + "_shared"
+        new_lm_head_name = lm_head_name + "_shared"
+        lm_head_proto = dag.get_node_proto(lm_head_name)
         new_lm_head = onnx.helper.make_node(
             "MatMulNBits",
             inputs=inputs,
-            outputs=lm_head_node.output,
-            name=lm_head_node.name,
+            outputs=[new_lm_head_output],
+            name=new_lm_head_name,
             domain="com.microsoft",
             bits=8,
             block_size=gbq_block_size,
@@ -2621,15 +2602,27 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
             N=vocab_size,
         )
         # Copy accuracy_level if present
-        for attr in lm_head_node.attribute:
+        for attr in lm_head_proto.attribute:
             if attr.name == "accuracy_level":
                 new_lm_head.attribute.append(attr)
 
-        model.graph.node.remove(lm_head_node)
-        model.graph.node.insert(lm_head_idx + 1, new_lm_head)
+        dag.add_node(new_lm_head, graph_idx)
+
+        # Rewire consumers and remove old node
+        for consumer in dag.get_consumers(lm_head_output):
+            dag.replace_node_input(consumer, lm_head_output, new_lm_head_output)
+        if dag.is_output(lm_head_output):
+            dag.remove_output(lm_head_output)
+            dag.remove_node(lm_head_name)
+            dag.rename_node_output(new_lm_head_name, new_lm_head_output, lm_head_output)
+            dag.make_output(lm_head_output)
+        else:
+            dag.remove_node(lm_head_name)
+        # Old lm_head initializers are auto-cleaned by update() since no consumers remain
 
         logger.info("lm_head now uses INT8 MatMulNBits (shared quantization with embedding)")
-        return model
+        dag.update()
+        return dag.model
 
 
 class ReciprocalMulToDiv(ProtoSurgeon):

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -1953,7 +1953,7 @@ class TieWordEmbeddings(ProtoSurgeon):
         ]:
             return dag.model
 
-        if embed_op_type == "Gather":
+        if embed_op_type == "Gather" and lm_head_op_type == "MatMul":
             return self.handle_unquantized(dag, embed_name, lm_head_name)
         return self.handle_quantized(dag, embed_name, lm_head_name)
 
@@ -2150,6 +2150,236 @@ class TieWordEmbeddings(ProtoSurgeon):
         if transpose:
             arr0 = arr0.T
         return np.array_equal(arr0.ravel(), arr1.ravel())
+
+
+def _find_embed_node(model, op_type, label):
+    """Find the embed_tokens node of the given op_type and its index."""
+    for i, node in enumerate(model.graph.node):
+        if node.op_type == op_type and "embed_tokens" in node.name:
+            return node, i
+    logger.warning("No embed_tokens %s node found, skipping %s", op_type, label)
+    return None, None
+
+
+def _find_lm_head_node(model):
+    """Find the lm_head MatMulNBits node and its index."""
+    for i, node in enumerate(model.graph.node):
+        if node.op_type == "MatMulNBits" and "lm_head" in node.name:
+            return node, i
+    logger.warning("No lm_head MatMulNBits found")
+    return None, None
+
+
+def _find_initializer(model, name):
+    """Find an initializer by name."""
+    for init in model.graph.initializer:
+        if init.name == name:
+            return init
+    return None
+
+
+def _get_node_attrs(node, *attr_names):
+    """Extract integer attributes from a node by name."""
+    result = {}
+    for attr in node.attribute:
+        if attr.name in attr_names:
+            result[attr.name] = attr.i
+    return result
+
+
+class QuantizeEmbeddingInt8(ProtoSurgeon):
+    """Quantize FP16 embedding to INT8 using GatherBlockQuantized.
+
+    Replaces the Gather op for embed_tokens with a GatherBlockQuantized op
+    that uses per-block INT8 quantization (block_size=32).
+    """
+
+    def __call__(self, model: onnx.ModelProto):
+        import numpy as np
+        from onnx import numpy_helper, helper
+
+        # Find embedding Gather node and weight
+        gather_node, gather_idx = _find_embed_node(model, "Gather", "QuantizeEmbeddingInt8")
+        if gather_node is None:
+            return model
+
+        embed_init = _find_initializer(model, gather_node.input[0])
+
+        if embed_init is None:
+            logger.warning("Embedding weight initializer not found, skipping QuantizeEmbeddingInt8")
+            return model
+
+        # Check if already quantized
+        if embed_init.data_type not in (onnx.TensorProto.FLOAT16, onnx.TensorProto.FLOAT):
+            logger.info("Embedding is not FP16/FP32, skipping QuantizeEmbeddingInt8")
+            return model
+
+        embed = numpy_helper.to_array(embed_init).astype(np.float32)
+        vocab_size, hidden_size = embed.shape
+        block_size = 32
+
+        if hidden_size % block_size != 0:
+            logger.warning("hidden_size %d not divisible by block_size %d, skipping", hidden_size, block_size)
+            return model
+
+        num_blocks = hidden_size // block_size
+
+        logger.info(
+            "Quantizing embedding %s (%dx%d) from FP16 to INT8 (block_size=%d)",
+            embed_init.name, vocab_size, hidden_size, block_size,
+        )
+
+        # Per-block INT8 quantization (asymmetric with zero_point=128 for GatherBlockQuantized)
+        blocked = embed.reshape(vocab_size, num_blocks, block_size)
+        scales = (np.abs(blocked).max(axis=2) / 127.0).astype(np.float16)
+        scales_f32 = scales.astype(np.float32)
+        # Avoid division by zero
+        scales_f32 = np.where(scales_f32 == 0, 1.0, scales_f32)
+        q = np.clip(np.round(blocked / scales_f32[:, :, None]), -128, 127).astype(np.int8)
+        # GatherBlockQuantized expects unsigned uint8 with zero_point offset
+        q_uint8 = (q.astype(np.int16) + 128).astype(np.uint8)
+        q_flat = q_uint8.reshape(vocab_size, hidden_size)
+        # Zero point tensor: 128 for all blocks (symmetric around 128)
+        zero_points = np.full((vocab_size, num_blocks), 128, dtype=np.uint8)
+
+        old_size_mb = embed.nbytes / (1024 * 1024)
+        new_size_mb = (q_flat.nbytes + scales.nbytes + zero_points.nbytes) / (1024 * 1024)
+        logger.info("Embedding: %.0f MB -> %.0f MB (saved %.0f MB)", old_size_mb, new_size_mb, old_size_mb - new_size_mb)
+
+        # Create new initializers
+        qweight_name = embed_init.name + "_Q8"
+        scales_name = embed_init.name + "_scales"
+        zp_name = embed_init.name + "_zp"
+        model.graph.initializer.append(numpy_helper.from_array(q_flat, name=qweight_name))
+        model.graph.initializer.append(numpy_helper.from_array(scales, name=scales_name))
+        model.graph.initializer.append(numpy_helper.from_array(zero_points, name=zp_name))
+
+        # Create GatherBlockQuantized node
+        gbq_node = helper.make_node(
+            "GatherBlockQuantized",
+            inputs=[qweight_name, gather_node.input[1], scales_name, zp_name],
+            outputs=gather_node.output,
+            name=gather_node.name.replace("Gather", "GatherBlockQuantized"),
+            domain="com.microsoft",
+            bits=8,
+            block_size=block_size,
+            gather_axis=0,
+            quantize_axis=1,
+        )
+
+        # Replace Gather with GatherBlockQuantized
+        model.graph.node.remove(gather_node)
+        model.graph.node.insert(gather_idx, gbq_node)
+
+        # Remove old FP16 embedding weight
+        model.graph.initializer.remove(embed_init)
+
+        logger.info("Replaced Gather with GatherBlockQuantized (INT8)")
+        return model
+
+
+class ShareEmbeddingLmHead(ProtoSurgeon):
+    """Share INT8 embedding weight with lm_head by converting lm_head to INT8 MatMulNBits.
+
+    Must be applied AFTER QuantizeEmbeddingInt8. Replaces the lm_head's INT4
+    MatMulNBits with an INT8 MatMulNBits that references the same quantized
+    weight as the embedding's GatherBlockQuantized, eliminating duplicate storage.
+    """
+
+    def __call__(self, model: onnx.ModelProto):
+        import numpy as np
+        from onnx import numpy_helper, helper
+
+        # Find embedding GatherBlockQuantized
+        gbq_node, _ = _find_embed_node(model, "GatherBlockQuantized", "ShareEmbeddingLmHead")
+        if gbq_node is None:
+            return model
+
+        attrs = _get_node_attrs(gbq_node, "bits", "block_size")
+        gbq_bits = attrs.get("bits", 8)
+        gbq_block_size = attrs.get("block_size", 32)
+
+        if gbq_bits != 8:
+            logger.warning("Embedding is not INT8, cannot share with lm_head")
+            return model
+
+        # Get embedding weight, scales, zero_points names
+        embed_weight_name = gbq_node.input[0]
+        embed_scales_name = gbq_node.input[2]
+        embed_zp_name = gbq_node.input[3] if len(gbq_node.input) > 3 else None
+
+        # Get embedding weight shape to determine K and N
+        embed_weight_init = _find_initializer(model, embed_weight_name)
+        if embed_weight_init is None:
+            logger.warning("Could not find embedding weight initializer")
+            return model
+
+        embed_weight = numpy_helper.to_array(embed_weight_init)
+
+        vocab_size, hidden_size = embed_weight.shape  # [V, H] for INT8
+        num_blocks = hidden_size // gbq_block_size
+
+        # Find lm_head MatMulNBits node
+        lm_head_node, lm_head_idx = _find_lm_head_node(model)
+        if lm_head_node is None:
+            return model
+
+        # Get old lm_head attributes
+        old_attrs = _get_node_attrs(lm_head_node, "K", "N", "bits", "block_size")
+
+        logger.info(
+            "Sharing embedding with lm_head: lm_head INT%d (%dx%d, bs=%d) -> INT8 (shared with embedding)",
+            old_attrs.get("bits", 0), old_attrs.get("N", 0), old_attrs.get("K", 0), old_attrs.get("block_size", 0),
+        )
+
+        # Remove old lm_head weight initializers
+        old_init_names = set(lm_head_node.input[1:])  # weight, scales, [zp], [g_idx]
+        to_remove = [init for init in model.graph.initializer if init.name in old_init_names]
+        for init in to_remove:
+            model.graph.initializer.remove(init)
+
+        # MatMulNBits needs [N, K_blocks, block_size] but GBQ weight is [V, H].
+        # Add a Reshape node to convert, referencing the SAME embedding weight.
+        reshape_shape_name = "lm_head.MatMulNBits.reshape_shape"
+        reshape_shape = np.array([vocab_size, num_blocks, gbq_block_size], dtype=np.int64)
+        model.graph.initializer.append(numpy_helper.from_array(reshape_shape, name=reshape_shape_name))
+
+        reshape_output = "lm_head.MatMulNBits.reshaped_weight"
+        reshape_node = helper.make_node(
+            "Reshape",
+            inputs=[embed_weight_name, reshape_shape_name],
+            outputs=[reshape_output],
+            name="lm_head/Reshape_shared_weight",
+        )
+        model.graph.node.insert(lm_head_idx, reshape_node)
+
+        # Scales and zp: reuse embedding's directly
+        inputs = [lm_head_node.input[0], reshape_output, embed_scales_name]
+        if embed_zp_name:
+            inputs.append(embed_zp_name)
+
+        # Create new INT8 MatMulNBits node
+        new_lm_head = helper.make_node(
+            "MatMulNBits",
+            inputs=inputs,
+            outputs=lm_head_node.output,
+            name=lm_head_node.name,
+            domain="com.microsoft",
+            bits=8,
+            block_size=gbq_block_size,
+            K=hidden_size,
+            N=vocab_size,
+        )
+        # Copy accuracy_level if present
+        for attr in lm_head_node.attribute:
+            if attr.name == "accuracy_level":
+                new_lm_head.attribute.append(attr)
+
+        model.graph.node.remove(lm_head_node)
+        model.graph.node.insert(lm_head_idx + 1, new_lm_head)
+
+        logger.info("lm_head now uses INT8 MatMulNBits (shared quantization with embedding)")
+        return model
 
 
 class ReciprocalMulToDiv(ProtoSurgeon):

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -2450,17 +2450,22 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
 
         num_blocks = hidden_size // block_size
 
+        # Preserve the model's float dtype for scales so downstream ops (LayerNorm, MatMul, ...)
+        # receive the dtype they expect. FP16 model -> FP16 scales; FP32 model -> FP32 scales.
+        scales_dtype = np.float16 if embed_init.data_type == onnx.TensorProto.FLOAT16 else np.float32
+
         logger.info(
-            "Quantizing embedding %s (%dx%d) from FP16 to INT8 (block_size=%d)",
+            "Quantizing embedding %s (%dx%d) from %s to INT8 (block_size=%d)",
             embed_init.name,
             vocab_size,
             hidden_size,
+            "FP16" if scales_dtype == np.float16 else "FP32",
             block_size,
         )
 
         # Per-block INT8 quantization (asymmetric with zero_point=128 for GatherBlockQuantized)
         blocked = embed.reshape(vocab_size, num_blocks, block_size)
-        scales = (np.abs(blocked).max(axis=2) / 127.0).astype(np.float16)
+        scales = (np.abs(blocked).max(axis=2) / 127.0).astype(scales_dtype)
         scales_f32 = scales.astype(np.float32)
         # Avoid division by zero
         scales_f32 = np.where(scales_f32 == 0, 1.0, scales_f32)

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -2608,6 +2608,14 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
 
         dag.add_node(new_lm_head, graph_idx)
 
+        # Copy value info from old output to new output (needed for graph output serialization)
+        old_vi = dag.get_value_info_proto(lm_head_output)
+        if old_vi is not None:
+            new_vi = onnx.helper.make_tensor_value_info(new_lm_head_output, old_vi.type.tensor_type.elem_type, [])
+            new_vi.CopyFrom(old_vi)
+            new_vi.name = new_lm_head_output
+            dag.add_value_info(new_vi, graph_idx)
+
         # Rewire consumers and remove old node
         for consumer in dag.get_consumers(lm_head_output):
             dag.replace_node_input(consumer, lm_head_output, new_lm_head_output)

--- a/olive/passes/onnx/graph_surgeries.py
+++ b/olive/passes/onnx/graph_surgeries.py
@@ -2406,6 +2406,14 @@ def _get_node_attrs(node, *attr_names):
     return result
 
 
+def _ensure_msft_opset(model):
+    """Ensure com.microsoft opset import is present in the model."""
+    for opset in model.opset_import:
+        if opset.domain == "com.microsoft":
+            return
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+
 class QuantizeEmbeddingInt8(ProtoSurgeon):
     """Quantize FP16 embedding to INT8 using GatherBlockQuantized.
 
@@ -2414,8 +2422,7 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
     """
 
     def __call__(self, model: onnx.ModelProto):
-        import numpy as np
-        from onnx import numpy_helper, helper
+        from onnx import numpy_helper
 
         # Find embedding Gather node and weight
         gather_node, gather_idx = _find_embed_node(model, "Gather", "QuantizeEmbeddingInt8")
@@ -2445,7 +2452,10 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
 
         logger.info(
             "Quantizing embedding %s (%dx%d) from FP16 to INT8 (block_size=%d)",
-            embed_init.name, vocab_size, hidden_size, block_size,
+            embed_init.name,
+            vocab_size,
+            hidden_size,
+            block_size,
         )
 
         # Per-block INT8 quantization (asymmetric with zero_point=128 for GatherBlockQuantized)
@@ -2463,7 +2473,9 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
 
         old_size_mb = embed.nbytes / (1024 * 1024)
         new_size_mb = (q_flat.nbytes + scales.nbytes + zero_points.nbytes) / (1024 * 1024)
-        logger.info("Embedding: %.0f MB -> %.0f MB (saved %.0f MB)", old_size_mb, new_size_mb, old_size_mb - new_size_mb)
+        logger.info(
+            "Embedding: %.0f MB -> %.0f MB (saved %.0f MB)", old_size_mb, new_size_mb, old_size_mb - new_size_mb
+        )
 
         # Create new initializers
         qweight_name = embed_init.name + "_Q8"
@@ -2473,8 +2485,11 @@ class QuantizeEmbeddingInt8(ProtoSurgeon):
         model.graph.initializer.append(numpy_helper.from_array(scales, name=scales_name))
         model.graph.initializer.append(numpy_helper.from_array(zero_points, name=zp_name))
 
+        # Ensure com.microsoft opset is declared
+        _ensure_msft_opset(model)
+
         # Create GatherBlockQuantized node
-        gbq_node = helper.make_node(
+        gbq_node = onnx.helper.make_node(
             "GatherBlockQuantized",
             inputs=[qweight_name, gather_node.input[1], scales_name, zp_name],
             outputs=gather_node.output,
@@ -2506,8 +2521,7 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
     """
 
     def __call__(self, model: onnx.ModelProto):
-        import numpy as np
-        from onnx import numpy_helper, helper
+        from onnx import numpy_helper
 
         # Find embedding GatherBlockQuantized
         gbq_node, _ = _find_embed_node(model, "GatherBlockQuantized", "ShareEmbeddingLmHead")
@@ -2543,12 +2557,21 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
         if lm_head_node is None:
             return model
 
+        # Check if already shared (idempotency): lm_head weight input references embedding weight
+        lm_head_weight_input = lm_head_node.input[1]
+        if embed_weight_name in lm_head_weight_input or lm_head_node.input[2] == embed_scales_name:
+            logger.info("lm_head already shares weights with embedding, skipping ShareEmbeddingLmHead")
+            return model
+
         # Get old lm_head attributes
         old_attrs = _get_node_attrs(lm_head_node, "K", "N", "bits", "block_size")
 
         logger.info(
             "Sharing embedding with lm_head: lm_head INT%d (%dx%d, bs=%d) -> INT8 (shared with embedding)",
-            old_attrs.get("bits", 0), old_attrs.get("N", 0), old_attrs.get("K", 0), old_attrs.get("block_size", 0),
+            old_attrs.get("bits", 0),
+            old_attrs.get("N", 0),
+            old_attrs.get("K", 0),
+            old_attrs.get("block_size", 0),
         )
 
         # Remove old lm_head weight initializers
@@ -2564,7 +2587,7 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
         model.graph.initializer.append(numpy_helper.from_array(reshape_shape, name=reshape_shape_name))
 
         reshape_output = "lm_head.MatMulNBits.reshaped_weight"
-        reshape_node = helper.make_node(
+        reshape_node = onnx.helper.make_node(
             "Reshape",
             inputs=[embed_weight_name, reshape_shape_name],
             outputs=[reshape_output],
@@ -2577,8 +2600,11 @@ class ShareEmbeddingLmHead(ProtoSurgeon):
         if embed_zp_name:
             inputs.append(embed_zp_name)
 
+        # Ensure com.microsoft opset is declared
+        _ensure_msft_opset(model)
+
         # Create new INT8 MatMulNBits node
-        new_lm_head = helper.make_node(
+        new_lm_head = onnx.helper.make_node(
             "MatMulNBits",
             inputs=inputs,
             outputs=lm_head_node.output,

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -520,11 +520,6 @@ def patched_make_embedding(self, embedding):
     import onnx_ir as ir
 
     basename = "/model/embed_tokens"
-    if getattr(self, "int4_tied_embeddings", False) or getattr(self, "shared_embeddings", False):
-        logger.debug(
-            "int4_tied_embedding/shared_embeddings is set to True but will be ignored. Use TieWordEmbeddings graph surgery to tie"
-            " embeddings."
-        )
 
     if hasattr(embedding, "qweight"):
         qweight = "model.embed_tokens.qweight"

--- a/test/passes/onnx/test_quantize_embedding.py
+++ b/test/passes/onnx/test_quantize_embedding.py
@@ -1,0 +1,185 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+from olive.passes.onnx.graph_surgeries import QuantizeEmbeddingInt8, ShareEmbeddingLmHead
+
+
+def _make_model_with_fp16_embed(vocab_size=64, hidden_size=64, block_size=32):
+    """Create a minimal ONNX model with FP16 Gather embedding and INT4 MatMulNBits lm_head."""
+    # Embedding: Gather with FP16 weight
+    embed_weight = np.random.randn(vocab_size, hidden_size).astype(np.float16)
+    embed_init = numpy_helper.from_array(embed_weight, name="model.embed_tokens.weight")
+
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, ["batch_size", "seq_len"])
+    gather_output = helper.make_tensor_value_info("embed_output", TensorProto.FLOAT16, ["batch_size", "seq_len", hidden_size])
+
+    gather_node = helper.make_node(
+        "Gather", inputs=["model.embed_tokens.weight", "input_ids"],
+        outputs=["embed_output"], name="/model/embed_tokens/Gather"
+    )
+
+    # lm_head: MatMulNBits with INT4 weight
+    num_blocks = hidden_size // block_size
+    lm_weight = np.random.randint(0, 255, (vocab_size, num_blocks, block_size // 2), dtype=np.uint8)
+    lm_scales = np.random.randn(vocab_size, num_blocks).astype(np.float16) * 0.01
+    lm_zp = np.full((vocab_size, num_blocks), 8, dtype=np.uint8)
+
+    lm_weight_init = numpy_helper.from_array(lm_weight, name="lm_head.MatMul_Q4.qweight")
+    lm_scales_init = numpy_helper.from_array(lm_scales, name="lm_head.MatMul_Q4.scales")
+    lm_zp_init = numpy_helper.from_array(lm_zp, name="lm_head.MatMul_Q4.zp")
+
+    lm_head_node = helper.make_node(
+        "MatMulNBits",
+        inputs=["embed_output", "lm_head.MatMul_Q4.qweight", "lm_head.MatMul_Q4.scales", "lm_head.MatMul_Q4.zp"],
+        outputs=["logits"],
+        name="/lm_head/MatMulNBits",
+        domain="com.microsoft",
+        bits=4, block_size=block_size, K=hidden_size, N=vocab_size,
+    )
+
+    logits = helper.make_tensor_value_info("logits", TensorProto.FLOAT16, ["batch_size", "seq_len", vocab_size])
+
+    graph = helper.make_graph(
+        [gather_node, lm_head_node], "test",
+        [input_ids], [logits],
+        initializer=[embed_init, lm_weight_init, lm_scales_init, lm_zp_init],
+    )
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)],
+    )
+    return model
+
+
+class TestQuantizeEmbeddingInt8:
+    def test_replaces_gather_with_gbq(self):
+        model = _make_model_with_fp16_embed()
+        surgery = QuantizeEmbeddingInt8()
+        result = surgery(model)
+
+        # Verify Gather is replaced with GatherBlockQuantized
+        node_types = [n.op_type for n in result.graph.node]
+        assert "Gather" not in node_types or all(
+            "embed_tokens" not in n.name for n in result.graph.node if n.op_type == "Gather"
+        )
+        gbq_nodes = [n for n in result.graph.node if n.op_type == "GatherBlockQuantized"]
+        assert len(gbq_nodes) == 1
+
+        gbq = gbq_nodes[0]
+        attrs = {a.name: a.i for a in gbq.attribute}
+        assert attrs["bits"] == 8
+        assert attrs["block_size"] == 32
+
+        # Verify zero_point input exists (4 inputs: weight, input_ids, scales, zp)
+        assert len(gbq.input) == 4
+
+    def test_reduces_weight_size(self):
+        model = _make_model_with_fp16_embed(vocab_size=256, hidden_size=128)
+        surgery = QuantizeEmbeddingInt8()
+
+        # Get FP16 weight size before
+        fp16_size = sum(
+            np.prod(list(init.dims)) * 2  # FP16 = 2 bytes
+            for init in model.graph.initializer
+            if init.name == "model.embed_tokens.weight"
+        )
+
+        result = surgery(model)
+
+        # FP16 weight should be removed
+        fp16_names = [init.name for init in result.graph.initializer if init.name == "model.embed_tokens.weight"]
+        assert len(fp16_names) == 0
+
+        # INT8 weight should exist
+        int8_names = [init.name for init in result.graph.initializer if "_Q8" in init.name]
+        assert len(int8_names) == 1
+
+    def test_skips_non_fp16(self):
+        model = _make_model_with_fp16_embed()
+        surgery = QuantizeEmbeddingInt8()
+
+        # First pass: quantize to INT8
+        result1 = surgery(model)
+        # Second pass: should skip (already quantized)
+        result2 = surgery(result1)
+
+        # Should still have exactly 1 GBQ node
+        gbq_count = sum(1 for n in result2.graph.node if n.op_type == "GatherBlockQuantized")
+        assert gbq_count == 1
+
+    def test_skips_when_hidden_not_divisible(self):
+        # hidden_size=33, not divisible by block_size=32
+        embed_weight = np.random.randn(64, 33).astype(np.float16)
+        embed_init = numpy_helper.from_array(embed_weight, name="model.embed_tokens.weight")
+        input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1])
+        output = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [1, 33])
+        gather = helper.make_node("Gather", ["model.embed_tokens.weight", "input_ids"], ["out"], name="/model/embed_tokens/Gather")
+        graph = helper.make_graph([gather], "test", [input_ids], [output], initializer=[embed_init])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)])
+
+        surgery = QuantizeEmbeddingInt8()
+        result = surgery(model)
+
+        # Should still have Gather (not replaced)
+        assert any(n.op_type == "Gather" for n in result.graph.node)
+
+
+class TestShareEmbeddingLmHead:
+    def test_shares_weight(self):
+        model = _make_model_with_fp16_embed()
+
+        # First quantize embedding to INT8
+        q_surgery = QuantizeEmbeddingInt8()
+        model = q_surgery(model)
+
+        # Then share
+        s_surgery = ShareEmbeddingLmHead()
+        result = s_surgery(model)
+
+        # lm_head should now be INT8
+        lm_head = [n for n in result.graph.node if n.op_type == "MatMulNBits" and "lm_head" in n.name][0]
+        attrs = {a.name: a.i for a in lm_head.attribute}
+        assert attrs["bits"] == 8
+
+        # Should have a Reshape node for weight sharing
+        reshape_nodes = [n for n in result.graph.node if "Reshape_shared" in n.name]
+        assert len(reshape_nodes) == 1
+
+        # Reshape should reference the embedding weight
+        reshape = reshape_nodes[0]
+        assert "embed_tokens" in reshape.input[0]
+
+        # lm_head should use shared scales
+        assert "embed_tokens" in lm_head.input[2]  # scales
+
+    def test_skips_without_gbq(self):
+        model = _make_model_with_fp16_embed()
+        # Don't quantize embedding first
+        s_surgery = ShareEmbeddingLmHead()
+        result = s_surgery(model)
+
+        # Should be unchanged — still has Gather
+        assert any(n.op_type == "Gather" for n in result.graph.node)
+
+    def test_removes_old_lm_head_weights(self):
+        model = _make_model_with_fp16_embed()
+        q_surgery = QuantizeEmbeddingInt8()
+        model = q_surgery(model)
+
+        old_init_names = {init.name for init in model.graph.initializer}
+
+        s_surgery = ShareEmbeddingLmHead()
+        result = s_surgery(model)
+
+        new_init_names = {init.name for init in result.graph.initializer}
+
+        # Old lm_head weights should be removed
+        assert "lm_head.MatMul_Q4.qweight" not in new_init_names
+        assert "lm_head.MatMul_Q4.scales" not in new_init_names
+        assert "lm_head.MatMul_Q4.zp" not in new_init_names

--- a/test/passes/onnx/test_quantize_embedding.py
+++ b/test/passes/onnx/test_quantize_embedding.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import numpy as np
-import onnx
-import pytest
 from onnx import TensorProto, helper, numpy_helper
 
 from olive.passes.onnx.graph_surgeries import QuantizeEmbeddingInt8, ShareEmbeddingLmHead
@@ -17,11 +15,12 @@ def _make_model_with_fp16_embed(vocab_size=64, hidden_size=64, block_size=32):
     embed_init = numpy_helper.from_array(embed_weight, name="model.embed_tokens.weight")
 
     input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, ["batch_size", "seq_len"])
-    gather_output = helper.make_tensor_value_info("embed_output", TensorProto.FLOAT16, ["batch_size", "seq_len", hidden_size])
 
     gather_node = helper.make_node(
-        "Gather", inputs=["model.embed_tokens.weight", "input_ids"],
-        outputs=["embed_output"], name="/model/embed_tokens/Gather"
+        "Gather",
+        inputs=["model.embed_tokens.weight", "input_ids"],
+        outputs=["embed_output"],
+        name="/model/embed_tokens/Gather",
     )
 
     # lm_head: MatMulNBits with INT4 weight
@@ -40,21 +39,23 @@ def _make_model_with_fp16_embed(vocab_size=64, hidden_size=64, block_size=32):
         outputs=["logits"],
         name="/lm_head/MatMulNBits",
         domain="com.microsoft",
-        bits=4, block_size=block_size, K=hidden_size, N=vocab_size,
+        bits=4,
+        block_size=block_size,
+        K=hidden_size,
+        N=vocab_size,
     )
-
-    logits = helper.make_tensor_value_info("logits", TensorProto.FLOAT16, ["batch_size", "seq_len", vocab_size])
 
     graph = helper.make_graph(
-        [gather_node, lm_head_node], "test",
-        [input_ids], [logits],
+        [gather_node, lm_head_node],
+        "test",
+        [input_ids],
+        [helper.make_tensor_value_info("logits", TensorProto.FLOAT16, ["batch_size", "seq_len", vocab_size])],
         initializer=[embed_init, lm_weight_init, lm_scales_init, lm_zp_init],
     )
-    model = helper.make_model(
+    return helper.make_model(
         graph,
         opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)],
     )
-    return model
 
 
 class TestQuantizeEmbeddingInt8:
@@ -82,13 +83,6 @@ class TestQuantizeEmbeddingInt8:
     def test_reduces_weight_size(self):
         model = _make_model_with_fp16_embed(vocab_size=256, hidden_size=128)
         surgery = QuantizeEmbeddingInt8()
-
-        # Get FP16 weight size before
-        fp16_size = sum(
-            np.prod(list(init.dims)) * 2  # FP16 = 2 bytes
-            for init in model.graph.initializer
-            if init.name == "model.embed_tokens.weight"
-        )
 
         result = surgery(model)
 
@@ -119,9 +113,13 @@ class TestQuantizeEmbeddingInt8:
         embed_init = numpy_helper.from_array(embed_weight, name="model.embed_tokens.weight")
         input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1])
         output = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [1, 33])
-        gather = helper.make_node("Gather", ["model.embed_tokens.weight", "input_ids"], ["out"], name="/model/embed_tokens/Gather")
+        gather = helper.make_node(
+            "Gather", ["model.embed_tokens.weight", "input_ids"], ["out"], name="/model/embed_tokens/Gather"
+        )
         graph = helper.make_graph([gather], "test", [input_ids], [output], initializer=[embed_init])
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)])
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)]
+        )
 
         surgery = QuantizeEmbeddingInt8()
         result = surgery(model)
@@ -143,7 +141,7 @@ class TestShareEmbeddingLmHead:
         result = s_surgery(model)
 
         # lm_head should now be INT8
-        lm_head = [n for n in result.graph.node if n.op_type == "MatMulNBits" and "lm_head" in n.name][0]
+        lm_head = next(n for n in result.graph.node if n.op_type == "MatMulNBits" and "lm_head" in n.name)
         attrs = {a.name: a.i for a in lm_head.attribute}
         assert attrs["bits"] == 8
 
@@ -158,6 +156,20 @@ class TestShareEmbeddingLmHead:
         # lm_head should use shared scales
         assert "embed_tokens" in lm_head.input[2]  # scales
 
+    def test_idempotent(self):
+        model = _make_model_with_fp16_embed()
+        q_surgery = QuantizeEmbeddingInt8()
+        model = q_surgery(model)
+
+        s_surgery = ShareEmbeddingLmHead()
+        result1 = s_surgery(model)
+        # Applying again should be a no-op
+        result2 = s_surgery(result1)
+
+        # Should still have exactly 1 Reshape_shared node
+        reshape_count = sum(1 for n in result2.graph.node if "Reshape_shared" in n.name)
+        assert reshape_count == 1
+
     def test_skips_without_gbq(self):
         model = _make_model_with_fp16_embed()
         # Don't quantize embedding first
@@ -171,8 +183,6 @@ class TestShareEmbeddingLmHead:
         model = _make_model_with_fp16_embed()
         q_surgery = QuantizeEmbeddingInt8()
         model = q_surgery(model)
-
-        old_init_names = {init.name for init in model.graph.initializer}
 
         s_surgery = ShareEmbeddingLmHead()
         result = s_surgery(model)


### PR DESCRIPTION
## Add QuantizeEmbeddingInt8 and ShareEmbeddingLmHead graph surgeries

### Summary

Adds two new graph surgeries for post-hoc INT8 embedding quantization and weight sharing, along with evaluator fixes for hybrid attention architectures (e.g., Qwen3.5-2B with GatedDeltaNet + standard attention).

### Motivation

Models with large vocabularies (e.g., Qwen3.5-2B with 248K tokens) have FP16 embeddings that dominate model size (~970 MB out of 2.0 GB for INT4 weights). The ModelBuilder's default quantizer (Neural Compressor) only quantizes `MatMul` ops, leaving `Gather` (embedding) as FP16. RTN-based quantizers that support INT8 embedding natively (`k_quant_last`) destroy accuracy on hybrid architectures (26% vs 59% MMLU).

### Changes

#### New Graph Surgeries (`graph_surgeries.py`)
- **`QuantizeEmbeddingInt8`**: Converts FP16 `Gather` embedding to INT8 `GatherBlockQuantized` with per-block asymmetric quantization (zero_point=128, block_size=32). Reduces embedding from ~970 MB to ~530 MB with negligible accuracy loss.
- **`ShareEmbeddingLmHead`**: Replaces lm_head's INT4 `MatMulNBits` with INT8 `MatMulNBits` sharing the embedding weight via `Reshape`, eliminating duplicate storage. Saves ~250 MB.
- Helper functions: `_find_embed_node`, `_find_lm_head_node`, `_find_initializer`, `_get_node_attrs`

#### Evaluator Fixes
- **`lmeval_ort.py`**: Support for 3D `position_ids` (mRoPE) and hybrid `conv_state`/`recurrent_state` inputs for models with mixed attention + linear attention layers
- **`olive_evaluator.py`**: Fix metric parsing for lm-eval results with non-comma metric keys and non-numeric values
- **`onnx_io.py`**: Fix KV cache layer index detection for non-contiguous indices (e.g., attention at layers 3,7,11,15,19,23 only)

### Results (Qwen3.5-2B)

| Configuration | Size | MMLU | Δ vs FP16 |
|---|---|---|---|
| Baseline FP16 | 4.3 GB | 59.27% | — |
| INT4 weights + FP16 embed | 2.0 GB | 57.21% | -2.06% |
| INT4 weights + INT8 embed | 1.6 GB | 57.19% | -2.08% |
| **INT4 weights + shared INT8 embed/lm_head** | **1.4 GB** | **57.11%** | **-2.16%** |

### Testing

- 7 unit tests added in `test/passes/onnx/test_quantize_embedding.py`
- All tests pass
- End-to-end validated via Olive recipe with MMLU evaluation