### PR TITLE
Fix node output issues

### DIFF
--- a/olive/passes/onnx/kquant_quantization.py
+++ b/olive/passes/onnx/kquant_quantization.py
@@ -380,7 +380,10 @@ class OnnxKQuantQuantization(Pass):
         if accuracy_level > 0:
             kwargs["accuracy_level"] = accuracy_level
 
-        node.outputs[0].name = node.outputs[0].name + f"_Q{bits}"
+        # Only rename intermediate outputs; preserve graph output names so
+        # downstream consumers (e.g. genai_config.json) keep working.
+        if node.outputs[0] not in node.graph.outputs:
+            node.outputs[0].name = node.outputs[0].name + f"_Q{bits}"
 
         return ir.node(
             domain=MSFT_DOMAIN,


### PR DESCRIPTION
This pull request updates the `_quantize_matmul` function to improve compatibility with downstream consumers by preserving the names of graph outputs during quantization. Now, only intermediate output names are modified, ensuring that external tools relying on specific output names continue to work as expected.

Output name handling:

* Updated `_quantize_matmul` in `olive/passes/onnx/kquant_quantization.py` to only rename intermediate outputs, preserving the names of graph outputs so downstream consumers (such as `genai_config.json`) remain compatible.