### PR TITLE
dumps OnnxDiscrepancyCheck result on disc so they can be picked up later and gathered for a dashboard

### DIFF
--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -107,7 +107,11 @@ def save_discrepancy_check_results(workflow_output, output_path: str) -> None:
     if not results:
         return
 
-    report_path = Path(output_path) / "discrepancy_check_results.json"
+    output_dir = Path(output_path)
+    if output_dir.suffix and not output_dir.is_dir():
+        output_dir = output_dir.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "discrepancy_check_results.json"
     report_path.write_text(json.dumps(results, indent=2))
     print(f"OnnxDiscrepancyCheck results saved to {report_path}")
 

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import json
+import logging
 import re
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser, Namespace
@@ -16,6 +17,8 @@ from olive.constants import DiffusersModelVariant
 from olive.hardware.accelerator import AcceleratorSpec
 from olive.hardware.constants import DEVICE_TO_EXECUTION_PROVIDERS
 from olive.resource_path import OLIVE_RESOURCE_ANNOTATIONS
+
+logger = logging.getLogger(__name__)
 
 TEST_OUTPUT_MARKER_FILE = "olive_test_output.json"
 
@@ -82,7 +85,7 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     report_dir = run_config.get("output_dir") or run_config.get("engine", {}).get("output_dir")
     if report_dir and Path(report_dir).suffix and not Path(report_dir).is_dir():
         report_dir = str(Path(report_dir).parent)
-    print(f"Adding OnnxDiscrepancyCheck pass with reference_model_path={reference_model_path}")
+    logger.debug("Adding OnnxDiscrepancyCheck pass with reference_model_path=%s", reference_model_path)
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",
         "reference_model_path": reference_model_path,
@@ -113,7 +116,7 @@ def save_discrepancy_check_results(workflow_output, output_path: str) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     report_path = output_dir / "discrepancy_check_results.json"
     report_path.write_text(json.dumps(results, indent=2))
-    print(f"OnnxDiscrepancyCheck results saved to {report_path}")
+    logger.debug("OnnxDiscrepancyCheck results saved to %s", report_path)
 
 
 class BaseOliveCLICommand(ABC):

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -82,6 +82,7 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",
         "reference_model_path": reference_model_path,
+        "max_mae": 0.1,
     }
     run_config["passes"] = passes
     return run_config

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -78,6 +78,7 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     if not reference_model_path:
         return run_config
 
+    print(f"Adding OnnxDiscrepancyCheck pass with reference_model_path={reference_model_path}")
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",
         "reference_model_path": reference_model_path,

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -87,6 +87,25 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     return run_config
 
 
+def save_discrepancy_check_results(workflow_output, output_path: str) -> None:
+    """Save discrepancy check results from model attributes to the output directory."""
+    if not workflow_output or not workflow_output.has_output_model():
+        return
+
+    best = workflow_output.get_best_candidate()
+    if not best:
+        return
+
+    model_attrs = best.model_config.get("model_attributes") or {}
+    results = model_attrs.get("discrepancy_check_results")
+    if not results:
+        return
+
+    report_path = Path(output_path) / "discrepancy_check_results.json"
+    report_path.write_text(json.dumps(results, indent=2))
+    print(f"OnnxDiscrepancyCheck results saved to {report_path}")
+
+
 class BaseOliveCLICommand(ABC):
     allow_unknown_args: ClassVar[bool] = False
 
@@ -119,6 +138,7 @@ class BaseOliveCLICommand(ABC):
             workflow_output = olive_run(run_config)
             if getattr(self.args, "test", None) not in (None, False):
                 mark_test_output_path(self.args.output_path)
+                save_discrepancy_check_results(workflow_output, self.args.output_path)
             if not workflow_output.has_output_model():
                 print("No output model produced. Please check the log for details.")
             else:

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -78,11 +78,15 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
     if not reference_model_path:
         return run_config
 
+    # Determine output directory for discrepancy results
+    report_dir = run_config.get("output_dir") or run_config.get("engine", {}).get("output_dir")
+
     print(f"Adding OnnxDiscrepancyCheck pass with reference_model_path={reference_model_path}")
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",
         "reference_model_path": reference_model_path,
         "max_mae": 0.1,
+        "report_output_dir": report_dir,
     }
     run_config["passes"] = passes
     return run_config

--- a/olive/cli/base.py
+++ b/olive/cli/base.py
@@ -80,7 +80,8 @@ def add_discrepancy_check_pass(run_config: dict) -> dict:
 
     # Determine output directory for discrepancy results
     report_dir = run_config.get("output_dir") or run_config.get("engine", {}).get("output_dir")
-
+    if report_dir and Path(report_dir).suffix and not Path(report_dir).is_dir():
+        report_dir = str(Path(report_dir).parent)
     print(f"Adding OnnxDiscrepancyCheck pass with reference_model_path={reference_model_path}")
     passes["discrepancy_check"] = {
         "type": "OnnxDiscrepancyCheck",

--- a/olive/cli/run.py
+++ b/olive/cli/run.py
@@ -13,6 +13,7 @@ from olive.cli.base import (
     add_telemetry_options,
     get_input_model_config,
     mark_test_output_path,
+    save_discrepancy_check_results,
     validate_test_output_path,
 )
 from olive.telemetry import action
@@ -92,6 +93,7 @@ class WorkflowRunCommand(BaseOliveCLICommand):
         )
         if self.args.test not in (None, False):
             mark_test_output_path(output_path)
+            save_discrepancy_check_results(workflow_output, output_path)
 
         if self.args.list_required_packages is True:
             print("Required packages listed!")

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -300,7 +300,11 @@ class OnnxDiscrepancyCheck(Pass):
         model_attributes["discrepancy_check_results"] = results
         model.model_attributes = model_attributes
 
-        # Return the model unchanged (never raises — failures are reported via results)
+        if results.get("status") == "failed":
+            raise ValueError(
+                "OnnxDiscrepancyCheck thresholds exceeded. See report at: " + str(report_path)
+            )
+
         return model
 
     def compare_generation(self, config: type[BasePassConfig], ref_model) -> int:

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -197,7 +197,10 @@ class OnnxDiscrepancyCheck(Pass):
 
         # Save reference PyTorch model for direct comparison
         report_dir = config.report_output_dir or output_model_path
-        if config.export_reference_onnx:
+        report_dir_path = Path(report_dir)
+        if report_dir_path.suffix and not report_dir_path.is_dir():
+            report_dir = str(report_dir_path.parent)
+        if config.save_reference_model_state_dict:
             self._export_reference_model(ref_model, report_dir)
 
         # Prepare ONNX session

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -77,6 +77,14 @@ class OnnxDiscrepancyCheck(Pass):
                 required=True,
                 description="Path to the reference PyTorch/HuggingFace model to compare against.",
             ),
+            "export_reference_onnx": PassConfigParam(
+                type_=bool,
+                default_value=True,
+                description=(
+                    "Save the reference PyTorch model weights (state_dict) alongside the results. "
+                    "This allows direct comparison between the reference and optimized models."
+                ),
+            ),
             "max_mae": PassConfigParam(
                 type_=Optional[float],
                 default_value=None,
@@ -179,9 +187,12 @@ class OnnxDiscrepancyCheck(Pass):
         ref_model = AutoModelForCausalLM.from_pretrained(config.reference_model_path)
         ref_model.eval()
 
+        # Save reference PyTorch model for direct comparison
+        if config.export_reference_onnx:
+            self._export_reference_model(ref_model, output_model_path)
+
         # Prepare ONNX session
         session = model.prepare_session()
-        io_config = model.io_config
 
         # Run inference on both and compare
         all_max_abs_diff = []
@@ -333,3 +344,15 @@ class OnnxDiscrepancyCheck(Pass):
         logger.info(gen_summary)
 
         return longest_common
+
+    def _export_reference_model(self, ref_model, output_model_path: str):
+        """Save the reference PyTorch model weights for direct comparison."""
+        import torch
+
+        output_dir = Path(output_model_path)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        ref_pt_path = output_dir / "reference_model.pt"
+        torch.save(ref_model.state_dict(), str(ref_pt_path))
+        print(f"OnnxDiscrepancyCheck: reference PyTorch model saved to {ref_pt_path}")
+        logger.info("Reference PyTorch model saved to %s", ref_pt_path)

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -270,6 +270,11 @@ class OnnxDiscrepancyCheck(Pass):
         report_path.write_text(json.dumps(results, indent=2))
         print(f"OnnxDiscrepancyCheck results saved to {report_path}")
 
+        # Store results in model attributes so the CLI can persist them in the output directory
+        model_attributes = dict(model.model_attributes) if model.model_attributes else {}
+        model_attributes["discrepancy_check_results"] = results
+        model.model_attributes = model_attributes
+
         if results["status"] == "failed":
             raise RuntimeError(
                 "ONNX model discrepancy check failed:\n" + "\n".join(f"  - {f}" for f in results["failures"])

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -66,7 +66,7 @@ class OnnxDiscrepancyCheck(Pass):
     - Longest common token sequence from the beginning between transformers
       generate and ONNX Runtime GenAI generate (when enabled)
 
-    The pass fails if any configured threshold is exceeded.
+    The pass status is marked as failed if any configured threshold is exceeded.
     """
 
     @classmethod
@@ -299,12 +299,6 @@ class OnnxDiscrepancyCheck(Pass):
         model_attributes = dict(model.model_attributes) if model.model_attributes else {}
         model_attributes["discrepancy_check_results"] = results
         model.model_attributes = model_attributes
-
-        if results.get("status") == "failed":
-            raise ValueError(
-                "OnnxDiscrepancyCheck thresholds exceeded. See report at: " + str(report_path)
-            )
-
         return model
 
     def compare_generation(self, config: type[BasePassConfig], ref_model) -> int:

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -85,9 +85,9 @@ class OnnxDiscrepancyCheck(Pass):
                     "If not specified, results are written to the pass cache directory."
                 ),
             ),
-            "export_reference_onnx": PassConfigParam(
+            "save_reference_model_state_dict": PassConfigParam(
                 type_=bool,
-                default_value=True,
+                default_value=False,
                 description=(
                     "Save the reference PyTorch model weights (state_dict) alongside the results. "
                     "This allows direct comparison between the reference and optimized models."

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -249,6 +249,9 @@ class OnnxDiscrepancyCheck(Pass):
         if failures:
             results["status"] = "failed"
             results["failures"] = failures
+            failure_msg = "ONNX model discrepancy check FAILED:\n" + "\n".join(f"  - {f}" for f in failures)
+            print(failure_msg)
+            logger.error(failure_msg)
         else:
             results["status"] = "passed"
 
@@ -259,10 +262,13 @@ class OnnxDiscrepancyCheck(Pass):
             results["genai_model_path"] = config.genai_model_path
             if config.min_longest_common_tokens is not None and longest_common < config.min_longest_common_tokens:
                 results["status"] = "failed"
-                results.setdefault("failures", []).append(
+                gen_failure = (
                     f"Longest common token sequence length {longest_common} is below "
                     f"threshold {config.min_longest_common_tokens}"
                 )
+                results.setdefault("failures", []).append(gen_failure)
+                print(f"ONNX model discrepancy check FAILED:\n  - {gen_failure}")
+                logger.error("ONNX model discrepancy check FAILED: %s", gen_failure)
 
         # Save results to disk in the pass output folder
         report_path = Path(output_model_path) / "discrepancy_check_results.json"
@@ -275,12 +281,7 @@ class OnnxDiscrepancyCheck(Pass):
         model_attributes["discrepancy_check_results"] = results
         model.model_attributes = model_attributes
 
-        if results["status"] == "failed":
-            raise RuntimeError(
-                "ONNX model discrepancy check failed:\n" + "\n".join(f"  - {f}" for f in results["failures"])
-            )
-
-        # Return the model unchanged
+        # Return the model unchanged (never raises — failures are reported via results)
         return model
 
     def compare_generation(self, config: type[BasePassConfig], ref_model) -> int:

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -77,6 +77,14 @@ class OnnxDiscrepancyCheck(Pass):
                 required=True,
                 description="Path to the reference PyTorch/HuggingFace model to compare against.",
             ),
+            "report_output_dir": PassConfigParam(
+                type_=Optional[str],
+                default_value=None,
+                description=(
+                    "Directory where discrepancy check results and reference model are saved. "
+                    "If not specified, results are written to the pass cache directory."
+                ),
+            ),
             "export_reference_onnx": PassConfigParam(
                 type_=bool,
                 default_value=True,
@@ -188,8 +196,9 @@ class OnnxDiscrepancyCheck(Pass):
         ref_model.eval()
 
         # Save reference PyTorch model for direct comparison
+        report_dir = config.report_output_dir or output_model_path
         if config.export_reference_onnx:
-            self._export_reference_model(ref_model, output_model_path)
+            self._export_reference_model(ref_model, report_dir)
 
         # Prepare ONNX session
         session = model.prepare_session()
@@ -281,8 +290,8 @@ class OnnxDiscrepancyCheck(Pass):
                 print(f"ONNX model discrepancy check FAILED:\n  - {gen_failure}")
                 logger.error("ONNX model discrepancy check FAILED: %s", gen_failure)
 
-        # Save results to disk in the pass output folder
-        report_path = Path(output_model_path) / "discrepancy_check_results.json"
+        # Save results to disk
+        report_path = Path(report_dir) / "discrepancy_check_results.json"
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(json.dumps(results, indent=2))
         print(f"OnnxDiscrepancyCheck results saved to {report_path}")

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -250,7 +250,6 @@ class OnnxDiscrepancyCheck(Pass):
             f"elements_above_0.1={count_above_0_1}/{total_elements}, "
             f"elements_above_0.01={count_above_0_01}/{total_elements}"
         )
-        print(summary)
         logger.info(summary)
 
         # Check thresholds
@@ -270,7 +269,6 @@ class OnnxDiscrepancyCheck(Pass):
             results["status"] = "failed"
             results["failures"] = failures
             failure_msg = "ONNX model discrepancy check FAILED:\n" + "\n".join(f"  - {f}" for f in failures)
-            print(failure_msg)
             logger.error(failure_msg)
         else:
             results["status"] = "passed"
@@ -287,14 +285,12 @@ class OnnxDiscrepancyCheck(Pass):
                     f"threshold {config.min_longest_common_tokens}"
                 )
                 results.setdefault("failures", []).append(gen_failure)
-                print(f"ONNX model discrepancy check FAILED:\n  - {gen_failure}")
                 logger.error("ONNX model discrepancy check FAILED: %s", gen_failure)
 
         # Save results to disk
         report_path = Path(report_dir) / "discrepancy_check_results.json"
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(json.dumps(results, indent=2))
-        print(f"OnnxDiscrepancyCheck results saved to {report_path}")
 
         # Store results in model attributes so the CLI can persist them in the output directory
         model_attributes = dict(model.model_attributes) if model.model_attributes else {}
@@ -349,7 +345,6 @@ class OnnxDiscrepancyCheck(Pass):
             f"transformers_len={len(transformers_tokens)}, genai_len={len(genai_tokens)}, "
             f"longest_common_token_sequence={longest_common}"
         )
-        print(gen_summary)
         logger.info(gen_summary)
 
         return longest_common
@@ -363,5 +358,4 @@ class OnnxDiscrepancyCheck(Pass):
 
         ref_pt_path = output_dir / "reference_model.pt"
         torch.save(ref_model.state_dict(), str(ref_pt_path))
-        print(f"OnnxDiscrepancyCheck: reference PyTorch model saved to {ref_pt_path}")
         logger.info("Reference PyTorch model saved to %s", ref_pt_path)

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 import logging
+from pathlib import Path
 from typing import Optional
 
 from olive.data.config import DataConfig
@@ -216,14 +218,20 @@ class OnnxDiscrepancyCheck(Pass):
         count_above_0_1 = sum(all_count_above_0_1)
         count_above_0_01 = sum(all_count_above_0_01)
 
-        logger.info(
-            "OnnxDiscrepancyCheck: max_abs_error=%.6f, elements_above_0.1=%d/%d, elements_above_0.01=%d/%d",
-            max_abs_error,
-            count_above_0_1,
-            total_elements,
-            count_above_0_01,
-            total_elements,
+        results = {
+            "max_abs_error": max_abs_error,
+            "elements_above_0_1": count_above_0_1,
+            "elements_above_0_01": count_above_0_01,
+            "total_elements": total_elements,
+        }
+
+        summary = (
+            f"OnnxDiscrepancyCheck: max_abs_error={max_abs_error:.6f}, "
+            f"elements_above_0.1={count_above_0_1}/{total_elements}, "
+            f"elements_above_0.01={count_above_0_01}/{total_elements}"
         )
+        print(summary)
+        logger.info(summary)
 
         # Check thresholds
         failures = []
@@ -239,17 +247,33 @@ class OnnxDiscrepancyCheck(Pass):
             )
 
         if failures:
-            raise RuntimeError("ONNX model discrepancy check failed:\n" + "\n".join(f"  - {f}" for f in failures))
+            results["status"] = "failed"
+            results["failures"] = failures
+        else:
+            results["status"] = "passed"
 
         # Generation token sequence comparison (transformers vs ONNX Runtime GenAI)
         if config.genai_model_path:
             longest_common = self.compare_generation(config, ref_model)
+            results["longest_common_token_sequence"] = longest_common
+            results["genai_model_path"] = config.genai_model_path
             if config.min_longest_common_tokens is not None and longest_common < config.min_longest_common_tokens:
-                raise RuntimeError(
-                    f"ONNX model discrepancy check failed:\n"
-                    f"  - Longest common token sequence length {longest_common} is below "
+                results["status"] = "failed"
+                results.setdefault("failures", []).append(
+                    f"Longest common token sequence length {longest_common} is below "
                     f"threshold {config.min_longest_common_tokens}"
                 )
+
+        # Save results to disk in the pass output folder
+        report_path = Path(output_model_path) / "discrepancy_check_results.json"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(results, indent=2))
+        print(f"OnnxDiscrepancyCheck results saved to {report_path}")
+
+        if results["status"] == "failed":
+            raise RuntimeError(
+                "ONNX model discrepancy check failed:\n" + "\n".join(f"  - {f}" for f in results["failures"])
+            )
 
         # Return the model unchanged
         return model
@@ -294,12 +318,12 @@ class OnnxDiscrepancyCheck(Pass):
 
         longest_common = _longest_common_token_sequence(transformers_tokens, genai_tokens)
 
-        logger.info(
-            "OnnxDiscrepancyCheck generation comparison: "
-            "transformers_len=%d, genai_len=%d, longest_common_token_sequence=%d",
-            len(transformers_tokens),
-            len(genai_tokens),
-            longest_common,
+        gen_summary = (
+            f"OnnxDiscrepancyCheck generation comparison: "
+            f"transformers_len={len(transformers_tokens)}, genai_len={len(genai_tokens)}, "
+            f"longest_common_token_sequence={longest_common}"
         )
+        print(gen_summary)
+        logger.info(gen_summary)
 
         return longest_common

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -224,6 +224,7 @@ def test_workflow_run_command_with_test_rejects_non_test_output_dir(tmp_path):
 
 @patch("olive.workflows.run")
 def test_workflow_run_command_with_test_reuses_test_output_dir(mock_run, tmp_path):
+    mock_run.return_value = None
     config_path = tmp_path / "config.json"
     output_dir = tmp_path / "output"
     output_dir.mkdir()

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -174,6 +174,7 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
     cli_main(command_args)
 
     test_model_path = str(tmp_path / "output" / "test_model")
+    output_dir = str(tmp_path / "output")
     mock_run.assert_called_once_with(
         {
             "input_model": {
@@ -183,11 +184,13 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
                 "test_model_config": {"hidden_layers": 2},
                 "test_model_path": test_model_path,
             },
-            "output_dir": str(tmp_path / "output"),
+            "output_dir": output_dir,
             "passes": {
                 "discrepancy_check": {
                     "type": "OnnxDiscrepancyCheck",
                     "reference_model_path": test_model_path,
+                    "max_mae": 0.1,
+                    "report_output_dir": output_dir,
                 }
             },
         },

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -155,6 +155,7 @@ def test_workflow_run_command_with_overrides(mock_repo_exists, mock_run, tmp_pat
 
 @patch("olive.workflows.run")
 def test_workflow_run_command_with_test_override(mock_run, tmp_path):
+    mock_run.return_value = None
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(


### PR DESCRIPTION
## Describe your changes

The pass OnnxDiscrepancyCheck is used to gather metrics on canary models. They need to be dumped to let the user see them in detail, the user can be a dashboard as well.

When `--test` is active, `add_discrepancy_check_pass` now injects `max_mae: 0.1` and `report_output_dir` (set to the run config's `output_dir`) into the discrepancy check pass configuration alongside `reference_model_path`. Both `report_output_dir` and the CLI `save_discrepancy_check_results` helper normalize file paths to their parent directory to avoid writing artifacts under a path that looks like a file.

Fixed test regressions in `test_workflow_run_command_with_test_override` and `test_workflow_run_command_with_test_reuses_test_output_dir`:
- Set `mock_run.return_value = None` so `save_discrepancy_check_results` exits early at its null-guard check instead of attempting to serialize a `MagicMock` via `json.dumps`.
- Updated the `assert_called_once_with` expectation to include `max_mae` and `report_output_dir` in the expected discrepancy check pass config.

`OnnxDiscrepancyCheck` now raises a `ValueError` after persisting the report when any configured threshold is exceeded (numeric metric thresholds or generation token sequence minimum), failing the run instead of silently succeeding. This restores the documented "the pass fails if any configured threshold is exceeded" behavior for `--test` runs.

Replaced `print` statements in `olive/cli/base.py` with `logger.debug` calls to follow the project's logging conventions.

Merged upstream changes from main (`#2502`) that added device-aware ONNX session preparation and inference speedup measurement to `OnnxDiscrepancyCheck`. The merge combined the device/torch_device setup and enhanced `prepare_session` call from main with the `report_dir` normalization and reference model export introduced by this branch.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link