### PR TITLE
Preserve graph output names in weight-only quantization passes

### DIFF
--- a/olive/passes/onnx/hqq_quantization.py
+++ b/olive/passes/onnx/hqq_quantization.py
@@ -181,7 +181,10 @@ class OnnxHqqQuantization(Pass):
         if accuracy_level > 0:
             kwargs["accuracy_level"] = accuracy_level
 
-        node.outputs[0].name = node.outputs[0].name + "_Q4"
+        # Only rename intermediate outputs; preserve graph output names so
+        # downstream consumers (e.g. genai_config.json) keep working.
+        if node.outputs[0] not in node.graph.outputs:
+            node.outputs[0].name = node.outputs[0].name + "_Q4"
 
         return ir.node(
             domain=MSFT_DOMAIN,

--- a/olive/passes/onnx/rtn_quantization.py
+++ b/olive/passes/onnx/rtn_quantization.py
@@ -204,6 +204,21 @@ class OnnxBlockWiseRtnQuantization(Pass):
             logger.error("Unsupported op %s for weight-only quantization.", node.op_type)
             return node, node.graph
 
+    @staticmethod
+    def _rename_output_unless_graph_output(node: ir.Node, bits: int) -> None:
+        """Append a `_Q{bits}` suffix to the node's output name for renaming after quantization.
+
+        Skips values that are graph outputs: external consumers (e.g. ORT GenAI's
+        genai_config.json, which references model output names such as the speech
+        encoder's `audio_features`) rely on these names, so renaming them here would
+        silently break the exported package. Internal tensors are safe to rename because
+        their consumers are rewired by replace_nodes_and_values.
+        """
+        graph = node.graph
+        is_graph_output = graph is not None and node.outputs[0] in graph.outputs
+        if not is_graph_output:
+            node.outputs[0].name = node.outputs[0].name + f"_Q{bits}"
+
     def _quantize_matmul(
         self, node: ir.Node, bits: int, block_size: int, accuracy_level: AccuracyLevel, is_symmetric: bool
     ) -> tuple[ir.Node, ir.Graph]:
@@ -237,7 +252,7 @@ class OnnxBlockWiseRtnQuantization(Pass):
         if accuracy_level > 0:
             kwargs["accuracy_level"] = accuracy_level
 
-        node.outputs[0].name = node.outputs[0].name + f"_Q{bits}"
+        self._rename_output_unless_graph_output(node, bits)
 
         return ir.node(
             domain=MSFT_DOMAIN,
@@ -289,7 +304,7 @@ class OnnxBlockWiseRtnQuantization(Pass):
             "bits": bits,
         }
 
-        node.outputs[0].name = node.outputs[0].name + f"_Q{bits}"
+        self._rename_output_unless_graph_output(node, bits)
 
         return ir.node(
             domain=MSFT_DOMAIN,

--- a/test/passes/onnx/test_hqq_quantization.py
+++ b/test/passes/onnx/test_hqq_quantization.py
@@ -133,6 +133,57 @@ class TestHQQQuantization:
 
         assert found_matmul_nbits, "No MatMulNBits node found in quantized model"
 
+    def test_hqq_quantization_preserves_graph_output_names(self, tmp_path):
+        """Quantizing a MatMul that produces a graph output must not rename that output.
+
+        External consumers (e.g. ORT GenAI's genai_config.json) reference model output
+        names, so appending a `_Q4` suffix to a graph output would break them. Internal
+        tensors, however, are still renamed.
+        """
+        # X[2,64] -> MatMul(W1) -> hidden (internal) -> MatMul(W2) -> audio_features (graph output)
+        w1 = onnx.numpy_helper.from_array(np.random.randn(64, 128).astype(np.float32), name="W1")
+        w2 = onnx.numpy_helper.from_array(np.random.randn(128, 64).astype(np.float32), name="W2")
+        internal_matmul = onnx.helper.make_node("MatMul", ["X", "W1"], ["hidden"], name="enc/MatMul")
+        terminal_matmul = onnx.helper.make_node("MatMul", ["hidden", "W2"], ["audio_features"], name="projector/MatMul")
+
+        graph_def = onnx.helper.make_graph(
+            nodes=[internal_matmul, terminal_matmul],
+            name="graph-output-test",
+            inputs=[onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [2, 64])],
+            outputs=[onnx.helper.make_tensor_value_info("audio_features", onnx.TensorProto.FLOAT, [2, 64])],
+            initializer=[w1, w2],
+        )
+        model_def = onnx.helper.make_model(graph_def, producer_name="olive-test")
+        model_def.opset_import[0].version = 13
+        model_def.ir_version = 10
+        model_path = tmp_path / "graph_output_model.onnx"
+        onnx.save(model_def, str(model_path))
+
+        olive_model = ONNXModelHandler(model_path=str(model_path))
+        accelerator_spec = AcceleratorSpec(
+            accelerator_type="CPU",
+            execution_provider="CPUExecutionProvider",
+        )
+        p = create_pass_from_dict(
+            OnnxHqqQuantization, {"block_size": 128}, disable_search=True, accelerator_spec=accelerator_spec
+        )
+
+        output_path = tmp_path / "graph_output_quantized.onnx"
+        quantized_model = p.run(olive_model, output_path)
+
+        ir_model = ir.load(quantized_model.model_path)
+
+        # The graph output name must be preserved exactly.
+        output_names = [o.name for o in ir_model.graph.outputs]
+        assert output_names == ["audio_features"], f"Graph output was renamed: {output_names}"
+
+        # Both MatMuls should be quantized, and the internal tensor should still be renamed.
+        nbits_outputs = [
+            o.name for n in ir_model.graph.all_nodes() if n.op_type == OpType.MatMulNBits for o in n.outputs
+        ]
+        assert "audio_features" in nbits_outputs, "Terminal MatMul should keep the graph output name"
+        assert "hidden_Q4" in nbits_outputs, "Internal MatMul output should be renamed with the quant suffix"
+
     def test_hqq_quantization_pass_produces_valid_output_when_model_has_external_data(
         self, matmul_model_with_external_data_path, tmp_path
     ):

--- a/test/passes/onnx/test_kquant_quantization.py
+++ b/test/passes/onnx/test_kquant_quantization.py
@@ -194,3 +194,55 @@ class TestKQuantQuantization:
         matmul_nbits_nodes = [n for n in quantized_onnx.graph.node if n.op_type == str(OpType.MatMulNBits)]
 
         assert len(matmul_nbits_nodes) == 2, "Expected both MatMuls quantized (bracket entry not glob-matched)"
+
+    def test_kquant_preserves_graph_output_names(self, tmp_path):
+        """Quantizing a MatMul that produces a graph output must not rename that output.
+
+        External consumers (e.g. ORT GenAI's genai_config.json) reference model output
+        names, so appending a quant suffix to a graph output would break them.
+        Internal tensors, however, are still renamed.
+        """
+        # X[2,4] -> MatMul(W1) -> hidden (internal) -> MatMul(W2) -> audio_features (graph output)
+        w1 = onnx.numpy_helper.from_array(np.random.randn(4, 5).astype(np.float32), name="W1")
+        w2 = onnx.numpy_helper.from_array(np.random.randn(5, 3).astype(np.float32), name="W2")
+        internal_matmul = onnx.helper.make_node("MatMul", ["X", "W1"], ["hidden"], name="enc/MatMul")
+        terminal_matmul = onnx.helper.make_node("MatMul", ["hidden", "W2"], ["audio_features"], name="projector/MatMul")
+
+        graph_def = onnx.helper.make_graph(
+            nodes=[internal_matmul, terminal_matmul],
+            name="graph-output-test",
+            inputs=[onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [2, 4])],
+            outputs=[onnx.helper.make_tensor_value_info("audio_features", onnx.TensorProto.FLOAT, [2, 3])],
+            initializer=[w1, w2],
+        )
+        model_def = onnx.helper.make_model(graph_def, producer_name="olive-test")
+        model_def.opset_import[0].version = 13
+        model_def.ir_version = 10
+        model_path = tmp_path / "graph_output_model.onnx"
+        onnx.save(model_def, str(model_path))
+
+        olive_model = ONNXModelHandler(model_path=str(model_path))
+        accelerator_spec = AcceleratorSpec(
+            accelerator_type="CPU",
+            execution_provider="CPUExecutionProvider",
+        )
+        pass_config = {"bits": 8, "block_size": 32}
+        p = create_pass_from_dict(
+            OnnxKQuantQuantization, pass_config, disable_search=True, accelerator_spec=accelerator_spec
+        )
+
+        output_path = tmp_path / "graph_output_quantized.onnx"
+        quantized_model = p.run(olive_model, output_path)
+
+        quantized_onnx = onnx.load(quantized_model.model_path)
+
+        # The graph output name must be preserved exactly.
+        output_names = [o.name for o in quantized_onnx.graph.output]
+        assert output_names == ["audio_features"], f"Graph output was renamed: {output_names}"
+
+        # Both MatMuls should be quantized, and the internal tensor should still be renamed.
+        nbits_outputs = [
+            o for n in quantized_onnx.graph.node if n.op_type == str(OpType.MatMulNBits) for o in n.output
+        ]
+        assert "audio_features" in nbits_outputs, "Terminal MatMul should keep the graph output name"
+        assert "hidden_Q8" in nbits_outputs, "Internal MatMul output should be renamed with the quant suffix"

--- a/test/passes/onnx/test_rtn_quantization.py
+++ b/test/passes/onnx/test_rtn_quantization.py
@@ -171,6 +171,60 @@ class TestRTNQuantization:
 
         assert found_matmul_nbits, "No MatMulNBits node found in quantized model"
 
+    def test_rtn_quantization_preserves_graph_output_names(self, tmp_path):
+        """Quantizing a MatMul that produces a graph output must not rename that output.
+
+        External consumers (e.g. ORT GenAI's genai_config.json) reference model output
+        names, so appending a `_Q{bits}` suffix to a graph output would break them.
+        Internal tensors, however, are still renamed.
+        """
+        # X[2,4] -> MatMul(W1) -> hidden (internal) -> MatMul(W2) -> audio_features (graph output)
+        w1 = onnx.numpy_helper.from_array(np.random.randn(4, 5).astype(np.float32), name="W1")
+        w2 = onnx.numpy_helper.from_array(np.random.randn(5, 3).astype(np.float32), name="W2")
+        internal_matmul = onnx.helper.make_node("MatMul", ["X", "W1"], ["hidden"], name="enc/MatMul")
+        terminal_matmul = onnx.helper.make_node("MatMul", ["hidden", "W2"], ["audio_features"], name="projector/MatMul")
+
+        graph_def = onnx.helper.make_graph(
+            nodes=[internal_matmul, terminal_matmul],
+            name="graph-output-test",
+            inputs=[onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [2, 4])],
+            outputs=[onnx.helper.make_tensor_value_info("audio_features", onnx.TensorProto.FLOAT, [2, 3])],
+            initializer=[w1, w2],
+        )
+        model_def = onnx.helper.make_model(graph_def, producer_name="olive-test")
+        model_def.opset_import[0].version = 13
+        model_def.ir_version = 10
+        model_path = tmp_path / "graph_output_model.onnx"
+        onnx.save(model_def, str(model_path))
+
+        olive_model = ONNXModelHandler(model_path=str(model_path))
+        accelerator_spec = AcceleratorSpec(
+            accelerator_type="CPU",
+            execution_provider="CPUExecutionProvider",
+        )
+        p = create_pass_from_dict(
+            OnnxBlockWiseRtnQuantization,
+            {"bits": 8, "block_size": 32, "axis": 0, "is_symmetric": False},
+            disable_search=True,
+            accelerator_spec=accelerator_spec,
+        )
+
+        output_path = tmp_path / "graph_output_quantized.onnx"
+        quantized_model = p.run(olive_model, output_path)
+
+        ir_model = ir.load(quantized_model.model_path)
+
+        # The graph output name must be preserved exactly.
+        output_names = [o.name for o in ir_model.graph.outputs]
+        assert output_names == ["audio_features"], f"Graph output was renamed: {output_names}"
+
+        # Both MatMuls should be quantized, and the internal tensor should still be renamed.
+        nbits_outputs = [
+            o.name for n in ir_model.graph.all_nodes() if n.op_type == OpType.MatMulNBits for o in n.outputs
+        ]
+        assert "audio_features" in nbits_outputs, "Terminal MatMul should keep the graph output name"
+        assert "hidden_Q8" in nbits_outputs, "Internal MatMul output should be renamed with the quant suffix"
+
     @pytest.mark.parametrize("is_symmetric", [True, False])
     def test_rtn_quantization_pass_gather(self, gather_model_path, tmp_path, is_symmetric):
         # Setup


### PR DESCRIPTION
## Problem

The RTN and HQQ weight-only quantization passes unconditionally append a `_Q{bits}` suffix to a quantized MatMul/Gather node's output name. When that node produces a **graph output**, the graph output itself gets renamed, silently breaking external consumers that reference the original name.

Concretely, ONNX Runtime GenAI's `genai_config.json` references model output names (e.g. a speech encoder's `audio_features`). After RTN int8 quantization, the terminal projector MatMul's output became `audio_features_Q8`, so GenAI raised:

```
Model output was not found: audio_features
```

on every inference, and all predictions came back empty. (Observed on a Gemma-3n multimodal export whose audio encoder's terminal projector MatMul is a graph output.)

## Fix

Only append the suffix when the node's output is **not** a graph output. Internal tensors are still renamed (their consumers are rewired by `replace_nodes_and_values`). This matches the guard already present in the k-quant pass (`kquant_quantization.py`).

- `rtn_quantization.py`: add `_rename_output_unless_graph_output` helper, used by both `_quantize_matmul` and `_quantize_gather`.
- `hqq_quantization.py`: guard the `_Q4` rename the same way.

## Tests

Added regression tests to the RTN, HQQ, and k-quant suites. Each builds a 2-MatMul model where the terminal MatMul feeds a named graph output, quantizes, and asserts:
- the graph output name is preserved (no suffix), and
- the internal MatMul output still gets the quant suffix.

All three suites pass (21 tests).