### PR TITLE
Fix vision VQA accuracy: align ground truth with A/B/C/D option labels

### DIFF
--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -495,11 +495,13 @@ def vision_vqa_pre_process(
             if isinstance(answer, (list, tuple)):
                 answer = "|".join(str(a) for a in answer) if answer else ""
 
-            # Convert 0-based answer index to 1-based to match the option numbering
+            # Convert 0-based answer index to letter to match the A/B/C/D option labeling
             if num_choices > 0:
                 try:
-                    idx = int(answer)
-                    answer = str(idx + 1)
+                    answer_idx = int(answer)
+                    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    if 0 <= answer_idx < min(num_choices, len(letters)):
+                        answer = letters[answer_idx]
                 except (ValueError, TypeError):
                     pass  # answer is already a non-numeric string (e.g., text label)
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -938,25 +938,15 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
                     sample_idx += 1
 
-                    # For multiple-choice tasks, extract the answer from responses.
-                    # First try digit extraction (for 1-based numbered options),
-                    # then fall back to letter extraction (for A/B/C/D options).
-                    if 1 <= num_choices <= 9 and pred:
-                        pattern = rf"\b([1-{num_choices}])\b"
-                        num_match = re.search(pattern, pred)
-                        if num_match:
-                            pred = num_match.group(1)
-                        else:
-                            # Fallback: find any single digit in the valid range
-                            valid_digits = {str(d) for d in range(1, num_choices + 1)}
-                            for ch in pred:
-                                if ch in valid_digits:
-                                    pred = ch
-                                    break
-                    elif extract_option_letter and pred:
-                        letter_match = re.search(r"\b([A-Z])\b", pred)
+                    # For multiple-choice tasks, extract the letter answer (A/B/C/D).
+                    # Restrict to valid option letters based on num_choices and accept lowercase.
+                    if extract_option_letter and pred and num_choices > 0:
+                        letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                        valid_letters = letters[:num_choices]
+                        pattern = rf"\b([{valid_letters}{valid_letters.lower()}])\b"
+                        letter_match = re.search(pattern, pred)
                         if letter_match:
-                            pred = letter_match.group(1)
+                            pred = letter_match.group(1).upper()
                     all_preds.append(pred)
 
                 # Collect reference texts (aligned with preds including empty ones for None images)

--- a/test/evaluator/test_accuracy.py
+++ b/test/evaluator/test_accuracy.py
@@ -414,3 +414,61 @@ class TestWordSortRatio:
         targets = [""]
         result = metric.measure(model_output, targets)
         assert result == 1.0
+
+
+class TestVisionVQALetterConversion:
+    """Test vision VQA multiple-choice letter conversion and extraction logic."""
+
+    def test_ground_truth_index_to_letter(self):
+        """Ground truth 0-based index should be converted to letter matching A/B/C/D labels."""
+        from datasets import Dataset
+
+        from olive.data.component.pre_process_data import vision_vqa_pre_process
+
+        ds = Dataset.from_dict({
+            "image": [None],
+            "question": ["What is shown?"],
+            "answer": [2],
+            "options": [["opt1", "opt2", "opt3", "opt4"]],
+        })
+        vqa_ds = vision_vqa_pre_process(ds, options_col="options")
+        _, answer = vqa_ds[0]
+        assert answer == "C"
+
+    def test_ground_truth_index_beyond_26_not_converted(self):
+        """Index >= 26 should not be converted to letter (no IndexError)."""
+        from datasets import Dataset
+
+        from olive.data.component.pre_process_data import vision_vqa_pre_process
+
+        options = [f"opt{i}" for i in range(30)]
+        ds = Dataset.from_dict({
+            "image": [None],
+            "question": ["Q?"],
+            "answer": [27],
+            "options": [options],
+        })
+        vqa_ds = vision_vqa_pre_process(ds, options_col="options")
+        _, answer = vqa_ds[0]
+        # Should not crash; answer stays as original string since idx >= len(letters)
+        assert answer == "27"
+
+    def test_exact_match_with_letter_prediction(self):
+        """ExactMatch metric should match letter prediction against letter ground truth."""
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["B"], logits=None)
+        targets = ["B"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0
+
+    def test_exact_match_letter_case_insensitive(self):
+        """ExactMatch should be case-insensitive."""
+        from olive.evaluator.accuracy import ExactMatch
+
+        metric = ExactMatch({})
+        model_output = OliveModelOutput(preds=["b"], logits=None)
+        targets = ["B"]
+        result = metric.measure(model_output, targets)
+        assert result == 1.0


### PR DESCRIPTION
## Describe your changes

PR #2501 changed multiple-choice option formatting from 1-based numbers (`1. 2. 3. 4.`) to letters (`A. B. C. D.`) but did not update the ground truth conversion, which still produced numeric answers (`"1", "2", "3", "4"`).

The evaluator's digit extraction logic (`if 1 <= num_choices <= 9`) took priority over the letter extraction branch (`elif extract_option_letter`), meaning the model's letter response (e.g., `"A"`) could never match the numeric ground truth (e.g., `"1"`).

**Impact:** AI2D accuracy dropped from ~75% to ~11% (near random chance).

### Changes:
- **`olive/data/component/pre_process_data.py`**: Convert 0-based answer index to letter (`A/B/C/D`) instead of 1-based number (`1/2/3/4`)
- **`olive/evaluator/olive_evaluator.py`**: Remove dead digit extraction code path; use letter extraction directly when `extract_option_letter` is set

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code