### PR TITLE
Revert "Fix input validation issues and update multiple-choice options handling (#2501)"

### DIFF
--- a/olive/data/component/pre_process_data.py
+++ b/olive/data/component/pre_process_data.py
@@ -478,16 +478,11 @@ def vision_vqa_pre_process(
             # Use 1-based numbering (1, 2, 3, 4) which aligns with how VLMs are
             # typically prompted and avoids confusion with diagram region labels.
             num_choices = 0
-            has_options = False
             if self.options_column and self.options_column in item:
                 options = item[self.options_column]
-                if isinstance(options, (list, tuple)):
-                    has_options = True
+                if isinstance(options, (list, tuple)) and len(options) > 0:
                     num_choices = len(options)
-                    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    options_text = "\n".join(
-                        f"{letters[i] if i < len(letters) else str(i)}. {opt}" for i, opt in enumerate(options)
-                    )
+                    options_text = "\n".join(f"{i + 1}. {opt}" for i, opt in enumerate(options))
                     question = f"{question}\n{options_text}"
 
             # Handle list/tuple answers (some datasets have multiple valid answers)
@@ -507,7 +502,6 @@ def vision_vqa_pre_process(
                 "image": image,
                 "question": question,
                 "system_prompt": self.system_prompt,
-                "extract_option_letter": has_options,
                 "num_choices": num_choices,
                 "max_length": self.max_length,
             }

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -881,7 +881,6 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
                     pil_image = item.get("image")
                     question = item.get("question", "")
                     sys_prompt = item.get("system_prompt", "")
-                    extract_option_letter = item.get("extract_option_letter", False)
                     num_choices = item.get("num_choices", 0)
                     max_length = item.get("max_length", default_max_length)
 
@@ -938,9 +937,9 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
                     sample_idx += 1
 
-                    # For multiple-choice tasks, extract the answer from responses.
-                    # First try digit extraction (for 1-based numbered options),
-                    # then fall back to letter extraction (for A/B/C/D options).
+                    # For multiple-choice tasks, extract the answer digit from responses
+                    # like "2", "The answer is 3", or "1. D" to match the expected answer format.
+                    # Only enabled when num_choices is between 1 and 9 (single-digit options).
                     if 1 <= num_choices <= 9 and pred:
                         pattern = rf"\b([1-{num_choices}])\b"
                         num_match = re.search(pattern, pred)
@@ -953,10 +952,6 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
                                 if ch in valid_digits:
                                     pred = ch
                                     break
-                    elif extract_option_letter and pred:
-                        letter_match = re.search(r"\b([A-Z])\b", pred)
-                        if letter_match:
-                            pred = letter_match.group(1)
                     all_preds.append(pred)
 
                 # Collect reference texts (aligned with preds including empty ones for None images)


### PR DESCRIPTION
## Describe your changes

Reverts PR #2501 which broke vision VQA accuracy by changing option labels from numbers (1/2/3/4) to letters (A/B/C/D) without updating the ground truth conversion.

### Problem
PR #2501 changed option formatting to A/B/C/D but the ground truth was still converted to 1-based numbers. The evaluator digit extraction took priority over letter extraction, so predictions never matched ground truth (~11% accuracy instead of ~66-75%).

### What this reverts
- `pre_process_data.py`: Restores 1-based numeric option labeling and removes `extract_option_letter` field
- `olive_evaluator.py`: Removes the dead letter extraction branch, restores digit-only extraction

### What is kept
The `graph_surgeries.py` change from #2501 (supporting `inputs_embeds`) is intentionally **not** reverted as it is unrelated and correct.

### Testing
Validated on AI2D with Qwen3-VL-2B-Instruct — accuracy restored from ~11% to expected ~66%.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code