### PR TITLE
add onnxruntime-genai fast tests with transformers token comparison by modality

### DIFF
--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -12,7 +12,13 @@ from pathlib import Path
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
-from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+from transformers import (
+    LlamaConfig,
+    LlamaForCausalLM,
+    PreTrainedTokenizerFast,
+    WhisperConfig,
+    WhisperForConditionalGeneration,
+)
 
 from olive.cli.base import TEST_OUTPUT_MARKER_FILE
 from olive.common.hf.utils import TEST_MODEL_MARKER_FILE
@@ -25,6 +31,11 @@ DEFAULT_MODEL_IDS = (
     "local/tiny-random-llama-a",
     "local/tiny-random-llama-b",
     "mistralai/Mistral-7B-Instruct-v0.3",
+    "microsoft/Phi-3-mini-4k-instruct",
+)
+DEFAULT_WHISPER_MODEL_IDS = (
+    "openai/whisper-tiny",
+    "microsoft/whisper-base",
 )
 MAX_ARTIFACT_SIZE_BYTES = 1024 * 1024
 
@@ -41,6 +52,43 @@ def _save_local_tiny_llama(model_path: Path):
                 "num_key_value_heads": 8,
                 "max_position_embeddings": 64,
             }
+        )
+    )
+    model.save_pretrained(model_path)
+
+    tokenizer = Tokenizer(
+        WordLevel(
+            vocab={"<pad>": 0, "<bos>": 1, "<eos>": 2, "hello": 3, "world": 4},
+            unk_token="<pad>",
+        )
+    )
+    tokenizer.pre_tokenizer = Whitespace()
+    PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token="<bos>",
+        eos_token="<eos>",
+        pad_token="<pad>",
+    ).save_pretrained(model_path)
+
+
+def _save_local_tiny_whisper(model_path: Path):
+    model = WhisperForConditionalGeneration(
+        WhisperConfig(
+            vocab_size=32,
+            num_mel_bins=80,
+            encoder_layers=2,
+            encoder_attention_heads=4,
+            decoder_layers=2,
+            decoder_attention_heads=4,
+            d_model=64,
+            encoder_ffn_dim=128,
+            decoder_ffn_dim=128,
+            max_source_positions=16,
+            max_target_positions=16,
+            pad_token_id=0,
+            bos_token_id=1,
+            eos_token_id=2,
+            decoder_start_token_id=1,
         )
     )
     model.save_pretrained(model_path)
@@ -172,6 +220,37 @@ class TestCliTestModelSmoke(unittest.TestCase):
                 if "model.onnx.data" in run_output_files:
                     self._assert_file_size_below_limit(run_output_dir / "model.onnx.data")
 
+    def test_genai_inference(self):
+        """Verify that the optimized ONNX model can be loaded and run with onnxruntime-genai."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_genai_inference(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_genai_inference(workdir)
+
+    def _assert_genai_inference(self, tmp_path: Path):
+        import onnxruntime_genai as og
+
+        input_ids = [1, 3, 4]  # [bos, hello, world]
+        for model_id in self.model_ids:
+            with self.subTest(model_id=model_id):
+                _, _, run_output_dir = _run_documented_test_model_smoke_flow(tmp_path, model_id)
+                # Load the quantized model with genai and generate one token
+                config = og.Config(str(run_output_dir))
+                config.clear_providers()
+                model = og.Model(config)
+                params = og.GeneratorParams(model)
+                params.set_search_options(
+                    max_length=len(input_ids) + 1, do_sample=False, past_present_share_buffer=False
+                )
+                generator = og.Generator(model, params)
+                generator.append_tokens([input_ids])
+                generator.generate_next_token()
+                token = generator.get_next_tokens()[0]
+                assert isinstance(token, int), f"Expected int token, got {type(token)}"
+
     def test_model_discrepancy(self):
         """Verify that OnnxDiscrepancyCheck runs successfully when auto-injected via --test."""
         if self.workdir is None:
@@ -235,6 +314,281 @@ class TestCliTestModelSmoke(unittest.TestCase):
         return {file_path.relative_to(path).as_posix() for file_path in path.rglob("*") if file_path.is_file()}
 
 
+def _run_whisper_capture_onnx_flow(tmp_path: Path, model_id: str):
+    """Export a tiny local Whisper model to ONNX via capture-onnx-graph with Model Builder."""
+    model_name = model_id.replace("/", "--")
+    model_path = tmp_path / "models" / model_name
+    run_output_dir = tmp_path / f"{model_name}-onnx"
+
+    _save_local_tiny_whisper(model_path)
+    _run_cli_main(
+        [
+            "capture-onnx-graph",
+            "-m",
+            str(model_path),
+            "--use_model_builder",
+            "--precision",
+            "fp32",
+            "--output_path",
+            str(run_output_dir),
+        ]
+    )
+
+    return run_output_dir
+
+
+class TestCliWhisperSmoke(unittest.TestCase):
+    """Smoke tests for Whisper encoder-decoder models exported via capture-onnx-graph."""
+
+    model_ids = DEFAULT_WHISPER_MODEL_IDS
+    workdir = None
+
+    def test_whisper_capture_onnx_graph(self):
+        """Verify that Whisper encoder and decoder are exported to ONNX successfully."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_whisper_export(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_whisper_export(workdir)
+
+    def _assert_whisper_export(self, tmp_path: Path):
+        expected_encoder_file = "encoder.onnx"
+        expected_decoder_file = "decoder.onnx"
+        for model_id in self.model_ids:
+            with self.subTest(model_id=model_id):
+                run_output_dir = _run_whisper_capture_onnx_flow(tmp_path, model_id)
+                output_files = self._list_relative_files(run_output_dir)
+                assert expected_encoder_file in output_files, (
+                    f"Expected {expected_encoder_file} in output, got: {output_files}"
+                )
+                assert expected_decoder_file in output_files, (
+                    f"Expected {expected_decoder_file} in output, got: {output_files}"
+                )
+                self._assert_file_size_below_limit(run_output_dir / expected_encoder_file)
+                self._assert_file_size_below_limit(run_output_dir / expected_decoder_file)
+
+    def test_whisper_genai_inference(self):
+        """Verify that the exported Whisper ONNX model can be loaded and run with onnxruntime-genai."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_whisper_genai_inference(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_whisper_genai_inference(workdir)
+
+    def _assert_whisper_genai_inference(self, tmp_path: Path):
+        import io
+
+        import numpy as np
+        import onnxruntime_genai as og
+        import soundfile as sf
+
+        for model_id in self.whisper_model_ids:
+            with self.subTest(model_id=model_id):
+                run_output_dir = _run_whisper_capture_onnx_flow(tmp_path, model_id)
+
+                # Load model with genai multimodal processor
+                config = og.Config(str(run_output_dir))
+                config.clear_providers()
+                og_model = og.Model(config)
+                processor = og_model.create_multimodal_processor()
+
+                # Create 1 second of silence as WAV bytes
+                sample_rate = 16000
+                audio_samples = np.zeros(sample_rate, dtype=np.float32)
+                buffer = io.BytesIO()
+                sf.write(buffer, audio_samples, samplerate=sample_rate, format="WAV")
+                audios = og.Audios.open_bytes(buffer.getvalue())
+
+                # Generate one decoder token
+                prompt = "<|startoftranscript|>"
+                inputs = processor([prompt], audios=audios)
+                params = og.GeneratorParams(og_model)
+                params.set_search_options(max_length=4, do_sample=False, batch_size=1)
+                generator = og.Generator(og_model, params)
+                generator.set_inputs(inputs)
+                generator.generate_next_token()
+                token = generator.get_next_tokens()[0]
+                assert isinstance(token, int), f"Expected int token, got {type(token)}"
+
+    def _assert_file_size_below_limit(self, path: Path):
+        assert path.exists()
+        assert path.stat().st_size < MAX_ARTIFACT_SIZE_BYTES
+
+    @staticmethod
+    def _list_relative_files(path: Path):
+        return {file_path.relative_to(path).as_posix() for file_path in path.rglob("*") if file_path.is_file()}
+
+
+def _get_transformers_first_token(model_path: Path, input_ids: list[int]) -> int:
+    """Generate one token with transformers and return its id."""
+    import torch
+
+    model = LlamaForCausalLM.from_pretrained(model_path)
+    model.eval()
+    input_tensor = torch.tensor([input_ids], dtype=torch.long)
+    with torch.no_grad():
+        output = model.generate(input_tensor, max_new_tokens=1, do_sample=False)
+    return output[0, len(input_ids)].item()
+
+
+def _get_genai_first_token(onnx_output_dir: Path, input_ids: list[int]) -> int:
+    """Generate one token with onnxruntime-genai and return its id."""
+    import onnxruntime_genai as og
+
+    config = og.Config(str(onnx_output_dir))
+    config.clear_providers()
+    model = og.Model(config)
+    params = og.GeneratorParams(model)
+    params.set_search_options(max_length=len(input_ids) + 1, do_sample=False, past_present_share_buffer=False)
+    generator = og.Generator(model, params)
+    generator.append_tokens([input_ids])
+    generator.generate_next_token()
+    return generator.get_next_tokens()[0]
+
+
+def _export_tiny_llama_fp32(tmp_path: Path, model_id: str) -> tuple[Path, Path]:
+    """Create a tiny LLaMA, export with model_builder fp32, return (model_path, onnx_output_dir)."""
+    model_name = model_id.replace("/", "--")
+    model_path = tmp_path / "models" / model_name
+    onnx_output_dir = tmp_path / f"{model_name}-fp32-onnx"
+
+    _save_local_tiny_llama(model_path)
+    _run_cli_main(
+        [
+            "capture-onnx-graph",
+            "-m",
+            str(model_path),
+            "--use_model_builder",
+            "--precision",
+            "fp32",
+            "--output_path",
+            str(onnx_output_dir),
+        ]
+    )
+
+    return model_path, onnx_output_dir
+
+
+def _export_tiny_whisper_fp32(tmp_path: Path, model_id: str) -> tuple[Path, Path]:
+    """Create a tiny Whisper, export with model_builder fp32, return (model_path, onnx_output_dir)."""
+    model_name = model_id.replace("/", "--")
+    model_path = tmp_path / "models" / model_name
+    onnx_output_dir = tmp_path / f"{model_name}-fp32-onnx"
+
+    _save_local_tiny_whisper(model_path)
+    _run_cli_main(
+        [
+            "capture-onnx-graph",
+            "-m",
+            str(model_path),
+            "--use_model_builder",
+            "--precision",
+            "fp32",
+            "--output_path",
+            str(onnx_output_dir),
+        ]
+    )
+
+    return model_path, onnx_output_dir
+
+
+class TestFirstTokenDiscrepancy(unittest.TestCase):
+    """Compare the first generated token between transformers and onnxruntime-genai."""
+
+    model_ids = DEFAULT_MODEL_IDS
+    whisper_model_ids = DEFAULT_WHISPER_MODEL_IDS
+    workdir = None
+
+    def test_first_token_llama(self):
+        """Verify first token from transformers matches onnxruntime-genai for LLaMA models."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_first_token_llama(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_first_token_llama(workdir)
+
+    def _assert_first_token_llama(self, tmp_path: Path):
+        # Use a simple prompt: [bos, hello, world] -> token ids [1, 3, 4]
+        input_ids = [1, 3, 4]
+        for model_id in self.model_ids:
+            with self.subTest(model_id=model_id):
+                model_path, onnx_output_dir = _export_tiny_llama_fp32(tmp_path, model_id)
+                transformers_token = _get_transformers_first_token(model_path, input_ids)
+                genai_token = _get_genai_first_token(onnx_output_dir, input_ids)
+                assert transformers_token == genai_token, (
+                    f"First token mismatch for {model_id}: "
+                    f"transformers={transformers_token}, genai={genai_token}"
+                )
+
+    def test_first_token_whisper(self):
+        """Verify first decoder token from transformers matches onnxruntime-genai for Whisper."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_first_token_whisper(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_first_token_whisper(workdir)
+
+    def _assert_first_token_whisper(self, tmp_path: Path):
+        import numpy as np
+
+        for model_id in self.whisper_model_ids:
+            with self.subTest(model_id=model_id):
+                model_path, onnx_output_dir = _export_tiny_whisper_fp32(tmp_path, model_id)
+
+                # Generate first decoder token with transformers
+                import torch
+
+                whisper_model = WhisperForConditionalGeneration.from_pretrained(model_path)
+                whisper_model.eval()
+                # Create dummy mel input: [batch, num_mel_bins, max_source_positions * 2]
+                mel_length = whisper_model.config.max_source_positions * 2
+                input_features = torch.randn(1, whisper_model.config.num_mel_bins, mel_length)
+                with torch.no_grad():
+                    output = whisper_model.generate(input_features, max_new_tokens=1, do_sample=False)
+                transformers_token = output[0, 1].item()  # skip decoder_start_token
+
+                # Generate first decoder token with onnxruntime-genai
+                import onnxruntime_genai as og
+
+                config = og.Config(str(onnx_output_dir))
+                config.clear_providers()
+                og_model = og.Model(config)
+                processor = og_model.create_multimodal_processor()
+
+                # Create audio input as WAV bytes
+                import io
+                import soundfile as sf
+
+                # Generate silence audio matching the expected mel length
+                sample_rate = 16000
+                audio_samples = np.zeros(sample_rate, dtype=np.float32)  # 1 second of silence
+                buffer = io.BytesIO()
+                sf.write(buffer, audio_samples, samplerate=sample_rate, format="WAV")
+                audios = og.Audios.open_bytes(buffer.getvalue())
+
+                prompt = "<|startoftranscript|>"
+                inputs = processor([prompt], audios=audios)
+                params = og.GeneratorParams(og_model)
+                params.set_search_options(max_length=4, do_sample=False, batch_size=1)
+                generator = og.Generator(og_model, params)
+                generator.set_inputs(inputs)
+                generator.generate_next_token()
+                genai_token = generator.get_next_tokens()[0]
+
+                assert transformers_token == genai_token, (
+                    f"First decoder token mismatch for {model_id}: "
+                    f"transformers={transformers_token}, genai={genai_token}"
+                )
+
+
 def _parse_args():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--workdir")
@@ -246,6 +600,8 @@ if __name__ == "__main__":
     parsed_args, remaining = _parse_args()
     if parsed_args.workdir:
         TestCliTestModelSmoke.workdir = Path(parsed_args.workdir)
+        TestCliWhisperSmoke.workdir = Path(parsed_args.workdir)
+        TestFirstTokenDiscrepancy.workdir = Path(parsed_args.workdir)
     if parsed_args.model_ids:
         TestCliTestModelSmoke.model_ids = tuple(parsed_args.model_ids)
     unittest.main(argv=[__file__, *remaining])

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -12,13 +12,6 @@ from pathlib import Path
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
-from transformers import (
-    LlamaConfig,
-    LlamaForCausalLM,
-    PreTrainedTokenizerFast,
-    WhisperConfig,
-    WhisperForConditionalGeneration,
-)
 
 from olive.cli.base import TEST_OUTPUT_MARKER_FILE
 from olive.common.hf.utils import TEST_MODEL_MARKER_FILE
@@ -41,6 +34,8 @@ MAX_ARTIFACT_SIZE_BYTES = 1024 * 1024
 
 
 def _save_local_tiny_llama(model_path: Path):
+    from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
     model = LlamaForCausalLM(
         LlamaConfig.from_dict(
             {
@@ -72,6 +67,8 @@ def _save_local_tiny_llama(model_path: Path):
 
 
 def _save_local_tiny_whisper(model_path: Path):
+    from transformers import PreTrainedTokenizerFast, WhisperConfig, WhisperForConditionalGeneration
+
     model = WhisperForConditionalGeneration(
         WhisperConfig(
             vocab_size=32,
@@ -255,6 +252,28 @@ class TestCliTestModelSmoke(unittest.TestCase):
                     f"First token mismatch for {model_id}: transformers={transformers_token}, genai={token}"
                 )
 
+    def test_first_token_llama(self):
+        """Verify first token from transformers matches onnxruntime-genai for LLaMA models."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_first_token_llama(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_first_token_llama(workdir)
+
+    def _assert_first_token_llama(self, tmp_path: Path):
+        input_ids = [1, 3, 4]
+        for model_id in self.model_ids:
+            with self.subTest(model_id=model_id):
+                model_path, onnx_output_dir = _export_tiny_llama_fp32(tmp_path, model_id)
+                transformers_token = _get_transformers_first_token(model_path, input_ids)
+                genai_token = _get_genai_first_token(onnx_output_dir, input_ids)
+                assert transformers_token == genai_token, (
+                    f"First token mismatch for {model_id}: "
+                    f"transformers={transformers_token}, genai={genai_token}"
+                )
+
     def test_model_discrepancy(self):
         """Verify that OnnxDiscrepancyCheck runs successfully when auto-injected via --test."""
         if self.workdir is None:
@@ -418,6 +437,62 @@ class TestCliWhisperSmoke(unittest.TestCase):
                 token = generator.get_next_tokens()[0]
                 assert isinstance(token, int), f"Expected int token, got {type(token)}"
 
+    def test_first_token_whisper(self):
+        """Verify first decoder token from transformers matches onnxruntime-genai for Whisper."""
+        if self.workdir is None:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._assert_first_token_whisper(Path(temp_dir))
+        else:
+            workdir = Path(self.workdir)
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._assert_first_token_whisper(workdir)
+
+    def _assert_first_token_whisper(self, tmp_path: Path):
+        import io
+
+        import numpy as np
+        import onnxruntime_genai as og
+        import soundfile as sf
+        import torch
+        from transformers import WhisperForConditionalGeneration
+
+        for model_id in self.model_ids:
+            with self.subTest(model_id=model_id):
+                model_path, onnx_output_dir = _export_tiny_whisper_fp32(tmp_path, model_id)
+
+                whisper_model = WhisperForConditionalGeneration.from_pretrained(model_path)
+                whisper_model.eval()
+                mel_length = whisper_model.config.max_source_positions * 2
+                input_features = torch.randn(1, whisper_model.config.num_mel_bins, mel_length)
+                with torch.no_grad():
+                    output = whisper_model.generate(input_features, max_new_tokens=1, do_sample=False)
+                transformers_token = output[0, 1].item()
+
+                config = og.Config(str(onnx_output_dir))
+                config.clear_providers()
+                og_model = og.Model(config)
+                processor = og_model.create_multimodal_processor()
+
+                sample_rate = 16000
+                audio_samples = np.zeros(sample_rate, dtype=np.float32)
+                buffer = io.BytesIO()
+                sf.write(buffer, audio_samples, samplerate=sample_rate, format="WAV")
+                audios = og.Audios.open_bytes(buffer.getvalue())
+
+                prompt = "<|startoftranscript|>"
+                inputs = processor([prompt], audios=audios)
+                params = og.GeneratorParams(og_model)
+                params.set_search_options(max_length=4, do_sample=False, batch_size=1)
+                generator = og.Generator(og_model, params)
+                generator.set_inputs(inputs)
+                generator.generate_next_token()
+                genai_token = generator.get_next_tokens()[0]
+
+                assert transformers_token == genai_token, (
+                    f"First decoder token mismatch for {model_id}: "
+                    f"transformers={transformers_token}, genai={genai_token}"
+                )
+
     def _assert_file_size_below_limit(self, path: Path):
         assert path.exists()
         assert path.stat().st_size < MAX_ARTIFACT_SIZE_BYTES
@@ -430,6 +505,7 @@ class TestCliWhisperSmoke(unittest.TestCase):
 def _get_transformers_first_token(model_path: Path, input_ids: list[int]) -> int:
     """Generate one token with transformers and return its id."""
     import torch
+    from transformers import LlamaForCausalLM
 
     model = LlamaForCausalLM.from_pretrained(model_path)
     model.eval()
@@ -499,100 +575,6 @@ def _export_tiny_whisper_fp32(tmp_path: Path, model_id: str) -> tuple[Path, Path
 
     return model_path, onnx_output_dir
 
-
-class TestFirstTokenDiscrepancy(unittest.TestCase):
-    """Compare the first generated token between transformers and onnxruntime-genai."""
-
-    model_ids = DEFAULT_MODEL_IDS
-    whisper_model_ids = DEFAULT_WHISPER_MODEL_IDS
-    workdir = None
-
-    def test_first_token_llama(self):
-        """Verify first token from transformers matches onnxruntime-genai for LLaMA models."""
-        if self.workdir is None:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                self._assert_first_token_llama(Path(temp_dir))
-        else:
-            workdir = Path(self.workdir)
-            workdir.mkdir(parents=True, exist_ok=True)
-            self._assert_first_token_llama(workdir)
-
-    def _assert_first_token_llama(self, tmp_path: Path):
-        # Use a simple prompt: [bos, hello, world] -> token ids [1, 3, 4]
-        input_ids = [1, 3, 4]
-        for model_id in self.model_ids:
-            with self.subTest(model_id=model_id):
-                model_path, onnx_output_dir = _export_tiny_llama_fp32(tmp_path, model_id)
-                transformers_token = _get_transformers_first_token(model_path, input_ids)
-                genai_token = _get_genai_first_token(onnx_output_dir, input_ids)
-                assert transformers_token == genai_token, (
-                    f"First token mismatch for {model_id}: "
-                    f"transformers={transformers_token}, genai={genai_token}"
-                )
-
-    def test_first_token_whisper(self):
-        """Verify first decoder token from transformers matches onnxruntime-genai for Whisper."""
-        if self.workdir is None:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                self._assert_first_token_whisper(Path(temp_dir))
-        else:
-            workdir = Path(self.workdir)
-            workdir.mkdir(parents=True, exist_ok=True)
-            self._assert_first_token_whisper(workdir)
-
-    def _assert_first_token_whisper(self, tmp_path: Path):
-        import numpy as np
-
-        for model_id in self.whisper_model_ids:
-            with self.subTest(model_id=model_id):
-                model_path, onnx_output_dir = _export_tiny_whisper_fp32(tmp_path, model_id)
-
-                # Generate first decoder token with transformers
-                import torch
-
-                whisper_model = WhisperForConditionalGeneration.from_pretrained(model_path)
-                whisper_model.eval()
-                # Create dummy mel input: [batch, num_mel_bins, max_source_positions * 2]
-                mel_length = whisper_model.config.max_source_positions * 2
-                input_features = torch.randn(1, whisper_model.config.num_mel_bins, mel_length)
-                with torch.no_grad():
-                    output = whisper_model.generate(input_features, max_new_tokens=1, do_sample=False)
-                transformers_token = output[0, 1].item()  # skip decoder_start_token
-
-                # Generate first decoder token with onnxruntime-genai
-                import onnxruntime_genai as og
-
-                config = og.Config(str(onnx_output_dir))
-                config.clear_providers()
-                og_model = og.Model(config)
-                processor = og_model.create_multimodal_processor()
-
-                # Create audio input as WAV bytes
-                import io
-                import soundfile as sf
-
-                # Generate silence audio matching the expected mel length
-                sample_rate = 16000
-                audio_samples = np.zeros(sample_rate, dtype=np.float32)  # 1 second of silence
-                buffer = io.BytesIO()
-                sf.write(buffer, audio_samples, samplerate=sample_rate, format="WAV")
-                audios = og.Audios.open_bytes(buffer.getvalue())
-
-                prompt = "<|startoftranscript|>"
-                inputs = processor([prompt], audios=audios)
-                params = og.GeneratorParams(og_model)
-                params.set_search_options(max_length=4, do_sample=False, batch_size=1)
-                generator = og.Generator(og_model, params)
-                generator.set_inputs(inputs)
-                generator.generate_next_token()
-                genai_token = generator.get_next_tokens()[0]
-
-                assert transformers_token == genai_token, (
-                    f"First decoder token mismatch for {model_id}: "
-                    f"transformers={transformers_token}, genai={genai_token}"
-                )
-
-
 def _parse_args():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--workdir")
@@ -605,7 +587,6 @@ if __name__ == "__main__":
     if parsed_args.workdir:
         TestCliTestModelSmoke.workdir = Path(parsed_args.workdir)
         TestCliWhisperSmoke.workdir = Path(parsed_args.workdir)
-        TestFirstTokenDiscrepancy.workdir = Path(parsed_args.workdir)
     if parsed_args.model_ids:
         TestCliTestModelSmoke.model_ids = tuple(parsed_args.model_ids)
     unittest.main(argv=[__file__, *remaining])

--- a/test/cli/test_cli_test_model_smoke.py
+++ b/test/cli/test_cli_test_model_smoke.py
@@ -237,6 +237,8 @@ class TestCliTestModelSmoke(unittest.TestCase):
         for model_id in self.model_ids:
             with self.subTest(model_id=model_id):
                 _, _, run_output_dir = _run_documented_test_model_smoke_flow(tmp_path, model_id)
+                model_path = tmp_path / "models" / model_id.replace("/", "--")
+                transformers_token = _get_transformers_first_token(model_path, input_ids)
                 # Load the quantized model with genai and generate one token
                 config = og.Config(str(run_output_dir))
                 config.clear_providers()
@@ -249,7 +251,9 @@ class TestCliTestModelSmoke(unittest.TestCase):
                 generator.append_tokens([input_ids])
                 generator.generate_next_token()
                 token = generator.get_next_tokens()[0]
-                assert isinstance(token, int), f"Expected int token, got {type(token)}"
+                assert transformers_token == token, (
+                    f"First token mismatch for {model_id}: transformers={transformers_token}, genai={token}"
+                )
 
     def test_model_discrepancy(self):
         """Verify that OnnxDiscrepancyCheck runs successfully when auto-injected via --test."""


### PR DESCRIPTION
## Describe your changes

add fast tests to validate models with onnxruntime-genai, including first-token checks against `transformers.generate`.

updated the smoke tests to keep modality-specific coverage:
- text-model first-token checks are in `TestCliTestModelSmoke`
- audio-model first-token checks are in `TestCliWhisperSmoke`

also moved `transformers` imports from module scope into local usage sites where needed.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link