### PR TITLE
[AMD] Add RyzenAI passes for latest flows; Restore legacy VitisAI passes for eager flow for backward compatibility

### DIFF
--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -600,6 +600,16 @@
             "run_on_target": true,
             "extra_dependencies": [ "amd-quark" ]
         },
+        "QuarkQuantizationVitisAI": {
+            "module_path": "olive.passes.quark_vitisai.quark_quantization_vitisai.QuarkQuantizationVitisAI",
+            "supported_providers": [ "CPUExecutionProvider", "ROCMExecutionProvider", "CUDAExecutionProvider" ],
+            "supported_accelerators": [ "cpu", "gpu" ],
+            "supported_precisions": [ "fp16", "fp32", "bf16" ],
+            "supported_algorithms": [ "awq" ],
+            "supported_quantization_encodings": [  ],
+            "run_on_target": true,
+            "extra_dependencies": [ "amd-quark" ]
+        },
         "QuaRot": {
             "module_path": "olive.passes.pytorch.rotate.QuaRot",
             "supported_providers": [ "*" ],

--- a/olive/olive_config.json
+++ b/olive/olive_config.json
@@ -682,6 +682,15 @@
             "supported_algorithms": [  ],
             "supported_quantization_encodings": [  ],
             "run_on_target": true
+        },
+        "RyzenGenerateModelLLM": {
+            "module_path": "olive.passes.onnx.ryzen_ai.ryzen_generate_model_llm.RyzenGenerateModelLLM",
+            "supported_providers": [ "CPUExecutionProvider" ],
+            "supported_accelerators": [ "cpu" ],
+            "supported_precisions": [ "int8" ],
+            "supported_algorithms": [  ],
+            "supported_quantization_encodings": [  ],
+            "run_on_target": true
         }
     },
     "extra_dependencies": {

--- a/olive/passes/onnx/ryzen_ai/__init__.py
+++ b/olive/passes/onnx/ryzen_ai/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/onnx/ryzen_ai/ryzen_generate_model_llm.py
+++ b/olive/passes/onnx/ryzen_ai/ryzen_generate_model_llm.py
@@ -14,7 +14,7 @@ from olive.passes.pass_config import BasePassConfig, PassConfigParam
 logger = logging.getLogger(__name__)
 
 
-class VitisGenerateModelLLM(Pass):
+class RyzenGenerateModelLLM(Pass):
     """Olive pass for generating optimized NPU/Hybrid models using AMD Vitis toolchain.
 
     Uses model_generate v2 API which wraps onnx_utils optimize.

--- a/olive/passes/onnx/ryzen_ai/ryzen_generate_model_llm.py
+++ b/olive/passes/onnx/ryzen_ai/ryzen_generate_model_llm.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+from olive.model import HfModelHandler, ONNXModelHandler
+from olive.passes import Pass
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+
+logger = logging.getLogger(__name__)
+
+
+class VitisGenerateModelLLM(Pass):
+    """Olive pass for generating optimized NPU/Hybrid models using AMD Vitis toolchain.
+
+    Uses model_generate v2 API which wraps onnx_utils optimize.
+
+    Supported modes:
+    - npu: NPU-only model with configurable recipe (default)
+    - hybrid: Hybrid model (NPU prefill + GPU token)
+
+    Supported recipes (NPU mode):
+    - full_fusion: Maximum performance (default)
+    - token_fusion: Better TPS with NPU token fusion
+    - eager: Eager execution (simplest, most compatible)
+    - basic: MatMulNBits only (safest for new/unsupported models)
+
+    Input can be:
+    - HfModelHandler: For models coming from quantization pass
+    - ONNXModelHandler: For pre-quantized or pre-exported OGA models
+    """
+
+    @classmethod
+    def _default_config(cls, accelerator_spec):
+        return {
+            "mode": PassConfigParam(
+                type_=str,
+                default_value="npu",
+                description="Generation mode: 'npu' or 'hybrid'.",
+            ),
+            "recipe": PassConfigParam(
+                type_=str,
+                default_value="full_fusion",
+                description=(
+                    "NPU recipe: 'full_fusion' (max performance), 'token_fusion' (better TPS), "
+                    "'eager' (simplest), 'basic' (safest for new models). Ignored for hybrid mode."
+                ),
+            ),
+            "mem_optimize": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description="Optimize for 16GB laptops (adds --priority memory).",
+            ),
+            "model_name": PassConfigParam(
+                type_=Optional[str],
+                default_value=None,
+                description="Input ONNX file name to optimize. Default: 'model.onnx'.",
+            ),
+            "output_model_name": PassConfigParam(
+                type_=Optional[str],
+                default_value=None,
+                description="Output ONNX file name. Default: same as model_name.",
+            ),
+            "extra_options": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                description=(
+                    "Additional onnx_utils options passed as key-value pairs. "
+                    "Examples: {'model_type': 'gpt-oss'}, {'max_seq_len': '4096'}, "
+                    "{'no_prune_logits': 'true'}."
+                ),
+            ),
+        }
+
+    def _run_for_config(
+        self, model: Union[HfModelHandler, ONNXModelHandler], config: BasePassConfig, output_model_path: str
+    ) -> ONNXModelHandler:
+        from model_generate import generate_model
+
+        # Resolve input model path
+        if isinstance(model, ONNXModelHandler):
+            input_model_path = Path(model.model_path)
+            if input_model_path.is_file():
+                input_model_path = input_model_path.parent
+        else:
+            input_model_path = Path(model.model_path)
+
+        output_dir = Path(output_model_path)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Generating Vitis model from: %s", input_model_path)
+        logger.info("Mode: %s, Recipe: %s", config.mode, config.recipe)
+
+        generate_model(
+            mode=config.mode,
+            output_dir=str(output_dir),
+            input_model=str(input_model_path),
+            recipe=config.recipe,
+            mem_optimize=config.mem_optimize,
+            model_name=config.model_name,
+            output_model_name=config.output_model_name,
+            extra_options=config.extra_options,
+            verbose=1,
+        )
+
+        # Determine output ONNX filename
+        output_model_name = config.output_model_name or config.model_name or "model.onnx"
+
+        logger.info("Model generated: %s", output_dir / output_model_name)
+
+        return ONNXModelHandler(
+            model_path=output_dir,
+            onnx_file_name=output_model_name,
+        )

--- a/olive/passes/onnx/vitis_ai/vitis_generate_model_llm.py
+++ b/olive/passes/onnx/vitis_ai/vitis_generate_model_llm.py
@@ -5,7 +5,6 @@
 
 import logging
 from pathlib import Path
-from typing import Optional, Union
 
 from olive.model import HfModelHandler, ONNXModelHandler
 from olive.passes import Pass
@@ -15,104 +14,41 @@ logger = logging.getLogger(__name__)
 
 
 class VitisGenerateModelLLM(Pass):
-    """Olive pass for generating optimized NPU/Hybrid models using AMD Vitis toolchain.
-
-    Uses model_generate v2 API which wraps onnx_utils optimize.
-
-    Supported modes:
-    - npu: NPU-only model with configurable recipe (default)
-    - hybrid: Hybrid model (NPU prefill + GPU token)
-
-    Supported recipes (NPU mode):
-    - full_fusion: Maximum performance (default)
-    - token_fusion: Better TPS with NPU token fusion
-    - eager: Eager execution (simplest, most compatible)
-    - basic: MatMulNBits only (safest for new/unsupported models)
-
-    Input can be:
-    - HfModelHandler: For models coming from quantization pass
-    - ONNXModelHandler: For pre-quantized or pre-exported OGA models
-    """
-
     @classmethod
     def _default_config(cls, accelerator_spec):
         return {
-            "mode": PassConfigParam(
-                type_=str,
-                default_value="npu",
-                description="Generation mode: 'npu' or 'hybrid'.",
+            "packed_const": PassConfigParam(
+                type_=bool, default_value=False, description="Enable packed constants optimization in NPU export."
             ),
-            "recipe": PassConfigParam(
-                type_=str,
-                default_value="full_fusion",
-                description=(
-                    "NPU recipe: 'full_fusion' (max performance), 'token_fusion' (better TPS), "
-                    "'eager' (simplest), 'basic' (safest for new models). Ignored for hybrid mode."
-                ),
-            ),
-            "mem_optimize": PassConfigParam(
+            "cpu_only": PassConfigParam(
                 type_=bool,
                 default_value=False,
-                description="Optimize for 16GB laptops (adds --priority memory).",
-            ),
-            "model_name": PassConfigParam(
-                type_=Optional[str],
-                default_value=None,
-                description="Input ONNX file name to optimize. Default: 'model.onnx'.",
-            ),
-            "output_model_name": PassConfigParam(
-                type_=Optional[str],
-                default_value=None,
-                description="Output ONNX file name. Default: same as model_name.",
-            ),
-            "extra_options": PassConfigParam(
-                type_=dict,
-                default_value=None,
-                description=(
-                    "Additional onnx_utils options passed as key-value pairs. "
-                    "Examples: {'model_type': 'gpt-oss'}, {'max_seq_len': '4096'}, "
-                    "{'no_prune_logits': 'true'}."
-                ),
+                description="Run only model builder OGA CPU only model, skip NPU-related steps.",
             ),
         }
 
     def _run_for_config(
-        self, model: Union[HfModelHandler, ONNXModelHandler], config: BasePassConfig, output_model_path: str
+        self, model: HfModelHandler, config: BasePassConfig, output_model_path: str
     ) -> ONNXModelHandler:
-        from model_generate import generate_model
+        logger.info("[DEBUG] Running VitisGenerateModelLLM with config: %s", config)
+        from model_generate import generate_npu_model
 
-        # Resolve input model path
-        if isinstance(model, ONNXModelHandler):
-            input_model_path = Path(model.model_path)
-            if input_model_path.is_file():
-                input_model_path = input_model_path.parent
-        else:
-            input_model_path = Path(model.model_path)
-
+        input_model_path = model.model_path
         output_dir = Path(output_model_path)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info("Generating Vitis model from: %s", input_model_path)
-        logger.info("Mode: %s, Recipe: %s", config.mode, config.recipe)
+        logger.info("[VitisGenerateModelLLM] Generating Vitis NPU model from: %s", input_model_path)
+        logger.info("[VitisGenerateModelLLM] Output directory: %s", output_dir)
+        logger.info("[VitisGenerateModelLLM] Packed constants: %s", config.packed_const)
 
-        generate_model(
-            mode=config.mode,
-            output_dir=str(output_dir),
+        # Generate the NPU model
+        generate_npu_model(
             input_model=str(input_model_path),
-            recipe=config.recipe,
-            mem_optimize=config.mem_optimize,
-            model_name=config.model_name,
-            output_model_name=config.output_model_name,
-            extra_options=config.extra_options,
-            verbose=1,
+            output_dir=str(output_dir),
+            packed_const=config.packed_const,
+            cpu_only=config.cpu_only,
         )
-
-        # Determine output ONNX filename
-        output_model_name = config.output_model_name or config.model_name or "model.onnx"
-
-        logger.info("Model generated: %s", output_dir / output_model_name)
-
         return ONNXModelHandler(
             model_path=output_dir,
-            onnx_file_name=output_model_name,
+            onnx_file_name="model.onnx",
         )

--- a/olive/passes/quark_vitisai/__init__.py
+++ b/olive/passes/quark_vitisai/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/onnx/__init__.py
+++ b/olive/passes/quark_vitisai/onnx/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/onnx/configuration_preparation.py
+++ b/olive/passes/quark_vitisai/onnx/configuration_preparation.py
@@ -1,0 +1,260 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+import logging
+from typing import Any
+
+from quark.onnx import ExtendedQuantType, QuantType
+from quark.onnx.quantization.config.algorithm import (
+    AdaQuantConfig,
+    AdaRoundConfig,
+    AlgoConfig,
+    AutoMixprecisionConfig,
+    BiasCorrectionConfig,
+    CLEConfig,
+    GPTQConfig,
+    QuarotConfig,
+    SmoothQuantConfig,
+)
+from quark.onnx.quantization.config.spec import (
+    BFloat16Spec,
+    BFP16Spec,
+    CalibMethod,
+    Int8Spec,
+    Int16Spec,
+    Int32Spec,
+    QLayerConfig,
+    QuantGranularity,
+    ScaleType,
+    UInt8Spec,
+    UInt16Spec,
+    UInt32Spec,
+    XInt8Spec,
+)
+
+logger = logging.getLogger(__name__)
+
+
+scale_type_mapping = {
+    "Float32": ScaleType.Float32,
+    "PowerOf2": ScaleType.PowerOf2,
+    "Int16": ScaleType.Int16,
+}
+
+
+calibration_method_mapping = {
+    "MinMax": CalibMethod.MinMax,
+    "Entropy": CalibMethod.Entropy,
+    "Percentile": CalibMethod.Percentile,
+    "Distribution": CalibMethod.Distribution,
+    "MinMSE": CalibMethod.MinMSE,
+    "LayerwisePercentile": CalibMethod.LayerwisePercentile,
+}
+
+
+quant_granularity_mapping = {
+    "Tensor": QuantGranularity.Tensor,
+    "Channel": QuantGranularity.Channel,
+    "Group": QuantGranularity.Group,
+}
+
+
+data_type_mapping = {
+    "Int8": Int8Spec,
+    "UInt8": UInt8Spec,
+    "XInt8": XInt8Spec,
+    "Int16": Int16Spec,
+    "UInt16": UInt16Spec,
+    "Int32": Int32Spec,
+    "UInt32": UInt32Spec,
+    "BFloat16": BFloat16Spec,
+    "BFP16": BFP16Spec,
+}
+
+
+def get_global_config(global_config_dict: dict[str, Any]) -> QLayerConfig:
+    activation_spec = UInt8Spec()
+    if isinstance(global_config_dict, dict) and "activation" in global_config_dict:
+        if "symmetric" in global_config_dict["activation"]:
+            activation_spec.set_symmetric(global_config_dict["activation"]["symmetric"])
+        if "scale_type" in global_config_dict["activation"]:
+            activation_spec.set_scale_type(scale_type_mapping[global_config_dict["activation"]["scale_type"]])
+        if "calibration_method" in global_config_dict["activation"]:
+            activation_spec.set_calibration_method(
+                calibration_method_mapping[global_config_dict["activation"]["calibration_method"]]
+            )
+        if "quant_granularity" in global_config_dict["activation"]:
+            activation_spec.set_quant_granularity(
+                quant_granularity_mapping[global_config_dict["activation"]["quant_granularity"]]
+            )
+        if "data_type" in global_config_dict["activation"]:
+            activation_spec.set_data_type(data_type_mapping[global_config_dict["activation"]["data_type"]]().data_type)
+
+    weight_spec = Int8Spec()
+    if isinstance(global_config_dict, dict) and "weight" in global_config_dict:
+        if "symmetric" in global_config_dict["weight"]:
+            weight_spec.set_symmetric(global_config_dict["weight"]["symmetric"])
+        if "scale_type" in global_config_dict["weight"]:
+            weight_spec.set_scale_type(scale_type_mapping[global_config_dict["weight"]["scale_type"]])
+        if "calibration_method" in global_config_dict["weight"]:
+            weight_spec.set_calibration_method(
+                calibration_method_mapping[global_config_dict["weight"]["calibration_method"]]
+            )
+        if "quant_granularity" in global_config_dict["weight"]:
+            weight_spec.set_quant_granularity(
+                quant_granularity_mapping[global_config_dict["weight"]["quant_granularity"]]
+            )
+        if "data_type" in global_config_dict["weight"]:
+            weight_spec.set_data_type(data_type_mapping[global_config_dict["weight"]["data_type"]]().data_type)
+
+    return QLayerConfig(activation=activation_spec, weight=weight_spec)
+
+
+algorithm_mapping = {
+    "smooth_quant": SmoothQuantConfig,
+    "cle": CLEConfig,
+    "bias_correction": BiasCorrectionConfig,
+    "gptq": GPTQConfig,
+    "auto_mixprecision": AutoMixprecisionConfig,
+    "adaround": AdaRoundConfig,
+    "adaquant": AdaQuantConfig,
+    "quarot": QuarotConfig,
+}
+
+
+def update_algo_config(algo_config: AlgoConfig, config_dict: dict[str, Any]) -> None:
+    if isinstance(algo_config, (AdaRoundConfig, AdaQuantConfig)):
+        if "optim_device" in config_dict:
+            algo_config.optim_device = config_dict["optim_device"]
+        if "infer_device" in config_dict:
+            algo_config.infer_device = config_dict["infer_device"]
+        if "fixed_seed" in config_dict:
+            algo_config.fixed_seed = config_dict["fixed_seed"]
+        if "data_size" in config_dict:
+            algo_config.data_size = config_dict["data_size"]
+        if "batch_size" in config_dict:
+            algo_config.batch_size = config_dict["batch_size"]
+        if "num_batches" in config_dict:
+            algo_config.num_batches = config_dict["num_batches"]
+        if "num_iterations" in config_dict:
+            algo_config.num_iterations = config_dict["num_iterations"]
+        if "learning_rate" in config_dict:
+            algo_config.learning_rate = config_dict["learning_rate"]
+        if "early_stop" in config_dict:
+            algo_config.early_stop = config_dict["early_stop"]
+        if "output_index" in config_dict:
+            algo_config.output_index = config_dict["output_index"]
+        if "lr_adjust" in config_dict:
+            algo_config.lr_adjust = tuple(config_dict["lr_adjust"])
+        if "target_op_type" in config_dict:
+            algo_config.target_op_type = config_dict["target_op_type"]
+        if "selective_update" in config_dict:
+            algo_config.selective_update = config_dict["selective_update"]
+        if "update_bias" in config_dict:
+            algo_config.update_bias = config_dict["update_bias"]
+        if "output_qdq" in config_dict:
+            algo_config.output_qdq = config_dict["output_qdq"]
+        if "drop_ratio" in config_dict:
+            algo_config.drop_ratio = config_dict["drop_ratio"]
+        if "mem_opt_level" in config_dict:
+            algo_config.mem_opt_level = config_dict["mem_opt_level"]
+        if "cache_dir" in config_dict:
+            algo_config.cache_dir = config_dict["cache_dir"]
+        if "log_period" in config_dict:
+            algo_config.log_period = config_dict["log_period"]
+        if "ref_model_path" in config_dict:
+            algo_config.ref_model_path = config_dict["ref_model_path"]
+        if "dynamic_batch" in config_dict:
+            algo_config.dynamic_batch = config_dict["dynamic_batch"]
+        if "parallel" in config_dict:
+            algo_config.parallel = config_dict["parallel"]
+        if "reg_param" in config_dict:
+            algo_config.reg_param = config_dict["reg_param"]
+        if "beta_range" in config_dict:
+            algo_config.beta_range = tuple(config_dict["beta_range"])
+        if "warm_start" in config_dict:
+            algo_config.warm_start = config_dict["warm_start"]
+
+    elif isinstance(algo_config, CLEConfig):
+        if "cle_balance_method" in config_dict:
+            algo_config.cle_balance_method = config_dict["cle_balance_method"]
+        if "cle_steps" in config_dict:
+            algo_config.cle_steps = config_dict["cle_steps"]
+        if "cle_weight_threshold" in config_dict:
+            algo_config.cle_weight_threshold = config_dict["cle_weight_threshold"]
+        if "cle_scale_append_bias" in config_dict:
+            algo_config.cle_scale_append_bias = config_dict["cle_scale_append_bias"]
+        if "cle_scale_use_threshold" in config_dict:
+            algo_config.cle_scale_use_threshold = config_dict["cle_scale_use_threshold"]
+        if "cle_total_layer_diff_threshold" in config_dict:
+            algo_config.cle_total_layer_diff_threshold = config_dict["cle_total_layer_diff_threshold"]
+
+    elif isinstance(algo_config, SmoothQuantConfig):
+        if "alpha" in config_dict:
+            algo_config.alpha = config_dict["alpha"]
+
+    else:
+        # TODO(Gengxin): Configure the rest algorithms
+        pass
+
+
+def get_algo_config(algo_config_list: list[dict[str, Any]] | None) -> list[AlgoConfig]:
+    algo_configs: list[AlgoConfig] = []
+
+    if algo_config_list is None:
+        return algo_configs
+
+    for config_dict in algo_config_list:
+        if "name" not in config_dict:
+            logger.warning("Unknown algorithm configuration. Ignoring.")
+            continue
+
+        if config_dict["name"] not in algorithm_mapping:
+            logger.warning("Unsupported algorithm %s. Ignoring.", config_dict["name"])
+            continue
+
+        algo_config = algorithm_mapping[config_dict["name"]]()
+        update_algo_config(algo_config, config_dict)
+        algo_configs.append(algo_config)
+
+    return algo_configs
+
+
+quant_type_mapping = {
+    "Int8": QuantType.QInt8,
+    "UInt8": QuantType.QUInt8,
+    "Int16": QuantType.QInt16,
+    "UInt16": QuantType.QUInt16,
+    "Int32": ExtendedQuantType.QInt32,
+    "UInt32": ExtendedQuantType.QUInt32,
+    "Float16": ExtendedQuantType.QFloat16,
+    "BFloat16": ExtendedQuantType.QBFloat16,
+    "BFP16": ExtendedQuantType.QBFP,
+    "BFP": ExtendedQuantType.QBFP,
+    "MX": ExtendedQuantType.QMX,
+}
+
+
+def get_extra_options(extra_options_dict: dict[str, Any] | None) -> dict[str, Any]:
+    extra_options: dict[str, Any] = {}
+
+    if extra_options_dict is None:
+        return extra_options
+
+    for key, value in extra_options_dict.items():
+        if key == "MixedPrecisionTensor":
+            if not isinstance(value, dict):
+                logger.warning("The value for extra option 'MixedPrecisionTensor' should be a dict.")
+                continue
+
+            mixed_precision_tensor = {}
+            for k, v in value.items():
+                quant_type = quant_type_mapping[k]
+                mixed_precision_tensor[quant_type] = v
+            extra_options[key] = mixed_precision_tensor
+        else:
+            extra_options[key] = value
+
+    return extra_options

--- a/olive/passes/quark_vitisai/onnx/quantize_quark.py
+++ b/olive/passes/quark_vitisai/onnx/quantize_quark.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+from argparse import Namespace
+
+from quark.onnx import ModelQuantizer
+from quark.onnx.quantization.config.config import QConfig
+
+from olive.passes.quark_vitisai.onnx.configuration_preparation import (
+    get_algo_config,
+    get_extra_options,
+    get_global_config,
+)
+
+
+def run_quark_quantization(args: Namespace) -> None:
+    input_model_path = args.model_input
+    output_model_path = args.model_output
+    calibration_data_reader = args.calibration_data_reader
+
+    global_config = get_global_config(args.global_config)
+    algo_config = get_algo_config(args.algo_config)
+    extra_options = get_extra_options(args.extra_options)
+
+    # If the JSON has no data config, use random data reader instead
+    if calibration_data_reader is None:
+        extra_options["UseRandomData"] = True
+
+    quant_config = QConfig(
+        global_config=global_config,
+        specific_layer_config=args.specific_layer_config,
+        layer_type_config=args.layer_type_config,
+        exclude=args.exclude,
+        algo_config=algo_config,
+        **extra_options,
+    )
+
+    quantizer = ModelQuantizer(quant_config)
+    quantizer.quantize_model(input_model_path, output_model_path, calibration_data_reader)

--- a/olive/passes/quark_vitisai/quark_quantization_vitisai.py
+++ b/olive/passes/quark_vitisai/quark_quantization_vitisai.py
@@ -1,0 +1,248 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+import json
+import logging
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+from typing import Optional, Union
+
+import onnx
+import torch
+from packaging import version
+
+from olive.common.config_utils import validate_config
+from olive.common.utils import exclude_keys
+from olive.data.config import DataConfig
+from olive.model import HfModelHandler, ONNXModelHandler
+from olive.model.utils import resolve_onnx_path
+from olive.passes import Pass
+from olive.passes.onnx.common import get_external_data_config, model_proto_to_olive_model
+from olive.passes.pass_config import BasePassConfig, PassConfigParam
+from olive.search.search_parameter import Categorical
+
+logger = logging.getLogger(__name__)
+
+
+class QuarkQuantizationVitisAI(Pass):
+    @classmethod
+    def _default_config(cls, accelerator_spec=None):
+        return {
+            "quant_scheme": PassConfigParam(
+                type_=str, default_value="w_uint4_per_group_asym", description="Quantization scheme to use."
+            ),
+            "quant_algo": PassConfigParam(type_=str, default_value="awq", description="Quantization algorithm."),
+            "dataset": PassConfigParam(
+                type_=str, default_value="pileval_for_awq_benchmark", description="Calibration dataset to use."
+            ),
+            "data_type": PassConfigParam(type_=str, default_value="bfloat16", description="Data type for model."),
+            "num_calib_data": PassConfigParam(
+                type_=int, default_value=128, description="Number of calibration samples."
+            ),
+            "model_export": PassConfigParam(
+                type_=list, default_value=["hf_format"], description="Model export format."
+            ),
+            "exclude_layers": PassConfigParam(
+                type_=list,
+                default_value=None,
+                description="List of layers to exclude. Set to [] to exclude nothing explicitly.",
+            ),
+            "quant_config": PassConfigParam(
+                type_=dict, default_value=None, description="Embedded quant configuration dictionary"
+            ),
+            "quant_mode": PassConfigParam(
+                type_=str,
+                default_value="static",
+                search_defaults=Categorical(["dynamic", "static"]),
+                description="Onnx Quantization mode. 'dynamic' for dynamic quantization, 'static' for static quantization. Default is 'static'",
+            ),
+            "quant_format": PassConfigParam(
+                type_=str,
+                default_value="QDQ",
+                search_defaults=Categorical(["QOperator", "QDQ"]),
+                description="Onnx Quantization format. 'QOperator' for quantizing models using QOperators, 'QDQ' for using Q/DQ. Default is 'QDQ'",
+            ),
+            "data_config": PassConfigParam(
+                type_=Optional[Union[DataConfig, dict]],
+                default_value=None,
+                description="Data config for calibration.",
+            ),
+            "global_config": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                description="Global quantization configuration applied to all layers unless overridden.",
+            ),
+            "specific_layer_config": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                description="Dictionary mapping specific layer names to their quantization configuration. Default is None.",
+            ),
+            "layer_type_config": PassConfigParam(
+                type_=dict,
+                default_value=None,
+                description="Dictionary mapping layer types (e.g., Conv, Gemm) to quantization configurations. Default is None.",
+            ),
+            "exclude": PassConfigParam(
+                type_=list,
+                default_value=None,
+                description="List of nodes or subgraphs excluded from quantization. Default is None.",
+            ),
+            "algo_config": PassConfigParam(
+                type_=list,
+                default_value=None,
+                description="Algorithm configuration, can be a list of algorithm configurations. Default is None.",
+            ),
+            "extra_options": PassConfigParam(
+                type_=dict, default_value=None, description="Extra options for quantization. Default is {}."
+            ),
+            **get_external_data_config(),
+        }
+
+    def _run_for_config(
+        self, model: Union[HfModelHandler, ONNXModelHandler], config: BasePassConfig, output_model_path: str
+    ) -> Union[HfModelHandler, ONNXModelHandler]:
+        if isinstance(model, ONNXModelHandler):
+            logger.info("[INFO] Running QuarkQuantization using Quark-ONNX API with config: %s", config)
+            return self._run_quark_onnx(model, config, output_model_path)
+        else:
+            logger.info("[INFO] Running QuarkQuantization using Quark-Torch API with config: %s", config)
+            return self._run_quark_torch(model, config, output_model_path)
+
+    def _run_quark_onnx(
+        self, model: ONNXModelHandler, config: BasePassConfig, output_model_path: str
+    ) -> ONNXModelHandler:
+        from quark import __version__ as QuarkVersion
+
+        if version.parse(QuarkVersion) < version.parse("0.10.0"):
+            raise ValueError("Quark onnx Quantization is only supported for amd-quark>=0.10.0")
+
+        from olive.passes.quark_vitisai.onnx.quantize_quark import run_quark_quantization
+
+        output_model_path = resolve_onnx_path(output_model_path, Path(model.model_path).name)
+
+        # to be safe, run the quantizer with use_external_data_format set to `True` and
+        # `model_output` to a temporary directory
+        # reload the model and save to output_model_path using the external data config
+        new_tmp_dir = tempfile.TemporaryDirectory(prefix="olive_tmp")  # pylint: disable=R1732
+        tmp_model_path = str(Path(new_tmp_dir.name) / Path(output_model_path).name)
+
+        data_reader = None
+        if config.data_config:
+            data_config = validate_config(config.data_config, DataConfig)
+            data_reader = data_config.to_data_container().create_calibration_dataloader()
+
+        run_config = config.model_dump()
+        to_delete = [
+            "data_config",
+            "quant_preprocess",
+        ]
+        to_delete += list(get_external_data_config().keys())
+        run_config = exclude_keys(run_config, to_delete)
+
+        args = Namespace(
+            model_input=model.model_path,
+            model_output=tmp_model_path,
+            calibration_data_reader=data_reader,
+            **run_config,
+        )
+
+        run_quark_quantization(args)
+        logger.info("[INFO] Quark quantized model saved to: %s", tmp_model_path)
+
+        # load the model
+        onnx_model = onnx.load(tmp_model_path)
+        # the model is loaded into memory, so it's safe to delete previously exported files
+        new_tmp_dir.cleanup()
+
+        # save the model to the output path and return the model
+        return model_proto_to_olive_model(onnx_model, output_model_path, config)
+
+    def _run_quark_torch(self, model: HfModelHandler, config: BasePassConfig, output_model_path: str) -> HfModelHandler:
+        from olive.passes.quark_vitisai.torch.language_modeling.llm_ptq.quantize_quark import run_quark_quantization
+
+        output_dir = Path(output_model_path)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if torch.cuda.is_available():
+            device = "cuda"
+        else:
+            device = "cpu"
+        quant_algo_config_file_path = None
+        if config.quant_config:
+            with tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".json") as tmp_file:
+                json.dump(config.quant_config, tmp_file)
+                quant_algo_config_file_path = tmp_file.name
+                logger.info("[INFO] Written quant_config to temporary file: %s", quant_algo_config_file_path)
+
+        args = Namespace(
+            model_dir=str(model.model_path),
+            output_dir=str(output_model_path),
+            quant_scheme=config.quant_scheme,
+            quant_algo=config.quant_algo,
+            dataset=config.dataset,
+            data_type=config.data_type,
+            num_calib_data=config.num_calib_data,
+            model_export=config.model_export,
+            exclude_layers=config.exclude_layers,
+            device=device,
+            quant_algo_config_file_path=quant_algo_config_file_path,
+            # Other args
+            multi_gpu=False,
+            model_attn_implementation="eager",
+            multi_device=False,
+            skip_quantization=False,
+            group_size=128,
+            group_size_per_layer=None,
+            kv_cache_dtype=None,
+            min_kv_scale=0.0,
+            pre_quantization_optimization=[],
+            pre_optimization_config_file_path=None,
+            scale_format="e4m3",
+            scale_calculation_mode="even",
+            fp8_attention_quant=False,
+            moe_experts_second_step_config=None,
+            model_reload=False,
+            import_model_dir=None,
+            params_load=False,
+            json_path=None,
+            safetensors_path=None,
+            import_file_format="quark_format",
+            custom_mode="quark",
+            torch_compile=False,
+            pack_method="reorder",
+            weight_matrix_merge=False,
+            export_weight_format="real_quantized",
+            params_save=False,
+            save_dir="model_params",
+            skip_evaluation=True,
+            save_metrics_to_csv=False,
+            metrics_output_dir="metrics_output_dir",
+            tasks=None,
+            use_ppl_eval_for_kv_cache=False,
+            ppl_eval_for_kv_cache_context_size=1024,
+            ppl_eval_for_kv_cache_sample_size=512,
+            ppl_eval_for_kv_cache_patch_size=None,
+            eval_batch_size="8",
+            max_eval_batch_size=None,
+            num_eval_data=-1,
+            num_fewshot=None,
+            apply_chat_template=False,
+            use_mlperf_rouge=False,
+            eval_data_dir=None,
+            use_tp=False,
+            seq_len=512,
+            batch_size=1,
+        )
+
+        run_quark_quantization(args)
+        logger.info("[INFO] Quark quantized model saved to: %s", output_model_path)
+        # Cleanup
+        if quant_algo_config_file_path:
+            tmp_path = Path(quant_algo_config_file_path)
+            if tmp_path.exists():
+                tmp_path.unlink()
+            logger.info("[INFO] Deleted temporary quant config file: %s", quant_algo_config_file_path)
+
+        return HfModelHandler(str(output_model_path))

--- a/olive/passes/quark_vitisai/torch/__init__.py
+++ b/olive/passes/quark_vitisai/torch/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/torch/language_modeling/__init__.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/__init__.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/configuration_preparation.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/configuration_preparation.py
@@ -1,0 +1,344 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+import argparse
+import copy
+import os
+
+from quark.shares.utils.log import ScreenLogger
+from quark.torch.export import ExporterConfig, JsonExporterConfig, OnnxExporterConfig
+from quark.torch.quantization import (
+    AutoSmoothQuantConfig,
+    AWQConfig,
+    Config,
+    FP8E4M3PerTensorSpec,
+    Int4PerChannelSpec,
+    ProgressiveSpec,
+    QuantizationConfig,
+    load_pre_optimization_config_from_file,
+    load_quant_algo_config_from_file,
+)
+
+from olive.passes.quark_vitisai.torch.language_modeling.llm_ptq.customized_configuration import (
+    DEPRECATED_QUANT_SCHEME,
+    INT8_PER_TENSOR_DYNAMIC_SPEC,
+    INT8_PER_TENSOR_SPEC,
+    INT8_PER_TOKEN_DYNAMIC_SPEC,
+    UINT4_PER_CHANNEL_ASYM_DYNAMIC_SPEC,
+    fp4_per_group_sym_spec,
+    fp6_e2m3_per_group_sym_spec,
+    fp6_e3m2_per_group_sym_spec,
+    get_global_config,
+    ocp_mxfp4_spec,
+    ocp_mxfp6_e2m3_spec,
+    ocp_mxfp6_e3m2_spec,
+    ocp_mxfp8_e4m3_spec,
+)
+from olive.passes.quark_vitisai.torch.language_modeling.llm_utils.model_preparation import (
+    MODEL_NAME_EXCLUDE_LAYERS_MAP,
+    MODEL_NAME_KV_LAYERS_MAP,
+    MODEL_NAME_Q_LAYERS_MAP,
+    MOE_MODEL_NAME_EXPERTS_LAYERS_MAP,
+)
+
+EXAMPLES_DIR = os.path.abspath(os.path.dirname(__file__))
+logger = ScreenLogger(__name__)
+
+"""
+Instructions for Setting Up Quark Quantization Configuration:
+Step 1: Configure `QuantizationSpec` for torch.Tensors. Specify attributes such as dtype, observer_method, etc.
+Step 2: Establish `QuantizationConfig` for nn.Module. Define the QuantizationSpec of input_tensors, output_tensors, weight, and bias.
+Step 3: Set up the overall `Config` for the model. This includes:
+        - global_quant_config (required)
+        - layer_type_quant_config
+        - layer_quant_config
+        - kv_cache_quant_config
+        - exclude
+        - pre_quant_opt_config
+        - algo_config
+        - quant_mode
+"""
+
+# Step 1: Configure `DataTypeSpec` for torch.Tensors. Specify attributes such as dtype, observer_method, etc. More customer settings refer customized_configuration.py
+FP8_PER_TENSOR_SPEC = FP8E4M3PerTensorSpec(observer_method="min_max", is_dynamic=False).to_quantization_spec()
+FP8_PER_TENSOR_SPEC_DYNAMIC = FP8E4M3PerTensorSpec(observer_method="min_max", is_dynamic=True).to_quantization_spec()
+INT4_PER_CHANNEL_SPEC = Int4PerChannelSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=False
+).to_quantization_spec()
+MXFP8_PER_GROUP_SPEC = ocp_mxfp8_e4m3_spec(is_dynamic=True)
+
+
+# Step 3: Set up the overall `Config` for the model.
+def get_config(args: argparse.Namespace, model_type: str) -> Config:
+    quant_scheme = args.quant_scheme
+    group_size = args.group_size
+    model_dir = args.model_dir
+    kv_cache_dtype = args.kv_cache_dtype
+    fp8_attention_quant = args.fp8_attention_quant
+    moe_experts_second_step_config = args.moe_experts_second_step_config
+    exclude_layers = args.exclude_layers
+    pre_quantization_optimization = args.pre_quantization_optimization
+    pre_optimization_config_file_path = args.pre_optimization_config_file_path
+    quant_algo = args.quant_algo
+    quant_algo_config_file_path = args.quant_algo_config_file_path
+    group_size_per_layer = args.group_size_per_layer
+    scale_format = args.scale_format
+    scale_calculation_mode = args.scale_calculation_mode
+
+    if quant_scheme in DEPRECATED_QUANT_SCHEME:
+        logger.info(
+            "[WARNING] The quantization scheme '%s' is deprecated and will be removed in the next AMD Quark release in favor of '%s'. "
+            "Please use '--quant_scheme %s'.",
+            quant_scheme,
+            DEPRECATED_QUANT_SCHEME[quant_scheme],
+            DEPRECATED_QUANT_SCHEME[quant_scheme],
+        )
+
+        quant_scheme = DEPRECATED_QUANT_SCHEME[quant_scheme]
+
+    supported_kv_cache_type = {
+        "fp8": FP8_PER_TENSOR_SPEC,
+        "fp8_dynamic": FP8_PER_TENSOR_SPEC_DYNAMIC,
+        "int8_per_tensor_static": INT8_PER_TENSOR_SPEC,
+        "int8_per_tensor_dynamic": INT8_PER_TENSOR_DYNAMIC_SPEC,
+        "int8_per_token": INT8_PER_TOKEN_DYNAMIC_SPEC,
+        "uint4": UINT4_PER_CHANNEL_ASYM_DYNAMIC_SPEC,
+        "mxfp8": MXFP8_PER_GROUP_SPEC,
+        "fp4_per_group": fp4_per_group_sym_spec(group_size, scale_format, None, True),
+        "mxfp4": ocp_mxfp4_spec(scale_calculation_mode, True),
+        "fp6e2m3_per_group": fp6_e2m3_per_group_sym_spec(group_size, scale_format, None, True),
+        "mxfp6_e2m3": ocp_mxfp6_e2m3_spec(scale_calculation_mode, True),
+        "fp6e3m2_per_group": fp6_e3m2_per_group_sym_spec(group_size, scale_format, None, True),
+        "mxfp6_e3m2": ocp_mxfp6_e3m2_spec(scale_calculation_mode, True),
+    }
+
+    if kv_cache_dtype is not None and kv_cache_dtype not in supported_kv_cache_type:
+        raise ValueError(f"The kv_cache_dtype='{kv_cache_dtype}' is not supported, only {supported_kv_cache_type} are.")
+
+    global_quant_config = get_global_config(quant_scheme, group_size, scale_format, scale_calculation_mode)
+
+    # Set up `layer_quant_config` and `kv_cache_quant_config`
+    layer_quant_config = {}
+    kv_cache_quant_config = {}
+    if kv_cache_dtype is not None:
+        kv_cache_spec = supported_kv_cache_type[kv_cache_dtype]
+
+        if model_type not in MODEL_NAME_KV_LAYERS_MAP:
+            raise ValueError(
+                f"KV cache configuration of {model_type} could not be supported automatically,"
+                "please add the KV layers in MODEL_NAME_KV_LAYERS_MAP"
+            )
+
+        kv_layers_name = MODEL_NAME_KV_LAYERS_MAP[model_type]
+        for layer_name in kv_layers_name:
+            kv_cache_quant_config[layer_name] = QuantizationConfig(
+                input_tensors=global_quant_config.input_tensors,
+                weight=global_quant_config.weight,
+                output_tensors=kv_cache_spec,
+            )
+        layer_quant_config = kv_cache_quant_config.copy()
+
+    group_size_per_layer = group_size_per_layer or []
+    for layer, raw_group_size in group_size_per_layer:
+        try:
+            group_size = int(raw_group_size)
+        except ValueError as err:
+            raise ValueError(
+                f"Invalid group size '{raw_group_size}' for layer '{layer}'. Group size must be an integer."
+            ) from err
+        layer_config = layer_quant_config.get(layer, copy.deepcopy(global_quant_config))
+        layer_config.weight.group_size = group_size
+        layer_quant_config[layer] = layer_config
+
+    if fp8_attention_quant:
+        attn_qspec = FP8_PER_TENSOR_SPEC
+
+        if model_type not in MODEL_NAME_Q_LAYERS_MAP:
+            raise ValueError(
+                f"Q_proj configuration of {model_type} could not be supported automatically,"
+                "please add the q_proj layers in MODEL_NAME_Q_LAYERS_MAP"
+            )
+
+        q_layers_name = MODEL_NAME_Q_LAYERS_MAP[model_type]
+        layer_quant_config[q_layers_name] = QuantizationConfig(
+            input_tensors=global_quant_config.input_tensors,
+            weight=global_quant_config.weight,
+            output_tensors=attn_qspec,
+        )
+    else:
+        attn_qspec = None
+
+    #  Add MoE experts second step quantization configuration
+    if moe_experts_second_step_config is not None:
+        assert moe_experts_second_step_config in ["w_int4_per_channel_sym"], (
+            "Currently, only w_int4_per_channel_sym is supported for MoE experts second step quantization, "
+            "please add the MoE experts second step quantization configuration in quantize_quark.py"
+        )
+
+        assert model_type in MOE_MODEL_NAME_EXPERTS_LAYERS_MAP, (
+            f"Currently, {model_type} is not supported for MoE experts second step quantization, "
+            f"please add {model_type} model in MOE_MODEL_NAME_EXPERTS_LAYERS_MAP"
+        )
+
+        if moe_experts_second_step_config == "w_int4_per_channel_sym":
+            weight_quant_spec = ProgressiveSpec(
+                first_stage=global_quant_config.weight, second_stage=INT4_PER_CHANNEL_SPEC
+            )
+            experts_layers_name = MOE_MODEL_NAME_EXPERTS_LAYERS_MAP[model_type]
+
+            for layer_name in experts_layers_name:
+                layer_quant_config[layer_name] = QuantizationConfig(
+                    input_tensors=global_quant_config.input_tensors,
+                    weight=weight_quant_spec.to_quantization_spec(),
+                    output_tensors=global_quant_config.output_tensors,
+                )
+
+    # Set up `exclude`
+    if "c4ai-command-r-08-2024" in model_dir.lower():  # no quantization for particular layer
+        MODEL_NAME_EXCLUDE_LAYERS_MAP["cohere"].append("*2.down_proj")
+
+    if exclude_layers is None:
+        if model_type in MODEL_NAME_EXCLUDE_LAYERS_MAP:
+            exclude_layers_final = MODEL_NAME_EXCLUDE_LAYERS_MAP[model_type]
+        else:
+            exclude_layers_final = ["lm_head"]
+            import warnings
+
+            warnings.warn(
+                f"Exclude layers configuration for {model_type} could not be supported automatically."
+                'Using EXCLUDE_LAYERS = ["lm_head"]. Please customize the exclude layers in MODEL_NAME_EXCLUDE_LAYERS_MAP.',
+                UserWarning,
+            )
+    else:
+        exclude_layers_final = exclude_layers
+
+    # Set up `pre_opt_config`
+    pre_optimization_configs = []
+    if "rotation" in pre_quantization_optimization:
+        pre_optimization_config_file_path = (
+            pre_optimization_config_file_path
+            if pre_optimization_config_file_path
+            else os.path.join(EXAMPLES_DIR, "models", model_type, "rotation_config.json")
+        )
+        pre_quant_opt_config = load_pre_optimization_config_from_file(pre_optimization_config_file_path)
+        pre_optimization_configs.append(pre_quant_opt_config)
+    if "quarot" in pre_quantization_optimization:
+        pre_optimization_config_file_path = (
+            pre_optimization_config_file_path
+            if pre_optimization_config_file_path
+            else os.path.join(EXAMPLES_DIR, "models", model_type, "quarot_config.json")
+        )
+        pre_quant_opt_config = load_pre_optimization_config_from_file(pre_optimization_config_file_path)
+        pre_quant_opt_config.kv_cache_quant = kv_cache_dtype is not None
+        pre_quant_opt_config.act_quant = global_quant_config.input_tensors is not None
+        pre_optimization_configs.append(pre_quant_opt_config)
+    if "smoothquant" in pre_quantization_optimization:
+        pre_optimization_config_file_path = (
+            pre_optimization_config_file_path
+            if pre_optimization_config_file_path
+            else os.path.join(EXAMPLES_DIR, "models", model_type, "smooth_config.json")
+        )
+        pre_opt_config = load_pre_optimization_config_from_file(pre_optimization_config_file_path)
+        pre_optimization_configs.append(pre_opt_config)
+
+        smoothquant_alpha = pre_opt_config.alpha
+        if global_quant_config.input_tensors is None and smoothquant_alpha > 0:
+            logger.info(
+                "[WARNING] Weight-only quantization is used, but SmoothQuant alpha=%s is larger than 0.0. In this case, using alpha = 0.0 is recommended to shift all the quantization difficulty from the weights into the activations.",
+                smoothquant_alpha,
+            )
+
+        if global_quant_config.weight is None and smoothquant_alpha < 1:
+            logger.info(
+                "[WARNING] Activation-only quantization is used, but SmoothQuant alpha=%s is smaller than 1.0. In this case, using alpha = 1.0 is recommended to shift all the quantization difficulty from the activations into the weights.",
+                smoothquant_alpha,
+            )
+
+        if (
+            global_quant_config.weight is not None
+            and global_quant_config.input_tensors is not None
+            and smoothquant_alpha in [0.0, 1.0]
+        ):
+            logger.info(
+                "[WARNING] Both weights and activations are quantized, but SmoothQuant alpha=%s is used. alpha = 0.0 shifts all the quantization difficulty to activations, while alpha = 1.0 shifts all the quantization difficulty to the weights. If this is the desired behavior, this warning can be ignored.",
+                smoothquant_alpha,
+            )
+
+    # Set up `algo_config`
+    algo_config = (
+        load_algo_config(quant_algo, quant_scheme, quant_algo_config_file_path, model_type) if quant_algo else None
+    )
+
+    return Config(
+        global_quant_config=global_quant_config,
+        layer_quant_config=layer_quant_config,
+        kv_cache_quant_config=kv_cache_quant_config,
+        softmax_quant_spec=attn_qspec,
+        exclude=exclude_layers_final,
+        pre_quant_opt_config=pre_optimization_configs,
+        algo_config=algo_config,
+    )
+
+
+def load_algo_config(quant_algo, quant_scheme, quant_algo_config_file_path, model_type):
+    default_algo_config_file = None
+    if quant_algo == "awq":
+        default_algo_config_file = os.path.join(EXAMPLES_DIR, "models", model_type, "awq_config.json")
+    elif quant_algo == "autosmoothquant":
+        default_algo_config_file = os.path.join(EXAMPLES_DIR, "models", model_type, "autosmoothquant_config.json")
+    elif quant_algo == "gptq":
+        if quant_scheme not in ["w_uint4_per_group_asym", "w_uint4_per_channel_asym", "w_mxfp4_a_mxfp4"]:
+            logger.warning(
+                "GPTQ is only tested with uint4_per_group, w_uint4_per_channel_asym, and w_mxfp4_a_mxfp4 quantization in Quark, be careful to apply GPTQ on %s.",
+                quant_scheme,
+            )
+        default_algo_config_file = os.path.join(EXAMPLES_DIR, "models", model_type, "gptq_config.json")
+    quant_algo_config_file_path = (
+        quant_algo_config_file_path if quant_algo_config_file_path else default_algo_config_file
+    )
+    if os.path.exists(quant_algo_config_file_path):
+        algo_config = load_quant_algo_config_from_file(quant_algo_config_file_path)
+    else:
+        if quant_algo == "awq":
+            algo_config = AWQConfig()
+        elif quant_algo == "autosmoothquant":
+            algo_config = AutoSmoothQuantConfig()
+        else:
+            raise ValueError("Missing quantization algorithm configuration")
+    return algo_config
+
+
+MERGE_REALQ_CONFIG = JsonExporterConfig(
+    weight_merge_groups=[["*up_proj", "*gate_proj"], ["*q_proj", "*k_proj", "*v_proj"]],
+    weight_format="real_quantized",
+    pack_method="reorder",
+)
+
+NO_MERGE_REALQ_CONFIG = JsonExporterConfig(weight_format="real_quantized", pack_method="reorder")
+
+
+def get_export_config(args: argparse.Namespace, model_type: str) -> ExporterConfig:
+    export_config = None
+    if args.weight_matrix_merge is True:
+        export_config = ExporterConfig(json_export_config=MERGE_REALQ_CONFIG, onnx_export_config=OnnxExporterConfig())
+    else:
+        export_config = ExporterConfig(
+            json_export_config=NO_MERGE_REALQ_CONFIG, onnx_export_config=OnnxExporterConfig()
+        )
+
+    if args.kv_cache_dtype is not None:
+        if model_type not in MODEL_NAME_KV_LAYERS_MAP:
+            raise ValueError(
+                f"KV cache configuration of {model_type} could not be supported automatically,"
+                "please add the KV layers in MODEL_NAME_KV_LAYERS_MAP"
+            )
+        export_config.json_export_config.kv_cache_group = MODEL_NAME_KV_LAYERS_MAP[model_type]
+
+    if args.pack_method == "order":
+        export_config.json_export_config.pack_method = "order"
+
+    export_config.json_export_config.min_kv_scale = args.min_kv_scale
+
+    return export_config

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/customized_configuration.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/customized_configuration.py
@@ -1,0 +1,577 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+from quark.torch.quantization import (
+    Bfloat16Spec,
+    BFP16Spec,
+    Float16Spec,
+    FP4PerGroupSpec,
+    FP6E2M3PerGroupSpec,
+    FP6E3M2PerGroupSpec,
+    FP8E4M3PerChannelSpec,
+    FP8E4M3PerGroupSpec,
+    FP8E4M3PerTensorSpec,
+    FP8E5M2PerGroupSpec,
+    Int2PerGroupSpec,
+    Int4PerChannelSpec,
+    Int4PerGroupSpec,
+    Int4PerTensorSpec,
+    Int8PerChannelSpec,
+    Int8PerGroupSpec,
+    Int8PerTensorSpec,
+    MX6Spec,
+    OCP_MXFP4DiffsSpec,
+    OCP_MXFP4Spec,
+    OCP_MXFP6E2M3Spec,
+    OCP_MXFP6E3M2Spec,
+    OCP_MXFP8E4M3Spec,
+    OCP_MXFP8E5M2Spec,
+    OCP_MXINT8Spec,
+    QuantizationConfig,
+    ScaleQuantSpec,
+    Uint4PerChannelSpec,
+    Uint4PerGroupSpec,
+    Uint8PerGroupSpec,
+    Uint8PerTensorSpec,
+)
+
+DEPRECATED_QUANT_SCHEME = {
+    "w_mx_fp4_a_mx_fp4_sym": "w_mxfp4_a_mxfp4",
+    "w_mx_fp6_e3m2_sym": "w_mxfp6_e3m2",
+    "w_mx_fp6_e2m3_sym": "w_mxfp6_e2m3",
+    "w_mx_int8_per_group_sym": "w_mxint8",
+    "w_mxfp4_a_mxfp4_sym": "w_mxfp4_a_mxfp4",
+    "w_mx_fp6_e2m3_a_mx_fp6_e2m3": "w_mxfp6_e2m3_a_mxfp6_e2m3",
+    "w_mx_fp6_e3m2_a_mx_fp6_e3m2": "w_mxfp6_e3m2_a_mxfp6_e3m2",
+    "w_mx_fp4_a_mx_fp6_sym": "w_mxfp4_a_mxfp6",
+    "w_mx_fp8_a_mx_fp8": "w_mxfp8_a_mxfp8",
+}
+
+OCP_MX_QUANT_SCHEME = [
+    "w_mx6",
+    "w_mx6_a_mx6",
+    "w_mxfp4",
+    "w_mxfp4_a_mxfp4",
+    "w_mxfp4_a_mxfp6",
+    "w_mxfp4_a_mxfp8",
+    "w_mxfp4_diffs",
+    "w_mxfp6_e2m3_a_mxfp6_e2m3",
+    "w_mxfp6_e2m3",
+    "w_mxfp6_e3m2_a_mxfp6_e3m2",
+    "w_mxfp6_e3m2",
+    "w_mxfp8",
+    "w_mxfp8_a_mxfp8",
+    "w_mxint8",
+]
+
+
+SUPPORTED_QUANT_SCHEME = [
+    *[
+        "w_bfp16",
+        "w_bfp16_a_bfp16",
+        "w_bfp16_per_group_sym",
+        "w_fp4_a_fp4_scale_fp8",
+        "w_fp4_per_group",
+        "w_fp4_per_group_a_fp4_per_group",
+        "w_fp4_per_group_a_fp8_e4m3_per_group",
+        "w_fp4_scale_fp8",
+        "w_fp6_e2m3_per_group_a_fp6_e2m3_per_group",
+        "w_fp6_e3m2_per_group_a_fp6_e3m2_per_group",
+        "w_fp8_a_fp8",
+        "w_fp8_a_fp8_o_fp8",
+        "w_fp8_per_channel_sym",
+        "w_int2_per_group_asym",
+        "w_int4_per_channel_asym",
+        "w_int4_per_channel_sym",
+        "w_int4_per_group_asym",
+        "w_int4_per_group_sym",
+        "w_int8_a_int8_per_tensor_sym",
+        "w_int8_a_int8_per_tensor_sym_dynamic",
+        "w_int8_a_int8_per_token_dynamic",
+        "w_int8_per_channel_a_int8_per_tensor_sym",
+        "w_int8_per_channel_a_int8_per_tensor_sym_dynamic",
+        "w_int8_per_group_sym",
+        "w_int8_per_tensor_mse",
+        "w_int8_per_tensor_percentile",
+        "w_int8_per_tensor_sym",
+        "w_uint4_a_bfloat16_per_group_asym",
+        "w_uint4_a_uint4_per_channel",
+        "w_uint4_per_channel_a_int8_per_tensor",
+        "w_uint4_per_channel_asym",
+        "w_uint4_per_channel_sym",
+        "w_uint4_per_group_a_int8_per_tensor",
+        "w_uint4_per_group_sym",
+        "w_uint4_per_group_asym",
+        "w_uint4_per_token_a_int8_per_channel",
+        "w_uint8_a_uint8_per_tensor_asym",
+        "w_uint8_per_group_asym",
+        "w_uint8_per_tensor_mse",
+        "w_uint8_per_tensor_percentile",
+    ],
+    *OCP_MX_QUANT_SCHEME,
+    *list(DEPRECATED_QUANT_SCHEME),
+]
+
+FLOAT16_SPEC = Float16Spec().to_quantization_spec()
+
+BFLOAT16_SPEC = Bfloat16Spec().to_quantization_spec()
+
+FP8_PER_TENSOR_SPEC = FP8E4M3PerTensorSpec(observer_method="min_max", is_dynamic=False).to_quantization_spec()
+
+FP8_PER_TENSOR_SPEC_DYNAMIC = FP8E4M3PerTensorSpec(observer_method="min_max", is_dynamic=True).to_quantization_spec()
+
+INT4_PER_TENSOR_SPEC = Int4PerTensorSpec(
+    observer_method="min_max", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+
+INT8_PER_CHANNEL_SPEC = Int8PerChannelSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=False
+).to_quantization_spec()
+
+
+UINT4_PER_GROUP_ASYM_SPEC = Uint4PerGroupSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+
+INT8_PER_TENSOR_SPEC = Int8PerTensorSpec(
+    observer_method="min_max", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+UINT8_PER_TENSOR_ASPEC = Uint8PerTensorSpec(
+    observer_method="min_max", symmetric=False, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+INT8_PER_TOKEN_DYNAMIC_SPEC = Int8PerChannelSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=True
+).to_quantization_spec()
+
+INT8_PER_TENSOR_DYNAMIC_SPEC = Int8PerTensorSpec(
+    observer_method="min_max", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=True
+).to_quantization_spec()
+
+INT8_PER_GROUP_SYM_SPEC = Int8PerGroupSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+
+UINT8_PER_GROUP_ASYM_SPEC = Uint8PerGroupSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+
+OCP_MXFP8_STATIC_SPEC = OCP_MXFP8E4M3Spec(ch_axis=-1, is_dynamic=False).to_quantization_spec()
+
+OCP_MXFP8_DYNAMIC_SPEC = OCP_MXFP8E4M3Spec(ch_axis=-1, is_dynamic=True).to_quantization_spec()
+
+W_BFP16_SPEC = BFP16Spec(is_dynamic=False, ch_axis=-1).to_quantization_spec()
+
+A_BFP16_SPEC = BFP16Spec(is_dynamic=True, ch_axis=-1).to_quantization_spec()
+
+W_MX6_SPEC = MX6Spec(ch_axis=-1, block_size=32, is_dynamic=False).to_quantization_spec()
+
+A_MX6_SPEC = MX6Spec(ch_axis=-1, block_size=32, is_dynamic=True).to_quantization_spec()
+
+# Data type spec for testing, not applied on the specific backend
+UINT8_PER_TENSOR_SPEC = Uint8PerTensorSpec(
+    observer_method="min_max", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+FP8_PER_CHANNEL_SPEC = FP8E4M3PerChannelSpec(is_dynamic=False, ch_axis=0).to_quantization_spec()
+
+INT4_PER_CHANNEL_ASYM_SPEC = Int4PerChannelSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=False
+).to_quantization_spec()
+
+INT4_PER_GROUP_ASYM_SPEC = Int4PerGroupSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+
+UINT4_PER_GROUP_SYM_SPEC = Uint4PerGroupSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+
+UINT4_PER_CHANNEL_SYM_SPEC = Uint4PerChannelSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=False
+).to_quantization_spec()
+
+UINT4_PER_CHANNEL_ASYM_SPEC = Uint4PerChannelSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=False
+).to_quantization_spec()
+
+UINT4_PER_CHANNEL_ASYM_DYNAMIC_SPEC = Uint4PerChannelSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=True
+).to_quantization_spec()
+
+INT8_PER_TENSOR_PERCENTILE_SPEC = Int8PerTensorSpec(
+    observer_method="percentile", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+INT8_PER_TENSOR_MSE_SPEC = Int8PerTensorSpec(
+    observer_method="MSE", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+UINT8_PER_TENSOR_PERCENTILE_SPEC = Uint8PerTensorSpec(
+    observer_method="percentile", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+UINT8_PER_TENSOR_MSE_SPEC = Uint8PerTensorSpec(
+    observer_method="MSE", symmetric=True, scale_type="float", round_method="half_even", is_dynamic=False
+).to_quantization_spec()
+
+FP4_PER_GROUP_SYM_STATIC_GS16_SPEC = FP4PerGroupSpec(
+    ch_axis=-1, group_size=16, is_dynamic=False, scale_format="e8m0", scale_calculation_mode="even"
+).to_quantization_spec()
+
+FP4_PER_GROUP_SYM_DYNAMIC_GS16_SPEC = FP4PerGroupSpec(
+    ch_axis=-1, group_size=16, is_dynamic=True, scale_format="e8m0", scale_calculation_mode="even"
+).to_quantization_spec()
+
+OCP_MX_SEPARATED_FP4_PER_GROUP_DIFFS_SPEC = OCP_MXFP4DiffsSpec(ch_axis=-1, is_dynamic=False).to_quantization_spec()
+
+# Two stage configurations
+# This configuration specifies that the first stage is a per-group FP4 quantization, and the second stage is a per-tensor FP8 quantization.
+# The first stage is used to quantize the input tensor, and the second stage is used to quantize the scale of the first stage.
+FP4_PER_GROUP_FP8_PER_TENSOR_SCALE_SPEC = ScaleQuantSpec(
+    first_stage=FP4PerGroupSpec(group_size=16, is_dynamic=False),
+    second_stage=FP8E4M3PerTensorSpec(observer_method="min_max", is_dynamic=False),
+).to_quantization_spec()
+
+FP4_PER_GROUP_FP8_PER_TENSOR_SCALE_SPEC_DYNAMIC = ScaleQuantSpec(
+    first_stage=FP4PerGroupSpec(group_size=16, is_dynamic=True),
+    second_stage=FP8E4M3PerTensorSpec(observer_method="min_max", is_dynamic=True),
+).to_quantization_spec()
+
+
+def ocp_mxfp6_e2m3_spec(scale_calculation_mode="even", is_dynamic=True):
+    return OCP_MXFP6E2M3Spec(
+        ch_axis=-1, scale_calculation_mode=scale_calculation_mode, is_dynamic=is_dynamic
+    ).to_quantization_spec()
+
+
+def ocp_mxfp6_e3m2_spec(scale_calculation_mode="even", is_dynamic=True):
+    return OCP_MXFP6E3M2Spec(
+        ch_axis=-1, scale_calculation_mode=scale_calculation_mode, is_dynamic=is_dynamic
+    ).to_quantization_spec()
+
+
+def ocp_mxfp4_spec(scale_calculation_mode="even", is_dynamic=True):
+    return OCP_MXFP4Spec(
+        ch_axis=-1, is_dynamic=is_dynamic, scale_calculation_mode=scale_calculation_mode
+    ).to_quantization_spec()
+
+
+def ocp_mxfp8_e4m3_spec(scale_calculation_mode="even", is_dynamic=True):
+    return OCP_MXFP8E4M3Spec(
+        scale_calculation_mode=scale_calculation_mode, ch_axis=-1, is_dynamic=is_dynamic
+    ).to_quantization_spec()
+
+
+def ocp_mxfp8_e5m2_spec(scale_calculation_mode="even", is_dynamic=True):
+    return OCP_MXFP8E5M2Spec(
+        scale_calculation_mode=scale_calculation_mode, ch_axis=-1, is_dynamic=is_dynamic
+    ).to_quantization_spec()
+
+
+def ocp_mxint8_spec(scale_calculation_mode="even", is_dynamic=True):
+    return OCP_MXINT8Spec(
+        scale_calculation_mode=scale_calculation_mode, ch_axis=-1, is_dynamic=is_dynamic
+    ).to_quantization_spec()
+
+
+# FP per-group config
+def fp8_e4m3_per_group_sym_spec(group_size, scale_format="e8m0", scale_calculation_mode="even", is_dynamic=True):
+    return FP8E4M3PerGroupSpec(
+        ch_axis=-1,
+        group_size=group_size,
+        scale_format=scale_format,
+        scale_calculation_mode=scale_calculation_mode,
+        is_dynamic=is_dynamic,
+    ).to_quantization_spec()
+
+
+def fp8_e5m2_per_group_sym_spec(group_size, scale_format="e8m0", scale_calculation_mode="even", is_dynamic=True):
+    return FP8E5M2PerGroupSpec(
+        ch_axis=-1,
+        group_size=group_size,
+        scale_format=scale_format,
+        scale_calculation_mode=scale_calculation_mode,
+        is_dynamic=is_dynamic,
+    ).to_quantization_spec()
+
+
+def fp4_per_group_sym_spec(group_size, scale_format="e8m0", scale_calculation_mode="even", is_dynamic=True):
+    return FP4PerGroupSpec(
+        ch_axis=-1,
+        group_size=group_size,
+        scale_format=scale_format,
+        scale_calculation_mode=scale_calculation_mode,
+        is_dynamic=is_dynamic,
+    ).to_quantization_spec()
+
+
+def fp6_e2m3_per_group_sym_spec(group_size, scale_format="e8m0", scale_calculation_mode="even", is_dynamic=True):
+    return FP6E2M3PerGroupSpec(
+        ch_axis=-1,
+        group_size=group_size,
+        scale_format=scale_format,
+        scale_calculation_mode=scale_calculation_mode,
+        is_dynamic=is_dynamic,
+    ).to_quantization_spec()
+
+
+def fp6_e3m2_per_group_sym_spec(group_size, scale_format="e8m0", scale_calculation_mode="even", is_dynamic=True):
+    return FP6E3M2PerGroupSpec(
+        ch_axis=-1,
+        group_size=group_size,
+        scale_format=scale_format,
+        scale_calculation_mode=scale_calculation_mode,
+        is_dynamic=is_dynamic,
+    ).to_quantization_spec()
+
+
+# BFloat16 config
+BFP16_PER_GROUP_SYM_SPEC = BFP16Spec(is_dynamic=True, ch_axis=-1).to_quantization_spec()
+
+
+# Float16 config
+FLOAT16_CONFIG = QuantizationConfig(input_tensors=FLOAT16_SPEC, weight=FLOAT16_SPEC)
+
+W_FP8_A_FP8_OFP8_PER_TENSOR_CONFIG = QuantizationConfig(
+    input_tensors=FP8_PER_TENSOR_SPEC, weight=FP8_PER_TENSOR_SPEC, output_tensors=FP8_PER_TENSOR_SPEC
+)
+
+# Int per tensor config
+W_INT4_PER_TENSOR_CONFIG = QuantizationConfig(weight=INT4_PER_TENSOR_SPEC)
+
+W_INT8_PER_TENSOR_CONFIG = QuantizationConfig(weight=INT8_PER_TENSOR_SPEC)
+
+W_INT8_A_INT8_PER_TENSOR_CONFIG = QuantizationConfig(input_tensors=INT8_PER_TENSOR_SPEC, weight=INT8_PER_TENSOR_SPEC)
+
+W_UINT8_A_UINT8_PER_TENSOR_CONFIG = QuantizationConfig(
+    input_tensors=UINT8_PER_TENSOR_ASPEC, weight=UINT8_PER_TENSOR_ASPEC
+)
+
+W_INT8_A_INT8_PER_TENSOR_DYNAMIC_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_DYNAMIC_SPEC, weight=INT8_PER_TENSOR_DYNAMIC_SPEC
+)
+
+# Int per Channel Config
+W_INT8_PER_CHANNEL_CONFIG = QuantizationConfig(weight=INT8_PER_CHANNEL_SPEC)
+
+W_INT8_PER_CHANNEL_A_INT8_PER_TENSOR_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_SPEC, weight=INT8_PER_CHANNEL_SPEC
+)
+
+W_INT8_PER_CHANNEL_A_INT8_PER_TENSOR_DYNAMIC_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_DYNAMIC_SPEC, weight=INT8_PER_CHANNEL_SPEC
+)
+
+# Int per Group Config
+W_UINT4_A_BFLOAT16_PER_GROUP_CONFIG = QuantizationConfig(input_tensors=BFLOAT16_SPEC, weight=UINT4_PER_GROUP_ASYM_SPEC)
+
+W_INT8_PER_GROUP_CONFIG = QuantizationConfig(weight=INT8_PER_GROUP_SYM_SPEC)
+
+W_UINT8_PER_GROUP_CONFIG = QuantizationConfig(weight=UINT8_PER_GROUP_ASYM_SPEC)
+
+W_MXFP8_CONFIG = QuantizationConfig(weight=OCP_MXFP8_STATIC_SPEC)
+W_MXFP8_A_MXFP8_CONFIG = QuantizationConfig(weight=OCP_MXFP8_STATIC_SPEC, input_tensors=OCP_MXFP8_DYNAMIC_SPEC)
+
+W_INT8_A_INT8_PER_TOKEN_DYNAMIC_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TOKEN_DYNAMIC_SPEC, weight=INT8_PER_CHANNEL_SPEC
+)
+
+W_BFP16_CONFIG = QuantizationConfig(weight=W_BFP16_SPEC)
+W_BFP16_A_BFP16_CONFIG = QuantizationConfig(input_tensors=A_BFP16_SPEC, weight=W_BFP16_SPEC)
+
+W_MX6_CONFIG = QuantizationConfig(weight=W_MX6_SPEC)
+W_MX6_A_MX6_CONFIG = QuantizationConfig(input_tensors=A_MX6_SPEC, weight=W_MX6_SPEC)
+
+# quant_scheme for testing, not applied on the specific backend
+W_UINT4_A_UINT4_PER_CHANNEL = QuantizationConfig(
+    input_tensors=UINT4_PER_CHANNEL_ASYM_SPEC, weight=UINT4_PER_CHANNEL_ASYM_SPEC
+)
+W_UINT4_PER_TOKEN_A_INT8_PER_CHANNEL = QuantizationConfig(
+    input_tensors=INT8_PER_TOKEN_DYNAMIC_SPEC, weight=UINT4_PER_CHANNEL_ASYM_SPEC
+)
+W_UINT4_PER_CHANNEL_A_INT8_PER_TENSOR_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_SPEC, weight=UINT4_PER_CHANNEL_SYM_SPEC
+)
+W_UINT4_PER_GROUP_A_INT8_PER_TENSOR_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_SPEC, weight=UINT4_PER_GROUP_SYM_SPEC
+)
+W_FP8_A_FP8_O_FP8_PER_CHANNEL_SYM_CONFIG = QuantizationConfig(
+    input_tensors=FP8_PER_TENSOR_SPEC, output_tensors=FP8_PER_TENSOR_SPEC, weight=FP8_PER_CHANNEL_SPEC
+)
+W_INT8_A_INT8_PER_TENSOR_PERCENTILE_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_SPEC, weight=INT8_PER_TENSOR_PERCENTILE_SPEC
+)
+W_INT8_A_INT8_PER_TENSOR_MSE_CONFIG = QuantizationConfig(
+    input_tensors=INT8_PER_TENSOR_SPEC, weight=INT8_PER_TENSOR_MSE_SPEC
+)
+W_UINT8_A_UINT8_PER_TENSOR_PERCENTILE_CONFIG = QuantizationConfig(
+    input_tensors=UINT8_PER_TENSOR_SPEC, weight=UINT8_PER_TENSOR_PERCENTILE_SPEC
+)
+W_UINT8_A_UINT8_PER_TENSOR_MSE_CONFIG = QuantizationConfig(
+    input_tensors=UINT8_PER_TENSOR_SPEC, weight=UINT8_PER_TENSOR_MSE_SPEC
+)
+W_UINT4_PER_CHANNEL_SYM_CONFIG = QuantizationConfig(weight=UINT4_PER_CHANNEL_SYM_SPEC)
+W_UINT4_PER_CHANNEL_ASYM_CONFIG = QuantizationConfig(weight=UINT4_PER_CHANNEL_ASYM_SPEC)
+W_UINT4_PER_GROUP_SYM_CONFIG = QuantizationConfig(weight=UINT4_PER_GROUP_SYM_SPEC)
+W_INT4_PER_CHANNEL_ASYM_CONFIG = QuantizationConfig(weight=INT4_PER_CHANNEL_ASYM_SPEC)
+W_INT4_PER_GROUP_ASYM_CONFIG = QuantizationConfig(weight=INT4_PER_GROUP_ASYM_SPEC)
+W_MXINT8_CONFIG = QuantizationConfig(weight=ocp_mxint8_spec(is_dynamic=False))
+W_BFP16_PER_GROUP_SYM_CONFIG = QuantizationConfig(weight=BFP16_PER_GROUP_SYM_SPEC)
+W_MXFP4_DIFFS_SYM_CONFIG = QuantizationConfig(weight=OCP_MX_SEPARATED_FP4_PER_GROUP_DIFFS_SPEC)
+
+# Two stage config
+W_FP4_SCALE_FP8_CONFIG = QuantizationConfig(weight=FP4_PER_GROUP_FP8_PER_TENSOR_SCALE_SPEC)
+W_FP4_A_FP4_SCALE_FP8_CONFIG = QuantizationConfig(
+    input_tensors=FP4_PER_GROUP_FP8_PER_TENSOR_SCALE_SPEC_DYNAMIC, weight=FP4_PER_GROUP_FP8_PER_TENSOR_SCALE_SPEC
+)
+
+INT4_PER_CHANNEL_SPEC = Int4PerChannelSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=0, is_dynamic=False
+).to_quantization_spec()
+INT4_PER_GROUP_SYM_SPEC = Int4PerGroupSpec(
+    symmetric=True, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+INT2_PER_GROUP_ASYM_SPEC = Int2PerGroupSpec(
+    symmetric=False, scale_type="float", round_method="half_even", ch_axis=1, is_dynamic=False, group_size=128
+).to_quantization_spec()
+
+W_FP8_A_FP8_PER_TENSOR_CONFIG = QuantizationConfig(input_tensors=FP8_PER_TENSOR_SPEC, weight=FP8_PER_TENSOR_SPEC)
+W_INT4_PER_CHANNEL_CONFIG = QuantizationConfig(weight=INT4_PER_CHANNEL_SPEC)
+W_INT4_PER_GROUP_SYM_CONFIG = QuantizationConfig(weight=INT4_PER_GROUP_SYM_SPEC)
+W_UINT4_PER_GROUP_CONFIG = QuantizationConfig(weight=UINT4_PER_GROUP_ASYM_SPEC)
+W_INT2_PER_GROUP_CONFIG = QuantizationConfig(weight=INT2_PER_GROUP_ASYM_SPEC)
+
+
+QUANT_SCHEME_TO_CONFIG = {
+    "w_bfp16": W_BFP16_CONFIG,
+    "w_bfp16_a_bfp16": W_BFP16_A_BFP16_CONFIG,
+    "w_bfp16_per_group_sym": W_BFP16_PER_GROUP_SYM_CONFIG,
+    "w_fp4_a_fp4_scale_fp8": W_FP4_A_FP4_SCALE_FP8_CONFIG,
+    "w_fp4_scale_fp8": W_FP4_SCALE_FP8_CONFIG,
+    "w_fp8_a_fp8": W_FP8_A_FP8_PER_TENSOR_CONFIG,
+    "w_fp8_a_fp8_o_fp8": W_FP8_A_FP8_OFP8_PER_TENSOR_CONFIG,
+    "w_fp8_per_channel_sym": W_FP8_A_FP8_O_FP8_PER_CHANNEL_SYM_CONFIG,
+    "w_int4_per_channel_asym": W_INT4_PER_CHANNEL_ASYM_CONFIG,
+    "w_int4_per_channel_sym": W_INT4_PER_CHANNEL_CONFIG,
+    "w_int8_a_int8_per_tensor_sym": W_INT8_A_INT8_PER_TENSOR_CONFIG,
+    "w_int8_a_int8_per_tensor_sym_dynamic": W_INT8_A_INT8_PER_TENSOR_DYNAMIC_CONFIG,
+    # only support batch_size=1 for activation per-token
+    "w_int8_a_int8_per_token_dynamic": W_INT8_A_INT8_PER_TOKEN_DYNAMIC_CONFIG,
+    "w_int8_per_channel_a_int8_per_tensor_sym": W_INT8_PER_CHANNEL_A_INT8_PER_TENSOR_CONFIG,
+    "w_int8_per_channel_a_int8_per_tensor_sym_dynamic": W_INT8_PER_CHANNEL_A_INT8_PER_TENSOR_DYNAMIC_CONFIG,
+    "w_int8_per_group_sym": W_INT8_PER_GROUP_CONFIG,
+    "w_int8_per_tensor_mse": W_INT8_A_INT8_PER_TENSOR_MSE_CONFIG,
+    "w_int8_per_tensor_percentile": W_INT8_A_INT8_PER_TENSOR_PERCENTILE_CONFIG,
+    "w_int8_per_tensor_sym": W_INT8_PER_TENSOR_CONFIG,
+    "w_mx6": W_MX6_CONFIG,
+    "w_mx6_a_mx6": W_MX6_A_MX6_CONFIG,
+    "w_mxfp4_diffs": W_MXFP4_DIFFS_SYM_CONFIG,
+    "w_mxfp8": W_MXFP8_CONFIG,
+    "w_mxfp8_a_mxfp8": W_MXFP8_A_MXFP8_CONFIG,
+    "w_mxint8": W_MXINT8_CONFIG,
+    "w_uint4_a_uint4_per_channel": W_UINT4_A_UINT4_PER_CHANNEL,
+    "w_uint4_per_channel_a_int8_per_tensor": W_UINT4_PER_CHANNEL_A_INT8_PER_TENSOR_CONFIG,
+    "w_uint4_per_channel_asym": W_UINT4_PER_CHANNEL_ASYM_CONFIG,
+    "w_uint4_per_channel_sym": W_UINT4_PER_CHANNEL_SYM_CONFIG,
+    "w_uint4_per_group_a_int8_per_tensor": W_UINT4_PER_GROUP_A_INT8_PER_TENSOR_CONFIG,
+    "w_uint4_per_token_a_int8_per_channel": W_UINT4_PER_TOKEN_A_INT8_PER_CHANNEL,
+    "w_uint8_a_uint8_per_tensor_asym": W_UINT8_A_UINT8_PER_TENSOR_CONFIG,
+    "w_uint8_per_group_asym": W_UINT8_PER_GROUP_CONFIG,
+    "w_uint8_per_tensor_mse": W_UINT8_A_UINT8_PER_TENSOR_MSE_CONFIG,
+    "w_uint8_per_tensor_percentile": W_UINT8_A_UINT8_PER_TENSOR_PERCENTILE_CONFIG,
+}
+
+
+def get_global_config(
+    quant_scheme: str, group_size: int, scale_format: str = "e4m3", scale_calculation_mode: str = "even"
+) -> QuantizationConfig:
+    if quant_scheme not in SUPPORTED_QUANT_SCHEME:
+        raise ValueError(
+            f"The quant_scheme {quant_scheme} is not supported, only {SUPPORTED_QUANT_SCHEME} are supported."
+        )
+
+    if quant_scheme in OCP_MX_QUANT_SCHEME and group_size != 32:
+        raise ValueError(
+            f"The quant_scheme {quant_scheme} requires group_size=32, got group_size={group_size}. Please use the option `--group-size 32`."
+        )
+
+    if quant_scheme in QUANT_SCHEME_TO_CONFIG:
+        global_quant_config = QUANT_SCHEME_TO_CONFIG[quant_scheme]
+    elif quant_scheme == "w_uint4_a_bfloat16_per_group_asym":
+        global_quant_config = W_UINT4_A_BFLOAT16_PER_GROUP_CONFIG
+        global_quant_config.weight.set_group_size(group_size)
+    elif quant_scheme == "w_mxfp6_e3m2":
+        global_quant_config = QuantizationConfig(weight=ocp_mxfp6_e3m2_spec(scale_calculation_mode, False))
+    elif quant_scheme == "w_mxfp6_e2m3":
+        global_quant_config = QuantizationConfig(weight=ocp_mxfp6_e2m3_spec(scale_calculation_mode, False))
+    elif quant_scheme == "w_mxfp4_a_fp8_per_group":
+        global_quant_config = QuantizationConfig(
+            input_tensors=FP8_PER_TENSOR_SPEC, weight=ocp_mxfp4_spec(scale_calculation_mode, False)
+        )
+    elif quant_scheme == "w_mxfp4_a_mxfp4":
+        global_quant_config = QuantizationConfig(
+            input_tensors=fp4_per_group_sym_spec(group_size, "e8m0", scale_calculation_mode, True),
+            weight=fp4_per_group_sym_spec(group_size, "e8m0", scale_calculation_mode, False),
+        )
+    elif quant_scheme == "w_fp4_a_fp4_dynamic_per_group_sym_gs16_scale_e8m0":
+        global_quant_config = QuantizationConfig(
+            input_tensors=FP4_PER_GROUP_SYM_DYNAMIC_GS16_SPEC, weight=FP4_PER_GROUP_SYM_STATIC_GS16_SPEC
+        )
+    elif quant_scheme == "w_mxfp4_a_mxfp6":
+        global_quant_config = QuantizationConfig(
+            input_tensors=ocp_mxfp6_e2m3_spec(scale_calculation_mode, True),
+            weight=ocp_mxfp4_spec(scale_calculation_mode, False),
+        )
+    elif quant_scheme == "w_int4_per_group_asym":
+        global_quant_config = W_INT4_PER_GROUP_ASYM_CONFIG
+        global_quant_config.weight.set_group_size(group_size)
+    elif quant_scheme == "w_uint4_per_group_sym":
+        global_quant_config = W_UINT4_PER_GROUP_SYM_CONFIG
+        global_quant_config.weight.set_group_size(group_size)
+    elif quant_scheme == "w_mxfp4_a_mxfp8":
+        global_quant_config = QuantizationConfig(
+            input_tensors=ocp_mxfp4_spec(scale_calculation_mode, True),
+            weight=ocp_mxfp4_spec(scale_calculation_mode, False),
+        )
+    elif quant_scheme == "w_mxfp4":
+        global_quant_config = QuantizationConfig(weight=ocp_mxfp4_spec(scale_calculation_mode, False))
+    elif quant_scheme == "w_fp4_per_group":
+        global_quant_config = QuantizationConfig(weight=fp4_per_group_sym_spec(group_size, scale_format, None, False))
+    elif quant_scheme == "w_mxfp6_e2m3_a_mxfp6_e2m3":
+        global_quant_config = QuantizationConfig(
+            input_tensors=ocp_mxfp6_e2m3_spec(scale_calculation_mode, True),
+            weight=ocp_mxfp6_e2m3_spec(scale_calculation_mode, False),
+        )
+    elif quant_scheme == "w_mxfp6_e3m2_a_mxfp6_e3m2":
+        global_quant_config = QuantizationConfig(
+            input_tensors=ocp_mxfp6_e3m2_spec(scale_calculation_mode, True),
+            weight=ocp_mxfp6_e3m2_spec(scale_calculation_mode, False),
+        )
+    elif quant_scheme == "w_fp6_e2m3_per_group_a_fp6_e2m3_per_group":
+        global_quant_config = QuantizationConfig(
+            input_tensors=fp6_e2m3_per_group_sym_spec(group_size, scale_format, None, True),
+            weight=fp6_e2m3_per_group_sym_spec(group_size, scale_format, None, False),
+        )
+    elif quant_scheme == "w_fp6_e3m2_per_group_a_fp6_e3m2_per_group":
+        global_quant_config = QuantizationConfig(
+            input_tensors=fp6_e3m2_per_group_sym_spec(group_size, scale_format, None, True),
+            weight=fp6_e3m2_per_group_sym_spec(group_size, scale_format, None, False),
+        )
+    elif quant_scheme == "w_int4_per_group_sym":
+        global_quant_config = W_INT4_PER_GROUP_SYM_CONFIG
+        global_quant_config.weight.set_group_size(group_size)
+    elif quant_scheme == "w_uint4_per_group_asym":
+        global_quant_config = W_UINT4_PER_GROUP_CONFIG
+        global_quant_config.weight.set_group_size(group_size)
+    elif quant_scheme == "w_int2_per_group_asym":
+        global_quant_config = W_INT2_PER_GROUP_CONFIG
+        global_quant_config.weight.set_group_size(group_size)
+    else:
+        raise ValueError(f"please set global quant config for {quant_scheme} at customized_configuration.py")
+
+    return global_quant_config

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/quantize_quark.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_ptq/quantize_quark.py
@@ -1,0 +1,178 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+
+import argparse
+import logging
+import warnings
+from pathlib import Path
+
+import torch
+from quark.torch import ModelExporter, ModelImporter, ModelQuantizer, load_params, save_params
+from quark.torch.export.api import _move_quantizer_to_dict
+from quark.torch.utils.device import TPDeviceManager
+from transformers import AutoProcessor
+
+from olive.passes.quark_vitisai.torch.language_modeling.llm_ptq.configuration_preparation import (
+    get_config,
+    get_export_config,
+)
+from olive.passes.quark_vitisai.torch.language_modeling.llm_utils.data_preparation import get_calib_dataloader
+from olive.passes.quark_vitisai.torch.language_modeling.llm_utils.model_preparation import (
+    get_model,
+    get_model_type,
+    get_tokenizer,
+    prepare_for_moe_quant,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_quark_quantization(args: argparse.Namespace) -> None:
+    # 1. Define original model
+    logger.info("\n[INFO]: Loading model ...")
+
+    # We currently use CPU memory to load large models because GPU memory is typically smaller.
+    # The model will be dispatched to different GPUs based on the total number of GPUs specified by torchrun --nproc-per-node.
+    # The current method results in high CPU memory consumption due to multiple copies of the same model.
+    # We plan to address this in the future by implementing a more efficient way to dispatch the model to devices.
+    if args.use_tp or not torch.cuda.is_available():
+        device = "cpu"
+    else:
+        device = args.device
+
+    model, _ = get_model(
+        args.model_dir, args.data_type, device, args.multi_gpu, args.multi_device, args.model_attn_implementation
+    )
+    prepare_for_moe_quant(model)
+
+    model_type = get_model_type(model)
+    tokenizer = get_tokenizer(args.model_dir, max_seq_len=args.seq_len, model_type=model_type)
+    multimodal = model_type in ["mllama"]
+    if multimodal:
+        processor = AutoProcessor.from_pretrained(args.model_dir)
+        if args.model_export is not None:
+            export_dir = Path(args.output_dir)
+            export_dir.mkdir(parents=True, exist_ok=True)
+            processor.save_pretrained(args.output_dir)
+
+    if args.use_tp:
+        TPDeviceManager.tp_mesh_init()
+
+    # 2. (Optional) Reload quantized model
+    if args.params_load:
+        logger.info("\nRestore quantized model from json and safetensors file ...")
+        model = load_params(model, json_path=args.json_path, safetensors_path=args.safetensors_path)
+        args.skip_quantization = True
+    elif args.model_reload:
+        logger.info("\nRestore quantized model from %s file ...", args.import_file_format)
+
+        importer = ModelImporter(
+            model_info_dir=args.import_model_dir, saved_format=args.import_file_format, multi_device=args.multi_device
+        )
+        model = importer.import_model_info(model)
+
+        args.skip_quantization = True
+
+    if args.use_tp:
+        if TPDeviceManager._tp_mesh is not None:  # pylint: disable=protected-access
+            _move_quantizer_to_dict(model.model)
+
+            device = TPDeviceManager._device  # pylint: disable=protected-access
+            tp_mesh = TPDeviceManager._tp_mesh  # pylint: disable=protected-access
+
+            model.tensor_parallel(tp_mesh)
+            model.to(device)
+        else:
+            warnings.warn(
+                "Quark tensor parallelism is not initialized properly. Please check the torchrun settings.", UserWarning
+            )
+            return
+
+    # 3. Define calibration dataloader(still need this step for weight only and dynamic quantization in Quark for current version.)
+    logger.info("\n[INFO]: Loading dataset ...")
+    # When the model is small, accelerate will place it on the last device
+    main_device = model.device if args.multi_gpu or args.multi_device else args.device
+    calib_dataloader = get_calib_dataloader(
+        dataset_name=args.dataset,
+        processor=processor if multimodal else None,
+        tokenizer=tokenizer,
+        batch_size=args.batch_size,
+        num_calib_data=args.num_calib_data,
+        seqlen=args.seq_len,
+        device=main_device,
+    )
+
+    # 4. Quantization
+    if not args.skip_quantization:
+        # 4-1. Set quantization configuration
+        quant_config = get_config(args, model_type)
+        # 4-2. In-place replacement of model modules with quantized versions.
+        quantizer = ModelQuantizer(quant_config, args.multi_device)
+        model = quantizer.quantize_model(model, calib_dataloader)
+        args.exclude_layers = quantizer.config.exclude
+
+    # 5. (Optional) Model freeze
+    if not args.skip_quantization and (args.model_export is not None or args.params_save or args.torch_compile):
+        # If user want to export the quantized model, please freeze the quantized model first
+        model = quantizer.freeze(model)
+
+    # 6. (Optional) Model exporting
+    if args.model_export is not None:
+        export_config = get_export_config(args, model_type)
+        if args.custom_mode != "quark" and args.export_weight_format == "fake_quantized":
+            raise ValueError("Exporting with 'fake_quantized' only supports custom_mode=quark")
+        export_config.json_export_config.weight_format = args.export_weight_format
+        exporter = ModelExporter(config=export_config, export_dir=args.output_dir)
+
+        # Export option 1: quark format: native json-pth format
+        if "quark_format" in args.model_export:
+            if args.custom_mode != "quark":
+                raise ValueError("To export the quark_format format, you must use 'args.custom_mode=quark'")
+            logger.info("\n[INFO]: Exporting quark native json and pth...")
+            with torch.no_grad():
+                quant_config = get_config(args, model_type)
+                exporter.export_quark_model(model, quant_config=quant_config, custom_mode=args.custom_mode)
+
+        # Export option 2: hugging-face safetensors format
+        if "hf_format" in args.model_export:
+            logger.info("\n[INFO]: Exporting hugging face format safetensors...")
+            with torch.no_grad():
+                quant_config = get_config(args, model_type)
+                exporter.export_safetensors_model(
+                    model, quant_config=quant_config, custom_mode=args.custom_mode, tokenizer=tokenizer
+                )
+
+        # Export option 3: onnx
+        if "onnx" in args.model_export:
+            logger.info("\n[INFO]: Exporting onnx graph...")
+            with torch.inference_mode():
+                batch_iter = iter(calib_dataloader)
+                input_args = next(batch_iter)
+                uint4_int4_flag = args.quant_scheme in [
+                    "w_int4_per_channel_sym",
+                    "w_uint4_per_group_asym",
+                    "w_int4_per_group_sym",
+                    "w_uint4_a_bfloat16_per_group_asym",
+                ]
+                exporter.export_onnx_model(model, input_args, uint4_int4_flag=uint4_int4_flag)
+        # Export option 3: gguf
+        if "gguf" in args.model_export:
+            logger.info("\n[INFO]: Exporting gguf model...")
+            with torch.inference_mode():
+                exporter.export_gguf_model(model, args.model_dir, model_type)
+
+    # 7. (Optional) Torch compile
+    if args.torch_compile:
+        logger.info("\n[INFO]: Calling PyTorch 2 torch.compile...")
+        # Note: The model after torch.compile may not be able to export to other format
+        model = torch.compile(model)
+
+    # 8. (Optional) Model Parameters Save
+    if args.params_save:
+        save_params(model, model_type=model_type, export_dir=args.save_dir)
+
+    if args.use_tp:
+        TPDeviceManager.tp_cleanup()

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_utils/__init__.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_utils/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_utils/data_preparation.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_utils/data_preparation.py
@@ -1,0 +1,334 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+from datasets import load_dataset
+from torch.utils.data import DataLoader, Dataset, Subset, TensorDataset
+from transformers import AutoProcessor, AutoTokenizer, PreTrainedTokenizer, default_data_collator
+
+logger = logging.getLogger(__name__)
+
+
+def get_pileval(
+    tokenizer: PreTrainedTokenizer, nsamples: int, seqlen: int, device: str | None, seed: int = 0
+) -> DataLoader[torch.Tensor]:
+    dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation").shuffle(seed=seed)
+
+    samples = []
+    n_run = 0
+    for data in dataset:
+        line_encoded = tokenizer.encode(data["text"].strip())
+        if 0 < len(line_encoded) <= seqlen:
+            sample = torch.tensor([line_encoded], device=device)
+            samples.append(sample)
+            n_run += 1
+        if n_run == nsamples:
+            break
+
+    # Concatenate all samples and split according to block size
+    cat_samples = torch.cat(samples, dim=1)
+    n_split = cat_samples.shape[1] // seqlen
+
+    # Create training dataset by splitting concatenated samples
+    train_dataset = [cat_samples[:, i * seqlen : (i + 1) * seqlen] for i in range(n_split)]
+
+    # Create batched samples
+    return torch.cat(train_dataset, dim=0)
+
+
+def get_wikitext2(
+    tokenizer: PreTrainedTokenizer, nsamples: int, seqlen: int, device: str | None, seed: int = 0
+) -> DataLoader[torch.Tensor]:
+    traindata = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="train")
+    trainenc = tokenizer("\n\n".join(traindata["text"]), return_tensors="pt")
+    trainenc = trainenc.to(device)
+
+    import random
+
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+
+    traindataset = []
+    for _ in range(nsamples):
+        i = random.randint(0, trainenc.input_ids.shape[1] - seqlen - 1)
+        j = i + seqlen
+        inp = trainenc.input_ids[:, i:j]
+        attention_mask = torch.ones_like(inp)
+        traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+    return torch.cat([sample["input_ids"] for sample in traindataset], dim=0)
+
+
+def get_calib_dataloader_for_benchmark(
+    dataset_name: str = "pileval_for_awq_benchmark",
+    tokenizer: AutoTokenizer | None = None,
+    batch_size: int = 1,
+    num_calib_data: int = 128,
+    seqlen: int = 2048,
+    device: str = "cpu",
+) -> DataLoader[torch.Tensor]:
+    if dataset_name == "pileval_for_awq_benchmark":
+        samples = get_pileval(tokenizer, num_calib_data, seqlen, device, seed=42)
+        if batch_size != len(samples):
+            logger.info(
+                "[INFO-Warning] For AWQ benchmark, batch_size should be %d. Changing batch_size to %d.",
+                len(samples),
+                len(samples),
+            )
+            batch_size = len(samples)
+    elif dataset_name == "wikitext_for_gptq_benchmark":
+        samples = get_wikitext2(tokenizer, num_calib_data, seqlen, device)
+    else:
+        raise NotImplementedError
+
+    calib_dataloader: DataLoader[list[dict[str, torch.Tensor]]] = DataLoader(
+        samples, batch_size=batch_size, shuffle=False, drop_last=True
+    )
+
+    return calib_dataloader
+
+
+def get_calib_dataloader_to_tensor(
+    dataset_name: str = "cnn_dailymail",
+    tokenizer: AutoTokenizer | None = None,
+    batch_size: int = 1,
+    num_calib_data: int = 512,
+    seqlen: int = 512,
+    shuffle: bool = False,
+    device: str | None = None,
+) -> DataLoader[torch.Tensor]:
+    if dataset_name == "pileval":
+        dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation")
+        text_data = dataset["text"][:num_calib_data]
+    elif dataset_name == "cnn_dailymail":
+        dataset = load_dataset("cnn_dailymail", name="3.0.0", split="train")
+        text_data = dataset["article"][:num_calib_data]
+    elif dataset_name == "wikitext":
+        dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="train")
+        text_data = dataset["text"][:num_calib_data]
+    else:
+        raise NotImplementedError
+
+    batch_encoded = tokenizer(text_data, return_tensors="pt", padding=True, truncation=True, max_length=seqlen)
+    if device:
+        batch_encoded = batch_encoded.to(device)
+    batch_encoded = batch_encoded["input_ids"]
+
+    return DataLoader(batch_encoded, batch_size=batch_size, shuffle=shuffle, drop_last=True)
+
+
+def get_calib_dataloader_to_dict(
+    dataset_name: str = "cnn_dailymail",
+    tokenizer: AutoTokenizer | None = None,
+    batch_size: int = 1,
+    num_calib_data: int = 512,
+    seqlen: int = 512,
+    device: str | None = None,
+) -> DataLoader[dict[str, torch.Tensor]]:
+    def make_data_block(
+        examples: dict[str, list[str]],
+        tokenizer: AutoTokenizer | None = None,
+        prompt_col_name: str = "",
+        max_length: int = 512,
+    ) -> dict[str, list[list[torch.Tensor]]]:
+        res: dict[str, list[list[torch.Tensor]]] = tokenizer(
+            examples[prompt_col_name], padding=True, truncation=True, max_length=max_length
+        )
+        return res
+
+    def my_collate_fn(blocks: list[dict[str, list[list[str]]]]) -> dict[str, torch.Tensor]:
+        data_batch = {}
+        data_batch["input_ids"] = torch.Tensor([block["input_ids"] for block in blocks])
+        if device:
+            data_batch["input_ids"] = data_batch["input_ids"].to(device)
+        return data_batch
+
+    if dataset_name == "pileval":
+        dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation")
+        prompt_col_name = "text"
+    elif dataset_name == "cnn_dailymail":
+        dataset = load_dataset("cnn_dailymail", name="3.0.0", split="train")
+        prompt_col_name = "article"
+    elif dataset_name == "wikitext":
+        dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="train")
+        prompt_col_name = "text"
+    else:
+        raise NotImplementedError
+
+    dataset = dataset.select(
+        indices=list(range(min(len(dataset), num_calib_data))),
+        keep_in_memory=True,
+    )
+    tokenized_datasets = dataset.map(
+        make_data_block,
+        batched=True,
+        batch_size=len(dataset),
+        num_proc=1,
+        remove_columns=dataset.column_names,
+        keep_in_memory=True,
+        fn_kwargs={"tokenizer": tokenizer, "prompt_col_name": prompt_col_name, "max_length": seqlen},
+    )
+
+    return DataLoader(tokenized_datasets, batch_size=batch_size, collate_fn=my_collate_fn)
+
+
+def get_ultrachat(
+    dataset_name: str = "HuggingFaceH4/ultrachat_200k",
+    tokenizer: AutoTokenizer | None = None,
+    batch_size: int = 1,
+    num_calib_data: int = 512,
+    seqlen: int = 512,
+    device: str | None = None,
+) -> DataLoader[list[dict[str, torch.Tensor]]]:
+    max_sequence_length = seqlen
+
+    ds = load_dataset(dataset_name, split="train_sft")
+    ds = ds.shuffle(seed=42).select(range(num_calib_data))
+
+    def preprocess(example):
+        return {
+            "text": tokenizer.apply_chat_template(
+                example["messages"],
+                tokenize=False,
+            )
+        }
+
+    ds = ds.map(preprocess)
+
+    def tokenize(sample):
+        return tokenizer(
+            sample["text"],
+            padding=False,
+            max_length=max_sequence_length,
+            truncation=True,
+            add_special_tokens=False,
+        )
+
+    ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+    traindataset = []
+    for i in range(len(ds["input_ids"])):
+        inp = torch.tensor([ds["input_ids"][i]], device=device)
+        attention_mask = torch.tensor([ds["attention_mask"][i]], device=device)
+        traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+
+    calib_dataloader: DataLoader[list[dict[str, torch.Tensor]]] = DataLoader(
+        traindataset, batch_size=None, shuffle=False
+    )
+    return calib_dataloader
+
+
+def get_calib_dataloader(
+    dataset_name: str, processor: AutoProcessor | None = None, **kwargs: Any
+) -> DataLoader[torch.Tensor] | DataLoader[list[dict[str, torch.Tensor]]] | DataLoader[dict[str, torch.Tensor]]:
+    if dataset_name in ["pileval", "cnn_dailymail", "wikitext"]:
+        return get_calib_dataloader_to_tensor(dataset_name, **kwargs)
+    elif dataset_name in ["pileval_for_awq_benchmark", "wikitext_for_gptq_benchmark"]:
+        return get_calib_dataloader_for_benchmark(dataset_name, **kwargs)
+    elif "ultrachat" in dataset_name:
+        return get_ultrachat(dataset_name, **kwargs)
+    else:
+        raise NotImplementedError
+
+
+class ConcatDataset(Dataset):
+    def __init__(self, dataset, max_length=4096):
+        self.dataset = dataset
+        self.samples = []
+        buffer = {"input_ids": [], "attention_mask": [], "labels": []}
+        for sample in self.dataset:
+            buffer = {k: v + sample[k] for k, v in buffer.items()}
+            while len(next(iter(buffer.values()))) > max_length:
+                self.samples.append({k: v[:max_length] for k, v in buffer.items()})
+                buffer = {k: v[max_length:] for k, v in buffer.items()}
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+    def __len__(self):
+        return len(self.samples)
+
+
+def get_trainer_dataset(path, subset, tokenizer, max_train_samples, max_eval_samples, seqlen=1024):
+    def tokenize_add_label(sample):
+        if path in ["Salesforce/wikitext"]:
+            input_text = sample["text"]
+
+        elif path in ["shibing624/AdvertiseGen"]:
+            input_text = sample["content"] + sample["summary"]
+        else:
+            raise ValueError(f"Unsupported dataset path: {path}")
+
+        input_ids = tokenizer.encode(tokenizer.bos_token + input_text + tokenizer.eos_token, add_special_tokens=False)
+
+        return {
+            "input_ids": input_ids,
+            "attention_mask": [1] * len(input_ids),
+            "labels": input_ids,
+        }
+
+    if path in ["Salesforce/wikitext"]:
+        train_dataset = load_dataset(path=path, name="wikitext-2-raw-v1", split=subset, trust_remote_code=True)
+    elif path in ["shibing624/AdvertiseGen"]:
+        train_dataset = load_dataset(path=path, split=subset, trust_remote_code=True)
+    else:
+        raise ValueError(f"Unsupported path: {path}")
+    # Using wikitext as default eval_dataset
+    eval_dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="test", trust_remote_code=True)
+
+    if max_train_samples:
+        max_train_samples = min(len(train_dataset), max_train_samples)
+        train_dataset = train_dataset.select(range(max_train_samples))
+        logger.info("select %s from training data to build train dataset ...", max_train_samples)
+
+    if max_eval_samples:
+        max_eval_samples = min(len(eval_dataset), max_eval_samples)
+        eval_dataset = eval_dataset.select(range(max_eval_samples))
+        logger.info("select %s from test data to build eval dataset ...", max_eval_samples)
+
+    train_dataset = train_dataset.map(tokenize_add_label, remove_columns=list(train_dataset.features))
+    train_dataset = ConcatDataset(train_dataset, seqlen)
+
+    eval_dataset = eval_dataset.map(tokenize_add_label, remove_columns=list(eval_dataset.features))
+    eval_dataset = ConcatDataset(eval_dataset, seqlen)
+    return {
+        "train_dataset": train_dataset,
+        "data_collator": default_data_collator,
+        "eval_dataset": eval_dataset,
+    }
+
+
+def get_dataset(path, subset, tokenizer, seqlen):
+    if path in ["Salesforce/wikitext"]:
+        text = load_dataset(path=path, name="wikitext-2-raw-v1", split=subset)
+        strtext = "\n\n".join(text["text"])
+    elif path in ["shibing624/AdvertiseGen"]:
+        text = load_dataset(path=path, split=subset)
+        strtext = "\n\n".join(str(i[0]) + str(i[1]) for i in list(zip(list(text["content"]), list(text["summary"]))))
+    else:
+        raise ValueError(f"Unsupported dataset path: {path}")
+    tokenized_text = tokenizer(strtext, return_tensors="pt")
+    tokenized_text_len = tokenized_text.input_ids.shape[1]
+
+    sample = [tokenized_text.input_ids[:, i : i + seqlen] for i in range(0, tokenized_text_len - seqlen - 1, seqlen)]
+    sample = torch.dstack(sample).squeeze(0).permute(1, 0)
+
+    return TensorDataset(sample)
+
+
+def get_loader(path, subset, tokenizer, seqlen=1024, num_batch=-1, batch_size=1, shuffle=False):
+    dataset = get_dataset(path, subset, tokenizer, seqlen)
+    data_size = len(dataset)
+
+    if num_batch != -1:  # num_batch == -1 using the whole dataset
+        sample_size = min(data_size, num_batch * batch_size)
+        subset_indices = torch.randperm(data_size)[:sample_size]
+        dataset = Subset(dataset, subset_indices)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle)

--- a/olive/passes/quark_vitisai/torch/language_modeling/llm_utils/model_preparation.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/llm_utils/model_preparation.py
@@ -1,0 +1,273 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+import logging
+import os
+import random
+from typing import Optional, Union
+
+import numpy as np
+import psutil
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME_KV_LAYERS_MAP = {
+    "mllama": ["*self_attn.k_proj", "*self_attn.v_proj"],
+    "llama": ["*k_proj", "*v_proj"],
+    "opt": ["*k_proj", "*v_proj"],
+    "qwen2moe": ["*k_proj", "*v_proj"],
+    "qwen2": ["*k_proj", "*v_proj"],
+    "qwen": ["*c_attn"],
+    "chatglm": ["*query_key_value"],
+    "phi3": ["*qkv_proj"],
+    "phi": ["*k_proj", "*v_proj"],
+    "mistral": ["*k_proj", "*v_proj"],
+    "mixtral": ["*k_proj", "*v_proj"],
+    "gptj": ["*k_proj", "*v_proj"],
+    "grok": ["*k_proj", "*v_proj"],
+    "cohere": ["*k_proj", "*v_proj"],
+    "dbrx": ["*Wqkv"],
+    "deepseekv2v3": ["*kv_b_proj"],
+    "deepseek": ["*k_proj", "*v_proj"],
+    "gemma2": ["*k_proj", "*v_proj"],
+}
+
+MODEL_NAME_Q_LAYERS_MAP = {
+    "mllama": "*self_attn.q_proj",
+    "llama": "*q_proj",
+    "opt": "*q_proj",
+    "qwen2moe": "*q_proj",
+    "qwen2": "*q_proj",
+    "chatglm": "*query_key_value",
+    "phi3": "*qkv_proj",
+    "phi": "*q_proj",
+    "mistral": "*q_proj",
+    "mixtral": "*q_proj",
+    "gptj": "*q_proj",
+    "grok": "*q_proj",
+    "cohere": "*q_proj",
+    "dbrx": ["*Wqkv"],
+    "deepseek": "*q_proj",
+    "deepseekv2v3": ["*q_a_proj", "*q_b_proj"],
+}
+
+MODEL_NAME_EXCLUDE_LAYERS_MAP = {
+    "mllama": ["*lm_head", "*patch_embedding", "multi_modal_projector"],
+    "llama": ["lm_head"],
+    "opt": ["lm_head"],
+    "qwen2moe": ["lm_head", "*.gate", "*.shared_expert_gate"],
+    "qwen2": ["lm_head"],
+    "qwen": ["lm_head"],
+    "qwq": ["lm_head"],
+    "chatglm": ["transformer.output_layer"],
+    "phi3": ["lm_head"],
+    "phi": ["lm_head"],
+    "mistral": ["lm_head"],
+    "mixtral": ["lm_head", "*.gate"],
+    "gptj": ["lm_head"],
+    "grok": ["lm_head", "*.gate"],
+    "cohere": ["lm_head"],
+    "dbrx": ["lm_head", "*router.layer"],
+    "deepseek": ["lm_head", "*.gate"],
+    "deepseekv2v3": ["lm_head", "*.gate"],
+    "olmo": ["lm_head"],
+    "gemma2": ["lm_head"],
+    "instella": ["lm_head"],
+}
+
+MOE_MODEL_NAME_EXPERTS_LAYERS_MAP = {
+    "llama4": ["*feed_forward.experts*", "*feed_forward.shared_expert*"],
+    "deepseek": ["*.mlp.experts.*"],
+    "grok": ["*.moe_block.experts.*"],
+}
+
+MODEL_NAME_PATTERN_MAP = {
+    "Mllama": "mllama",
+    "Llama": "llama",
+    "OPT": "opt",
+    "Qwen2Moe": "qwen2moe",
+    "QWen2": "qwen2",
+    "QWen": "qwen",
+    "ChatGLM": "chatglm",
+    "Phi3": "phi3",
+    "Phi": "phi",
+    "Mistral": "mistral",
+    "Mixtral": "mixtral",
+    "GPTJ": "gptj",
+    "Grok": "grok",
+    "Cohere": "cohere",
+    "dbrx": "dbrx",
+    "DeepseekV": "deepseekv2v3",
+    "Deepseek": "deepseek",
+    "olmo": "olmo",
+    "gemma2": "gemma2",
+    "instella": "instella",
+}
+
+
+def get_tokenizer(ckpt_path: str, max_seq_len: int = 2048, model_type: Optional[str] = None) -> AutoTokenizer:
+    logger.info("Initializing tokenizer from %s", ckpt_path)
+    use_fast = model_type in ["grok", "cohere", "olmo", "instella", "deepseekv2v3"]
+    tokenizer = AutoTokenizer.from_pretrained(
+        ckpt_path, model_max_length=max_seq_len, padding_side="left", trust_remote_code=True, use_fast=use_fast
+    )
+    if model_type and model_type in ["qwen", "qwen2"]:
+        # qwen2 use token id 151643 as pad and eos tokens
+        tokenizer.pad_token = tokenizer.convert_ids_to_tokens(151643)
+        tokenizer.eos_token = tokenizer.convert_ids_to_tokens(151643)
+
+    if tokenizer.pad_token != "<unk>":
+        tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    assert tokenizer.pad_token is not None, f"Pad token for {model_type} cannot be set!"
+
+    return tokenizer
+
+
+def prepare_for_moe_quant(model: nn.Module):
+    from quark.torch.quantization.utils import set_op_by_name
+    from transformers.models.dbrx.modeling_dbrx import DbrxExperts, DbrxForCausalLM
+
+    from olive.passes.quark_vitisai.torch.language_modeling.module_replacement.dbrx_expert import DbrxExpertsQuark
+
+    if isinstance(model, DbrxForCausalLM):
+        for name, module in model.named_modules(remove_duplicate=False):
+            if isinstance(module, DbrxExperts):
+                new_experts = DbrxExpertsQuark.from_float(module)
+                set_op_by_name(model, name, new_experts)
+                logger.info("module %s has been replaced", name)
+
+
+def get_model(
+    ckpt_path: str,
+    data_type: str = "auto",
+    device: str = "cuda",
+    multi_gpu: bool = False,
+    multi_device=False,
+    attn_implementation: str = "eager",
+) -> tuple[nn.Module, torch.dtype]:
+    if data_type == "float16":
+        model_dtype = torch.float16
+    elif data_type == "bfloat16":
+        model_dtype = torch.bfloat16
+    elif data_type == "float32":
+        model_dtype = torch.float32
+    elif data_type == "auto":
+        model_dtype = data_type
+    else:
+        raise ValueError(f"{data_type} not support for current model")
+    mllama_list = [
+        "Llama-3.2-11B-Vision",
+        "Llama-3.2-90B-Vision",
+        "Llama-3.2-11B-Vision-Instruct",
+        "Llama-3.2-90B-Vision-Instruct",
+    ]
+    model_name = os.path.basename(os.path.normpath(ckpt_path))
+    max_memory = None
+    if multi_device:
+        device = "auto"
+        max_memory = get_device_max_memory()
+    if multi_gpu:
+        device = "auto"
+    if model_name in mllama_list:
+        from transformers import MllamaForConditionalGeneration
+
+        model = MllamaForConditionalGeneration.from_pretrained(
+            ckpt_path,
+            device_map=device,
+            torch_dtype=model_dtype,
+            max_memory=max_memory,
+            trust_remote_code=True,
+            attn_implementation=attn_implementation,
+        )
+    else:
+        try:
+            model = AutoModelForCausalLM.from_pretrained(
+                ckpt_path,
+                device_map=device,
+                torch_dtype=model_dtype,
+                max_memory=max_memory,
+                trust_remote_code=True,
+                attn_implementation=attn_implementation,
+            )
+        except Exception:
+            model = AutoModelForCausalLM.from_pretrained(
+                ckpt_path, device_map=device, torch_dtype=model_dtype, max_memory=max_memory, trust_remote_code=True
+            )
+    if multi_device and hasattr(model, "hf_device_map"):
+        logger.info("device_map: %s", model.hf_device_map)
+    # For certain models, the attribute model.config._name_or_path is an empty string; enforce the setting here.
+    model.config._name_or_path = ckpt_path  # pylint: disable=protected-access
+
+    model.eval()
+    model_dtype = next(model.parameters()).dtype
+
+    return model, model_dtype
+
+
+def get_model_type(model: nn.Module) -> str:
+    for k, v in MODEL_NAME_PATTERN_MAP.items():
+        if k.lower() in type(model).__name__.lower():
+            return v
+    logger.info("\n[INFO]: This model: %s has not been tested with the example provided!", type(model).__name__.lower())
+    logger.info("There may be risks associated with model loading, algorithm configuration, and exporting.")
+    logger.info("However, this does not mean that Quark definitively does not support this model.")
+    logger.info(
+        "If you choose to run this model, please add the model information to the `get_model_type` function in utils/model_preparation.py."
+    )
+    return "unknown"
+
+
+def save_model(model: nn.Module, tokenizer: AutoTokenizer, save_dir: str) -> None:
+    model.save_pretrained(save_dir, safe_serialization=True)
+
+    model_name_or_path = getattr(model.config, "name_or_path", None)
+    if tokenizer is None and model_name_or_path:
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=True)
+            logger.info("Saved the tokenizer from pretrained: %s", model_name_or_path)
+        except Exception as e:
+            logger.info("An error occurred when loading tokenizer: %s", e)
+
+    if tokenizer is not None:
+        tokenizer.save_pretrained(save_dir)
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.backends.cudnn.deterministic = True
+
+
+def get_device_max_memory() -> dict[Union[int, str], Union[int, str]]:
+    for i in range(torch.cuda.device_count()):
+        _ = torch.tensor([0], device=i)
+        cuda_avail_memory = {i: torch.cuda.mem_get_info(i)[0] for i in range(torch.cuda.device_count())}
+        cpu_avail_memory = psutil.virtual_memory().available
+        max_memory = {}
+        for cuda_num, cuda_memory in cuda_avail_memory.items():
+            cuda_memory_gb = cuda_memory / (10**9)
+            logger.info("GPU%s cuda_avail_memory: %.1fGB", cuda_num, cuda_memory_gb)
+            if cuda_num == 0:
+                # The ratio is an experience value that you can manually adjust yourself.
+                gpu0_ratio = 0.5 if cuda_memory_gb > 30 else 0.3
+                max_memory[cuda_num] = f"{cuda_memory_gb * gpu0_ratio:.1f}GB"
+            else:
+                other_ratio = 0.875 if cuda_memory_gb > 30 else 0.7
+                max_memory[cuda_num] = f"{cuda_memory_gb * other_ratio:.1f}GB"
+        logger.info("cpu_avail_memory: %.1fGB", cpu_avail_memory / (10**9))
+        cpu_ratio = 0.875
+        max_memory["cpu"] = f"{cpu_avail_memory / (10**9) * cpu_ratio:.1f}GB"
+        logger.info("final_use_model_kwargs: %s", max_memory)
+        # max_memory =  {0: '0.1GB', 'cpu': '100GB'}
+
+    return max_memory

--- a/olive/passes/quark_vitisai/torch/language_modeling/module_replacement/__init__.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/module_replacement/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#

--- a/olive/passes/quark_vitisai/torch/language_modeling/module_replacement/dbrx_expert.py
+++ b/olive/passes/quark_vitisai/torch/language_modeling/module_replacement/dbrx_expert.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+import torch
+from transformers.models.dbrx.modeling_dbrx import DbrxExpertGLU, DbrxExperts
+
+
+class DbrxExpertGlu(torch.nn.Module):
+    def __init__(self, mlp: DbrxExpertGLU):
+        super().__init__()
+        self.w1 = torch.nn.Linear(mlp.hidden_size, mlp.ffn_hidden_size, device=mlp.w1.device, bias=False)
+        self.v1 = torch.nn.Linear(mlp.hidden_size, mlp.ffn_hidden_size, device=mlp.v1.device, bias=False)
+        self.w2 = torch.nn.Linear(mlp.ffn_hidden_size, mlp.hidden_size, device=mlp.w2.device, bias=False)
+        self.activation_fn = mlp.activation_fn
+
+    def forward(self, x: torch.Tensor):
+        gate_proj = self.activation_fn(self.w1(x))
+        up_proj = self.v1(x)
+        intermediate_states = gate_proj * up_proj
+        return self.w2(intermediate_states)
+
+
+class DbrxExpertsQuark(torch.nn.Module):
+    def __init__(self, experts_module: DbrxExperts):
+        super().__init__()
+        self.moe_num_experts = experts_module.moe_num_experts
+        self.mlp = torch.nn.ModuleList([DbrxExpertGlu(experts_module.mlp) for _ in range(self.moe_num_experts)])
+        w1_chunked = experts_module.mlp.w1.view(
+            experts_module.mlp.moe_num_experts, experts_module.mlp.ffn_hidden_size, experts_module.mlp.hidden_size
+        )
+        v1_chunked = experts_module.mlp.v1.view(
+            experts_module.mlp.moe_num_experts, experts_module.mlp.ffn_hidden_size, experts_module.mlp.hidden_size
+        )
+        w2_chunked = experts_module.mlp.w2.view(
+            experts_module.mlp.moe_num_experts, experts_module.mlp.ffn_hidden_size, experts_module.mlp.hidden_size
+        )
+        for idx in range(self.moe_num_experts):
+            self.mlp[idx].w1.weight.data = w1_chunked[idx].contiguous()
+            self.mlp[idx].v1.weight.data = v1_chunked[idx].contiguous()
+            self.mlp[idx].w2.weight.data = w2_chunked[idx].t().contiguous()
+        experts_module.mlp.w1 = None
+        experts_module.mlp.v1 = None
+        experts_module.mlp.w2 = None
+
+    @classmethod
+    def from_float(cls, float_module: DbrxExperts) -> DbrxExperts:
+        return cls(experts_module=float_module)
+
+    def forward(
+        self, x: torch.Tensor, weights: torch.Tensor, top_weights: torch.Tensor, top_experts: torch.LongTensor
+    ) -> torch.Tensor:
+        bsz, q_len, hidden_size = x.shape
+        x = x.view(-1, hidden_size)
+        out = torch.zeros_like(x)
+        expert_mask = torch.nn.functional.one_hot(  # pylint: disable=not-callable
+            top_experts, num_classes=self.moe_num_experts
+        ).permute(2, 1, 0)
+        for expert_idx in range(self.moe_num_experts):
+            topk_idx, token_idx = torch.where(expert_mask[expert_idx])
+            if token_idx.shape[0] == 0:
+                continue
+            token_list = token_idx
+            topk_list = topk_idx
+            expert_tokens = x[None, token_list].reshape(-1, hidden_size)
+            expert_out = self.mlp[expert_idx](expert_tokens) * top_weights[token_list, topk_list, None]
+            out.index_add_(0, token_idx, expert_out)
+        return out.reshape(bsz, q_len, hidden_size)


### PR DESCRIPTION
## Describe your changes
Adds the `RyzenGenerateModelLLM` Olive pass for the new RyzenAI full-fusion / token-fusion flow on AMD NPU/hybrid devices, and restores two legacy passes to support the older VitisAI eager flow in parallel:

- `VitisGenerateModelLLM` (from commit a24d73a) - legacy eager model generation
- `QuarkQuantizationVitisAI` (from commit 1615bda, originally `QuarkQuantization`) - legacy Quark 0.9 quantization

The legacy quantization class was renamed to avoid a name collision with the existing `QuarkQuantization` pass (Quark 0.11+) used by the new fusion flow. Legacy module path: `olive.passes.quark_vitisai`.

## Pass mapping

| Flow | Quark | Generation pass | Quantization pass |
|------|-------|------------------|--------------------|
| New (RyzenAI fusion) | 0.11 | `RyzenGenerateModelLLM` | `QuarkQuantization` |
| Legacy (VitisAI eager) | 0.9 | `VitisGenerateModelLLM` | `QuarkQuantizationVitisAI` |

## Companion olive-recipes PR
microsoft/olive-recipes#[PR-440](https://github.com/microsoft/olive-recipes/pull/440)— uses these passes per model in `RyzenAI/` and `VitisAI/` subfolders.
