### PR TITLE
Add genie_overrides to QairtEncapsulation for GenAIConfig customization

### DIFF
--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -153,7 +153,11 @@ class QairtEncapsulation(Pass):
 
         export_kwargs = {"export_format": qairt.ExportFormat.LM_EXECUTOR}
         if config.engine_config_overrides:
-            if "engine_config" in inspect.signature(container.export).parameters:
+            try:
+                supports_engine_config = "engine_config" in inspect.signature(container.export).parameters
+            except (TypeError, ValueError):
+                supports_engine_config = False
+            if supports_engine_config:
                 overrides = dict(config.engine_config_overrides)
                 htp_overrides = overrides.pop("htp", None)
                 htp_cfg = qairt_genai.HTPEngineConfig(**htp_overrides) if htp_overrides else None

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -162,7 +162,8 @@ class QairtEncapsulation(Pass):
             else:
                 logger.warning(
                     "engine_config_overrides ignored: installed qairt does not support "
-                    "engine_config in LLMContainer.export() (requires qairt-dev with AISW-184594)"
+                    "engine_config in LLMContainer.export(). Upgrade qairt-dev to a version "
+                    "that exposes engine_config in LLMContainer.export()."
                 )
 
         # Input/Output metadata

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -99,17 +99,19 @@ class QairtEncapsulation(Pass):
                     "extensions config, the override is used as the entire config."
                 ),
             ),
-            "htp_execution_overrides": PassConfigParam(
+            "engine_config_overrides": PassConfigParam(
                 type_=dict,
                 default_value=None,
                 required=False,
                 description=(
-                    "HTP deployment parameters passed to LLMContainer.export() as an "
-                    "HTPExecutionConfig. Dict keys map directly to HTPExecutionConfig fields: "
-                    "cpu_mask, n_threads, use_mmap, spill_fill_bufsize, mmap_budget, "
+                    "Engine deployment parameters passed to LLMContainer.export() as an "
+                    "EngineConfig. Top-level keys (n_threads) map to EngineConfig fields; "
+                    "HTP-specific keys go under a nested 'htp' dict mapping to HTPEngineConfig "
+                    "fields: cpu_mask, poll, use_mmap, spill_fill_bufsize, mmap_budget, "
                     "pos_id_dim, kv_update_method, allow_async_init, enable_graph_switching. "
+                    "Example: {'n_threads': 0, 'htp': {'cpu_mask': '0xe0', 'poll': False}}. "
                     "Requires backend='HTP'. Ignored with a warning if the installed qairt "
-                    "does not support htp_execution_config in LLMContainer.export() "
+                    "does not support engine_config in LLMContainer.export() "
                     "(requires qairt-dev with AISW-184594)."
                 ),
             ),
@@ -121,8 +123,8 @@ class QairtEncapsulation(Pass):
         config: type[BasePassConfig],
         accelerator_spec: AcceleratorSpec,
     ) -> bool:
-        if config.htp_execution_overrides and config.backend != QairtBackend.HTP:
-            logger.error("htp_execution_overrides is unsupported on non-HTP backends")
+        if config.engine_config_overrides and config.backend != QairtBackend.HTP:
+            logger.error("engine_config_overrides is unsupported on non-HTP backends")
             return False
         return True
 
@@ -175,14 +177,17 @@ class QairtEncapsulation(Pass):
                 )
 
         export_kwargs = {"export_format": qairt.ExportFormat.LM_EXECUTOR}
-        if config.htp_execution_overrides:
-            htp_exec_cfg = qairt_genai.HTPExecutionConfig(**config.htp_execution_overrides)
-            if "htp_execution_config" in inspect.signature(container.export).parameters:
-                export_kwargs["htp_execution_config"] = htp_exec_cfg
+        if config.engine_config_overrides:
+            overrides = config.engine_config_overrides
+            htp_overrides = overrides.pop("htp", None)
+            htp_cfg = qairt_genai.HTPEngineConfig(**htp_overrides) if htp_overrides else None
+            engine_cfg = qairt_genai.EngineConfig(**overrides, htp=htp_cfg)
+            if "engine_config" in inspect.signature(container.export).parameters:
+                export_kwargs["engine_config"] = engine_cfg
             else:
                 logger.warning(
-                    "htp_execution_overrides ignored: installed qairt does not support "
-                    "htp_execution_config in LLMContainer.export()"
+                    "engine_config_overrides ignored: installed qairt does not support "
+                    "engine_config in LLMContainer.export() (requires qairt-dev with AISW-184594)"
                 )
 
         # Input/Output metadata

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -45,8 +45,6 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
             for i, ov in enumerate(v):
                 if i < len(result[k]) and isinstance(result[k][i], dict) and isinstance(ov, dict):
                     merged.append(_deep_merge(result[k][i], ov))
-                elif i < len(result[k]):
-                    merged.append(ov)
                 else:
                     merged.append(ov)
             merged.extend(result[k][len(v) :])
@@ -177,7 +175,7 @@ class QairtEncapsulation(Pass):
 
         export_kwargs = {"export_format": qairt.ExportFormat.LM_EXECUTOR}
         if config.engine_config_overrides:
-            overrides = config.engine_config_overrides
+            overrides = dict(config.engine_config_overrides)
             htp_overrides = overrides.pop("htp", None)
             htp_cfg = qairt_genai.HTPEngineConfig(**htp_overrides) if htp_overrides else None
             engine_cfg = qairt_genai.EngineConfig(**overrides, htp=htp_cfg)

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -35,10 +35,7 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
     elements are appended. A ``None`` override value deletes the key from
     the result. The returned dict shares no references with *base*.
     """
-    # Shallow-copy base so untouched keys start in result; deep-copy them
-    # below only when they are not recursively merged (avoids a full
-    # deepcopy of the entire subtree on every recursive call).
-    result = dict(base)
+    result = copy.deepcopy(base)
     for k, v in overrides.items():
         if v is None:
             result.pop(k, None)
@@ -51,15 +48,10 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
                     merged.append(_deep_merge(result[k][i], ov))
                 else:
                     merged.append(copy.deepcopy(ov))
-            merged.extend(copy.deepcopy(item) for item in result[k][len(v) :])
+            merged.extend(result[k][len(v) :])
             result[k] = merged
         else:
             result[k] = copy.deepcopy(v)
-    # Deep-copy any base values not touched by overrides so the returned
-    # dict is fully independent of base.
-    for k, existing in result.items():
-        if k not in overrides:
-            result[k] = copy.deepcopy(existing)
     return result
 
 

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 # --------------------------------------------------------------------------
 
+import copy
 import inspect
 import logging
 import os
@@ -46,11 +47,16 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
                 if i < len(result[k]) and isinstance(result[k][i], dict) and isinstance(ov, dict):
                     merged.append(_deep_merge(result[k][i], ov))
                 else:
-                    merged.append(ov)
-            merged.extend(result[k][len(v) :])
+                    merged.append(copy.deepcopy(ov))
+            merged.extend(copy.deepcopy(item) for item in result[k][len(v) :])
             result[k] = merged
         else:
-            result[k] = v
+            result[k] = copy.deepcopy(v)
+    # Deep-copy any base values that were not touched by overrides so the
+    # returned dict is fully independent of base.
+    for k, existing in result.items():
+        if k not in overrides:
+            result[k] = copy.deepcopy(existing)
     return result
 
 

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -171,18 +171,18 @@ class QairtEncapsulation(Pass):
 
         if config.genie_overrides:
             if hasattr(container, "_gen_ai_config"):
-                gen_ai_cfg = container._gen_ai_config
+                gen_ai_cfg = container._gen_ai_config  # pylint: disable=protected-access
                 current = gen_ai_cfg.model_dump(mode="json", by_alias=False, exclude_none=True)
                 merged = _deep_merge(current, config.genie_overrides)
-                container._gen_ai_config = gen_ai_cfg.model_validate(merged)
+                container._gen_ai_config = gen_ai_cfg.model_validate(merged)  # pylint: disable=protected-access
                 logger.info("Applied genie_overrides to GenAIConfig: %s", list(config.genie_overrides.keys()))
             else:
                 logger.warning("genie_overrides ignored: _gen_ai_config not found in installed qairt version")
 
         if config.backend_extensions_overrides:
             if hasattr(container, "_backend_extensions_config"):
-                container._backend_extensions_config = _deep_merge(
-                    container._backend_extensions_config or {}, config.backend_extensions_overrides
+                container._backend_extensions_config = _deep_merge(  # pylint: disable=protected-access
+                    container._backend_extensions_config or {}, config.backend_extensions_overrides  # pylint: disable=protected-access
                 )
                 logger.info(
                     "Applied backend_extensions_overrides: %s", list(config.backend_extensions_overrides.keys())

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -33,9 +33,9 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
     element-wise by index — the override list need not be the same length as
     the base list; extra base elements are preserved and extra override
     elements are appended. A ``None`` override value deletes the key from
-    the result.
+    the result. The returned dict shares no references with *base*.
     """
-    result = dict(base)
+    result = copy.deepcopy(base)
     for k, v in overrides.items():
         if v is None:
             result.pop(k, None)
@@ -52,11 +52,6 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
             result[k] = merged
         else:
             result[k] = copy.deepcopy(v)
-    # Deep-copy any base values that were not touched by overrides so the
-    # returned dict is fully independent of base.
-    for k, existing in result.items():
-        if k not in overrides:
-            result[k] = copy.deepcopy(existing)
     return result
 
 
@@ -160,7 +155,10 @@ class QairtEncapsulation(Pass):
         export_kwargs = {"export_format": qairt.ExportFormat.LM_EXECUTOR}
         if config.engine_config_overrides:
             try:
-                supports_engine_config = "engine_config" in inspect.signature(container.export).parameters
+                sig = inspect.signature(container.export).parameters
+                supports_engine_config = "engine_config" in sig or any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.values()
+                )
             except (TypeError, ValueError):
                 supports_engine_config = False
             if supports_engine_config:

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -294,7 +294,7 @@ def create_genai_config(
     generation_config_path = Path(output_path) / "generation_config.json"
 
     if not generation_config_path.exists():
-        raise ValueError("Cannot create genai_config.json if generation config doesn't exist")
+        raise ValueError("Cannot create genai_config.json if generation config doesn't exist.")
 
     genai_config = {
         "model": {

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -153,11 +153,11 @@ class QairtEncapsulation(Pass):
 
         export_kwargs = {"export_format": qairt.ExportFormat.LM_EXECUTOR}
         if config.engine_config_overrides:
-            overrides = dict(config.engine_config_overrides)
-            htp_overrides = overrides.pop("htp", None)
-            htp_cfg = qairt_genai.HTPEngineConfig(**htp_overrides) if htp_overrides else None
-            engine_cfg = qairt_genai.EngineConfig(**overrides, htp=htp_cfg)
             if "engine_config" in inspect.signature(container.export).parameters:
+                overrides = dict(config.engine_config_overrides)
+                htp_overrides = overrides.pop("htp", None)
+                htp_cfg = qairt_genai.HTPEngineConfig(**htp_overrides) if htp_overrides else None
+                engine_cfg = qairt_genai.EngineConfig(**overrides, htp=htp_cfg)
                 export_kwargs["engine_config"] = engine_cfg
             else:
                 logger.warning(

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -83,44 +83,22 @@ class QairtEncapsulation(Pass):
                 type_=dict,
                 default_value=None,
                 required=False,
-                description=(
-                    "Deep-merged into the GenAIConfig before the Genie DLC is produced. "
-                    "Use Python field names (underscores). Nested dicts are merged recursively — "
-                    "only the specified keys are overridden; all other GenAIBuilder defaults are "
-                    "preserved. Any field on GenAIConfig is valid: kv_dim, rope_theta, n_heads, "
-                    "n_layer, n_embd, allow_async_init, enable_graph_switching, "
-                    "positional_encoding (nested dict), etc. Note: top-level rope_theta and "
-                    "rope_scaling are not forwarded by the Genie factory — use "
-                    "positional_encoding.rope_theta to override RoPE theta in the DLC."
-                ),
+                description="Override GenAIConfig fields before DLC export without modifying the builder pass. "
+                "Only the specified keys are changed; all other builder defaults are preserved.",
             ),
             "backend_extensions_overrides": PassConfigParam(
                 type_=dict,
                 default_value=None,
                 required=False,
-                description=(
-                    "Deep-merged into the backend extensions config before the Genie DLC is "
-                    "produced. Use the raw JSON key names (hyphens) as they appear in "
-                    "backend_extensions.json. Nested dicts are merged recursively — only the "
-                    "specified keys are overridden; all other backend extension defaults set "
-                    "by the builder are preserved. If the container has no existing backend "
-                    "extensions config, the override is used as the entire config."
-                ),
+                description="Override backend extension settings (context, devices, memory, groupContext) "
+                "before DLC export. Use the same key names as backend_extensions.json.",
             ),
             "engine_config_overrides": PassConfigParam(
                 type_=dict,
                 default_value=None,
                 required=False,
-                description=(
-                    "Engine deployment parameters passed to LLMContainer.export() as an "
-                    "EngineConfig. Top-level keys (n_threads) map to EngineConfig fields; "
-                    "HTP-specific keys go under a nested 'htp' dict mapping to HTPEngineConfig "
-                    "fields: cpu_mask, poll, use_mmap, spill_fill_bufsize, mmap_budget, "
-                    "pos_id_dim, kv_update_method, allow_async_init, enable_graph_switching. "
-                    "Example: {'n_threads': 0, 'htp': {'cpu_mask': '0xe0', 'poll': False}}. "
-                    "Ignored with a warning if the installed qairt does not support engine_config "
-                    "in LLMContainer.export() (requires qairt-dev with AISW-184594)."
-                ),
+                description="Set engine deployment parameters (e.g. n_threads, cpu_mask) passed to the "
+                "Genie runtime at export. HTP-specific settings go under a nested 'htp' key.",
             ),
         }
 

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -48,7 +48,7 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
                     merged.append(_deep_merge(result[k][i], ov))
                 else:
                     merged.append(copy.deepcopy(ov))
-            merged.extend(copy.deepcopy(item) for item in result[k][len(v) :])
+            merged.extend(result[k][len(v) :])
             result[k] = merged
         else:
             result[k] = copy.deepcopy(v)
@@ -164,7 +164,7 @@ class QairtEncapsulation(Pass):
             if supports_engine_config:
                 overrides = dict(config.engine_config_overrides)
                 htp_overrides = overrides.pop("htp", None)
-                htp_cfg = qairt_genai.HTPEngineConfig(**htp_overrides) if htp_overrides else None
+                htp_cfg = qairt_genai.HTPEngineConfig(**(htp_overrides or {})) if htp_overrides is not None else None
                 engine_cfg = qairt_genai.EngineConfig(**overrides, htp=htp_cfg)
                 export_kwargs["engine_config"] = engine_cfg
             else:
@@ -289,12 +289,12 @@ def create_genai_config(
     source_config_path = Path(output_path) / "config.json"
 
     if not source_config_path.exists():
-        raise ValueError("Cannot create gen_ai_config.json if source model config doesn't exist.")
+        raise ValueError("Cannot create genai_config.json if source model config doesn't exist.")
 
     generation_config_path = Path(output_path) / "generation_config.json"
 
     if not generation_config_path.exists():
-        raise ValueError("Cannot create gen_ai_config.json if generation config doesn't exist")
+        raise ValueError("Cannot create genai_config.json if generation config doesn't exist")
 
     genai_config = {
         "model": {

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -29,13 +29,29 @@ MAX_GENIE_CONTEXT_LENGTH = 4096
 def _deep_merge(base: dict, overrides: dict) -> dict:
     """Recursively merge *overrides* into *base*, returning a new dict.
 
-    Nested dicts are merged rather than replaced, so only the keys present in
-    *overrides* are changed; all other keys from *base* are preserved.
+    Nested dicts are merged rather than replaced. Lists of dicts are merged
+    element-wise by index — the override list need not be the same length as
+    the base list; extra base elements are preserved and extra override
+    elements are appended. A ``None`` override value deletes the key from
+    the result.
     """
     result = dict(base)
     for k, v in overrides.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+        if v is None:
+            result.pop(k, None)
+        elif k in result and isinstance(result[k], dict) and isinstance(v, dict):
             result[k] = _deep_merge(result[k], v)
+        elif k in result and isinstance(result[k], list) and isinstance(v, list):
+            merged = []
+            for i, ov in enumerate(v):
+                if i < len(result[k]) and isinstance(result[k][i], dict) and isinstance(ov, dict):
+                    merged.append(_deep_merge(result[k][i], ov))
+                elif i < len(result[k]):
+                    merged.append(ov)
+                else:
+                    merged.append(ov)
+            merged.extend(result[k][len(v):])
+            result[k] = merged
         else:
             result[k] = v
     return result

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -35,7 +35,10 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
     elements are appended. A ``None`` override value deletes the key from
     the result. The returned dict shares no references with *base*.
     """
-    result = copy.deepcopy(base)
+    # Shallow-copy base so untouched keys start in result; deep-copy them
+    # below only when they are not recursively merged (avoids a full
+    # deepcopy of the entire subtree on every recursive call).
+    result = dict(base)
     for k, v in overrides.items():
         if v is None:
             result.pop(k, None)
@@ -48,10 +51,15 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
                     merged.append(_deep_merge(result[k][i], ov))
                 else:
                     merged.append(copy.deepcopy(ov))
-            merged.extend(result[k][len(v) :])
+            merged.extend(copy.deepcopy(item) for item in result[k][len(v) :])
             result[k] = merged
         else:
             result[k] = copy.deepcopy(v)
+    # Deep-copy any base values not touched by overrides so the returned
+    # dict is fully independent of base.
+    for k, existing in result.items():
+        if k not in overrides:
+            result[k] = copy.deepcopy(existing)
     return result
 
 

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -79,6 +79,19 @@ class QairtEncapsulation(Pass):
                     "positional_encoding.rope_theta to override RoPE theta in the DLC."
                 ),
             ),
+            "backend_extensions_override": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                required=False,
+                description=(
+                    "Deep-merged into the backend extensions config before the Genie DLC is "
+                    "produced. Use the raw JSON key names (hyphens) as they appear in "
+                    "backend_extensions.json. Nested dicts are merged recursively — only the "
+                    "specified keys are overridden; all other backend extension defaults set "
+                    "by the builder are preserved. If the container has no existing backend "
+                    "extensions config, the override is used as the entire config."
+                ),
+            ),
         }
 
     def _run_for_config(
@@ -112,6 +125,12 @@ class QairtEncapsulation(Pass):
             merged = _deep_merge(current, config.genie_overrides)
             container._gen_ai_config = gen_ai_cfg.model_validate(merged)
             logger.info("Applied genie_overrides to GenAIConfig: %s", list(config.genie_overrides.keys()))
+
+        if config.backend_extensions_override:
+            container._backend_extensions_config = _deep_merge(
+                container._backend_extensions_config or {}, config.backend_extensions_override
+            )
+            logger.info("Applied backend_extensions_override: %s", list(config.backend_extensions_override.keys()))
 
         # Input/Output metadata
         container.inputs = [("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])]

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -49,7 +49,7 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
                     merged.append(ov)
                 else:
                     merged.append(ov)
-            merged.extend(result[k][len(v):])
+            merged.extend(result[k][len(v) :])
             result[k] = merged
         else:
             result[k] = v
@@ -164,7 +164,8 @@ class QairtEncapsulation(Pass):
         if config.backend_extensions_overrides:
             if hasattr(container, "_backend_extensions_config"):
                 container._backend_extensions_config = _deep_merge(  # pylint: disable=protected-access
-                    container._backend_extensions_config or {}, config.backend_extensions_overrides  # pylint: disable=protected-access
+                    container._backend_extensions_config or {},  # pylint: disable=protected-access
+                    config.backend_extensions_overrides,
                 )
                 logger.info(
                     "Applied backend_extensions_overrides: %s", list(config.backend_extensions_overrides.keys())

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -18,7 +18,6 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler, QairtModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
-from olive.passes.qairt.gen_ai_builder import QairtBackend
 from olive.passes.qairt.utils import QairtLogLevel
 
 logger = logging.getLogger(__name__)
@@ -82,11 +81,6 @@ class QairtEncapsulation(Pass):
                 required=False,
                 description="Opset name and version to be added in the generated context model",
             ),
-            "backend": PassConfigParam(
-                type_=QairtBackend,
-                default_value=QairtBackend.HTP,
-                description="Target accelerator backend for the DLC being encapsulated. Accepted values are 'CPU' and 'HTP'.",
-            ),
             "genie_overrides": PassConfigParam(
                 type_=dict,
                 default_value=None,
@@ -126,23 +120,11 @@ class QairtEncapsulation(Pass):
                     "fields: cpu_mask, poll, use_mmap, spill_fill_bufsize, mmap_budget, "
                     "pos_id_dim, kv_update_method, allow_async_init, enable_graph_switching. "
                     "Example: {'n_threads': 0, 'htp': {'cpu_mask': '0xe0', 'poll': False}}. "
-                    "Requires backend='HTP'. Ignored with a warning if the installed qairt "
-                    "does not support engine_config in LLMContainer.export() "
-                    "(requires qairt-dev with AISW-184594)."
+                    "Ignored with a warning if the installed qairt does not support engine_config "
+                    "in LLMContainer.export() (requires qairt-dev with AISW-184594)."
                 ),
             ),
         }
-
-    @classmethod
-    def validate_config(
-        cls,
-        config: type[BasePassConfig],
-        accelerator_spec: AcceleratorSpec,
-    ) -> bool:
-        if config.engine_config_overrides and config.backend != QairtBackend.HTP:
-            logger.error("engine_config_overrides is unsupported on non-HTP backends")
-            return False
-        return True
 
     def _run_for_config(
         self,

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -177,9 +177,9 @@ class QairtEncapsulation(Pass):
                 export_kwargs["engine_config"] = engine_cfg
             else:
                 logger.warning(
-                    "engine_config_overrides ignored: installed qairt does not support "
-                    "engine_config in LLMContainer.export(). Upgrade qairt-dev to a version "
-                    "that exposes engine_config in LLMContainer.export()."
+                    "engine_config_overrides ignored: installed qairt-dev does not support "
+                    "the engine_config parameter in LLMContainer.export(). "
+                    "Upgrade to a newer version of qairt-dev to enable this parameter."
                 )
 
         # Input/Output metadata

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 # --------------------------------------------------------------------------
 
+import inspect
 import logging
 import os
 from pathlib import Path
@@ -17,6 +18,7 @@ from olive.hardware.accelerator import AcceleratorSpec
 from olive.model import ONNXModelHandler, QairtModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
+from olive.passes.qairt.gen_ai_builder import QairtBackend
 from olive.passes.qairt.utils import QairtLogLevel
 
 logger = logging.getLogger(__name__)
@@ -64,6 +66,11 @@ class QairtEncapsulation(Pass):
                 required=False,
                 description="Opset name and version to be added in the generated context model",
             ),
+            "backend": PassConfigParam(
+                type_=QairtBackend,
+                default_value=QairtBackend.HTP,
+                description="Target accelerator backend for the DLC being encapsulated. Accepted values are 'CPU' and 'HTP'.",
+            ),
             "genie_overrides": PassConfigParam(
                 type_=dict,
                 default_value=None,
@@ -79,7 +86,7 @@ class QairtEncapsulation(Pass):
                     "positional_encoding.rope_theta to override RoPE theta in the DLC."
                 ),
             ),
-            "backend_extensions_override": PassConfigParam(
+            "backend_extensions_overrides": PassConfigParam(
                 type_=dict,
                 default_value=None,
                 required=False,
@@ -92,7 +99,32 @@ class QairtEncapsulation(Pass):
                     "extensions config, the override is used as the entire config."
                 ),
             ),
+            "htp_execution_overrides": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                required=False,
+                description=(
+                    "HTP deployment parameters passed to LLMContainer.export() as an "
+                    "HTPExecutionConfig. Dict keys map directly to HTPExecutionConfig fields: "
+                    "cpu_mask, n_threads, use_mmap, spill_fill_bufsize, mmap_budget, "
+                    "pos_id_dim, kv_update_method, allow_async_init, enable_graph_switching. "
+                    "Requires backend='HTP'. Ignored with a warning if the installed qairt "
+                    "does not support htp_execution_config in LLMContainer.export() "
+                    "(requires qairt-dev with AISW-184594)."
+                ),
+            ),
         }
+
+    @classmethod
+    def validate_config(
+        cls,
+        config: type[BasePassConfig],
+        accelerator_spec: AcceleratorSpec,
+    ) -> bool:
+        if config.htp_execution_overrides and config.backend != QairtBackend.HTP:
+            logger.error("htp_execution_overrides is unsupported on non-HTP backends")
+            return False
+        return True
 
     def _run_for_config(
         self,
@@ -120,17 +152,38 @@ class QairtEncapsulation(Pass):
         container: qairt_genai.LLMContainer = qairt_genai.LLMContainer.load(model.model_path)
 
         if config.genie_overrides:
-            gen_ai_cfg = container._gen_ai_config
-            current = gen_ai_cfg.model_dump(mode="json", by_alias=False, exclude_none=True)
-            merged = _deep_merge(current, config.genie_overrides)
-            container._gen_ai_config = gen_ai_cfg.model_validate(merged)
-            logger.info("Applied genie_overrides to GenAIConfig: %s", list(config.genie_overrides.keys()))
+            if hasattr(container, "_gen_ai_config"):
+                gen_ai_cfg = container._gen_ai_config
+                current = gen_ai_cfg.model_dump(mode="json", by_alias=False, exclude_none=True)
+                merged = _deep_merge(current, config.genie_overrides)
+                container._gen_ai_config = gen_ai_cfg.model_validate(merged)
+                logger.info("Applied genie_overrides to GenAIConfig: %s", list(config.genie_overrides.keys()))
+            else:
+                logger.warning("genie_overrides ignored: _gen_ai_config not found in installed qairt version")
 
-        if config.backend_extensions_override:
-            container._backend_extensions_config = _deep_merge(
-                container._backend_extensions_config or {}, config.backend_extensions_override
-            )
-            logger.info("Applied backend_extensions_override: %s", list(config.backend_extensions_override.keys()))
+        if config.backend_extensions_overrides:
+            if hasattr(container, "_backend_extensions_config"):
+                container._backend_extensions_config = _deep_merge(
+                    container._backend_extensions_config or {}, config.backend_extensions_overrides
+                )
+                logger.info(
+                    "Applied backend_extensions_overrides: %s", list(config.backend_extensions_overrides.keys())
+                )
+            else:
+                logger.warning(
+                    "backend_extensions_overrides ignored: _backend_extensions_config not found in installed qairt version"
+                )
+
+        export_kwargs = {"export_format": qairt.ExportFormat.LM_EXECUTOR}
+        if config.htp_execution_overrides:
+            htp_exec_cfg = qairt_genai.HTPExecutionConfig(**config.htp_execution_overrides)
+            if "htp_execution_config" in inspect.signature(container.export).parameters:
+                export_kwargs["htp_execution_config"] = htp_exec_cfg
+            else:
+                logger.warning(
+                    "htp_execution_overrides ignored: installed qairt does not support "
+                    "htp_execution_config in LLMContainer.export()"
+                )
 
         # Input/Output metadata
         container.inputs = [("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])]
@@ -149,7 +202,7 @@ class QairtEncapsulation(Pass):
         for name, datatype, shape in container.outputs:
             outputs.append(helper.make_tensor_value_info(name, datatype, shape))
 
-        container.export(output_model_path, export_format=qairt.ExportFormat.LM_EXECUTOR)
+        container.export(output_model_path, **export_kwargs)
 
         # Find the .dlc file in the output directory
         output_path_obj = Path(output_model_path)

--- a/olive/passes/qairt/encapsulation.py
+++ b/olive/passes/qairt/encapsulation.py
@@ -24,6 +24,21 @@ logger = logging.getLogger(__name__)
 MAX_GENIE_CONTEXT_LENGTH = 4096
 
 
+def _deep_merge(base: dict, overrides: dict) -> dict:
+    """Recursively merge *overrides* into *base*, returning a new dict.
+
+    Nested dicts are merged rather than replaced, so only the keys present in
+    *overrides* are changed; all other keys from *base* are preserved.
+    """
+    result = dict(base)
+    for k, v in overrides.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
 class QairtEncapsulation(Pass):
     """Encapsulates a QAIRT DLC model with an onnx protobuf."""
 
@@ -48,6 +63,21 @@ class QairtEncapsulation(Pass):
                 ],
                 required=False,
                 description="Opset name and version to be added in the generated context model",
+            ),
+            "genie_overrides": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                required=False,
+                description=(
+                    "Deep-merged into the GenAIConfig before the Genie DLC is produced. "
+                    "Use Python field names (underscores). Nested dicts are merged recursively — "
+                    "only the specified keys are overridden; all other GenAIBuilder defaults are "
+                    "preserved. Any field on GenAIConfig is valid: kv_dim, rope_theta, n_heads, "
+                    "n_layer, n_embd, allow_async_init, enable_graph_switching, "
+                    "positional_encoding (nested dict), etc. Note: top-level rope_theta and "
+                    "rope_scaling are not forwarded by the Genie factory — use "
+                    "positional_encoding.rope_theta to override RoPE theta in the DLC."
+                ),
             ),
         }
 
@@ -75,6 +105,13 @@ class QairtEncapsulation(Pass):
             os.environ["QAIRT_LOG_LEVEL"] = config.log_level
 
         container: qairt_genai.LLMContainer = qairt_genai.LLMContainer.load(model.model_path)
+
+        if config.genie_overrides:
+            gen_ai_cfg = container._gen_ai_config
+            current = gen_ai_cfg.model_dump(mode="json", by_alias=False, exclude_none=True)
+            merged = _deep_merge(current, config.genie_overrides)
+            container._gen_ai_config = gen_ai_cfg.model_validate(merged)
+            logger.info("Applied genie_overrides to GenAIConfig: %s", list(config.genie_overrides.keys()))
 
         # Input/Output metadata
         container.inputs = [("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])]

--- a/test/passes/qairt/conftest.py
+++ b/test/passes/qairt/conftest.py
@@ -3,9 +3,43 @@
 # SPDX-License-Identifier: MIT
 # --------------------------------------------------------------------------
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _make_minimal_onnx(path):
+    """Write a minimal ONNX model to *path* so create_genai_config can load it."""
+    import onnx
+    from onnx import TensorProto
+
+    input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+    node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+    graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+    onnx.save(model, path)
+
+
+@pytest.fixture(name="mock_container")
+def mock_container_fixture(tmp_path):
+    """Provide a pre-configured LLMContainer mock with input/output metadata and an export stub.
+
+    Tests are responsible for wiring LLMContainer.load.return_value so they can customise
+    container attributes before the pass runs.
+    """
+    container = MagicMock()
+    container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, *args, **kwargs):
+        output_dir_path = Path(output_dir)
+        output_dir_path.mkdir(parents=True, exist_ok=True)
+        (output_dir_path / "model.dlc").write_text("dummy dlc content")
+
+    container.export.side_effect = mock_export
+    return container
 
 
 @pytest.fixture(name="mock_qairt_modules")

--- a/test/passes/qairt/conftest.py
+++ b/test/passes/qairt/conftest.py
@@ -9,21 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _make_minimal_onnx(path):
-    """Write a minimal ONNX model to *path* so create_genai_config can load it."""
-    import onnx
-    from onnx import TensorProto
-
-    input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-    node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-    graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
-    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-    onnx.save(model, path)
-
-
 @pytest.fixture(name="mock_container")
-def mock_container_fixture(tmp_path):
+def mock_container_fixture():
     """Provide a pre-configured LLMContainer mock with input/output metadata and an export stub.
 
     Tests are responsible for wiring LLMContainer.load.return_value so they can customise

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -6,28 +6,38 @@
 
 import builtins
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import onnx
 import pytest
+from conftest import _make_minimal_onnx
 
-from olive.model import ONNXModelHandler
+from olive.model import ONNXModelHandler, QairtModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.qairt.encapsulation import QairtEncapsulation
 
 
-def test_encapsulation_default_config(mock_accelerator_spec):
-    """Test that the default config is correctly generated."""
-    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
+@pytest.mark.parametrize(
+    ("key", "expected_default", "expected_required"),
+    [
+        ("log_level", None, False),
+        ("run_checker", False, False),
+        ("opset_imports", [["com.microsoft", 1]], False),
+        ("genie_overrides", None, False),
+        ("backend_extensions_overrides", None, False),
+        ("engine_config_overrides", None, False),
+    ],
+)
+def test_encapsulation_default_config(key, expected_default, expected_required, mock_accelerator_spec):
+    config = QairtEncapsulation._default_config(mock_accelerator_spec)
+    assert key in config
+    assert config[key].default_value == expected_default
+    assert config[key].required is expected_required
 
-    assert "log_level" in config
-    assert "run_checker" in config
-    assert config["run_checker"].default_value is False
-    assert "opset_imports" in config
-    assert config["opset_imports"].default_value == [["com.microsoft", 1]]
 
-
-def test_encapsulation_successful_execution(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_successful_execution(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """Test successful encapsulation of a QAIRT model."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -49,51 +59,14 @@ def test_encapsulation_successful_execution(tmp_path, mock_qairt_model, mock_qai
     gen_config_data = {"eos_token_id": 2, "pad_token_id": 0}
     (model_path / "generation_config.json").write_text(json.dumps(gen_config_data))
 
-    # Mock export to create a .dlc file
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc content")
-
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.export = MagicMock(side_effect=mock_export)
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
     # Configure LLMContainer.load to return our mock_container
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    # Mock onnx module - but let save actually create a file
-    def mock_save_func(model_def, path):
-        # Create a minimal valid ONNX file so create_genai_config can load it
-        import onnx
-        from onnx import TensorProto
-
-        # Create a minimal valid ONNX model
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func) as mock_save,
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)) as mock_save,
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {},
@@ -118,7 +91,7 @@ def test_encapsulation_successful_execution(tmp_path, mock_qairt_model, mock_qai
         mock_save.assert_called_once()
 
 
-def test_encapsulation_multiple_dlc_files(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_multiple_dlc_files(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """Test that a warning is logged when multiple DLC files are found."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -128,13 +101,8 @@ def test_encapsulation_multiple_dlc_files(tmp_path, mock_qairt_model, mock_qairt
     (model_path / "config.json").write_text('{"model_type": "llama", "hidden_size": 4096}')
     (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    # Mock export to create multiple .dlc files
-    def mock_export(output_dir, export_format):
+    # Override export to create multiple .dlc files
+    def mock_export(output_dir, *args, **kwargs):
         output_dir_path = Path(output_dir)
         output_dir_path.mkdir(parents=True, exist_ok=True)
         (output_dir_path / "model1.dlc").write_text("dummy dlc 1")
@@ -143,33 +111,12 @@ def test_encapsulation_multiple_dlc_files(tmp_path, mock_qairt_model, mock_qairt
     mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    # Mock save to create actual ONNX file
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
         patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {},
@@ -183,7 +130,7 @@ def test_encapsulation_multiple_dlc_files(tmp_path, mock_qairt_model, mock_qairt
         assert isinstance(result, ONNXModelHandler)
 
 
-def test_encapsulation_no_dlc_file(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_no_dlc_file(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """Test that FileNotFoundError is raised when no DLC file is found."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -193,13 +140,8 @@ def test_encapsulation_no_dlc_file(tmp_path, mock_qairt_model, mock_qairt_module
     (model_path / "config.json").write_text('{"model_type": "llama"}')
     (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    # Mock export to NOT create any .dlc files
-    def mock_export(output_dir, export_format):
+    # Override export to NOT create any .dlc files
+    def mock_export(output_dir, *args, **kwargs):
         output_dir_path = Path(output_dir)
         output_dir_path.mkdir(parents=True, exist_ok=True)
         # Don't create any .dlc files
@@ -217,7 +159,7 @@ def test_encapsulation_no_dlc_file(tmp_path, mock_qairt_model, mock_qairt_module
         encap_pass.run(mock_qairt_model, str(output_path))
 
 
-def test_encapsulation_with_checker(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_with_checker(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """Test that ONNX checker is called when run_checker is True."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -227,44 +169,13 @@ def test_encapsulation_with_checker(tmp_path, mock_qairt_model, mock_qairt_modul
     (model_path / "config.json").write_text('{"model_type": "llama", "hidden_size": 4096}')
     (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker") as mock_checker,
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"run_checker": True},
@@ -278,7 +189,7 @@ def test_encapsulation_with_checker(tmp_path, mock_qairt_model, mock_qairt_modul
         assert isinstance(result, ONNXModelHandler)
 
 
-def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """Test that custom opset imports are used."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -288,44 +199,13 @@ def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qai
     (model_path / "config.json").write_text('{"model_type": "llama", "hidden_size": 4096}')
     (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
-
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
 
     with (
         patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         custom_opsets = [["com.microsoft", 1], ["ai.onnx", 14]]
 
         encap_pass = create_pass_from_dict(
@@ -341,125 +221,40 @@ def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qai
         assert isinstance(result, ONNXModelHandler)
 
 
-def test_encapsulation_missing_config_json(tmp_path, mock_qairt_model, mock_qairt_modules):
-    """Test that ValueError is raised when config.json is missing."""
+@pytest.mark.parametrize(
+    ("file_to_remove", "expected_match"),
+    [
+        ("config.json", r"Cannot create gen_ai_config\.json if source model config doesn't exist"),
+        ("generation_config.json", r"Cannot create gen_ai_config\.json if generation config doesn't exist"),
+    ],
+)
+def test_encapsulation_missing_required_file(
+    file_to_remove, expected_match, tmp_path, mock_qairt_model, mock_qairt_modules, mock_container
+):
+    """Test that ValueError is raised when a required source config file is missing."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
 
-    # Don't create config.json in the source model directory
+    # Populate both required files, then remove the one under test
     model_path = Path(mock_qairt_model.model_path)
-    # Remove config.json if it exists
-    config_file = model_path / "config.json"
-    if config_file.exists():
-        config_file.unlink()
-    (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
-
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
-    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
-
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
-    with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
-        patch("olive.passes.qairt.encapsulation.checker"),
-    ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
-        encap_pass = create_pass_from_dict(
-            QairtEncapsulation,
-            {},
-            disable_search=True,
-        )
-
-        with pytest.raises(ValueError, match=r"Cannot create gen_ai_config\.json if source model config doesn't exist"):
-            encap_pass.run(mock_qairt_model, str(output_path))
-
-
-def test_encapsulation_missing_generation_config(tmp_path, mock_qairt_model, mock_qairt_modules):
-    """Test that ValueError is raised when generation_config.json is missing."""
-    output_path = tmp_path / "output"
-    output_path.mkdir(parents=True, exist_ok=True)
-
-    # Create config.json but not generation_config.json in the source model directory
-    model_path = Path(mock_qairt_model.model_path)
-    # Remove generation_config.json if it exists
-    gen_config_file = model_path / "generation_config.json"
-    if gen_config_file.exists():
-        gen_config_file.unlink()
     (model_path / "config.json").write_text('{"model_type": "llama", "hidden_size": 4096}')
+    (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
+    (model_path / file_to_remove).unlink()
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {},
             disable_search=True,
         )
 
-        with pytest.raises(ValueError, match=r"Cannot create gen_ai_config\.json if generation config doesn't exist"):
+        with pytest.raises(ValueError, match=expected_match):
             encap_pass.run(mock_qairt_model, str(output_path))
 
 
@@ -484,7 +279,7 @@ def test_encapsulation_import_error_qairt(tmp_path, mock_qairt_model):
             encap_pass.run(mock_qairt_model, str(tmp_path / "output"))
 
 
-def test_encapsulation_passthrough_files(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_passthrough_files(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """Test that passthrough files are copied to output."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -497,44 +292,13 @@ def test_encapsulation_passthrough_files(tmp_path, mock_qairt_model, mock_qairt_
     (model_path / "tokenizer.json").write_text('{"vocab": {}}')
     (model_path / "tokenizer_config.json").write_text('{"model_max_length": 2048}')
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {},
@@ -566,89 +330,101 @@ def test_encapsulation_sdk_version_check_old_version(tmp_path, mock_qairt_model,
         encap_pass.run(mock_qairt_model, str(output_path))
 
 
-def test_encapsulation_sdk_version_check_valid_version(tmp_path, mock_qairt_model, mock_qairt_modules):
-    """Test that encapsulation works with QAIRT SDK version >= 2.45.0."""
+def test_encapsulation_epcontext_node_outputs(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
+    """The encapsulated model contains a single EPContext node with the expected attributes."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
 
-    # Mock SDK version to be >= 2.45.0
-    mock_qairt_modules["qairt"].__sdk_version__ = "2.45.0"
-
-    # Create required config files
     model_path = Path(mock_qairt_model.model_path)
-    config_data = {
-        "model_type": "llama",
-        "hidden_size": 4096,
-        "num_attention_heads": 32,
-        "num_hidden_layers": 32,
-        "num_key_value_heads": 32,
-        "max_position_embeddings": 2048,
-        "bos_token_id": 1,
-        "vocab_size": 32000,
-    }
-    (model_path / "config.json").write_text(json.dumps(config_data))
+    (model_path / "config.json").write_text('{"model_type": "llama", "hidden_size": 4096}')
     (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
 
-    # Mock LLMContainer
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        output_dir_path = Path(output_dir)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        (output_dir_path / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        input_tensor = onnx.helper.make_tensor_value_info(
-            "input_ids", TensorProto.INT32, ["batch_size", "sequence_length"]
-        )
-        output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "test_graph", [input_tensor], [output_tensor])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
-    with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
-        patch("olive.passes.qairt.encapsulation.checker"),
-    ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
+    # Note: helper and save are NOT mocked, so the real ONNX model is written to disk.
+    with patch("olive.passes.qairt.encapsulation.checker"):
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {},
             disable_search=True,
         )
+        encap_pass.run(mock_qairt_model, str(output_path))
 
-        # Should not raise an error
-        result = encap_pass.run(mock_qairt_model, str(output_path))
-        assert result is not None
+    dlc_files = list(output_path.glob("*.dlc"))
+    assert len(dlc_files) == 1
+    dlc_filename = dlc_files[0].name
+
+    model_def = onnx.load(output_path / "model.onnx")
+    assert model_def.ir_version == 10
+
+    assert len(model_def.graph.node) == 1
+    node = model_def.graph.node[0]
+    assert node.op_type == "EPContext"
+    assert node.domain == "com.microsoft"
+
+    attrs = {attr.name: onnx.helper.get_attribute_value(attr) for attr in node.attribute}
+    assert attrs["ep_context_type"] == b"dlc"
+    assert attrs["ep_dlc_context"] == dlc_filename.encode()
+    assert attrs["source"] == b"QAIRTExport"
 
 
-def _make_minimal_onnx(path):
-    """Write a minimal ONNX model to *path* so create_genai_config can load it."""
-    import onnx
-    from onnx import TensorProto
+def test_encapsulation_log_level_sets_env(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
+    """Setting log_level exports QAIRT_LOG_LEVEL into the environment."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
 
-    input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-    node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-    graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
-    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-    onnx.save(model, path)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text('{"model_type": "llama", "hidden_size": 4096}')
+    (model_path / "generation_config.json").write_text('{"eos_token_id": 2}')
+
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"log_level": "ERROR"},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+        assert os.environ.get("QAIRT_LOG_LEVEL") == "ERROR"
+
+
+def test_encapsulation_sequence_lengths_wiring(tmp_path, mock_qairt_modules, mock_container):
+    """sequence_lengths from the model is plumbed into create_genai_config to cap max_length."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    source_path = tmp_path / "source_model"
+    source_path.mkdir(parents=True, exist_ok=True)
+    (source_path / "config.json").write_text(json.dumps({"model_type": "llama", "max_position_embeddings": 4096}))
+    (source_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+    (source_path / "model.dlc").write_text("dummy dlc content")
+    model = QairtModelHandler(model_path=str(source_path), model_attributes={"sequence_lengths": [32, 128]})
+
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {},
+            disable_search=True,
+        )
+        encap_pass.run(model, str(output_path))
+
+    with open(output_path / "genai_config.json") as f:
+        result = json.load(f)
+
+    assert result["search"]["max_length"] == 4096 - 32
 
 
 def test_create_genai_config_head_size_valid(tmp_path):
@@ -1011,15 +787,7 @@ def test_deep_merge_none_override_deletes_key():
 # ---------------------------------------------------------------------------
 
 
-def test_encapsulation_default_config_includes_genie_overrides(mock_accelerator_spec):
-    """genie_overrides is present in _default_config with None default."""
-    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
-    assert "genie_overrides" in config
-    assert config["genie_overrides"].default_value is None
-    assert config["genie_overrides"].required is False
-
-
-def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_qairt_modules, mock_container):
     """When genie_overrides is set, _gen_ai_config is deep-merged before export."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -1027,10 +795,6 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
     model_path = Path(mock_qairt_model.model_path)
     (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
     (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
-
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
 
     # Represent the existing GenAIConfig state after LLMContainer.load()
     initial_gen_ai_state = {
@@ -1045,38 +809,15 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
     mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state
     original_gen_ai_config_mock = mock_container._gen_ai_config
 
-    def mock_export(output_dir, export_format):
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
-
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
 
     overrides = {"kv_dim": 128, "positional_encoding": {"rope_theta": 500000.0}}
 
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"genie_overrides": overrides},
@@ -1097,7 +838,7 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
 
 
 def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
-    tmp_path, mock_qairt_model, mock_qairt_modules
+    tmp_path, mock_qairt_model, mock_qairt_modules, mock_container
 ):
     """When genie_overrides is None, _gen_ai_config.model_dump is never called."""
     output_path = tmp_path / "output"
@@ -1107,40 +848,13 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
     (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
     (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
 
-    mock_container = MagicMock()
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {},
@@ -1157,24 +871,8 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
 # ---------------------------------------------------------------------------
 
 
-def test_encapsulation_default_config_includes_backend_extensions_overrides(mock_accelerator_spec):
-    """backend_extensions_overrides is present in _default_config with None default."""
-    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
-    assert "backend_extensions_overrides" in config
-    assert config["backend_extensions_overrides"].default_value is None
-    assert config["backend_extensions_overrides"].required is False
-
-
-def test_encapsulation_default_config_includes_engine_config_overrides(mock_accelerator_spec):
-    """engine_config_overrides is present in _default_config with None default."""
-    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
-    assert "engine_config_overrides" in config
-    assert config["engine_config_overrides"].default_value is None
-    assert config["engine_config_overrides"].required is False
-
-
 def test_encapsulation_backend_extensions_overrides_merges_into_existing(
-    tmp_path, mock_qairt_model, mock_qairt_modules
+    tmp_path, mock_qairt_model, mock_qairt_modules, mock_container
 ):
     """Override is deep-merged into the existing _backend_extensions_config."""
     output_path = tmp_path / "output"
@@ -1183,41 +881,14 @@ def test_encapsulation_backend_extensions_overrides_merges_into_existing(
     (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
     (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
 
-    mock_container = MagicMock()
     mock_container._backend_extensions_config = {"context": {"n-threads": 6, "kv-cache-size": 512}}
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
-
-    def mock_export(output_dir, export_format):
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"backend_extensions_overrides": {"context": {"n-threads": 4}}},
@@ -1229,12 +900,11 @@ def test_encapsulation_backend_extensions_overrides_merges_into_existing(
     assert mock_container._backend_extensions_config == {"context": {"n-threads": 4, "kv-cache-size": 512}}
 
 
-def test_encapsulation_backend_extensions_overrides_from_empty(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_backend_extensions_overrides_from_empty(
+    tmp_path, mock_qairt_model, mock_qairt_modules, mock_container
+):
     """When the container has no existing backend extensions config, the override becomes the config."""
-    mock_container = MagicMock()
     mock_container._backend_extensions_config = None
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
 
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -1242,36 +912,13 @@ def test_encapsulation_backend_extensions_overrides_from_empty(tmp_path, mock_qa
     (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
     (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
 
-    def mock_export(output_dir, export_format):
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"backend_extensions_overrides": {"context": {"n-threads": 4}}},
@@ -1283,15 +930,11 @@ def test_encapsulation_backend_extensions_overrides_from_empty(tmp_path, mock_qa
 
 
 def test_encapsulation_no_backend_extensions_overrides_leaves_config_untouched(
-    tmp_path, mock_qairt_model, mock_qairt_modules
+    tmp_path, mock_qairt_model, mock_qairt_modules, mock_container
 ):
     """When backend_extensions_overrides is None the container config is not touched."""
     original_ext_cfg = {"context": {"n-threads": 6}}
-
-    mock_container = MagicMock()
     mock_container._backend_extensions_config = original_ext_cfg
-    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
-    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
 
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -1299,36 +942,13 @@ def test_encapsulation_no_backend_extensions_overrides_leaves_config_untouched(
     (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
     (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
 
-    def mock_export(output_dir, export_format):
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
-
-    mock_container.export.side_effect = mock_export
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(QairtEncapsulation, {}, disable_search=True)
         encap_pass.run(mock_qairt_model, str(output_path))
 
@@ -1361,32 +981,14 @@ def test_encapsulation_engine_config_overrides_applied_when_supported(tmp_path, 
     mock_container.export = MagicMock(side_effect=mock_export)
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     fake_sig = inspect.signature(mock_export)
 
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
         patch("olive.passes.qairt.encapsulation.inspect.signature", return_value=fake_sig),
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         fake_engine_cfg = MagicMock()
         mock_qairt_modules["gen_ai_api"].EngineConfig.return_value = fake_engine_cfg
         mock_qairt_modules["gen_ai_api"].HTPEngineConfig.return_value = MagicMock()
@@ -1429,33 +1031,15 @@ def test_encapsulation_engine_config_overrides_skipped_when_not_supported(
     mock_container.export = MagicMock(side_effect=mock_export_old)
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     fake_sig = inspect.signature(mock_export_old)
 
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
         patch("olive.passes.qairt.encapsulation.inspect.signature", return_value=fake_sig),
         patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"engine_config_overrides": {"n_threads": 4}},
@@ -1495,30 +1079,12 @@ def test_encapsulation_genie_overrides_skipped_when_private_attr_missing(
     mock_container.export = MagicMock(side_effect=mock_export)
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
         patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"genie_overrides": {"kv_dim": 128}},
@@ -1551,30 +1117,12 @@ def test_encapsulation_backend_extensions_overrides_skipped_when_private_attr_mi
     mock_container.export = MagicMock(side_effect=mock_export)
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
-    def mock_save_func(model_def, path):
-        import onnx
-        from onnx import TensorProto
-
-        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
-        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
-        graph = onnx.helper.make_graph([node], "g", [inp], [out])
-        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-        onnx.save(model, path)
-
     with (
-        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
-        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
         patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
     ):
-        mock_helper.make_node.return_value = MagicMock()
-        mock_helper.make_attribute.return_value = MagicMock()
-        mock_helper.make_tensor_value_info.return_value = MagicMock()
-        mock_helper.make_graph.return_value = MagicMock()
-        mock_helper.make_opsetid.return_value = MagicMock()
-        mock_helper.make_model.return_value = MagicMock()
-
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"backend_extensions_overrides": {"context": {"n-threads": 4}}},

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -225,7 +225,7 @@ def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qai
     ("file_to_remove", "expected_match"),
     [
         ("config.json", r"Cannot create genai_config\.json if source model config doesn't exist"),
-        ("generation_config.json", r"Cannot create genai_config\.json if generation config doesn't exist"),
+        ("generation_config.json", r"Cannot create genai_config\.json if generation config doesn't exist\."),
     ],
 )
 def test_encapsulation_missing_required_file(

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -224,8 +224,8 @@ def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qai
 @pytest.mark.parametrize(
     ("file_to_remove", "expected_match"),
     [
-        ("config.json", r"Cannot create gen_ai_config\.json if source model config doesn't exist"),
-        ("generation_config.json", r"Cannot create gen_ai_config\.json if generation config doesn't exist"),
+        ("config.json", r"Cannot create genai_config\.json if source model config doesn't exist"),
+        ("generation_config.json", r"Cannot create genai_config\.json if generation config doesn't exist"),
     ],
 )
 def test_encapsulation_missing_required_file(

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -2,6 +2,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: MIT
 # --------------------------------------------------------------------------
+# pylint: disable=protected-access
 
 import builtins
 import json

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -1087,15 +1087,32 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
 # ---------------------------------------------------------------------------
 
 
-def test_encapsulation_default_config_includes_backend_extensions_override(mock_accelerator_spec):
-    """backend_extensions_override is present in _default_config with None default."""
+def test_encapsulation_default_config_includes_backend(mock_accelerator_spec):
+    """backend is present in _default_config with HTP as the default."""
+    from olive.passes.qairt.gen_ai_builder import QairtBackend
+
     config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
-    assert "backend_extensions_override" in config
-    assert config["backend_extensions_override"].default_value is None
-    assert config["backend_extensions_override"].required is False
+    assert "backend" in config
+    assert config["backend"].default_value == QairtBackend.HTP
 
 
-def test_encapsulation_backend_extensions_override_merges_into_existing(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_default_config_includes_backend_extensions_overrides(mock_accelerator_spec):
+    """backend_extensions_overrides is present in _default_config with None default."""
+    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
+    assert "backend_extensions_overrides" in config
+    assert config["backend_extensions_overrides"].default_value is None
+    assert config["backend_extensions_overrides"].required is False
+
+
+def test_encapsulation_default_config_includes_htp_execution_overrides(mock_accelerator_spec):
+    """htp_execution_overrides is present in _default_config with None default."""
+    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
+    assert "htp_execution_overrides" in config
+    assert config["htp_execution_overrides"].default_value is None
+    assert config["htp_execution_overrides"].required is False
+
+
+def test_encapsulation_backend_extensions_overrides_merges_into_existing(tmp_path, mock_qairt_model, mock_qairt_modules):
     """Override is deep-merged into the existing _backend_extensions_config."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -1140,7 +1157,7 @@ def test_encapsulation_backend_extensions_override_merges_into_existing(tmp_path
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "backend_extensions_override": {"context": {"n-threads": 4}}},
+            {"backend": "CPU", "backend_extensions_overrides": {"context": {"n-threads": 4}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1149,7 +1166,7 @@ def test_encapsulation_backend_extensions_override_merges_into_existing(tmp_path
     assert mock_container._backend_extensions_config == {"context": {"n-threads": 4, "kv-cache-size": 512}}
 
 
-def test_encapsulation_backend_extensions_override_from_empty(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_backend_extensions_overrides_from_empty(tmp_path, mock_qairt_model, mock_qairt_modules):
     """When the container has no existing backend extensions config, the override becomes the config."""
     mock_container = MagicMock()
     mock_container._backend_extensions_config = None
@@ -1194,7 +1211,7 @@ def test_encapsulation_backend_extensions_override_from_empty(tmp_path, mock_qai
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "backend_extensions_override": {"context": {"n-threads": 4}}},
+            {"backend": "CPU", "backend_extensions_overrides": {"context": {"n-threads": 4}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1202,10 +1219,10 @@ def test_encapsulation_backend_extensions_override_from_empty(tmp_path, mock_qai
     assert mock_container._backend_extensions_config == {"context": {"n-threads": 4}}
 
 
-def test_encapsulation_no_backend_extensions_override_leaves_config_untouched(
+def test_encapsulation_no_backend_extensions_overrides_leaves_config_untouched(
     tmp_path, mock_qairt_model, mock_qairt_modules
 ):
-    """When backend_extensions_override is None the container config is not touched."""
+    """When backend_extensions_overrides is None the container config is not touched."""
     original_ext_cfg = {"context": {"n-threads": 6}}
 
     mock_container = MagicMock()
@@ -1253,3 +1270,275 @@ def test_encapsulation_no_backend_extensions_override_leaves_config_untouched(
         encap_pass.run(mock_qairt_model, str(output_path))
 
     assert mock_container._backend_extensions_config is original_ext_cfg
+
+
+# ---------------------------------------------------------------------------
+# validate_config tests
+# ---------------------------------------------------------------------------
+
+
+def test_encapsulation_validate_config_rejects_htp_execution_overrides_on_non_htp(mock_accelerator_spec):
+    """validate_config returns False when htp_execution_overrides is set on a non-HTP backend."""
+    encap_pass = create_pass_from_dict(
+        QairtEncapsulation,
+        {"backend": "CPU", "htp_execution_overrides": {"n_threads": 4}},
+        disable_search=True,
+    )
+    assert encap_pass.validate_config(encap_pass.config, mock_accelerator_spec) is False
+
+
+def test_encapsulation_validate_config_accepts_htp_execution_overrides_on_htp(mock_accelerator_spec):
+    """validate_config returns True when htp_execution_overrides is set on HTP backend."""
+    encap_pass = create_pass_from_dict(
+        QairtEncapsulation,
+        {"backend": "HTP", "htp_execution_overrides": {"n_threads": 4}},
+        disable_search=True,
+    )
+    assert encap_pass.validate_config(encap_pass.config, mock_accelerator_spec) is True
+
+
+# ---------------------------------------------------------------------------
+# htp_execution_overrides integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_encapsulation_htp_execution_overrides_applied_when_supported(tmp_path, mock_qairt_model, mock_qairt_modules):
+    """htp_execution_overrides is passed to export() when the installed qairt supports it."""
+    import inspect
+
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock()
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, export_format, htp_execution_config=None):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export = MagicMock(side_effect=mock_export)
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    fake_sig = inspect.signature(mock_export)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+        patch("olive.passes.qairt.encapsulation.inspect.signature", return_value=fake_sig),
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        fake_htp_cfg = MagicMock()
+        mock_qairt_modules["gen_ai_api"].HTPExecutionConfig.return_value = fake_htp_cfg
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "HTP", "htp_execution_overrides": {"n_threads": 4, "cpu_mask": "0x3"}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    mock_qairt_modules["gen_ai_api"].HTPExecutionConfig.assert_called_once_with(n_threads=4, cpu_mask="0x3")
+    _, call_kwargs = mock_container.export.call_args
+    assert call_kwargs.get("htp_execution_config") is fake_htp_cfg
+
+
+def test_encapsulation_htp_execution_overrides_skipped_when_not_supported(
+    tmp_path, mock_qairt_model, mock_qairt_modules
+):
+    """htp_execution_overrides is ignored with a warning when export() has no htp_execution_config param."""
+    import inspect
+
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock()
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export_old(output_dir, export_format):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export = MagicMock(side_effect=mock_export_old)
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    fake_sig = inspect.signature(mock_export_old)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+        patch("olive.passes.qairt.encapsulation.inspect.signature", return_value=fake_sig),
+        patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "HTP", "htp_execution_overrides": {"n_threads": 4}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    warning_messages = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("htp_execution_overrides ignored" in msg for msg in warning_messages)
+    _, call_kwargs = mock_container.export.call_args
+    assert "htp_execution_config" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# hasattr guard tests
+# ---------------------------------------------------------------------------
+
+
+def test_encapsulation_genie_overrides_skipped_when_private_attr_missing(
+    tmp_path, mock_qairt_model, mock_qairt_modules
+):
+    """genie_overrides is ignored with a warning when _gen_ai_config is absent from the container."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock(spec=["inputs", "outputs", "export"])
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, **kwargs):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export = MagicMock(side_effect=mock_export)
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+        patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "CPU", "genie_overrides": {"kv_dim": 128}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    warning_messages = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("genie_overrides ignored" in msg for msg in warning_messages)
+
+
+def test_encapsulation_backend_extensions_overrides_skipped_when_private_attr_missing(
+    tmp_path, mock_qairt_model, mock_qairt_modules
+):
+    """backend_extensions_overrides is ignored with a warning when _backend_extensions_config is absent."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock(spec=["inputs", "outputs", "export"])
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, **kwargs):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export = MagicMock(side_effect=mock_export)
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+        patch("olive.passes.qairt.encapsulation.logger") as mock_logger,
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "CPU", "backend_extensions_overrides": {"context": {"n-threads": 4}}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    warning_messages = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("backend_extensions_overrides ignored" in msg for msg in warning_messages)

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -96,7 +96,7 @@ def test_encapsulation_successful_execution(tmp_path, mock_qairt_model, mock_qai
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -172,7 +172,7 @@ def test_encapsulation_multiple_dlc_files(tmp_path, mock_qairt_model, mock_qairt
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -209,7 +209,7 @@ def test_encapsulation_no_dlc_file(tmp_path, mock_qairt_model, mock_qairt_module
 
     encap_pass = create_pass_from_dict(
         QairtEncapsulation,
-        {"backend": "CPU"},
+        {},
         disable_search=True,
     )
 
@@ -267,7 +267,7 @@ def test_encapsulation_with_checker(tmp_path, mock_qairt_model, mock_qairt_modul
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "run_checker": True},
+            {"run_checker": True},
             disable_search=True,
         )
 
@@ -330,7 +330,7 @@ def test_encapsulation_custom_opset_imports(tmp_path, mock_qairt_model, mock_qai
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "opset_imports": custom_opsets},
+            {"opset_imports": custom_opsets},
             disable_search=True,
         )
 
@@ -394,7 +394,7 @@ def test_encapsulation_missing_config_json(tmp_path, mock_qairt_model, mock_qair
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -455,7 +455,7 @@ def test_encapsulation_missing_generation_config(tmp_path, mock_qairt_model, moc
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -476,7 +476,7 @@ def test_encapsulation_import_error_qairt(tmp_path, mock_qairt_model):
     with patch("builtins.__import__", side_effect=import_side_effect):
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -537,7 +537,7 @@ def test_encapsulation_passthrough_files(tmp_path, mock_qairt_model, mock_qairt_
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -558,7 +558,7 @@ def test_encapsulation_sdk_version_check_old_version(tmp_path, mock_qairt_model,
 
     encap_pass = create_pass_from_dict(
         QairtEncapsulation,
-        {"backend": "CPU"},
+        {},
         disable_search=True,
     )
 
@@ -629,7 +629,7 @@ def test_encapsulation_sdk_version_check_valid_version(tmp_path, mock_qairt_mode
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -1079,7 +1079,7 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "genie_overrides": overrides},
+            {"genie_overrides": overrides},
             disable_search=True,
         )
 
@@ -1143,7 +1143,7 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU"},
+            {},
             disable_search=True,
         )
 
@@ -1155,15 +1155,6 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
 # ---------------------------------------------------------------------------
 # backend_extensions_override integration tests
 # ---------------------------------------------------------------------------
-
-
-def test_encapsulation_default_config_includes_backend(mock_accelerator_spec):
-    """Backend is present in _default_config with HTP as the default."""
-    from olive.passes.qairt.gen_ai_builder import QairtBackend
-
-    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
-    assert "backend" in config
-    assert config["backend"].default_value == QairtBackend.HTP
 
 
 def test_encapsulation_default_config_includes_backend_extensions_overrides(mock_accelerator_spec):
@@ -1227,7 +1218,7 @@ def test_encapsulation_backend_extensions_overrides_merges_into_existing(tmp_pat
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "backend_extensions_overrides": {"context": {"n-threads": 4}}},
+            {"backend_extensions_overrides": {"context": {"n-threads": 4}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1281,7 +1272,7 @@ def test_encapsulation_backend_extensions_overrides_from_empty(tmp_path, mock_qa
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "backend_extensions_overrides": {"context": {"n-threads": 4}}},
+            {"backend_extensions_overrides": {"context": {"n-threads": 4}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1336,35 +1327,10 @@ def test_encapsulation_no_backend_extensions_overrides_leaves_config_untouched(
         mock_helper.make_opsetid.return_value = MagicMock()
         mock_helper.make_model.return_value = MagicMock()
 
-        encap_pass = create_pass_from_dict(QairtEncapsulation, {"backend": "CPU"}, disable_search=True)
+        encap_pass = create_pass_from_dict(QairtEncapsulation, {}, disable_search=True)
         encap_pass.run(mock_qairt_model, str(output_path))
 
     assert mock_container._backend_extensions_config is original_ext_cfg
-
-
-# ---------------------------------------------------------------------------
-# validate_config tests
-# ---------------------------------------------------------------------------
-
-
-def test_encapsulation_validate_config_rejects_engine_config_overrides_on_non_htp(mock_accelerator_spec):
-    """validate_config returns False when engine_config_overrides is set on a non-HTP backend."""
-    encap_pass = create_pass_from_dict(
-        QairtEncapsulation,
-        {"backend": "CPU", "engine_config_overrides": {"n_threads": 0, "htp": {"cpu_mask": "0x3"}}},
-        disable_search=True,
-    )
-    assert encap_pass.validate_config(encap_pass.config, mock_accelerator_spec) is False
-
-
-def test_encapsulation_validate_config_accepts_engine_config_overrides_on_htp(mock_accelerator_spec):
-    """validate_config returns True when engine_config_overrides is set on HTP backend."""
-    encap_pass = create_pass_from_dict(
-        QairtEncapsulation,
-        {"backend": "HTP", "engine_config_overrides": {"n_threads": 4}},
-        disable_search=True,
-    )
-    assert encap_pass.validate_config(encap_pass.config, mock_accelerator_spec) is True
 
 
 # ---------------------------------------------------------------------------
@@ -1425,7 +1391,7 @@ def test_encapsulation_engine_config_overrides_applied_when_supported(tmp_path, 
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "HTP", "engine_config_overrides": {"n_threads": 4, "htp": {"cpu_mask": "0x3"}}},
+            {"engine_config_overrides": {"n_threads": 4, "htp": {"cpu_mask": "0x3"}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1488,7 +1454,7 @@ def test_encapsulation_engine_config_overrides_skipped_when_not_supported(
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "HTP", "engine_config_overrides": {"n_threads": 4}},
+            {"engine_config_overrides": {"n_threads": 4}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1551,7 +1517,7 @@ def test_encapsulation_genie_overrides_skipped_when_private_attr_missing(
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "genie_overrides": {"kv_dim": 128}},
+            {"genie_overrides": {"kv_dim": 128}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
@@ -1607,7 +1573,7 @@ def test_encapsulation_backend_extensions_overrides_skipped_when_private_attr_mi
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "CPU", "backend_extensions_overrides": {"context": {"n-threads": 4}}},
+            {"backend_extensions_overrides": {"context": {"n-threads": 4}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -938,6 +938,74 @@ def test_deep_merge_base_unmodified():
     assert base["a"]["b"] == 1
 
 
+def test_deep_merge_list_of_dicts_merged_elementwise():
+    """List-of-dicts elements are merged element-wise; base keys absent from the override are preserved.
+
+    This is the core regression test for the backend_extensions_overrides bug where
+    context[weight_sharing_enabled] and devices[device_id/soc_model/dsp_arch/cores] were
+    being dropped because the override list fully replaced the base list.
+    """
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    base = {
+        "context": [{"weight_sharing_enabled": True}],
+        "devices": [{"device_id": 0, "soc_model": 60, "dsp_arch": "v73", "cores": [{"core_id": 0}]}],
+        "memory": {"mem_type": "shared_buffer"},
+    }
+    overrides = {
+        "context": [{"reused_io_limit_mb": 100}],
+        "devices": [{"pd_session": "unsigned"}],
+    }
+    result = _deep_merge(base, overrides)
+
+    # context: override key added, base key preserved
+    assert result["context"] == [{"weight_sharing_enabled": True, "reused_io_limit_mb": 100}]
+    # devices: override key added, all base keys preserved
+    assert result["devices"] == [
+        {"device_id": 0, "soc_model": 60, "dsp_arch": "v73", "cores": [{"core_id": 0}], "pd_session": "unsigned"}
+    ]
+    # memory: untouched
+    assert result["memory"] == {"mem_type": "shared_buffer"}
+
+
+def test_deep_merge_list_override_shorter_than_base_preserves_tail():
+    """Extra base list elements beyond the override length are appended to the result."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    base = {"graphs": [{"vtcm_mb": 8, "graph_names": ["g1"]}, {"vtcm_mb": 8, "graph_names": ["g2"]}]}
+    overrides = {"graphs": [{"vtcm_mb": 16}]}
+    result = _deep_merge(base, overrides)
+
+    assert result["graphs"] == [
+        {"vtcm_mb": 16, "graph_names": ["g1"]},
+        {"vtcm_mb": 8, "graph_names": ["g2"]},
+    ]
+
+
+def test_deep_merge_list_override_longer_than_base_appends_extras():
+    """Extra override list elements beyond the base length are appended."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    base = {"items": [{"a": 1}]}
+    overrides = {"items": [{"a": 2}, {"b": 3}]}
+    result = _deep_merge(base, overrides)
+
+    assert result["items"] == [{"a": 2}, {"b": 3}]
+
+
+def test_deep_merge_none_override_deletes_key():
+    """A None override value removes the key from the result entirely."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    base = {"context": [{"weight_sharing_enabled": True}], "graphs": [{"vtcm_mb": 8}], "memory": {}}
+    overrides = {"graphs": None}
+    result = _deep_merge(base, overrides)
+
+    assert "graphs" not in result
+    assert "context" in result
+    assert "memory" in result
+
+
 # ---------------------------------------------------------------------------
 # genie_overrides integration tests
 # ---------------------------------------------------------------------------

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -894,3 +894,194 @@ def test_create_genai_config_provider_options_key_lowercase(tmp_path):
     assert len(provider_options) == 1
     assert "qnn" in provider_options[0]
     assert "QNN" not in provider_options[0]
+
+
+# ---------------------------------------------------------------------------
+# _deep_merge unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_deep_merge_flat():
+    """Flat keys in overrides replace or add keys in base."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    result = _deep_merge({"a": 1, "b": 2}, {"b": 99, "c": 3})
+    assert result == {"a": 1, "b": 99, "c": 3}
+
+
+def test_deep_merge_nested_dicts_are_merged_not_replaced():
+    """Nested dicts are recursively merged, preserving keys not in overrides."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    base = {"positional_encoding": {"type": "rope", "rope_dim": 64, "rope_theta": 10000.0}}
+    overrides = {"positional_encoding": {"rope_theta": 500000.0}}
+    result = _deep_merge(base, overrides)
+    assert result["positional_encoding"] == {"type": "rope", "rope_dim": 64, "rope_theta": 500000.0}
+
+
+def test_deep_merge_nested_override_replaces_non_dict():
+    """A dict override replaces a non-dict base value at the same key."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    result = _deep_merge({"a": 42}, {"a": {"nested": 1}})
+    assert result == {"a": {"nested": 1}}
+
+
+def test_deep_merge_base_unmodified():
+    """_deep_merge does not mutate base."""
+    from olive.passes.qairt.encapsulation import _deep_merge
+
+    base = {"a": {"b": 1}}
+    overrides = {"a": {"b": 2}}
+    _deep_merge(base, overrides)
+    assert base["a"]["b"] == 1
+
+
+# ---------------------------------------------------------------------------
+# genie_overrides integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_encapsulation_default_config_includes_genie_overrides(mock_accelerator_spec):
+    """genie_overrides is present in _default_config with None default."""
+    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
+    assert "genie_overrides" in config
+    assert config["genie_overrides"].default_value is None
+    assert config["genie_overrides"].required is False
+
+
+def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_qairt_modules):
+    """When genie_overrides is set, _gen_ai_config is deep-merged before export."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock()
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    # Represent the existing GenAIConfig state after LLMContainer.load()
+    initial_gen_ai_state = {
+        "context_length": 4096,
+        "n_vocab": 32000,
+        "bos_token": 1,
+        "eos_token": 2,
+        "tokenizer_path": str(tmp_path / "tokenizer.json"),
+        "kv_dim": None,
+        "positional_encoding": {"type": "rope", "rope_dim": 64},
+    }
+    mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state
+
+    def mock_export(output_dir, export_format):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export.side_effect = mock_export
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    overrides = {"kv_dim": 128, "positional_encoding": {"rope_theta": 500000.0}}
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "CPU", "genie_overrides": overrides},
+            disable_search=True,
+        )
+
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    # model_dump was called to capture current state
+    mock_container._gen_ai_config.model_dump.assert_called_once_with(mode="json", by_alias=False, exclude_none=True)
+    # model_validate was called with the deep-merged result
+    expected_merged = {
+        **initial_gen_ai_state,
+        "kv_dim": 128,
+        "positional_encoding": {"type": "rope", "rope_dim": 64, "rope_theta": 500000.0},
+    }
+    mock_container._gen_ai_config.model_validate.assert_called_once_with(expected_merged)
+    # _gen_ai_config was reassigned to the validated result
+    assert (
+        mock_container._gen_ai_config
+        is not mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value._gen_ai_config
+    )
+
+
+def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
+    tmp_path, mock_qairt_model, mock_qairt_modules
+):
+    """When genie_overrides is None, _gen_ai_config.model_dump is never called."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock()
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, export_format):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export.side_effect = mock_export
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "CPU"},
+            disable_search=True,
+        )
+
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    mock_container._gen_ai_config.model_dump.assert_not_called()

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -12,11 +12,11 @@ from unittest.mock import MagicMock, patch
 
 import onnx
 import pytest
-from conftest import _make_minimal_onnx
 
 from olive.model import ONNXModelHandler, QairtModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.qairt.encapsulation import QairtEncapsulation
+from test.passes.qairt.utils import make_minimal_onnx as _make_minimal_onnx
 
 
 @pytest.mark.parametrize(
@@ -355,7 +355,7 @@ def test_encapsulation_epcontext_node_outputs(tmp_path, mock_qairt_model, mock_q
     dlc_filename = dlc_files[0].name
 
     model_def = onnx.load(output_path / "model.onnx")
-    assert model_def.ir_version == 10
+    assert model_def.ir_version >= 8
 
     assert len(model_def.graph.node) == 1
     node = model_def.graph.node[0]

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -380,11 +380,12 @@ def test_encapsulation_log_level_sets_env(tmp_path, mock_qairt_model, mock_qairt
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 
     with (
-        patch.dict(os.environ, {}, clear=False),
+        patch.dict(os.environ, {"QAIRT_LOG_LEVEL": ""}, clear=False),
         patch("olive.passes.qairt.encapsulation.helper"),
         patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
         patch("olive.passes.qairt.encapsulation.checker"),
     ):
+        os.environ.pop("QAIRT_LOG_LEVEL", None)
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
             {"log_level": "ERROR"},

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -810,8 +810,8 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
         "kv_dim": None,
         "positional_encoding": {"type": "rope", "rope_dim": 64},
     }
-    mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state
-    original_gen_ai_config_mock = mock_container._gen_ai_config
+    mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state  # pylint: disable=protected-access
+    original_gen_ai_config_mock = mock_container._gen_ai_config  # pylint: disable=protected-access
 
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -1012,6 +1012,51 @@ def test_encapsulation_engine_config_overrides_applied_when_supported(tmp_path, 
     assert call_kwargs.get("engine_config") is fake_engine_cfg
 
 
+def test_encapsulation_engine_config_overrides_without_htp(tmp_path, mock_qairt_model, mock_qairt_modules):
+    """engine_config_overrides without an 'htp' key constructs EngineConfig with htp=None."""
+    import inspect
+
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock()
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, export_format, engine_config=None):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export = MagicMock(side_effect=mock_export)
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    fake_sig = inspect.signature(mock_export)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper"),
+        patch("olive.passes.qairt.encapsulation.save", side_effect=lambda _m, p: _make_minimal_onnx(p)),
+        patch("olive.passes.qairt.encapsulation.checker"),
+        patch("olive.passes.qairt.encapsulation.inspect.signature", return_value=fake_sig),
+    ):
+        fake_engine_cfg = MagicMock()
+        mock_qairt_modules["gen_ai_api"].EngineConfig.return_value = fake_engine_cfg
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"engine_config_overrides": {"n_threads": 4}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    mock_qairt_modules["gen_ai_api"].HTPEngineConfig.assert_not_called()
+    mock_qairt_modules["gen_ai_api"].EngineConfig.assert_called_once_with(n_threads=4, htp=None)
+    _, call_kwargs = mock_container.export.call_args
+    assert call_kwargs.get("engine_config") is fake_engine_cfg
+
+
 def test_encapsulation_engine_config_overrides_skipped_when_not_supported(
     tmp_path, mock_qairt_model, mock_qairt_modules
 ):

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -355,7 +355,6 @@ def test_encapsulation_epcontext_node_outputs(tmp_path, mock_qairt_model, mock_q
     dlc_filename = dlc_files[0].name
 
     model_def = onnx.load(output_path / "model.onnx")
-    assert model_def.ir_version >= 8
 
     assert len(model_def.graph.node) == 1
     node = model_def.graph.node[0]
@@ -706,13 +705,17 @@ def test_deep_merge_nested_override_replaces_non_dict():
 
 
 def test_deep_merge_base_unmodified():
-    """_deep_merge does not mutate base."""
+    """_deep_merge does not mutate base, and the result shares no references with base."""
     from olive.passes.qairt.encapsulation import _deep_merge
 
-    base = {"a": {"b": 1}}
+    base = {"a": {"b": 1}, "c": [{"d": 2}]}
     overrides = {"a": {"b": 2}}
-    _deep_merge(base, overrides)
+    result = _deep_merge(base, overrides)
+    # base is unchanged
     assert base["a"]["b"] == 1
+    # mutating the result's untouched branch does not affect base
+    result["c"][0]["d"] = 99
+    assert base["c"][0]["d"] == 2
 
 
 def test_deep_merge_list_of_dicts_merged_elementwise():

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -1024,11 +1024,6 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
         "positional_encoding": {"type": "rope", "rope_dim": 64, "rope_theta": 500000.0},
     }
     mock_container._gen_ai_config.model_validate.assert_called_once_with(expected_merged)
-    # _gen_ai_config was reassigned to the validated result
-    assert (
-        mock_container._gen_ai_config
-        is not mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value._gen_ai_config
-    )
 
 
 def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
@@ -1085,3 +1080,176 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
         encap_pass.run(mock_qairt_model, str(output_path))
 
     mock_container._gen_ai_config.model_dump.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# backend_extensions_override integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_encapsulation_default_config_includes_backend_extensions_override(mock_accelerator_spec):
+    """backend_extensions_override is present in _default_config with None default."""
+    config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
+    assert "backend_extensions_override" in config
+    assert config["backend_extensions_override"].default_value is None
+    assert config["backend_extensions_override"].required is False
+
+
+def test_encapsulation_backend_extensions_override_merges_into_existing(tmp_path, mock_qairt_model, mock_qairt_modules):
+    """Override is deep-merged into the existing _backend_extensions_config."""
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    mock_container = MagicMock()
+    mock_container._backend_extensions_config = {"context": {"n-threads": 6, "kv-cache-size": 512}}
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    def mock_export(output_dir, export_format):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export.side_effect = mock_export
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "CPU", "backend_extensions_override": {"context": {"n-threads": 4}}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    # n-threads overridden; kv-cache-size from original preserved
+    assert mock_container._backend_extensions_config == {"context": {"n-threads": 4, "kv-cache-size": 512}}
+
+
+def test_encapsulation_backend_extensions_override_from_empty(tmp_path, mock_qairt_model, mock_qairt_modules):
+    """When the container has no existing backend extensions config, the override becomes the config."""
+    mock_container = MagicMock()
+    mock_container._backend_extensions_config = None
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    def mock_export(output_dir, export_format):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export.side_effect = mock_export
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(
+            QairtEncapsulation,
+            {"backend": "CPU", "backend_extensions_override": {"context": {"n-threads": 4}}},
+            disable_search=True,
+        )
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    assert mock_container._backend_extensions_config == {"context": {"n-threads": 4}}
+
+
+def test_encapsulation_no_backend_extensions_override_leaves_config_untouched(
+    tmp_path, mock_qairt_model, mock_qairt_modules
+):
+    """When backend_extensions_override is None the container config is not touched."""
+    original_ext_cfg = {"context": {"n-threads": 6}}
+
+    mock_container = MagicMock()
+    mock_container._backend_extensions_config = original_ext_cfg
+    mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
+    mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
+
+    output_path = tmp_path / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    model_path = Path(mock_qairt_model.model_path)
+    (model_path / "config.json").write_text(json.dumps({"model_type": "llama", "hidden_size": 4096}))
+    (model_path / "generation_config.json").write_text(json.dumps({"eos_token_id": 2}))
+
+    def mock_export(output_dir, export_format):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "model.dlc").write_text("dummy dlc")
+
+    mock_container.export.side_effect = mock_export
+    mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
+
+    def mock_save_func(model_def, path):
+        import onnx
+        from onnx import TensorProto
+
+        inp = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+        out = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+        node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+        graph = onnx.helper.make_graph([node], "g", [inp], [out])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+        onnx.save(model, path)
+
+    with (
+        patch("olive.passes.qairt.encapsulation.helper") as mock_helper,
+        patch("olive.passes.qairt.encapsulation.save", side_effect=mock_save_func),
+        patch("olive.passes.qairt.encapsulation.checker"),
+    ):
+        mock_helper.make_node.return_value = MagicMock()
+        mock_helper.make_attribute.return_value = MagicMock()
+        mock_helper.make_tensor_value_info.return_value = MagicMock()
+        mock_helper.make_graph.return_value = MagicMock()
+        mock_helper.make_opsetid.return_value = MagicMock()
+        mock_helper.make_model.return_value = MagicMock()
+
+        encap_pass = create_pass_from_dict(QairtEncapsulation, {"backend": "CPU"}, disable_search=True)
+        encap_pass.run(mock_qairt_model, str(output_path))
+
+    assert mock_container._backend_extensions_config is original_ext_cfg

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -810,8 +810,8 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
         "kv_dim": None,
         "positional_encoding": {"type": "rope", "rope_dim": 64},
     }
-    mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state  # pylint: disable=protected-access
-    original_gen_ai_config_mock = mock_container._gen_ai_config  # pylint: disable=protected-access
+    mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state
+    original_gen_ai_config_mock = mock_container._gen_ai_config
 
     mock_qairt_modules["gen_ai_api"].LLMContainer.load.return_value = mock_container
 

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -1173,7 +1173,9 @@ def test_encapsulation_default_config_includes_engine_config_overrides(mock_acce
     assert config["engine_config_overrides"].required is False
 
 
-def test_encapsulation_backend_extensions_overrides_merges_into_existing(tmp_path, mock_qairt_model, mock_qairt_modules):
+def test_encapsulation_backend_extensions_overrides_merges_into_existing(
+    tmp_path, mock_qairt_model, mock_qairt_modules
+):
     """Override is deep-merged into the existing _backend_extensions_config."""
     output_path = tmp_path / "output"
     output_path.mkdir(parents=True, exist_ok=True)
@@ -1397,7 +1399,9 @@ def test_encapsulation_engine_config_overrides_applied_when_supported(tmp_path, 
         encap_pass.run(mock_qairt_model, str(output_path))
 
     mock_qairt_modules["gen_ai_api"].HTPEngineConfig.assert_called_once_with(cpu_mask="0x3")
-    mock_qairt_modules["gen_ai_api"].EngineConfig.assert_called_once_with(n_threads=4, htp=mock_qairt_modules["gen_ai_api"].HTPEngineConfig.return_value)
+    mock_qairt_modules["gen_ai_api"].EngineConfig.assert_called_once_with(
+        n_threads=4, htp=mock_qairt_modules["gen_ai_api"].HTPEngineConfig.return_value
+    )
     _, call_kwargs = mock_container.export.call_args
     assert call_kwargs.get("engine_config") is fake_engine_cfg
 

--- a/test/passes/qairt/test_encapsulation.py
+++ b/test/passes/qairt/test_encapsulation.py
@@ -974,6 +974,7 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
         "positional_encoding": {"type": "rope", "rope_dim": 64},
     }
     mock_container._gen_ai_config.model_dump.return_value = initial_gen_ai_state
+    original_gen_ai_config_mock = mock_container._gen_ai_config
 
     def mock_export(output_dir, export_format):
         Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -1016,14 +1017,14 @@ def test_encapsulation_genie_overrides_applied(tmp_path, mock_qairt_model, mock_
         encap_pass.run(mock_qairt_model, str(output_path))
 
     # model_dump was called to capture current state
-    mock_container._gen_ai_config.model_dump.assert_called_once_with(mode="json", by_alias=False, exclude_none=True)
+    original_gen_ai_config_mock.model_dump.assert_called_once_with(mode="json", by_alias=False, exclude_none=True)
     # model_validate was called with the deep-merged result
     expected_merged = {
         **initial_gen_ai_state,
         "kv_dim": 128,
         "positional_encoding": {"type": "rope", "rope_dim": 64, "rope_theta": 500000.0},
     }
-    mock_container._gen_ai_config.model_validate.assert_called_once_with(expected_merged)
+    original_gen_ai_config_mock.model_validate.assert_called_once_with(expected_merged)
 
 
 def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
@@ -1088,7 +1089,7 @@ def test_encapsulation_no_genie_overrides_leaves_gen_ai_config_untouched(
 
 
 def test_encapsulation_default_config_includes_backend(mock_accelerator_spec):
-    """backend is present in _default_config with HTP as the default."""
+    """Backend is present in _default_config with HTP as the default."""
     from olive.passes.qairt.gen_ai_builder import QairtBackend
 
     config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
@@ -1104,12 +1105,12 @@ def test_encapsulation_default_config_includes_backend_extensions_overrides(mock
     assert config["backend_extensions_overrides"].required is False
 
 
-def test_encapsulation_default_config_includes_htp_execution_overrides(mock_accelerator_spec):
-    """htp_execution_overrides is present in _default_config with None default."""
+def test_encapsulation_default_config_includes_engine_config_overrides(mock_accelerator_spec):
+    """engine_config_overrides is present in _default_config with None default."""
     config = QairtEncapsulation._default_config(mock_accelerator_spec)  # pylint: disable=protected-access
-    assert "htp_execution_overrides" in config
-    assert config["htp_execution_overrides"].default_value is None
-    assert config["htp_execution_overrides"].required is False
+    assert "engine_config_overrides" in config
+    assert config["engine_config_overrides"].default_value is None
+    assert config["engine_config_overrides"].required is False
 
 
 def test_encapsulation_backend_extensions_overrides_merges_into_existing(tmp_path, mock_qairt_model, mock_qairt_modules):
@@ -1277,33 +1278,33 @@ def test_encapsulation_no_backend_extensions_overrides_leaves_config_untouched(
 # ---------------------------------------------------------------------------
 
 
-def test_encapsulation_validate_config_rejects_htp_execution_overrides_on_non_htp(mock_accelerator_spec):
-    """validate_config returns False when htp_execution_overrides is set on a non-HTP backend."""
+def test_encapsulation_validate_config_rejects_engine_config_overrides_on_non_htp(mock_accelerator_spec):
+    """validate_config returns False when engine_config_overrides is set on a non-HTP backend."""
     encap_pass = create_pass_from_dict(
         QairtEncapsulation,
-        {"backend": "CPU", "htp_execution_overrides": {"n_threads": 4}},
+        {"backend": "CPU", "engine_config_overrides": {"n_threads": 0, "htp": {"cpu_mask": "0x3"}}},
         disable_search=True,
     )
     assert encap_pass.validate_config(encap_pass.config, mock_accelerator_spec) is False
 
 
-def test_encapsulation_validate_config_accepts_htp_execution_overrides_on_htp(mock_accelerator_spec):
-    """validate_config returns True when htp_execution_overrides is set on HTP backend."""
+def test_encapsulation_validate_config_accepts_engine_config_overrides_on_htp(mock_accelerator_spec):
+    """validate_config returns True when engine_config_overrides is set on HTP backend."""
     encap_pass = create_pass_from_dict(
         QairtEncapsulation,
-        {"backend": "HTP", "htp_execution_overrides": {"n_threads": 4}},
+        {"backend": "HTP", "engine_config_overrides": {"n_threads": 4}},
         disable_search=True,
     )
     assert encap_pass.validate_config(encap_pass.config, mock_accelerator_spec) is True
 
 
 # ---------------------------------------------------------------------------
-# htp_execution_overrides integration tests
+# engine_config_overrides integration tests
 # ---------------------------------------------------------------------------
 
 
-def test_encapsulation_htp_execution_overrides_applied_when_supported(tmp_path, mock_qairt_model, mock_qairt_modules):
-    """htp_execution_overrides is passed to export() when the installed qairt supports it."""
+def test_encapsulation_engine_config_overrides_applied_when_supported(tmp_path, mock_qairt_model, mock_qairt_modules):
+    """engine_config_overrides is passed to export() when the installed qairt supports it."""
     import inspect
 
     output_path = tmp_path / "output"
@@ -1316,7 +1317,7 @@ def test_encapsulation_htp_execution_overrides_applied_when_supported(tmp_path, 
     mock_container.inputs = [("input_ids", 7, ["batch_size", "sequence_length"])]
     mock_container.outputs = [("logits", 1, ["batch_size", 1, "vocab_size"])]
 
-    def mock_export(output_dir, export_format, htp_execution_config=None):
+    def mock_export(output_dir, export_format, engine_config=None):
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         (Path(output_dir) / "model.dlc").write_text("dummy dlc")
 
@@ -1349,25 +1350,27 @@ def test_encapsulation_htp_execution_overrides_applied_when_supported(tmp_path, 
         mock_helper.make_opsetid.return_value = MagicMock()
         mock_helper.make_model.return_value = MagicMock()
 
-        fake_htp_cfg = MagicMock()
-        mock_qairt_modules["gen_ai_api"].HTPExecutionConfig.return_value = fake_htp_cfg
+        fake_engine_cfg = MagicMock()
+        mock_qairt_modules["gen_ai_api"].EngineConfig.return_value = fake_engine_cfg
+        mock_qairt_modules["gen_ai_api"].HTPEngineConfig.return_value = MagicMock()
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "HTP", "htp_execution_overrides": {"n_threads": 4, "cpu_mask": "0x3"}},
+            {"backend": "HTP", "engine_config_overrides": {"n_threads": 4, "htp": {"cpu_mask": "0x3"}}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
 
-    mock_qairt_modules["gen_ai_api"].HTPExecutionConfig.assert_called_once_with(n_threads=4, cpu_mask="0x3")
+    mock_qairt_modules["gen_ai_api"].HTPEngineConfig.assert_called_once_with(cpu_mask="0x3")
+    mock_qairt_modules["gen_ai_api"].EngineConfig.assert_called_once_with(n_threads=4, htp=mock_qairt_modules["gen_ai_api"].HTPEngineConfig.return_value)
     _, call_kwargs = mock_container.export.call_args
-    assert call_kwargs.get("htp_execution_config") is fake_htp_cfg
+    assert call_kwargs.get("engine_config") is fake_engine_cfg
 
 
-def test_encapsulation_htp_execution_overrides_skipped_when_not_supported(
+def test_encapsulation_engine_config_overrides_skipped_when_not_supported(
     tmp_path, mock_qairt_model, mock_qairt_modules
 ):
-    """htp_execution_overrides is ignored with a warning when export() has no htp_execution_config param."""
+    """engine_config_overrides is ignored with a warning when export() has no engine_config param."""
     import inspect
 
     output_path = tmp_path / "output"
@@ -1416,15 +1419,15 @@ def test_encapsulation_htp_execution_overrides_skipped_when_not_supported(
 
         encap_pass = create_pass_from_dict(
             QairtEncapsulation,
-            {"backend": "HTP", "htp_execution_overrides": {"n_threads": 4}},
+            {"backend": "HTP", "engine_config_overrides": {"n_threads": 4}},
             disable_search=True,
         )
         encap_pass.run(mock_qairt_model, str(output_path))
 
     warning_messages = [str(call) for call in mock_logger.warning.call_args_list]
-    assert any("htp_execution_overrides ignored" in msg for msg in warning_messages)
+    assert any("engine_config_overrides ignored" in msg for msg in warning_messages)
     _, call_kwargs = mock_container.export.call_args
-    assert "htp_execution_config" not in call_kwargs
+    assert "engine_config" not in call_kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -9,16 +9,21 @@ from pathlib import Path
 def make_minimal_onnx(path: Path) -> None:
     """Write a minimal ONNX model to *path* for use in tests.
 
-    Mirrors the LM_EXECUTOR shape: INT32 input_ids → Cast → FLOAT logits.
+    Mirrors the LM_EXECUTOR shape: INT32 input_ids [batch, seq] →
+    Cast → FLOAT → Reshape → FLOAT logits [batch, 1, vocab_size].
+    The graph is schema-valid for opset 14 and passes onnx.checker.
     """
     import onnx
     from onnx import TensorProto
 
     input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])
     output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
-    node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["cast_out"], to=TensorProto.FLOAT)
-    reshape = onnx.helper.make_node("Unsqueeze", inputs=["cast_out", "axes"], outputs=["logits"])
-    axes = onnx.helper.make_tensor("axes", TensorProto.INT64, [1], [1])
-    graph = onnx.helper.make_graph([node, reshape], "g", [input_tensor], [output_tensor], initializer=[axes])
+    cast_node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["cast_out"], to=TensorProto.FLOAT)
+    reshape_node = onnx.helper.make_node("Reshape", inputs=["cast_out", "new_shape"], outputs=["logits"])
+    new_shape = onnx.helper.make_tensor("new_shape", TensorProto.INT64, [3], [0, 1, -1])
+    graph = onnx.helper.make_graph(
+        [cast_node, reshape_node], "g", [input_tensor], [output_tensor], initializer=[new_shape]
+    )
     model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+    onnx.checker.check_model(model)
     onnx.save(model, str(path))

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -4,9 +4,10 @@
 # --------------------------------------------------------------------------
 
 from pathlib import Path
+from typing import Union
 
 
-def make_minimal_onnx(path: Path) -> None:
+def make_minimal_onnx(path: Union[Path, str]) -> None:
     """Write a minimal ONNX model to *path* for use in tests.
 
     Graph: INT32 input_ids [batch_size, sequence_length]
@@ -20,7 +21,9 @@ def make_minimal_onnx(path: Path) -> None:
     from onnx import TensorProto
 
     input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
+    output_tensor = onnx.helper.make_tensor_value_info(
+        "logits", TensorProto.FLOAT, ["batch_size", 1, "sequence_length"]
+    )
     cast_node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["cast_out"], to=TensorProto.FLOAT)
     reshape_node = onnx.helper.make_node("Reshape", inputs=["cast_out", "new_shape"], outputs=["logits"])
     new_shape = onnx.helper.make_tensor("new_shape", TensorProto.INT64, [3], [0, 1, -1])

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -9,9 +9,12 @@ from pathlib import Path
 def make_minimal_onnx(path: Path) -> None:
     """Write a minimal ONNX model to *path* for use in tests.
 
-    Mirrors the LM_EXECUTOR shape: INT32 input_ids [batch, seq] →
-    Cast → FLOAT → Reshape → FLOAT logits [batch, 1, vocab_size].
-    The graph is schema-valid for opset 14 and passes onnx.checker.
+    Graph: INT32 input_ids [batch_size, sequence_length]
+           → Cast (FLOAT)
+           → Reshape [0, 1, -1]  (last dim inferred from sequence_length)
+           → FLOAT logits [batch_size, 1, sequence_length]
+
+    The model is schema-valid for opset 14 and passes onnx.checker.
     """
     import onnx
     from onnx import TensorProto

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -14,9 +14,11 @@ def make_minimal_onnx(path: Path) -> None:
     import onnx
     from onnx import TensorProto
 
-    input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", "seq"])
-    node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["logits"], to=TensorProto.FLOAT)
-    graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
+    input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])
+    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab_size"])
+    node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["cast_out"], to=TensorProto.FLOAT)
+    reshape = onnx.helper.make_node("Unsqueeze", inputs=["cast_out", "axes"], outputs=["logits"])
+    axes = onnx.helper.make_tensor("axes", TensorProto.INT64, [1], [1])
+    graph = onnx.helper.make_graph([node, reshape], "g", [input_tensor], [output_tensor], initializer=[axes])
     model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
     onnx.save(model, str(path))

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -7,13 +7,16 @@ from pathlib import Path
 
 
 def make_minimal_onnx(path: Path) -> None:
-    """Write a minimal ONNX Identity model to *path* for use in tests."""
+    """Write a minimal ONNX model to *path* for use in tests.
+
+    Mirrors the LM_EXECUTOR shape: INT32 input_ids → Cast → FLOAT logits.
+    """
     import onnx
     from onnx import TensorProto
 
     input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.INT32, ["batch_size", 1, "vocab"])
-    node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+    node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["logits"], to=TensorProto.FLOAT)
     graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
     model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
     onnx.save(model, path)

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+# --------------------------------------------------------------------------
+
+from pathlib import Path
+
+
+def make_minimal_onnx(path: Path) -> None:
+    """Write a minimal ONNX Identity model to *path* for use in tests."""
+    import onnx
+    from onnx import TensorProto
+
+    input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
+    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+    node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
+    graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
+    onnx.save(model, path)

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -12,7 +12,7 @@ def make_minimal_onnx(path: Path) -> None:
     from onnx import TensorProto
 
     input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.INT32, ["batch_size", 1, "vocab"])
     node = onnx.helper.make_node("Identity", inputs=["input_ids"], outputs=["logits"])
     graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
     model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])

--- a/test/passes/qairt/utils.py
+++ b/test/passes/qairt/utils.py
@@ -15,8 +15,8 @@ def make_minimal_onnx(path: Path) -> None:
     from onnx import TensorProto
 
     input_tensor = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "seq"])
-    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", 1, "vocab"])
+    output_tensor = onnx.helper.make_tensor_value_info("logits", TensorProto.FLOAT, ["batch_size", "seq"])
     node = onnx.helper.make_node("Cast", inputs=["input_ids"], outputs=["logits"], to=TensorProto.FLOAT)
     graph = onnx.helper.make_graph([node], "g", [input_tensor], [output_tensor])
     model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 14)])
-    onnx.save(model, path)
+    onnx.save(model, str(path))


### PR DESCRIPTION
Introduce a `genie_overrides` PassConfigParam that deep-merges user-supplied fields into the GenAIConfig before `LLMContainer.export()` bakes them into the Genie DLC. This allows callers to override any GenAIConfig field (engine config, positional encoding, etc.) without modifying `QairtGenAIBuilder` or `QairtPipelinePass`.

Nested dicts are merged recursively so only the specified keys are changed; all other values set by the upstream builder pass are preserved.

## Describe your changes

Add a `genie_overrides` parameter to `QairtEncapsulation`. When provided, the value is deep-merged into the `GenAIConfig` dict just before `LLMContainer.export()` is called. The merge is recursive: nested dicts are merged key-by-key so callers only need to specify the fields they want to change. A helper `_deep_merge` utility handles the recursion and is unit-tested directly. Integration tests cover round-trip behavior with nested overrides and verify that unrelated config fields are left untouched.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

  **Release note:** `QairtEncapsulation` now accepts `genie_overrides`, `backend_extensions_overrides`, and `engine_config_overrides` parameters that allow users to override the behavior of underlying Genie components when building Genie DLCs.

## (Optional) Issue link

N/A
