### PR TITLE
Fix LMEval ONNX evaluator `device` assignment with recent lm-eval

### DIFF
--- a/olive/evaluator/lmeval_ort.py
+++ b/olive/evaluator/lmeval_ort.py
@@ -38,6 +38,18 @@ LogLikelihoodInputs = tuple[tuple[str, str], list[int], list[int]]
 class LMEvalOnnxBase(TemplateLM):
     """Base class for ONNX model evaluation."""
 
+    @property
+    def device(self):
+        # lm-eval's LM base class exposes ``device`` as a read-only property
+        # (backed by ``_device``). The ONNX evaluators assign ``self.device``
+        # in ``__init__`` (e.g. for IOBinding placement), so provide a setter
+        # to keep that assignment working across lm-eval versions.
+        return getattr(self, "_device", None)
+
+    @device.setter
+    def device(self, value):
+        self._device = value
+
     @abstractmethod
     def prepare(self, requests: list[LogLikelihoodInputs]):
         pass

--- a/test/evaluator/test_lmeval_ort.py
+++ b/test/evaluator/test_lmeval_ort.py
@@ -7,7 +7,7 @@ import pytest
 # The lmeval_ort module imports lm_eval at module load time.
 pytest.importorskip("lm_eval")
 
-from olive.evaluator.lmeval_ort import LMEvalOnnxBase
+from olive.evaluator.lmeval_ort import LMEvalOnnxBase  # pylint: disable=wrong-import-position
 
 
 def test_device_property_has_setter():

--- a/test/evaluator/test_lmeval_ort.py
+++ b/test/evaluator/test_lmeval_ort.py
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import pytest
+
+# The lmeval_ort module imports lm_eval at module load time.
+pytest.importorskip("lm_eval")
+
+from olive.evaluator.lmeval_ort import LMEvalOnnxBase
+
+
+def test_device_property_has_setter():
+    """LMEvalOnnxBase must override lm-eval's read-only ``device`` property.
+
+    lm-eval's ``LM`` base class exposes ``device`` as a read-only property,
+    but the ONNX evaluators assign ``self.device`` in ``__init__``. Without a
+    setter this raises ``AttributeError: property 'device' ... has no setter``.
+    This is a regression test for that incompatibility.
+    """
+    device_prop = LMEvalOnnxBase.__dict__.get("device")
+    assert isinstance(device_prop, property)
+    assert device_prop.fset is not None, "device property must define a setter"
+
+
+def test_device_property_round_trips():
+    """The setter stores and the getter returns the assigned value."""
+    device_prop = LMEvalOnnxBase.__dict__["device"]
+
+    # Use a bare holder to exercise the descriptor without instantiating the
+    # abstract base class (which has unrelated abstract methods).
+    class _Holder:
+        pass
+
+    holder = _Holder()
+    assert device_prop.fget(holder) is None  # unset -> None
+
+    device_prop.fset(holder, "cuda")
+    assert device_prop.fget(holder) == "cuda"
+
+    device_prop.fset(holder, "cpu")
+    assert device_prop.fget(holder) == "cpu"


### PR DESCRIPTION
## Problem

`get_model("ortgenai")` / `get_model("ort")` based evaluation crashes with recent `lm-eval` versions (reproduced on `lm-eval==0.4.12`):

```
AttributeError: property 'device' of 'LMEvalORTGenAIEvaluator' object has no setter
```

### Root cause

lm-eval's `LM` base class exposes `device` as a **read-only** property (backed by `self._device`). Olive's ONNX evaluators in `olive/evaluator/lmeval_ort.py` assign `self.device = ...` in `__init__`:

- `LMEvalORTEvaluator.__init__` — `self.device = "cuda" if ep == "CUDAExecutionProvider" else "cpu"`
- `LMEvalORTGenAIEvaluator.__init__` — `self.device = device`

With the read-only property inherited from lm-eval, both assignments raise `AttributeError`, so evaluation never starts.

## Fix

Add a `device` property **with a setter** to the shared `LMEvalOnnxBase` (backed by `_device`), overriding lm-eval's read-only property. The existing `self.device = ...` assignments keep working across lm-eval versions, and reads of `self.device` (used for IOBinding placement and `.to(self.device)`) are unchanged.

## Testing

- Added `test/evaluator/test_lmeval_ort.py` (guarded by `pytest.importorskip("lm_eval")`) verifying the `device` property has a setter and round-trips. Both tests pass.
- Verified end-to-end: ran MMLU-Pro evaluation through `get_model("ortgenai")` on a CUDA INT4 ONNX model (Gemma 4 12B) — evaluation now runs to completion and reports a score (previously crashed at model init).
- `ruff check` clean on the changed files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>