### PR TITLE
Add vision evaluation metrics (exact_match, relaxed_accuracy, word_sort_ratio)

### DIFF
--- a/docs/source/how-to/configure-workflows/metrics-configuration.md
+++ b/docs/source/how-to/configure-workflows/metrics-configuration.md
@@ -153,3 +153,131 @@ WER can be used as an accuracy sub-type when your data pipeline returns text pre
 - `wer` (Word Error Rate): Measures transcription errors. Lower is better (defaults to `higher_is_better: false`).
 - `rtfx` (Real-Time Factor): Ratio of audio duration to inference time. Higher means faster (defaults to `higher_is_better: true`).
 ```
+
+## Vision Evaluation Metrics
+
+Olive provides three built-in accuracy sub-types for evaluating vision/multimodal models:
+
+| Metric | Task Type | Description | Suitable Benchmarks |
+|--------|-----------|-------------|---------------------|
+| `exact_match` | `vision-vqa` | Case-insensitive string equality | AI2D, ScienceQA, TextVQA, MMMU |
+| `relaxed_accuracy` | `vision-chart-qa` | ±5% numeric tolerance for numbers | ChartQA |
+| `word_sort_ratio` | `vision-ocr` | Word-level overlap ratio | OCR benchmarks |
+
+### Example: VQA with TextVQA (exact_match)
+
+```json
+{
+    "data_configs": [
+        {
+            "name": "textvqa_data",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": {
+                "data_name": "facebook/textvqa",
+                "split": "validation"
+            },
+            "pre_process_data_config": {
+                "type": "vision_vqa_pre_process",
+                "image_col": "image",
+                "question_col": "question",
+                "answer_col": "answers",
+                "limit": 100
+            },
+            "dataloader_config": {
+                "batch_size": 1
+            }
+        }
+    ],
+    "metrics": [
+        {
+            "name": "vqa_accuracy",
+            "type": "accuracy",
+            "data_config": "textvqa_data",
+            "sub_types": [
+                {"name": "exact_match", "priority": 1, "goal": {"type": "max-degradation", "value": 0.05}}
+            ]
+        }
+    ]
+}
+```
+
+### Example: ChartQA with relaxed_accuracy
+
+```json
+{
+    "data_configs": [
+        {
+            "name": "chartqa_data",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": {
+                "data_name": "HuggingFaceM4/ChartQA",
+                "split": "test"
+            },
+            "pre_process_data_config": {
+                "type": "vision_vqa_pre_process",
+                "image_col": "image",
+                "question_col": "question",
+                "answer_col": "answer",
+                "limit": 100
+            },
+            "dataloader_config": {
+                "batch_size": 1
+            }
+        }
+    ],
+    "metrics": [
+        {
+            "name": "chart_accuracy",
+            "type": "accuracy",
+            "data_config": "chartqa_data",
+            "sub_types": [
+                {"name": "relaxed_accuracy", "priority": 1, "goal": {"type": "max-degradation", "value": 0.05}}
+            ]
+        }
+    ]
+}
+```
+
+### Example: OCR with DocumentVQA (word_sort_ratio)
+
+```json
+{
+    "data_configs": [
+        {
+            "name": "docvqa_data",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": {
+                "data_name": "HuggingFaceM4/DocumentVQA",
+                "split": "validation"
+            },
+            "pre_process_data_config": {
+                "type": "vision_vqa_pre_process",
+                "image_col": "image",
+                "question_col": "question",
+                "answer_col": "answers",
+                "limit": 100
+            },
+            "dataloader_config": {
+                "batch_size": 1
+            }
+        }
+    ],
+    "metrics": [
+        {
+            "name": "ocr_accuracy",
+            "type": "accuracy",
+            "data_config": "docvqa_data",
+            "sub_types": [
+                {"name": "word_sort_ratio", "priority": 1, "goal": {"type": "max-degradation", "value": 0.05}}
+            ]
+        }
+    ]
+}
+```
+
+```{Note}
+- Vision metrics compare predicted answer strings to ground truth. The model's `post_func` must decode model output into text.
+- Use `batch_size: 1` since images have variable sizes.
+- Multiple valid answers (lists) are joined with `|` and the metric matches against any valid answer.
+- For ONNX models, provide a custom pre-process that applies the processor/tokenizer to produce numeric tensors.
+```

--- a/olive/data/component/dataloader.py
+++ b/olive/data/component/dataloader.py
@@ -56,6 +56,14 @@ def no_auto_batch_dataloader(dataset, **kwargs):
 
 
 @Registry.register_dataloader()
+def vision_vqa_dataloader(dataset, batch_size=1, **kwargs):
+    from torch.utils.data import DataLoader
+
+    collate_fn = getattr(dataset, "collate_fn", None)
+    return DataLoader(dataset, batch_size=batch_size, collate_fn=collate_fn, **kwargs)
+
+
+@Registry.register_dataloader()
 def default_calibration_dataloader(
     dataloader,
     model_path: Optional[str] = None,

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -452,9 +452,10 @@ def vision_vqa_pre_process(
             image = item[self.image_column]
             question = item[self.question_column]
             answer = item[self.answer_column]
-            # Handle list answers (some datasets have multiple valid answers)
-            if isinstance(answer, list):
-                answer = answer[0] if answer else ""
+            # Handle list/tuple answers (some datasets have multiple valid answers)
+            # Join with | separator so metrics can match against any valid answer
+            if isinstance(answer, (list, tuple)):
+                answer = "|".join(str(a) for a in answer) if answer else ""
             return {"image": image, "question": question}, str(answer)
 
         @staticmethod

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -397,6 +397,12 @@ def vision_vqa_pre_process(
     Loads image, question, and ground truth answer from a HuggingFace dataset.
     Returns a dataset of ({"image": image, "question": question}, answer) pairs.
 
+    Note: This returns raw PIL images and question strings. For the PyTorch evaluator,
+    the model's own processor/tokenizer should be applied in the post_func or within
+    the model's forward method. For the ONNX evaluator, provide a custom pre-process
+    component that applies the appropriate processor/tokenizer to produce numeric
+    tensors matching the model's io_config.
+
     Args:
         dataset: HuggingFace dataset with image, question, and answer columns.
         image_col: Name of the image column. Defaults to "image".

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -398,10 +398,10 @@ def vision_vqa_pre_process(
     Returns a dataset of ({"image": image, "question": question}, answer) pairs.
 
     Note: This returns raw PIL images and question strings. For the PyTorch evaluator,
-    the model's own processor/tokenizer should be applied in the post_func or within
-    the model's forward method. For the ONNX evaluator, provide a custom pre-process
-    component that applies the appropriate processor/tokenizer to produce numeric
-    tensors matching the model's io_config.
+    the model's own processor/tokenizer should be applied within the model's forward
+    method (or via a custom pre-process component). For the ONNX evaluator, provide a
+    custom pre-process component that applies the appropriate processor/tokenizer to
+    produce numeric tensors matching the model's io_config.
 
     Args:
         dataset: HuggingFace dataset with image, question, and answer columns.
@@ -460,7 +460,11 @@ def vision_vqa_pre_process(
 
         @staticmethod
         def collate_fn(batch):
-            """Collate VQA batches. Use with batch_size=1 for variable-size images."""
+            """Collate VQA batches. Use with batch_size=1 for variable-size images.
+
+            Note: answers are always strings at this point (list/tuple answers are
+            joined with "|" in __getitem__), so no list-of-lists issue arises.
+            """
             if len(batch) == 1:
                 input_dict, answer = batch[0]
                 return (input_dict, [answer])

--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -379,3 +379,86 @@ def speech_transcription_pre_process(
             return (audios, texts)
 
     return SpeechTranscriptionDataset(dataset, audio_col, text_col)
+
+
+@Registry.register_pre_process()
+def vision_vqa_pre_process(
+    dataset,
+    image_col: str = "image",
+    question_col: str = "question",
+    answer_col: str = "answer",
+    max_samples: Optional[int] = None,
+    limit: Optional[float] = None,
+    seed: int = 42,
+    **kwargs,
+):
+    """Pre-process data for vision VQA evaluation.
+
+    Loads image, question, and ground truth answer from a HuggingFace dataset.
+    Returns a dataset of ({"image": image, "question": question}, answer) pairs.
+
+    Args:
+        dataset: HuggingFace dataset with image, question, and answer columns.
+        image_col: Name of the image column. Defaults to "image".
+        question_col: Name of the question column. Defaults to "question".
+        answer_col: Name of the answer column. Defaults to "answer".
+        max_samples: Maximum number of samples (deprecated, use limit). Defaults to None.
+        limit: Sampling limit following Olive convention:
+            If >= 1: use first N samples.
+            If 0 < limit < 1: randomly sample that percentage.
+            If 0 or None: use all samples.
+        seed: Random seed for percentage-based sampling. Defaults to 42.
+        **kwargs: Additional arguments.
+
+    """
+    # Apply sampling: prefer limit over max_samples
+    effective_limit = limit if limit is not None else (max_samples if max_samples else 0)
+    if effective_limit and effective_limit != 0:
+        from random import Random
+
+        total = len(dataset)
+        if 0 < effective_limit < 1:
+            n = max(1, int(total * effective_limit))
+            rng = Random(seed)
+            indices = sorted(rng.sample(range(total), min(n, total)))
+            dataset = dataset.select(indices)
+        elif effective_limit >= 1:
+            n = min(int(effective_limit), total)
+            dataset = dataset.select(range(n))
+
+    class VisionVQADataset:
+        """Dataset that returns (input_dict, answer_text) pairs for VQA evaluation.
+
+        Note: Use batch_size=1 in dataloader config as images have variable sizes.
+        """
+
+        def __init__(self, hf_dataset, image_column, question_column, answer_column):
+            self.dataset = hf_dataset
+            self.image_column = image_column
+            self.question_column = question_column
+            self.answer_column = answer_column
+
+        def __len__(self):
+            return len(self.dataset)
+
+        def __getitem__(self, idx):
+            item = self.dataset[idx]
+            image = item[self.image_column]
+            question = item[self.question_column]
+            answer = item[self.answer_column]
+            # Handle list answers (some datasets have multiple valid answers)
+            if isinstance(answer, list):
+                answer = answer[0] if answer else ""
+            return {"image": image, "question": question}, str(answer)
+
+        @staticmethod
+        def collate_fn(batch):
+            """Collate VQA batches. Use with batch_size=1 for variable-size images."""
+            if len(batch) == 1:
+                input_dict, answer = batch[0]
+                return (input_dict, [answer])
+            inputs = [item[0] for item in batch]
+            answers = [item[1] for item in batch]
+            return (inputs, answers)
+
+    return VisionVQADataset(dataset, image_col, question_col, answer_col)

--- a/olive/data/container/huggingface_container.py
+++ b/olive/data/container/huggingface_container.py
@@ -41,4 +41,13 @@ class HuggingfaceContainer(DataContainer):
         "speech-transcription": {
             DataComponentType.PRE_PROCESS_DATA.value: "speech_transcription_pre_process",
         },
+        "vision-vqa": {
+            DataComponentType.PRE_PROCESS_DATA.value: "vision_vqa_pre_process",
+        },
+        "vision-chart-qa": {
+            DataComponentType.PRE_PROCESS_DATA.value: "vision_vqa_pre_process",
+        },
+        "vision-ocr": {
+            DataComponentType.PRE_PROCESS_DATA.value: "vision_vqa_pre_process",
+        },
     }

--- a/olive/data/container/huggingface_container.py
+++ b/olive/data/container/huggingface_container.py
@@ -43,11 +43,14 @@ class HuggingfaceContainer(DataContainer):
         },
         "vision-vqa": {
             DataComponentType.PRE_PROCESS_DATA.value: "vision_vqa_pre_process",
+            DataComponentType.DATALOADER.value: "vision_vqa_dataloader",
         },
         "vision-chart-qa": {
             DataComponentType.PRE_PROCESS_DATA.value: "vision_vqa_pre_process",
+            DataComponentType.DATALOADER.value: "vision_vqa_dataloader",
         },
         "vision-ocr": {
             DataComponentType.PRE_PROCESS_DATA.value: "vision_vqa_pre_process",
+            DataComponentType.DATALOADER.value: "vision_vqa_dataloader",
         },
     }

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -225,6 +225,8 @@ class ExactMatch(AccuracyBase):
     Compares predicted answer strings to ground truth answers using
     case-insensitive, whitespace-normalized string equality.
     Returns the fraction of samples with an exact match.
+
+    Suitable for benchmarks: AI2D, ScienceQA, TextVQA, MathVista, MMMU, InterGPS.
     """
 
     name: Optional[str] = "exact_match"
@@ -266,6 +268,8 @@ class RelaxedAccuracy(AccuracyBase):
     For numeric answers, allows a ±5% tolerance (standard for ChartQA).
     For non-numeric answers, falls back to exact string match.
     Returns the fraction of samples that match within tolerance.
+
+    Suitable for benchmarks: ChartQA.
     """
 
     name: Optional[str] = "relaxed_accuracy"
@@ -337,6 +341,8 @@ class WordSortRatio(AccuracyBase):
     after sorting words alphabetically. This measures word-level overlap
     regardless of word order.
     Returns the average ratio across all samples.
+
+    Suitable for benchmarks: OCR.
     """
 
     name: Optional[str] = "word_sort_ratio"

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -258,7 +258,13 @@ class ExactMatch(AccuracyBase):
                 f"number of references ({len(refs)}) for exact_match metric."
             )
 
-        correct = sum(1 for p, r in zip(preds, refs) if self._normalize(str(p)) == self._normalize(str(r)))
+        correct = 0
+        for p, r in zip(preds, refs):
+            pred_norm = self._normalize(str(p))
+            # Support multiple valid answers separated by |
+            ref_answers = str(r).split("|") if "|" in str(r) else [str(r)]
+            if any(pred_norm == self._normalize(ref_a) for ref_a in ref_answers):
+                correct += 1
         return correct / len(refs) if refs else 0.0
 
 
@@ -315,23 +321,25 @@ class RelaxedAccuracy(AccuracyBase):
         correct = 0
         for pred, ref in zip(preds, refs):
             pred_str = str(pred)
-            ref_str = str(ref)
-            pred_is_num, pred_val = self._try_parse_number(pred_str)
-            ref_is_num, ref_val = self._try_parse_number(ref_str)
-
-            if pred_is_num and ref_is_num:
-                # Numeric comparison with tolerance
-                if ref_val == 0:
-                    if pred_val == 0:
-                        correct += 1
-                elif abs(pred_val - ref_val) / abs(ref_val) <= tolerance:
-                    correct += 1
-            else:
-                # String comparison (exact match, case-insensitive)
-                if self._normalize(pred_str) == self._normalize(ref_str):
-                    correct += 1
+            # Support multiple valid answers separated by |
+            ref_answers = str(ref).split("|") if "|" in str(ref) else [str(ref)]
+            if self._matches_any(pred_str, ref_answers, tolerance):
+                correct += 1
 
         return correct / len(refs) if refs else 0.0
+
+    def _matches_any(self, pred_str: str, ref_answers: list, tolerance: float) -> bool:
+        """Check if prediction matches any of the reference answers."""
+        pred_is_num, pred_val = self._try_parse_number(pred_str)
+        for ref_str in ref_answers:
+            ref_is_num, ref_val = self._try_parse_number(ref_str)
+            if pred_is_num and ref_is_num:
+                if (ref_val == pred_val) or (ref_val != 0 and abs(pred_val - ref_val) / abs(ref_val) <= tolerance):
+                    return True
+            else:
+                if self._normalize(pred_str) == self._normalize(ref_str):
+                    return True
+        return False
 
 
 class WordSortRatio(AccuracyBase):

--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -217,3 +217,169 @@ class RealTimeFactor(AccuracyBase):
         if total_inference == 0:
             return float("inf")
         return round(total_audio / total_inference, 2)
+
+
+class ExactMatch(AccuracyBase):
+    """Exact match metric for vision VQA evaluation.
+
+    Compares predicted answer strings to ground truth answers using
+    case-insensitive, whitespace-normalized string equality.
+    Returns the fraction of samples with an exact match.
+    """
+
+    name: Optional[str] = "exact_match"
+
+    @classmethod
+    def _default_config(cls) -> dict[str, ConfigParam]:
+        return {}
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        """Normalize text for comparison: lowercase and collapse whitespace."""
+        return " ".join(text.strip().lower().split())
+
+    def measure(self, model_output, target):
+        preds = model_output.preds
+        refs = target
+        if isinstance(preds, str):
+            preds = [preds]
+        elif not isinstance(preds, list):
+            preds = list(preds)
+        if isinstance(refs, str):
+            refs = [refs]
+        elif not isinstance(refs, list):
+            refs = list(refs)
+
+        if len(preds) != len(refs):
+            raise ValueError(
+                f"Number of predictions ({len(preds)}) does not match "
+                f"number of references ({len(refs)}) for exact_match metric."
+            )
+
+        correct = sum(1 for p, r in zip(preds, refs) if self._normalize(str(p)) == self._normalize(str(r)))
+        return correct / len(refs) if refs else 0.0
+
+
+class RelaxedAccuracy(AccuracyBase):
+    """Relaxed accuracy metric for chart/math VQA evaluation.
+
+    For numeric answers, allows a ±5% tolerance (standard for ChartQA).
+    For non-numeric answers, falls back to exact string match.
+    Returns the fraction of samples that match within tolerance.
+    """
+
+    name: Optional[str] = "relaxed_accuracy"
+
+    @classmethod
+    def _default_config(cls) -> dict[str, ConfigParam]:
+        return {
+            "tolerance": ConfigParam(type_=float, required=False, default_value=0.05),
+        }
+
+    @staticmethod
+    def _try_parse_number(text: str):
+        """Try to parse text as a number. Returns (True, value) or (False, None)."""
+        text = text.strip().replace(",", "").replace("%", "")
+        try:
+            return True, float(text)
+        except ValueError:
+            return False, None
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return " ".join(text.strip().lower().split())
+
+    def measure(self, model_output, target):
+        preds = model_output.preds
+        refs = target
+        if isinstance(preds, str):
+            preds = [preds]
+        elif not isinstance(preds, list):
+            preds = list(preds)
+        if isinstance(refs, str):
+            refs = [refs]
+        elif not isinstance(refs, list):
+            refs = list(refs)
+
+        if len(preds) != len(refs):
+            raise ValueError(
+                f"Number of predictions ({len(preds)}) does not match "
+                f"number of references ({len(refs)}) for relaxed_accuracy metric."
+            )
+
+        tolerance = self.config_dict.get("tolerance", 0.05)
+        correct = 0
+        for pred, ref in zip(preds, refs):
+            pred_str = str(pred)
+            ref_str = str(ref)
+            pred_is_num, pred_val = self._try_parse_number(pred_str)
+            ref_is_num, ref_val = self._try_parse_number(ref_str)
+
+            if pred_is_num and ref_is_num:
+                # Numeric comparison with tolerance
+                if ref_val == 0:
+                    if pred_val == 0:
+                        correct += 1
+                elif abs(pred_val - ref_val) / abs(ref_val) <= tolerance:
+                    correct += 1
+            else:
+                # String comparison (exact match, case-insensitive)
+                if self._normalize(pred_str) == self._normalize(ref_str):
+                    correct += 1
+
+        return correct / len(refs) if refs else 0.0
+
+
+class WordSortRatio(AccuracyBase):
+    """Word sort ratio metric for OCR evaluation.
+
+    Computes the ratio of matching words between prediction and reference
+    after sorting words alphabetically. This measures word-level overlap
+    regardless of word order.
+    Returns the average ratio across all samples.
+    """
+
+    name: Optional[str] = "word_sort_ratio"
+
+    @classmethod
+    def _default_config(cls) -> dict[str, ConfigParam]:
+        return {}
+
+    @staticmethod
+    def _compute_word_sort_ratio(pred: str, ref: str) -> float:
+        """Compute word sort ratio between two strings."""
+        pred_words = sorted(pred.strip().lower().split())
+        ref_words = sorted(ref.strip().lower().split())
+
+        if not ref_words:
+            return 1.0 if not pred_words else 0.0
+
+        # Count matching words using multiset intersection
+        from collections import Counter
+
+        pred_counter = Counter(pred_words)
+        ref_counter = Counter(ref_words)
+        intersection = sum((pred_counter & ref_counter).values())
+        total = max(len(pred_words), len(ref_words))
+        return intersection / total if total > 0 else 0.0
+
+    def measure(self, model_output, target):
+        preds = model_output.preds
+        refs = target
+        if isinstance(preds, str):
+            preds = [preds]
+        elif not isinstance(preds, list):
+            preds = list(preds)
+        if isinstance(refs, str):
+            refs = [refs]
+        elif not isinstance(refs, list):
+            refs = list(refs)
+
+        if len(preds) != len(refs):
+            raise ValueError(
+                f"Number of predictions ({len(preds)}) does not match "
+                f"number of references ({len(refs)}) for word_sort_ratio metric."
+            )
+
+        total_ratio = sum(self._compute_word_sort_ratio(str(p), str(r)) for p, r in zip(preds, refs))
+        return total_ratio / len(refs) if refs else 0.0

--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -40,7 +40,7 @@ class AccuracySubType(StrEnumBase):
     PERPLEXITY = "perplexity"
     WER = "wer"
     RTFX = "rtfx"
-    # Vision metrics (aligned with LITE babelbench benchmarks)
+    # Vision metrics (aligned with standard public vision benchmarks)
     EXACT_MATCH = "exact_match"  # AI2D, ScienceQA, TextVQA, MathVista, MMMU, InterGPS
     RELAXED_ACCURACY = "relaxed_accuracy"  # ChartQA (±5% numeric tolerance)
     WORD_SORT_RATIO = "word_sort_ratio"  # OCR (word-level overlap)

--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -40,10 +40,10 @@ class AccuracySubType(StrEnumBase):
     PERPLEXITY = "perplexity"
     WER = "wer"
     RTFX = "rtfx"
-    # Vision metrics
-    EXACT_MATCH = "exact_match"
-    RELAXED_ACCURACY = "relaxed_accuracy"
-    WORD_SORT_RATIO = "word_sort_ratio"
+    # Vision metrics (aligned with LITE babelbench benchmarks)
+    EXACT_MATCH = "exact_match"  # AI2D, ScienceQA, TextVQA, MathVista, MMMU, InterGPS
+    RELAXED_ACCURACY = "relaxed_accuracy"  # ChartQA (±5% numeric tolerance)
+    WORD_SORT_RATIO = "word_sort_ratio"  # OCR (word-level overlap)
 
 
 class LatencySubType(StrEnumBase):

--- a/olive/evaluator/metric.py
+++ b/olive/evaluator/metric.py
@@ -40,6 +40,10 @@ class AccuracySubType(StrEnumBase):
     PERPLEXITY = "perplexity"
     WER = "wer"
     RTFX = "rtfx"
+    # Vision metrics
+    EXACT_MATCH = "exact_match"
+    RELAXED_ACCURACY = "relaxed_accuracy"
+    WORD_SORT_RATIO = "word_sort_ratio"
 
 
 class LatencySubType(StrEnumBase):

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -743,6 +743,9 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         output_names = io_config["output_names"]
         is_single_tensor_output = len(output_names) == 1
 
+        # Note: This assumes the model produces the full answer in a single forward pass
+        # (e.g., classification-style VQA models). For autoregressive generation models,
+        # use the PyTorch evaluator with a generation loop in post_func instead.
         for batch in dataloader:
             input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
             input_feed = format_data(input_data, io_config)

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -63,7 +63,11 @@ class OliveModelOutput(NamedTuple):
 _TEXT_BASED_ACCURACY_SUBTYPES = {AccuracySubType.WER, AccuracySubType.RTFX}
 _VISION_ACCURACY_SUBTYPES = {AccuracySubType.EXACT_MATCH, AccuracySubType.RELAXED_ACCURACY, AccuracySubType.WORD_SORT_RATIO}
 
-# Task-to-metric validation: maps data task types to their allowed vision metrics
+# Task-to-metric validation: maps data task types to their allowed vision metrics.
+# Metrics are aligned with standard vision benchmarks used in LITE (babelbench):
+#   - vision-vqa (exact_match): AI2D, ScienceQA, TextVQA, MathVista, MMMU, InterGPS
+#   - vision-chart-qa (relaxed_accuracy): ChartQA (±5% numeric tolerance)
+#   - vision-ocr (word_sort_ratio): OCR (word-level overlap)
 _VISION_TASK_METRIC_MAP = {
     "vision-vqa": {AccuracySubType.EXACT_MATCH},
     "vision-chart-qa": {AccuracySubType.RELAXED_ACCURACY},

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -61,6 +61,14 @@ class OliveModelOutput(NamedTuple):
 
 # Text-based accuracy sub-types that work with string predictions/targets
 _TEXT_BASED_ACCURACY_SUBTYPES = {AccuracySubType.WER, AccuracySubType.RTFX}
+_VISION_ACCURACY_SUBTYPES = {AccuracySubType.EXACT_MATCH, AccuracySubType.RELAXED_ACCURACY, AccuracySubType.WORD_SORT_RATIO}
+
+# Task-to-metric validation: maps data task types to their allowed vision metrics
+_VISION_TASK_METRIC_MAP = {
+    "vision-vqa": {AccuracySubType.EXACT_MATCH},
+    "vision-chart-qa": {AccuracySubType.RELAXED_ACCURACY},
+    "vision-ocr": {AccuracySubType.WORD_SORT_RATIO},
+}
 
 
 def _is_text_based_metric(metric: "Metric") -> bool:
@@ -78,6 +86,56 @@ def _is_text_based_metric(metric: "Metric") -> bool:
             "(accuracy_score, f1_score, etc.) in the same metric. Please define them as separate metrics."
         )
     return all(text_based)
+
+
+def _is_vision_metric(metric: "Metric") -> bool:
+    """Check if metric uses vision accuracy sub-types (exact_match, relaxed_accuracy, word_sort_ratio).
+
+    Raises ValueError if vision sub-types are mixed with non-vision sub-types,
+    as they require different inference paths.
+    """
+    if metric.type != MetricType.ACCURACY:
+        return False
+    vision_based = [sub.name in _VISION_ACCURACY_SUBTYPES for sub in metric.sub_types]
+    if any(vision_based) and not all(vision_based):
+        raise ValueError(
+            "Cannot mix vision accuracy sub-types (exact_match, relaxed_accuracy, word_sort_ratio) "
+            "with other sub-types in the same metric. Please define them as separate metrics."
+        )
+    return all(vision_based)
+
+
+def _validate_vision_task_metric(metric: "Metric") -> None:
+    """Validate that the vision metric sub-types are compatible with the data task type.
+
+    Raises ValueError if the metric is not compatible with the task.
+    """
+    if not _is_vision_metric(metric):
+        return
+
+    task_type = None
+    if metric.data_config and hasattr(metric.data_config, "task_type"):
+        task_type = metric.data_config.task_type
+    elif metric.data_config and hasattr(metric.data_config, "params_config"):
+        task_type = getattr(metric.data_config.params_config, "task_type", None)
+
+    if task_type is None:
+        # No task type specified, allow any vision metric
+        return
+
+    allowed_metrics = _VISION_TASK_METRIC_MAP.get(task_type)
+    if allowed_metrics is None:
+        raise ValueError(
+            f"Unknown vision task type '{task_type}'. "
+            f"Supported task types: {list(_VISION_TASK_METRIC_MAP.keys())}."
+        )
+
+    for sub in metric.sub_types:
+        if sub.name not in allowed_metrics:
+            raise ValueError(
+                f"Metric sub-type '{sub.name}' is not compatible with task type '{task_type}'. "
+                f"Allowed metrics for '{task_type}': {[m.value for m in allowed_metrics]}."
+            )
 
 
 class OliveEvaluator(ABC):
@@ -518,7 +576,12 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         device: Device = Device.CPU,
         execution_providers: Optional[Union[str, list[str]]] = None,
     ) -> MetricResult:
-        if _is_text_based_metric(metric):
+        if _is_vision_metric(metric):
+            _validate_vision_task_metric(metric)
+            inference_output, targets = self._inference_vision(
+                model, metric, dataloader, post_func, device, execution_providers
+            )
+        elif _is_text_based_metric(metric):
             # Auto-detect genai model by checking for genai_config.json
             genai_config_path = Path(model.model_path).parent / "genai_config.json"
             if genai_config_path.exists():
@@ -645,6 +708,74 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             "total_inference_time": total_inference_time,
         }
         return OliveModelOutput(preds=all_preds, logits=timing_metadata), all_targets
+
+    def _inference_vision(
+        self,
+        model: ONNXModelHandler,
+        metric: Metric,
+        dataloader: "DataLoader",
+        post_func=None,
+        device: Device = Device.CPU,
+        execution_providers: Optional[Union[str, list[str]]] = None,
+    ) -> tuple[OliveModelOutput, Any]:
+        """Vision-based inference for VQA/OCR metrics (exact_match, relaxed_accuracy, word_sort_ratio).
+
+        The post_func must return predicted answer strings per batch.
+        Labels from the dataloader must be reference answer strings.
+        """
+        session, inference_settings = OnnxEvaluator.get_session_wrapper(
+            model, metric, dataloader, device, execution_providers
+        )
+        io_config = model.io_config
+        run_kwargs = metric.get_run_kwargs()
+
+        all_preds = []
+        all_targets = []
+        output_names = io_config["output_names"]
+        is_single_tensor_output = len(output_names) == 1
+
+        for batch in dataloader:
+            input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
+            input_feed = format_data(input_data, io_config)
+            result = model.run_session(session, input_feed, **run_kwargs)
+            if is_single_tensor_output:
+                result = torch.from_numpy(result[0]) if hasattr(result[0], "__array__") else torch.tensor(result[0])
+            else:
+                result = {
+                    name: torch.from_numpy(result[i]) if hasattr(result[i], "__array__") else torch.tensor(result[i])
+                    for i, name in enumerate(output_names)
+                }
+            # post_func must decode model output to answer strings
+            outputs = post_func(result) if post_func else result
+            if isinstance(outputs, str):
+                all_preds.append(outputs)
+            elif isinstance(outputs, (list, tuple)):
+                if not outputs:
+                    continue
+                if not isinstance(outputs[0], str):
+                    raise ValueError(
+                        f"post_func must return str or list[str] for vision metrics, "
+                        f"but got list of {type(outputs[0]).__name__}. "
+                        f"Ensure your post_func decodes model output to answer text."
+                    )
+                all_preds.extend(outputs)
+            else:
+                raise ValueError(
+                    f"post_func must return str or list[str] for vision metrics, "
+                    f"but got {type(outputs).__name__}. "
+                    f"Ensure your post_func decodes model output to answer text."
+                )
+            # labels should be reference answer strings
+            if isinstance(labels, (list, tuple)):
+                all_targets.extend(labels)
+            else:
+                all_targets.append(labels)
+
+        tuning_result_file = inference_settings.get("tuning_result_file")
+        if tuning_result_file:
+            dump_tuning_result(session.session, tuning_result_file)
+
+        return OliveModelOutput(preds=all_preds, logits=None), all_targets
 
     def _inference_text_genai(
         self,
@@ -1216,7 +1347,12 @@ class PyTorchEvaluator(_OliveEvaluator):
         device: Device = Device.CPU,
         execution_providers: Optional[Union[str, list[str]]] = None,
     ) -> MetricResult:
-        if _is_text_based_metric(metric):
+        if _is_vision_metric(metric):
+            _validate_vision_task_metric(metric)
+            inference_output, targets = self._inference_vision(
+                model, metric, dataloader, post_func, device, execution_providers
+            )
+        elif _is_text_based_metric(metric):
             inference_output, targets = self._inference_text(
                 model, metric, dataloader, post_func, device, execution_providers
             )
@@ -1301,6 +1437,60 @@ class PyTorchEvaluator(_OliveEvaluator):
             "total_inference_time": total_inference_time,
         }
         return OliveModelOutput(preds=all_preds, logits=timing_metadata), all_targets
+
+    @torch.no_grad()
+    def _inference_vision(
+        self,
+        model: "PyTorchModelHandler",
+        metric: Metric,
+        dataloader: "DataLoader",
+        post_func=None,
+        device: Device = Device.CPU,
+        execution_providers: Optional[Union[str, list[str]]] = None,
+    ) -> tuple[OliveModelOutput, Any]:
+        """Vision-based inference for VQA/OCR metrics (exact_match, relaxed_accuracy, word_sort_ratio)."""
+        session = model.prepare_session()
+        all_preds = []
+        all_targets = []
+        torch_device = _OliveEvaluator.device_string_to_torch_device(device)
+        run_kwargs = metric.get_run_kwargs()
+        session.to(torch_device)
+
+        for batch in dataloader:
+            input_data_i, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
+            input_data = tensor_data_to_device(input_data_i, torch_device)
+            result = model.run_session(session, input_data, **run_kwargs)
+            outputs = post_func(result) if post_func else result
+
+            if isinstance(outputs, str):
+                all_preds.append(outputs)
+            elif isinstance(outputs, (list, tuple)):
+                if not outputs:
+                    continue
+                if not isinstance(outputs[0], str):
+                    raise ValueError(
+                        f"post_func must return str or list[str] for vision metrics, "
+                        f"but got list of {type(outputs[0]).__name__}. "
+                        f"Ensure your post_func decodes model output to answer text."
+                    )
+                all_preds.extend(outputs)
+            else:
+                raise ValueError(
+                    f"post_func must return str or list[str] for vision metrics, "
+                    f"but got {type(outputs).__name__}. "
+                    f"Ensure your post_func decodes model output to answer text."
+                )
+            if isinstance(labels, (list, tuple)):
+                all_targets.extend(labels)
+            else:
+                all_targets.append(labels)
+
+        if torch_device:
+            session.to("cpu")
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        return OliveModelOutput(preds=all_preds, logits=None), all_targets
 
     @torch.no_grad()
     def _evaluate_raw_latency(

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -64,7 +64,7 @@ _TEXT_BASED_ACCURACY_SUBTYPES = {AccuracySubType.WER, AccuracySubType.RTFX}
 _VISION_ACCURACY_SUBTYPES = {AccuracySubType.EXACT_MATCH, AccuracySubType.RELAXED_ACCURACY, AccuracySubType.WORD_SORT_RATIO}
 
 # Task-to-metric validation: maps data task types to their allowed vision metrics.
-# Metrics are aligned with standard vision benchmarks used in LITE (babelbench):
+# Metrics are aligned with standard public vision benchmarks:
 #   - vision-vqa (exact_match): AI2D, ScienceQA, TextVQA, MathVista, MMMU, InterGPS
 #   - vision-chart-qa (relaxed_accuracy): ChartQA (±5% numeric tolerance)
 #   - vision-ocr (word_sort_ratio): OCR (word-level overlap)

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -61,7 +61,11 @@ class OliveModelOutput(NamedTuple):
 
 # Text-based accuracy sub-types that work with string predictions/targets
 _TEXT_BASED_ACCURACY_SUBTYPES = {AccuracySubType.WER, AccuracySubType.RTFX}
-_VISION_ACCURACY_SUBTYPES = {AccuracySubType.EXACT_MATCH, AccuracySubType.RELAXED_ACCURACY, AccuracySubType.WORD_SORT_RATIO}
+_VISION_ACCURACY_SUBTYPES = {
+    AccuracySubType.EXACT_MATCH,
+    AccuracySubType.RELAXED_ACCURACY,
+    AccuracySubType.WORD_SORT_RATIO,
+}
 
 # Task-to-metric validation: maps data task types to their allowed vision metrics.
 # Metrics are aligned with standard public vision benchmarks:
@@ -118,10 +122,12 @@ def _validate_vision_task_metric(metric: "Metric") -> None:
         return
 
     task_type = None
-    if metric.data_config and hasattr(metric.data_config, "task_type"):
-        task_type = metric.data_config.task_type
-    elif metric.data_config and hasattr(metric.data_config, "params_config"):
-        task_type = getattr(metric.data_config.params_config, "task_type", None)
+    if metric.data_config:
+        # Extract task from pre_process_data_config params, which is how HuggingfaceContainer
+        # maps task types (e.g., "vision-vqa", "vision-chart-qa", "vision-ocr") to components.
+        pre_process_config = metric.data_config.pre_process_data_config
+        if pre_process_config and pre_process_config.params:
+            task_type = pre_process_config.params.get("task")
 
     if task_type is None:
         # No task type specified, allow any vision metric
@@ -130,8 +136,7 @@ def _validate_vision_task_metric(metric: "Metric") -> None:
     allowed_metrics = _VISION_TASK_METRIC_MAP.get(task_type)
     if allowed_metrics is None:
         raise ValueError(
-            f"Unknown vision task type '{task_type}'. "
-            f"Supported task types: {list(_VISION_TASK_METRIC_MAP.keys())}."
+            f"Unknown vision task type '{task_type}'. Supported task types: {list(_VISION_TASK_METRIC_MAP.keys())}."
         )
 
     for sub in metric.sub_types:

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -126,8 +126,14 @@ def _validate_vision_task_metric(metric: "Metric") -> None:
         # Extract task from pre_process_data_config params, which is how HuggingfaceContainer
         # maps task types (e.g., "vision-vqa", "vision-chart-qa", "vision-ocr") to components.
         pre_process_config = metric.data_config.pre_process_data_config
-        if pre_process_config and pre_process_config.params:
-            task_type = pre_process_config.params.get("task")
+        if pre_process_config:
+            if pre_process_config.params:
+                task_type = pre_process_config.params.get("task")
+            # Also try to infer task from the component type name if params don't specify it
+            if task_type is None and pre_process_config.type == "vision_vqa_pre_process":
+                # Default component is used but task param is missing; skip validation
+                # since we can't determine which specific vision task is intended
+                return
 
     if task_type is None:
         # No task type specified, allow any vision metric

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -725,6 +725,6 @@
         "tf": [ "tensorflow==1.15.0" ],
         "torch-tensorrt": [ "torch-tensorrt" ],
         "tune-session-params": [ "psutil" ],
-        "vision": [ "Pillow" ]
+        "vision": [ "pillow" ]
     }
 }

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -724,6 +724,7 @@
         "speech": [ "jiwer", "librosa", "soundfile" ],
         "tf": [ "tensorflow==1.15.0" ],
         "torch-tensorrt": [ "torch-tensorrt" ],
-        "tune-session-params": [ "psutil" ]
+        "tune-session-params": [ "psutil" ],
+        "vision": [ "Pillow" ]
     }
 }

--- a/test/evaluator/test_accuracy.py
+++ b/test/evaluator/test_accuracy.py
@@ -213,3 +213,204 @@ class TestRealTimeFactor:
         model_output = OliveModelOutput(preds=["text"], logits=None)
         with pytest.raises(ValueError, match="RTFx metric requires timing metadata"):
             rtfx.measure(model_output, ["text"])
+
+
+class TestExactMatch:
+    def test_perfect_match(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["A", "B", "C"], logits=None)
+        targets = ["A", "B", "C"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_case_insensitive(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["Hello World", "TEST"], logits=None)
+        targets = ["hello world", "test"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_whitespace_normalization(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["  hello   world  "], logits=None)
+        targets = ["hello world"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_partial_match(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["A", "wrong", "C"], logits=None)
+        targets = ["A", "B", "C"]
+        result = metric.measure(model_output, targets)
+        assert abs(result - 2.0 / 3.0) < 1e-6
+
+    def test_no_match(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["X", "Y"], logits=None)
+        targets = ["A", "B"]
+        result = metric.measure(model_output, targets)
+        assert result == 0.0
+
+    def test_single_string_input(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds="answer", logits=None)
+        targets = "answer"
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_length_mismatch_raises(self):
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["A", "B"], logits=None)
+        targets = ["A"]
+        with pytest.raises(ValueError, match="does not match"):
+            metric.measure(model_output, targets)
+
+
+class TestRelaxedAccuracy:
+    def test_exact_numeric_match(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        model_output = OliveModelOutput(preds=["42.0"], logits=None)
+        targets = ["42.0"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_within_tolerance(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        # 41 is within 5% of 42 (42 * 0.05 = 2.1, |42-41| = 1 < 2.1)
+        model_output = OliveModelOutput(preds=["41"], logits=None)
+        targets = ["42"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_outside_tolerance(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        # 35 is outside 5% of 42 (42 * 0.05 = 2.1, |42-35| = 7 > 2.1)
+        model_output = OliveModelOutput(preds=["35"], logits=None)
+        targets = ["42"]
+        result = metric.measure(model_output, targets)
+        assert result == 0.0
+
+    def test_string_exact_match(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        model_output = OliveModelOutput(preds=["yes"], logits=None)
+        targets = ["yes"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_string_no_match(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        model_output = OliveModelOutput(preds=["yes"], logits=None)
+        targets = ["no"]
+        result = metric.measure(model_output, targets)
+        assert result == 0.0
+
+    def test_percentage_values(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        # 50% parsed as 50, within 5% of 50
+        model_output = OliveModelOutput(preds=["51%"], logits=None)
+        targets = ["50%"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_zero_target(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({})
+        model_output = OliveModelOutput(preds=["0"], logits=None)
+        targets = ["0"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_custom_tolerance(self):
+        from olive.evaluator.accuracy import RelaxedAccuracy
+
+        metric = RelaxedAccuracy({"tolerance": 0.1})
+        # 38 is within 10% of 42 (42 * 0.1 = 4.2, |42-38| = 4 < 4.2)
+        model_output = OliveModelOutput(preds=["38"], logits=None)
+        targets = ["42"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+
+class TestWordSortRatio:
+    def test_perfect_match(self):
+        from olive.evaluator.accuracy import WordSortRatio
+
+        metric = WordSortRatio({})
+        model_output = OliveModelOutput(preds=["hello world"], logits=None)
+        targets = ["hello world"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_reordered_words(self):
+        from olive.evaluator.accuracy import WordSortRatio
+
+        metric = WordSortRatio({})
+        # Same words, different order → ratio = 1.0 (sorted comparison)
+        model_output = OliveModelOutput(preds=["world hello"], logits=None)
+        targets = ["hello world"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_partial_overlap(self):
+        from olive.evaluator.accuracy import WordSortRatio
+
+        metric = WordSortRatio({})
+        # "hello" matches, "earth" doesn't match "world"
+        model_output = OliveModelOutput(preds=["hello earth"], logits=None)
+        targets = ["hello world"]
+        result = metric.measure(model_output, targets)
+        assert 0.0 < result < 1.0
+
+    def test_no_overlap(self):
+        from olive.evaluator.accuracy import WordSortRatio
+
+        metric = WordSortRatio({})
+        model_output = OliveModelOutput(preds=["foo bar"], logits=None)
+        targets = ["hello world"]
+        result = metric.measure(model_output, targets)
+        assert result == 0.0
+
+    def test_case_insensitive(self):
+        from olive.evaluator.accuracy import WordSortRatio
+
+        metric = WordSortRatio({})
+        model_output = OliveModelOutput(preds=["HELLO WORLD"], logits=None)
+        targets = ["hello world"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_empty_reference(self):
+        from olive.evaluator.accuracy import WordSortRatio
+
+        metric = WordSortRatio({})
+        model_output = OliveModelOutput(preds=[""], logits=None)
+        targets = [""]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -11,13 +11,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
-from olive.evaluator.metric import AccuracySubType, LatencySubType, ThroughputSubType
+from olive.evaluator.metric import AccuracySubType, LatencySubType, MetricType, ThroughputSubType
 from olive.evaluator.olive_evaluator import (
     OliveEvaluator,
     OliveEvaluatorConfig,
     OnnxEvaluator,
     OpenVINOEvaluator,
     PyTorchEvaluator,
+    _is_vision_metric,
+    _validate_vision_task_metric,
 )
 from olive.exception import OliveEvaluationError
 from olive.hardware.accelerator import Device
@@ -558,3 +560,65 @@ class TestLMEvalORTGenAIChatTemplate:
             add_generation_prompt=False,
             continue_final_message=True,
         )
+
+
+class TestVisionMetricValidation:
+    """Tests for vision metric detection and task/metric validation."""
+
+    def _make_vision_metric(self, sub_type_names, task=None):
+        """Create a metric with vision sub-types and optional task param."""
+        from unittest.mock import MagicMock
+
+        metric = MagicMock()
+        metric.type = MetricType.ACCURACY
+        metric.sub_types = [MagicMock(name=n) for n in sub_type_names]
+        # MagicMock.name is special, set it explicitly
+        for st, name in zip(metric.sub_types, sub_type_names):
+            st.name = name
+
+        if task is not None:
+            metric.data_config.pre_process_data_config.type = "vision_vqa_pre_process"
+            metric.data_config.pre_process_data_config.params = {"task": task}
+        else:
+            metric.data_config = None
+        return metric
+
+    def test_is_vision_metric_with_exact_match(self):
+        metric = self._make_vision_metric(["exact_match"])
+        assert _is_vision_metric(metric) is True
+
+    def test_is_vision_metric_with_relaxed_accuracy(self):
+        metric = self._make_vision_metric(["relaxed_accuracy"])
+        assert _is_vision_metric(metric) is True
+
+    def test_is_vision_metric_with_word_sort_ratio(self):
+        metric = self._make_vision_metric(["word_sort_ratio"])
+        assert _is_vision_metric(metric) is True
+
+    def test_is_vision_metric_returns_false_for_standard(self):
+        metric = self._make_vision_metric(["accuracy_score"])
+        assert _is_vision_metric(metric) is False
+
+    def test_is_vision_metric_raises_on_mixed_subtypes(self):
+        with pytest.raises(ValueError, match="Cannot mix vision accuracy sub-types"):
+            _is_vision_metric(self._make_vision_metric(["exact_match", "accuracy_score"]))
+
+    def test_validate_vision_task_metric_compatible(self):
+        metric = self._make_vision_metric(["exact_match"], task="vision-vqa")
+        # Should not raise
+        _validate_vision_task_metric(metric)
+
+    def test_validate_vision_task_metric_incompatible(self):
+        metric = self._make_vision_metric(["exact_match"], task="vision-ocr")
+        with pytest.raises(ValueError, match="not compatible with task type"):
+            _validate_vision_task_metric(metric)
+
+    def test_validate_vision_task_metric_unknown_task(self):
+        metric = self._make_vision_metric(["exact_match"], task="unknown-task")
+        with pytest.raises(ValueError, match="Unknown vision task type"):
+            _validate_vision_task_metric(metric)
+
+    def test_validate_vision_task_metric_no_task_skips(self):
+        metric = self._make_vision_metric(["exact_match"])
+        # No task specified, should not raise
+        _validate_vision_task_metric(metric)

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -567,8 +567,6 @@ class TestVisionMetricValidation:
 
     def _make_vision_metric(self, sub_type_names, task=None):
         """Create a metric with vision sub-types and optional task param."""
-        from unittest.mock import MagicMock
-
         metric = MagicMock()
         metric.type = MetricType.ACCURACY
         metric.sub_types = [MagicMock(name=n) for n in sub_type_names]


### PR DESCRIPTION
## Summary

Extends Olive's evaluator framework with three vision-oriented accuracy sub-metrics for VQA, ChartQA, and OCR evaluation, following the existing pattern used for speech metrics (PR #2444).

## New Metrics

| Metric | Task Type | Suitable Benchmarks |
|--------|-----------|-------------------|
| `exact_match` | `vision-vqa` | AI2D, ScienceQA, TextVQA, MathVista, MMMU, InterGPS |
| `relaxed_accuracy` | `vision-chart-qa` | ChartQA (±5% numeric tolerance for numbers) |
| `word_sort_ratio` | `vision-ocr` | OCR benchmarks (word-level overlap) |

## Public HuggingFace Datasets

These metrics are designed to work with publicly available datasets:

| Metric | Recommended Dataset | HuggingFace ID |
|--------|-------------------|----------------|
| `exact_match` | TextVQA | `facebook/textvqa` |
| `relaxed_accuracy` | ChartQA | `HuggingFaceM4/ChartQA` |
| `word_sort_ratio` | DocumentVQA | `HuggingFaceM4/DocumentVQA` |

Example configuration snippets are provided in `docs/source/how-to/configure-workflows/metrics-configuration.md`.

## Changes

- **`olive/evaluator/metric.py`**: Adds `EXACT_MATCH`, `RELAXED_ACCURACY`, `WORD_SORT_RATIO` to `AccuracySubType` enum
- **`olive/evaluator/accuracy.py`**: Implements the three metric classes with multi-answer support
- **`olive/evaluator/olive_evaluator.py`**: Adds vision inference path and task-metric validation
- **`olive/data/component/pre_process_data.py`**: Adds `vision_vqa_pre_process` component
- **`olive/data/component/dataloader.py`**: Adds `vision_vqa_dataloader` with custom collate_fn for PIL images
- **`olive/data/container/huggingface_container.py`**: Registers `vision-vqa`, `vision-chart-qa`, `vision-ocr` task types with appropriate dataloader
- **`olive/olive_config.json`**: Adds `vision` extras (pillow)
- **`docs/source/how-to/configure-workflows/metrics-configuration.md`**: Adds vision metrics documentation with public dataset examples
- **`test/evaluator/test_accuracy.py`**: Unit tests covering all new metrics

## Design

- Vision metrics are text-based (compare predicted answer string to ground truth), task-dependent
- Multiple valid answers supported via `|` separator (metrics match against any valid answer)
- Task-metric validation ensures incompatible combinations raise `ValueError`
- Custom `vision_vqa_dataloader` handles PIL images with a collate_fn that avoids PyTorch default collation issues
- PyTorch path: model processor handles images natively
- ONNX path: single forward pass assumed (classification-style VQA); for autoregressive models use PyTorch evaluator with generation loop