### PR TITLE
add a pass to measure the discrepancies on the test model

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -81,6 +81,21 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",
         "reference_model_path": reference_model_path,
+        "data_config": {
+            "name": "discrepancy_check_data",
+            "type": "DummyDataContainer",
+            "load_dataset_config": {
+                "type": "dummy_dataset",
+                "params": {
+                    "input_names": ["input_ids", "attention_mask"],
+                    "input_shapes": [[1, 8], [1, 8]],
+                    "input_types": ["int64", "int64"],
+                    "max_samples": 2,
+                },
+            },
+            "pre_process_data_config": {"type": "skip_pre_process"},
+            "post_process_data_config": {"type": "skip_post_process"},
+        },
     }
     run_config["passes"] = passes
     return run_config

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -64,6 +64,28 @@ def mark_test_output_path(output_path: Optional[str]) -> None:
     _get_test_output_marker_path(output_path).write_text(json.dumps({"type": "olive_hf_test_output"}, indent=2))
 
 
+def add_discrepancy_check_pass(run_config: dict) -> dict:
+    """Inject OnnxDiscrepancyCheck pass when --test is active and not already configured."""
+    passes = run_config.get("passes", {})
+    # Skip if already configured
+    for pass_config in passes.values():
+        if isinstance(pass_config, dict) and pass_config.get("type", "").lower() == "onnxdiscrepancycheck":
+            return run_config
+
+    # Get the reference model path from the input_model test_model_path
+    input_model = run_config.get("input_model", {})
+    reference_model_path = input_model.get("test_model_path")
+    if not reference_model_path:
+        return run_config
+
+    passes["discrepancy_check"] = {
+        "type": "OnnxDiscrepancyCheck",
+        "reference_model_path": reference_model_path,
+    }
+    run_config["passes"] = passes
+    return run_config
+
+
 class BaseOliveCLICommand(ABC):
     allow_unknown_args: ClassVar[bool] = False
 
@@ -84,6 +106,8 @@ class BaseOliveCLICommand(ABC):
 
         with tempfile.TemporaryDirectory(prefix="olive-cli-tmp-", dir=self.args.output_path) as tempdir:
             run_config = self._get_run_config(tempdir)
+            if getattr(self.args, "test", None) not in (None, False):
+                run_config = add_discrepancy_check_pass(run_config)
             if self.args.save_config_file or self.args.dry_run:
                 self._save_config_file(run_config)
             if self.args.dry_run:

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -81,21 +81,6 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",
         "reference_model_path": reference_model_path,
-        "data_config": {
-            "name": "discrepancy_check_data",
-            "type": "DummyDataContainer",
-            "load_dataset_config": {
-                "type": "dummy_dataset",
-                "params": {
-                    "input_names": ["input_ids", "attention_mask"],
-                    "input_shapes": [[1, 8], [1, 8]],
-                    "input_types": ["int64", "int64"],
-                    "max_samples": 2,
-                },
-            },
-            "pre_process_data_config": {"type": "skip_pre_process"},
-            "post_process_data_config": {"type": "skip_post_process"},
-        },
     }
     run_config["passes"] = passes
     return run_config

--- a/olive/cli/run.py
+++ b/olive/cli/run.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser
 
 from olive.cli.base import (
     BaseOliveCLICommand,
+    add_discrepancy_check_pass,
     add_hf_test_model_config,
     add_input_model_options,
     add_logging_options,
@@ -81,6 +82,8 @@ class WorkflowRunCommand(BaseOliveCLICommand):
 
         output_path = run_config.get("output_dir") or run_config.get("engine", {}).get("output_dir")
         validate_test_output_path(output_path, self.args.test)
+        if self.args.test not in (None, False):
+            run_config = add_discrepancy_check_pass(run_config)
         workflow_output = olive_run(
             run_config,
             list_required_packages=self.args.list_required_packages,

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -303,11 +303,11 @@
         },
         "OnnxDiscrepancyCheck": {
             "module_path": "olive.passes.onnx.discrepancy_check.OnnxDiscrepancyCheck",
-            "supported_providers": ["*"],
-            "supported_accelerators": ["*"],
-            "supported_precisions": ["*"],
-            "supported_algorithms": [],
-            "supported_quantization_encodings": []
+            "supported_providers": [ "*" ],
+            "supported_accelerators": [ "*" ],
+            "supported_precisions": [ "*" ],
+            "supported_algorithms": [ ],
+            "supported_quantization_encodings": [ ]
         },
         "OnnxDynamicQuantization": {
             "module_path": "olive.passes.onnx.quantization.OnnxDynamicQuantization",

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -306,8 +306,8 @@
             "supported_providers": [ "*" ],
             "supported_accelerators": [ "*" ],
             "supported_precisions": [ "*" ],
-            "supported_algorithms": [ ],
-            "supported_quantization_encodings": [ ]
+            "supported_algorithms": [  ],
+            "supported_quantization_encodings": [  ]
         },
         "OnnxDynamicQuantization": {
             "module_path": "olive.passes.onnx.quantization.OnnxDynamicQuantization",

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -301,6 +301,14 @@
             "supported_quantization_encodings": [  ],
             "dataset": "dataset_optional"
         },
+        "OnnxDiscrepancyCheck": {
+            "module_path": "olive.passes.onnx.discrepancy_check.OnnxDiscrepancyCheck",
+            "supported_providers": ["*"],
+            "supported_accelerators": ["*"],
+            "supported_precisions": ["*"],
+            "supported_algorithms": [],
+            "supported_quantization_encodings": []
+        },
         "OnnxDynamicQuantization": {
             "module_path": "olive.passes.onnx.quantization.OnnxDynamicQuantization",
             "supported_providers": [ "CPUExecutionProvider" ],

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-from typing import Optional, Union
+from typing import Optional
 
 from olive.data.config import DataConfig
 from olive.hardware import AcceleratorSpec

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -108,7 +108,15 @@ class OnnxDiscrepancyCheck(Pass):
         dataloader = dc.create_dataloader()
 
         # Load reference PyTorch model
-        from transformers import AutoModelForCausalLM
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        ref_cfg = AutoConfig.from_pretrained(config.reference_model_path)
+        architectures = getattr(ref_cfg, "architectures", None) or []
+        if not any("ForCausalLM" in arch for arch in architectures):
+            raise ValueError(
+                "OnnxDiscrepancyCheck currently supports only HuggingFace causal language models (ForCausalLM). "
+                f"Got architectures={architectures}"
+            )
 
         ref_model = AutoModelForCausalLM.from_pretrained(config.reference_model_path)
         ref_model.eval()

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -76,7 +76,6 @@ class OnnxDiscrepancyCheck(Pass):
 
         from olive.common.config_utils import validate_config
         from olive.common.utils import format_data
-        from olive.data.config import DataConfig
         from olive.data.template import dummy_data_config_template
         from olive.model.config.io_config import is_io_config_static
 

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -23,7 +23,19 @@ def _infer_shape(dynamic_shape, known_values=None):
     }
     if known_values:
         default_values.update(known_values)
-    return tuple(d if isinstance(d, int) else default_values[d] for d in dynamic_shape)
+    inferred_shape = []
+    for dim in dynamic_shape:
+        if isinstance(dim, int):
+            inferred_shape.append(dim)
+            continue
+        if dim not in default_values:
+            raise KeyError(
+                f"Unsupported symbolic dimension '{dim}' in shape {dynamic_shape}. "
+                f"Known symbols are: {sorted(default_values)}. "
+                "Update OnnxDiscrepancyCheck to handle this new case."
+            )
+        inferred_shape.append(default_values[dim])
+    return tuple(inferred_shape)
 
 
 class OnnxDiscrepancyCheck(Pass):

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -100,8 +100,9 @@ class OnnxDiscrepancyCheck(Pass):
             data_config = validate_config(data_config, DataConfig)
             data_config.load_dataset_config.params["max_samples"] = 1
         else:
-            raise RuntimeError(f"No data_config provided and model IO config is not static, io_config={io_config}")
-
+            raise RuntimeError(
+                f"Model IO config is missing for {model.model_path}; cannot generate dummy inputs for discrepancy check."
+            )
         # Create dataloader
         dc = data_config.to_data_container()
         dataloader = dc.create_dataloader()

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -14,6 +14,18 @@ from olive.passes.pass_config import BasePassConfig, PassConfigParam
 logger = logging.getLogger(__name__)
 
 
+def _infer_shape(dynamic_shape, known_values=None):
+    default_values = {
+        "batch_size": 1,
+        "past_sequence_length": 2,
+        "total_sequence_length": 3,
+        "sequence_length": 1,
+    }
+    if known_values:
+        default_values.update(known_values)
+    return tuple(d if isinstance(d, int) else default_values[d] for d in dynamic_shape)
+
+
 class OnnxDiscrepancyCheck(Pass):
     """Validates ONNX model outputs against a reference PyTorch model.
 
@@ -58,14 +70,6 @@ class OnnxDiscrepancyCheck(Pass):
                     "If exceeded, the pass fails."
                 ),
             ),
-            "data_config": PassConfigParam(
-                type_=Union[DataConfig, dict],
-                default_value=None,
-                description=(
-                    "Data configuration for the evaluation dataset. "
-                    "If not provided, a dummy dataset matching the model's IO config is used."
-                ),
-            ),
         }
 
     def _run_for_config(
@@ -79,20 +83,23 @@ class OnnxDiscrepancyCheck(Pass):
         from olive.data.template import dummy_data_config_template
         from olive.model.config.io_config import is_io_config_static
 
-        # Set up data config
-        if config.data_config is not None:
-            data_config = config.data_config
-            if isinstance(data_config, dict):
-                data_config = validate_config(data_config, DataConfig)
-        else:
-            io_config = model.io_config
-            if io_config and is_io_config_static(io_config):
-                data_config = dummy_data_config_template(
-                    io_config.get("input_shapes"), io_config.get("input_names"), io_config.get("input_types")
-                )
-                data_config = validate_config(data_config, DataConfig)
+        io_config = model.io_config
+        if io_config:
+            if is_io_config_static(io_config):
+                input_shapes = io_config.get("input_shapes")
             else:
-                raise RuntimeError("No data_config provided and model IO config is not static.")
+                input_shapes = []
+                known = {}
+                for shape in io_config.get("input_shapes"):
+                    new_shape = _infer_shape(shape, known)
+                    input_shapes.append(new_shape)
+                    known.update(dict(zip(shape, new_shape)))
+            data_config = dummy_data_config_template(
+                input_shapes, io_config.get("input_names"), io_config.get("input_types")
+            )
+            data_config = validate_config(data_config, DataConfig)
+        else:
+            raise RuntimeError(f"No data_config provided and model IO config is not static, io_config={io_config}")
 
         # Create dataloader
         dc = data_config.to_data_container()

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -32,7 +32,7 @@ class OnnxDiscrepancyCheck(Pass):
     This pass does not transform the model. It runs inference on both the
     ONNX model and a reference PyTorch/HuggingFace model with the same inputs,
     then compares outputs element-wise. It reports:
-    - Maximum absolute error (MAE)
+    - Maximum absolute error (MaxAE)
     - Number of elements where the absolute difference exceeds 0.1
     - Number of elements where the absolute difference exceeds 0.01
 

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -1,0 +1,176 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+from typing import Optional, Union
+
+from olive.data.config import DataConfig
+from olive.hardware import AcceleratorSpec
+from olive.model import ONNXModelHandler
+from olive.passes import Pass
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
+logger = logging.getLogger(__name__)
+
+
+class OnnxDiscrepancyCheck(Pass):
+    """Validates ONNX model outputs against a reference PyTorch model.
+
+    This pass does not transform the model. It runs inference on both the
+    ONNX model and a reference PyTorch/HuggingFace model with the same inputs,
+    then compares outputs element-wise. It reports:
+    - Maximum absolute error (MAE)
+    - Number of elements where the absolute difference exceeds 0.1
+    - Number of elements where the absolute difference exceeds 0.01
+
+    The pass fails if any configured threshold is exceeded.
+    """
+
+    @classmethod
+    def _default_config(cls, accelerator_spec: AcceleratorSpec) -> dict[str, PassConfigParam]:
+        return {
+            "reference_model_path": PassConfigParam(
+                type_=str,
+                required=True,
+                description="Path to the reference PyTorch/HuggingFace model to compare against.",
+            ),
+            "max_mae": PassConfigParam(
+                type_=Optional[float],
+                default_value=None,
+                description=(
+                    "Maximum acceptable absolute error. "
+                    "If the max absolute difference exceeds this value, the pass fails."
+                ),
+            ),
+            "max_elements_above_0_1": PassConfigParam(
+                type_=Optional[int],
+                default_value=None,
+                description=(
+                    "Maximum acceptable number of elements with absolute difference > 0.1. If exceeded, the pass fails."
+                ),
+            ),
+            "max_elements_above_0_01": PassConfigParam(
+                type_=Optional[int],
+                default_value=None,
+                description=(
+                    "Maximum acceptable number of elements with absolute difference > 0.01. "
+                    "If exceeded, the pass fails."
+                ),
+            ),
+            "data_config": PassConfigParam(
+                type_=Union[DataConfig, dict],
+                default_value=None,
+                description=(
+                    "Data configuration for the evaluation dataset. "
+                    "If not provided, a dummy dataset matching the model's IO config is used."
+                ),
+            ),
+        }
+
+    def _run_for_config(
+        self, model: ONNXModelHandler, config: type[BasePassConfig], output_model_path: str
+    ) -> ONNXModelHandler:
+        import numpy as np
+        import torch
+
+        from olive.common.config_utils import validate_config
+        from olive.common.utils import format_data
+        from olive.data.config import DataConfig
+        from olive.data.template import dummy_data_config_template
+        from olive.model.config.io_config import is_io_config_static
+
+        # Set up data config
+        if config.data_config is not None:
+            data_config = config.data_config
+            if isinstance(data_config, dict):
+                data_config = validate_config(data_config, DataConfig)
+        else:
+            io_config = model.io_config
+            if io_config and is_io_config_static(io_config):
+                data_config = dummy_data_config_template(
+                    io_config.get("input_shapes"), io_config.get("input_names"), io_config.get("input_types")
+                )
+                data_config = validate_config(data_config, DataConfig)
+            else:
+                raise RuntimeError("No data_config provided and model IO config is not static.")
+
+        # Create dataloader
+        dc = data_config.to_data_container()
+        dataloader = dc.create_dataloader()
+
+        # Load reference PyTorch model
+        from transformers import AutoModelForCausalLM
+
+        ref_model = AutoModelForCausalLM.from_pretrained(config.reference_model_path)
+        ref_model.eval()
+
+        # Prepare ONNX session
+        import onnxruntime as ort
+
+        session = ort.InferenceSession(model.model_path)
+        io_config = model.io_config
+
+        # Run inference on both and compare
+        all_max_abs_diff = []
+        all_count_above_0_1 = []
+        all_count_above_0_01 = []
+        total_elements = 0
+
+        with torch.no_grad():
+            for batch in dataloader:
+                # Extract input data (batch may be (data, label) or just data)
+                input_data = batch[0] if isinstance(batch, (tuple, list)) else batch
+
+                # Run PyTorch inference
+                if isinstance(input_data, dict):
+                    torch_inputs = {k: v.clone() for k, v in input_data.items()}
+                else:
+                    torch_inputs = input_data
+
+                torch_output = ref_model(**torch_inputs)
+                torch_logits = torch_output.logits.numpy()
+
+                # Run ONNX inference
+                onnx_input_feed = format_data(input_data, io_config)
+                onnx_outputs = session.run(None, onnx_input_feed)
+                onnx_logits = onnx_outputs[0]
+
+                # Compute element-wise differences
+                abs_diff = np.abs(torch_logits.astype(np.float64) - onnx_logits.astype(np.float64))
+                all_max_abs_diff.append(float(np.max(abs_diff)))
+                all_count_above_0_1.append(int(np.sum(abs_diff > 0.1)))
+                all_count_above_0_01.append(int(np.sum(abs_diff > 0.01)))
+                total_elements += abs_diff.size
+
+        max_abs_error = max(all_max_abs_diff)
+        count_above_0_1 = sum(all_count_above_0_1)
+        count_above_0_01 = sum(all_count_above_0_01)
+
+        logger.info(
+            "OnnxDiscrepancyCheck: max_abs_error=%.6f, elements_above_0.1=%d/%d, elements_above_0.01=%d/%d",
+            max_abs_error,
+            count_above_0_1,
+            total_elements,
+            count_above_0_01,
+            total_elements,
+        )
+
+        # Check thresholds
+        failures = []
+        if config.max_mae is not None and max_abs_error > config.max_mae:
+            failures.append(f"Max absolute error {max_abs_error:.6f} exceeds threshold {config.max_mae:.6f}")
+        if config.max_elements_above_0_1 is not None and count_above_0_1 > config.max_elements_above_0_1:
+            failures.append(
+                f"Elements with diff > 0.1: {count_above_0_1} exceeds threshold {config.max_elements_above_0_1}"
+            )
+        if config.max_elements_above_0_01 is not None and count_above_0_01 > config.max_elements_above_0_01:
+            failures.append(
+                f"Elements with diff > 0.01: {count_above_0_01} exceeds threshold {config.max_elements_above_0_01}"
+            )
+
+        if failures:
+            raise RuntimeError("ONNX model discrepancy check failed:\n" + "\n".join(f"  - {f}" for f in failures))
+
+        # Return the model unchanged
+        return model

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -135,8 +135,7 @@ class OnnxDiscrepancyCheck(Pass):
                     torch_inputs = input_data
 
                 torch_output = ref_model(**torch_inputs)
-                torch_logits = torch_output.logits.numpy()
-
+                torch_logits = torch_output.logits.detach().cpu().numpy()
                 # Run ONNX inference
                 onnx_input_feed = format_data(input_data, io_config)
                 onnx_outputs = session.run(None, onnx_input_feed)

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -98,6 +98,7 @@ class OnnxDiscrepancyCheck(Pass):
                 input_shapes, io_config.get("input_names"), io_config.get("input_types")
             )
             data_config = validate_config(data_config, DataConfig)
+            data_config.load_dataset_config.params["max_samples"] = 1
         else:
             raise RuntimeError(f"No data_config provided and model IO config is not static, io_config={io_config}")
 

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -114,9 +114,7 @@ class OnnxDiscrepancyCheck(Pass):
         ref_model.eval()
 
         # Prepare ONNX session
-        import onnxruntime as ort
-
-        session = ort.InferenceSession(model.model_path)
+        session = model.prepare_session()
         io_config = model.io_config
 
         # Run inference on both and compare

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -172,6 +172,7 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
 
     cli_main(command_args)
 
+    test_model_path = str(tmp_path / "output" / "test_model")
     mock_run.assert_called_once_with(
         {
             "input_model": {
@@ -179,9 +180,15 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
                 "model_path": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "load_kwargs": {"attn_implementation": "eager", "trust_remote_code": False},
                 "test_model_config": {"hidden_layers": 2},
-                "test_model_path": str(tmp_path / "output" / "test_model"),
+                "test_model_path": test_model_path,
             },
             "output_dir": str(tmp_path / "output"),
+            "passes": {
+                "discrepancy_check": {
+                    "type": "OnnxDiscrepancyCheck",
+                    "reference_model_path": test_model_path,
+                }
+            },
         },
         list_required_packages=False,
         package_config=None,

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -213,7 +213,7 @@ class TestCliTestModelSmoke(unittest.TestCase):
                 assert config_path.exists()
                 _set_offline_gptq_data_config(config_path)
 
-                # Run with --test; OnnxDiscrepancyCheck is auto-injected and validates output quality
+                # Run with --test; OnnxDiscrepancyCheck is auto-injected and reports discrepancy metrics (fails only if thresholds are configured)
                 _run_cli_main(
                     [
                         "run",

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -86,31 +86,6 @@ def _run_cli_main(args):
     cli_main(args)
 
 
-def _add_discrepancy_check_pass(config_path: Path, reference_model_path: Path):
-    """Add an OnnxDiscrepancyCheck pass to the workflow config to validate model outputs."""
-    config = json.loads(config_path.read_text())
-    config["passes"]["discrepancy_check"] = {
-        "type": "OnnxDiscrepancyCheck",
-        "reference_model_path": str(reference_model_path),
-        "data_config": {
-            "name": "test_discrepancy_data",
-            "type": "DummyDataContainer",
-            "load_dataset_config": {
-                "type": "dummy_dataset",
-                "params": {
-                    "input_names": ["input_ids", "attention_mask"],
-                    "input_shapes": [[1, 8], [1, 8]],
-                    "input_types": ["int64", "int64"],
-                    "max_samples": 2,
-                },
-            },
-            "pre_process_data_config": {"type": "skip_pre_process"},
-            "post_process_data_config": {"type": "skip_post_process"},
-        },
-    }
-    config_path.write_text(json.dumps(config, indent=2))
-
-
 def _run_documented_test_model_smoke_flow(tmp_path: Path, model_id: str):
     model_name = model_id.replace("/", "--")
     model_path = tmp_path / "models" / model_name
@@ -196,7 +171,7 @@ class TestCliTestModelSmoke(unittest.TestCase):
                     self._assert_file_size_below_limit(run_output_dir / "model.onnx.data")
 
     def test_model_discrepancy(self):
-        """Verify that the optimized ONNX model has acceptable accuracy via OnnxAccuracyCheck pass."""
+        """Verify that the optimized ONNX model has acceptable discrepancy via OnnxDiscrepancyCheck pass."""
         if self.workdir is None:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self._assert_discrepancy(Path(temp_dir))
@@ -235,9 +210,8 @@ class TestCliTestModelSmoke(unittest.TestCase):
                 config_path = config_output_dir / "config.json"
                 assert config_path.exists()
                 _set_offline_gptq_data_config(config_path)
-                _add_discrepancy_check_pass(config_path, model_path)
 
-                # Run the workflow; the OnnxAccuracyCheck pass will fail if perplexity is unacceptable
+                # Run with --test; OnnxDiscrepancyCheck is auto-injected and validates output quality
                 _run_cli_main(
                     [
                         "run",

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -173,7 +173,7 @@ class TestCliTestModelSmoke(unittest.TestCase):
                     self._assert_file_size_below_limit(run_output_dir / "model.onnx.data")
 
     def test_model_discrepancy(self):
-        """Verify that the optimized ONNX model has acceptable discrepancy via OnnxDiscrepancyCheck pass."""
+        """Verify that OnnxDiscrepancyCheck runs successfully when auto-injected via --test."""
         if self.workdir is None:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self._assert_discrepancy(Path(temp_dir))

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -86,6 +86,31 @@ def _run_cli_main(args):
     cli_main(args)
 
 
+def _add_discrepancy_check_pass(config_path: Path, reference_model_path: Path):
+    """Add an OnnxDiscrepancyCheck pass to the workflow config to validate model outputs."""
+    config = json.loads(config_path.read_text())
+    config["passes"]["discrepancy_check"] = {
+        "type": "OnnxDiscrepancyCheck",
+        "reference_model_path": str(reference_model_path),
+        "data_config": {
+            "name": "test_discrepancy_data",
+            "type": "DummyDataContainer",
+            "load_dataset_config": {
+                "type": "dummy_dataset",
+                "params": {
+                    "input_names": ["input_ids", "attention_mask"],
+                    "input_shapes": [[1, 8], [1, 8]],
+                    "input_types": ["int64", "int64"],
+                    "max_samples": 2,
+                },
+            },
+            "pre_process_data_config": {"type": "skip_pre_process"},
+            "post_process_data_config": {"type": "skip_post_process"},
+        },
+    }
+    config_path.write_text(json.dumps(config, indent=2))
+
+
 def _run_documented_test_model_smoke_flow(tmp_path: Path, model_id: str):
     model_name = model_id.replace("/", "--")
     model_path = tmp_path / "models" / model_name
@@ -169,6 +194,61 @@ class TestCliTestModelSmoke(unittest.TestCase):
                 self._assert_file_size_below_limit(test_model_dir / "model.safetensors")
                 if "model.onnx.data" in run_output_files:
                     self._assert_file_size_below_limit(run_output_dir / "model.onnx.data")
+
+    def test_model_discrepancy(self):
+        """Verify that the optimized ONNX model has acceptable accuracy via OnnxAccuracyCheck pass."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_discrepancy(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_discrepancy(workdir)
+
+    def _assert_discrepancy(self, tmp_path: Path):
+        for model_id in self.model_ids:
+            with self.subTest(model_id=model_id):
+                model_name = model_id.replace("/", "--")
+                model_path = tmp_path / "models" / f"{model_name}-disc"
+                config_output_dir = tmp_path / f"{model_name}-disc-cfg"
+                test_model_dir = tmp_path / f"{model_name}-disc-test-model"
+                run_output_dir = tmp_path / f"{model_name}-disc-run"
+
+                _save_local_tiny_llama(model_path)
+                _run_cli_main(
+                    [
+                        "optimize",
+                        "-m",
+                        str(model_path),
+                        "--device",
+                        "cpu",
+                        "--provider",
+                        "CPUExecutionProvider",
+                        "--precision",
+                        "int4",
+                        "--output_path",
+                        str(config_output_dir),
+                        "--dry_run",
+                    ]
+                )
+
+                config_path = config_output_dir / "config.json"
+                assert config_path.exists()
+                _set_offline_gptq_data_config(config_path)
+                _add_discrepancy_check_pass(config_path, model_path)
+
+                # Run the workflow; the OnnxAccuracyCheck pass will fail if perplexity is unacceptable
+                _run_cli_main(
+                    [
+                        "run",
+                        "--config",
+                        str(config_path),
+                        "--test",
+                        str(test_model_dir),
+                        "--output_path",
+                        str(run_output_dir),
+                    ]
+                )
 
     def _assert_file_size_below_limit(self, path: Path):
         assert path.exists()

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -94,6 +94,7 @@ def _run_documented_test_model_smoke_flow(tmp_path: Path, model_id: str):
     run_output_dir = tmp_path / f"{model_name}-test-run"
 
     _save_local_tiny_llama(model_path)
+    # optimize -m arnir0/Tiny-LLM --device cpu --provider CPUExecutionProvider --precision int4 --output_path dump --dry_run
     _run_cli_main(
         [
             "optimize",
@@ -114,6 +115,7 @@ def _run_documented_test_model_smoke_flow(tmp_path: Path, model_id: str):
     config_path = config_output_dir / "config.json"
     assert config_path.exists()
     _set_offline_gptq_data_config(config_path)
+    # run --config dump/config.json --test dump/test --output_path dump/run
     _run_cli_main(
         [
             "run",


### PR DESCRIPTION
## Describe your changes

Add a pass (`OnnxDiscrepancyCheck`) to measure the discrepancies between the torch model and the ONNX model. It measures the max absolute error and other metrics. It can fail if it is too high.

When `--test` is used with `olive run`, the `OnnxDiscrepancyCheck` pass is automatically injected into the run config using the test model path as the reference model.

Also refined the discrepancy pass behavior for dynamic input shapes: unsupported symbolic dimensions still fail fast by design, but now with a more explicit error message that includes the unknown symbol, the full shape, and known symbols to simplify debugging.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link