### PR TITLE
Fix genai_config.json discovery for nested multi-component model layouts

### DIFF
--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -584,9 +584,14 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
     @staticmethod
     def _load_genai_config(model: ONNXModelHandler) -> Optional[dict]:
-        """Load genai_config.json from the model directory, or return None if not found."""
-        genai_config_path = Path(model.model_path).parent / "genai_config.json"
-        if not genai_config_path.exists():
+        """Load genai_config.json from the model directory, or return None if not found.
+
+        Searches upward from the ONNX file's parent directory to support nested
+        multi-component model layouts (e.g. ``models/decoder/model.onnx`` where
+        ``genai_config.json`` lives at ``models/``).
+        """
+        genai_config_path = OliveEvaluator._find_genai_config(model)
+        if genai_config_path is None:
             return None
         import json
 
@@ -595,6 +600,35 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
                 return json.load(f)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in genai config file: {genai_config_path}") from e
+
+    @staticmethod
+    def _find_genai_config(model: ONNXModelHandler) -> Optional[Path]:
+        """Find genai_config.json by searching upward from the ONNX file's parent directory.
+
+        Returns the Path to genai_config.json if found, or None. Searches at most
+        3 levels up to avoid traversing unrelated directories.
+        """
+        candidate = Path(model.model_path).parent
+        for _ in range(3):
+            genai_path = candidate / "genai_config.json"
+            if genai_path.exists():
+                return genai_path
+            parent = candidate.parent
+            if parent == candidate:
+                break
+            candidate = parent
+        return None
+
+    @staticmethod
+    def _get_genai_model_dir(model: ONNXModelHandler) -> str:
+        """Get the ORT GenAI model root directory (where genai_config.json lives).
+
+        Falls back to the ONNX file's parent directory if genai_config.json is not found.
+        """
+        genai_config_path = OliveEvaluator._find_genai_config(model)
+        if genai_config_path is not None:
+            return str(genai_config_path.parent)
+        return str(Path(model.model_path).parent)
 
     def _evaluate_onnx_accuracy(
         self,
@@ -845,7 +879,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         except ImportError as e:
             raise ImportError("Pillow is required for vision evaluation. Install it with: pip install Pillow") from e
 
-        model_dir = str(Path(model.model_path).parent)
+        model_dir = self._get_genai_model_dir(model)
 
         # Default max_length; can be overridden per-sample from the data config.
         default_max_length = 4096
@@ -991,7 +1025,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
         import soundfile as sf
 
-        model_dir = str(Path(model.model_path).parent)
+        model_dir = self._get_genai_model_dir(model)
 
         # Read genai_config to determine model properties
         with (Path(model_dir) / "genai_config.json").open() as f:
@@ -1125,7 +1159,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
         import json
 
-        model_dir = str(Path(model.model_path).parent)
+        model_dir = self._get_genai_model_dir(model)
 
         with (Path(model_dir) / "genai_config.json").open() as f:
             genai_config = json.load(f)
@@ -1947,7 +1981,7 @@ class LMEvaluator(OliveEvaluator):
             }
         elif self.model_class == "ortgenai":
             init_args = {
-                "pretrained": str(Path(model.model_path).parent),
+                "pretrained": OliveEvaluator._get_genai_model_dir(model),
                 "ep": self.ep or execution_providers,
                 "ep_options": self.ep_options,
                 "device": device,
@@ -2062,8 +2096,8 @@ class MTEBEvaluator(OliveEvaluator):
                 model_class = "hf"
             elif isinstance(model, ONNXModelHandler):
                 # ModelBuilder outputs ONNXModelHandler but with genai_config.json
-                genai_config = Path(model.model_path).parent / "genai_config.json"
-                model_class = "ortgenai" if genai_config.exists() else "ort"
+                genai_config_path = OliveEvaluator._find_genai_config(model)
+                model_class = "ortgenai" if genai_config_path is not None else "ort"
             else:
                 raise ValueError(
                     "Unable to auto-detect model_class for MTEBEvaluator from model handler "
@@ -2098,7 +2132,7 @@ class MTEBEvaluator(OliveEvaluator):
             )
         elif model_class == "ortgenai":
             mteb_model = MTEBORTGenAIEvaluator(
-                pretrained=str(Path(model.model_path).parent),
+                pretrained=OliveEvaluator._get_genai_model_dir(model),
                 batch_size=self.batch_size,
                 max_length=self.max_length,
                 ep=self.ep


### PR DESCRIPTION
## Description

The evaluator previously assumed `genai_config.json` is in the same directory as the ONNX model file (`Path(model.model_path).parent`). For nested multi-component model layouts (e.g., `models/decoder/model.onnx` where `genai_config.json` lives at `models/`), this caused evaluation to fail because the config file was not found.

This is the case for models exported by `MobiusBuilder` (gemma4, etc.), which creates a nested layout:
```
models/
├── genai_config.json
├── decoder/model.onnx
├── vision_encoder/model.onnx
├── audio_encoder/model.onnx
└── embedding/model.onnx
```

When the evaluator loads the decoder (`models/decoder/model.onnx`), `Path(model.model_path).parent` resolves to `models/decoder/`, missing the `genai_config.json` at `models/`.

## Changes

- Added `_find_genai_config()` static helper that searches upward (up to 3 levels) from the ONNX file's parent directory to find `genai_config.json`
- Added `_get_genai_model_dir()` static helper that returns the root model directory containing `genai_config.json` (falls back to ONNX file's parent if not found)
- Updated all 7 occurrences of `Path(model.model_path).parent` used for genai config discovery to use these new helpers:
  - `_load_genai_config()` — already fixed to use `_find_genai_config()`
  - `_inference_text_genai()` — uses `_get_genai_model_dir()`
  - `_inference_text_genai_streaming()` — uses `_get_genai_model_dir()`
  - `LMEvaluator.evaluate()` — uses `_get_genai_model_dir()`
  - `MTEBEvaluator.evaluate()` — uses `_find_genai_config()` and `_get_genai_model_dir()`

## Motivation

This fix enables evaluation of multimodal models with nested component layouts (e.g., gemma4-E2B exported by MobiusBuilder) using Olive's built-in evaluator.