### PR TITLE
Fix extended udma context config on newer qairt-dev versions

### DIFF
--- a/olive/passes/qairt/gen_ai_builder.py
+++ b/olive/passes/qairt/gen_ai_builder.py
@@ -218,6 +218,12 @@ class QairtGenAIBuilder(Pass):
                 dev_cfg = gen_ai_builder._compilation_config.device_custom_configs[0]
                 arch_version = int(str(dev_cfg.dsp_arch).lstrip("v"))
                 if arch_version >= 81:
+                    # qairt-dev 0.8.0 no longer pre-populates context_custom_configs in set_targets();
+                    # initialize it here if absent, mirroring htp_mixin.set_compilation_options().
+                    if not gen_ai_builder._compilation_config.context_custom_configs:
+                        from qairt.api.common.backends.htp.config import HtpContextConfig
+
+                        gen_ai_builder._compilation_config.context_custom_configs = [HtpContextConfig()]
                     gen_ai_builder._compilation_config.context_custom_configs[0].extended_udma = True
                 else:
                     raise ValueError("extended_udma is unsupported on DSP architectures less than v81")

--- a/olive/passes/qairt/gen_ai_builder.py
+++ b/olive/passes/qairt/gen_ai_builder.py
@@ -219,11 +219,13 @@ class QairtGenAIBuilder(Pass):
                 arch_version = int(str(dev_cfg.dsp_arch).lstrip("v"))
                 if arch_version >= 81:
                     # qairt-dev 0.8.0 no longer pre-populates context_custom_configs in set_targets();
-                    # initialize it here if absent, mirroring htp_mixin.set_compilation_options().
+                    # initialize it here if absent. weight_sharing_enabled=True matches the 0.5.0 default.
                     if not gen_ai_builder._compilation_config.context_custom_configs:
                         from qairt.api.common.backends.htp.config import HtpContextConfig
 
-                        gen_ai_builder._compilation_config.context_custom_configs = [HtpContextConfig()]
+                        gen_ai_builder._compilation_config.context_custom_configs = [
+                            HtpContextConfig(weight_sharing_enabled=True)
+                        ]
                     gen_ai_builder._compilation_config.context_custom_configs[0].extended_udma = True
                 else:
                     raise ValueError("extended_udma is unsupported on DSP architectures less than v81")

--- a/test/passes/qairt/test_gen_ai_builder.py
+++ b/test/passes/qairt/test_gen_ai_builder.py
@@ -495,3 +495,51 @@ def test_gen_ai_builder_native_kv_validation_valid_sequence_lengths(mock_acceler
     ).config
 
     assert QairtGenAIBuilder.validate_config(config, mock_accelerator_spec) is True
+
+
+def test_gen_ai_builder_extended_udma_initializes_none_context_configs(
+    tmp_path, mock_qairt_prepared_model, mock_qairt_modules
+):
+    """Test that extended_udma initializes context_custom_configs when it is None.
+
+    Regression test for qairt-dev 0.8.0, where set_targets() no longer pre-populates
+    context_custom_configs. Without the fix, accessing context_custom_configs[0] raises
+    TypeError: 'NoneType' object is not subscriptable.
+    """
+    output_path = tmp_path / "output"
+
+    mock_htp_context_config_instance = MagicMock()
+    mock_htp_context_config_cls = MagicMock(return_value=mock_htp_context_config_instance)
+    mock_htp_config_module = MagicMock()
+    mock_htp_config_module.HtpContextConfig = mock_htp_context_config_cls
+
+    mock_builder = MagicMock()
+    mock_container = MagicMock()
+    mock_builder.build.return_value = mock_container
+    mock_builder._compilation_config = MagicMock()
+    mock_builder._compilation_config.device_custom_configs = [MagicMock()]
+    mock_builder._compilation_config.device_custom_configs[0].dsp_arch = "v81"
+    mock_builder._compilation_config.context_custom_configs = None  # qairt-dev 0.8.0: not pre-populated
+    mock_builder._compilation_config.graph_custom_configs = [MagicMock()]
+    mock_builder._transformation_config = MagicMock()
+    mock_builder._transformation_config.model_transformer_config = MagicMock()
+    mock_builder._transformation_config.model_transformer_config.arn_cl_options = MagicMock()
+    mock_builder._transformation_config.model_transformer_config.split_model = MagicMock()
+
+    mock_qairt_modules["gen_ai_api"].GenAIBuilderFactory.create.return_value = mock_builder
+
+    gen_ai_pass = create_pass_from_dict(
+        QairtGenAIBuilder,
+        {"backend": "HTP", "extended_udma": True},
+        disable_search=True,
+    )
+
+    with patch.dict("sys.modules", {"qairt.api.common.backends.htp.config": mock_htp_config_module}):
+        result = gen_ai_pass.run(mock_qairt_prepared_model, str(output_path))
+
+    # Verify HtpContextConfig was initialized with weight_sharing_enabled=True (matching 0.5.0 defaults)
+    mock_htp_context_config_cls.assert_called_once_with(weight_sharing_enabled=True)
+    # Verify context_custom_configs was populated and extended_udma set on the new instance
+    assert mock_builder._compilation_config.context_custom_configs == [mock_htp_context_config_instance]
+    assert mock_htp_context_config_instance.extended_udma is True
+    assert isinstance(result, QairtModelHandler)


### PR DESCRIPTION
## Describe your changes

Fixes an error where context config was left uninitialized on newer qairt-dev versions (0.8.0)

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
