### PR TITLE
use torch to compute discrepancies in OnnxDiscrepancyCheck

### DIFF
--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -269,13 +269,6 @@ class OnnxDiscrepancyCheck(Pass):
         onnx_weight_dtype = _infer_onnx_weight_dtype(model.load_model())
         if onnx_weight_dtype is not None:
             weight_dtype = _onnx_dtype_to_torch(onnx_weight_dtype)
-        if weight_dtype is not None:
-            ref_model = ref_model.to(weight_dtype)
-            logger.info(
-                "OnnxDiscrepancyCheck casting reference model weights to %s to match the ONNX model.",
-                weight_dtype,
-            )
-
         # Prepare ONNX session on the target device (fallback to CPU)
         device = self.accelerator_spec.accelerator_type if self.accelerator_spec else None
         execution_provider = self.accelerator_spec.execution_provider if self.accelerator_spec else None
@@ -292,7 +285,20 @@ class OnnxDiscrepancyCheck(Pass):
         torch_device = torch.device("cpu")
         if device == Device.GPU and torch.cuda.is_available():
             torch_device = torch.device("cuda")
-        ref_model = ref_model.to(torch_device)
+        if weight_dtype is not None and torch_device.type == "cpu" and weight_dtype in (torch.float16, torch.bfloat16):
+            logger.info(
+                "OnnxDiscrepancyCheck skipping reference model cast to %s on CPU because the dtype is not supported.",
+                weight_dtype,
+            )
+            ref_model = ref_model.to(torch_device)
+        elif weight_dtype is not None:
+            ref_model = ref_model.to(device=torch_device, dtype=weight_dtype)
+            logger.info(
+                "OnnxDiscrepancyCheck casting reference model weights to %s to match the ONNX model.",
+                weight_dtype,
+            )
+        else:
+            ref_model = ref_model.to(torch_device)
 
         # Save reference PyTorch model for direct comparison
         report_dir = config.report_output_dir or output_model_path

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -62,7 +62,10 @@ def _infer_onnx_weight_dtype(onnx_model):
     counts = Counter()
     for initializer in onnx_model.graph.initializer:
         if initializer.data_type in float_types:
-            counts[initializer.data_type] += 1
+            numel = 1
+            for d in initializer.dims:
+                numel *= d
+            counts[initializer.data_type] += numel
     if not counts:
         return None
     return counts.most_common(1)[0][0]

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -42,6 +42,46 @@ def _infer_shape(dynamic_shape, known_values=None):
     return tuple(inferred_shape)
 
 
+def _infer_onnx_weight_dtype(onnx_model):
+    """Infer the dominant floating-point dtype used by the ONNX model weights.
+
+    Inspects the model initializers (weights) and returns the most common
+    floating-point ONNX TensorProto data type. Returns ``None`` when no
+    floating-point initializer is found.
+    """
+    from collections import Counter
+
+    import onnx
+
+    float_types = {
+        onnx.TensorProto.FLOAT,
+        onnx.TensorProto.FLOAT16,
+        onnx.TensorProto.BFLOAT16,
+        onnx.TensorProto.DOUBLE,
+    }
+    counts = Counter()
+    for initializer in onnx_model.graph.initializer:
+        if initializer.data_type in float_types:
+            counts[initializer.data_type] += 1
+    if not counts:
+        return None
+    return counts.most_common(1)[0][0]
+
+
+def _onnx_dtype_to_torch(onnx_dtype):
+    """Map an ONNX TensorProto floating-point data type to a torch dtype."""
+    import onnx
+    import torch
+
+    mapping = {
+        onnx.TensorProto.FLOAT: torch.float32,
+        onnx.TensorProto.FLOAT16: torch.float16,
+        onnx.TensorProto.BFLOAT16: torch.bfloat16,
+        onnx.TensorProto.DOUBLE: torch.float64,
+    }
+    return mapping.get(onnx_dtype)
+
+
 def _longest_common_token_sequence(seq_a: list[int], seq_b: list[int]) -> int:
     """Compute the length of the longest common token sequence starting from the beginning.
 
@@ -165,7 +205,6 @@ class OnnxDiscrepancyCheck(Pass):
     def _run_for_config(
         self, model: ONNXModelHandler, config: type[BasePassConfig], output_model_path: str
     ) -> ONNXModelHandler:
-        import numpy as np
         import torch
 
         from olive.common.config_utils import validate_config
@@ -210,6 +249,20 @@ class OnnxDiscrepancyCheck(Pass):
 
         ref_model = AutoModelForCausalLM.from_pretrained(config.reference_model_path)
         ref_model.eval()
+
+        # Determine the floating-point dtype used by the ONNX model weights and
+        # cast the reference PyTorch model to match, so the comparison uses the
+        # same numeric precision for the weights on both sides.
+        weight_dtype = None
+        onnx_weight_dtype = _infer_onnx_weight_dtype(model.load_model())
+        if onnx_weight_dtype is not None:
+            weight_dtype = _onnx_dtype_to_torch(onnx_weight_dtype)
+        if weight_dtype is not None:
+            ref_model = ref_model.to(weight_dtype)
+            logger.info(
+                "OnnxDiscrepancyCheck casting reference model weights to %s to match the ONNX model.",
+                weight_dtype,
+            )
 
         # Prepare ONNX session on the target device (fallback to CPU)
         device = self.accelerator_spec.accelerator_type if self.accelerator_spec else None
@@ -260,18 +313,20 @@ class OnnxDiscrepancyCheck(Pass):
                     torch_inputs = input_data.to(torch_device)
 
                 torch_output = ref_model(**torch_inputs)
-                torch_logits = torch_output.logits.detach().cpu().numpy()
+                torch_logits = torch_output.logits.detach()
                 # Run ONNX inference
                 onnx_input_feed = format_data(input_data, io_config)
                 onnx_outputs = session.run(None, onnx_input_feed)
-                onnx_logits = onnx_outputs[0]
+                onnx_logits = torch.as_tensor(onnx_outputs[0])
 
-                # Compute element-wise differences
-                abs_diff = np.abs(torch_logits.astype(np.float64) - onnx_logits.astype(np.float64))
-                all_max_abs_diff.append(float(np.max(abs_diff)))
-                all_count_above_0_1.append(int(np.sum(abs_diff > 0.1)))
-                all_count_above_0_01.append(int(np.sum(abs_diff > 0.01)))
-                total_elements += abs_diff.size
+                # Compute element-wise differences using torch in double precision
+                torch_logits = torch_logits.to(torch.float64).cpu()
+                onnx_logits = onnx_logits.to(torch.float64).cpu()
+                abs_diff = torch.abs(torch_logits - onnx_logits)
+                all_max_abs_diff.append(float(torch.max(abs_diff)))
+                all_count_above_0_1.append(int(torch.sum(abs_diff > 0.1)))
+                all_count_above_0_01.append(int(torch.sum(abs_diff > 0.01)))
+                total_elements += abs_diff.numel()
 
         max_abs_error = max(all_max_abs_diff)
         count_above_0_1 = sum(all_count_above_0_1)

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -89,7 +89,9 @@ def _onnx_output_to_torch(onnx_output, reference_dtype):
     import torch
 
     onnx_tensor = torch.as_tensor(onnx_output)
-    if onnx_tensor.dtype == torch.uint16 and reference_dtype == torch.bfloat16:
+    # ORT may return BFLOAT16 as uint16 because numpy has no bf16; reinterpret whenever we're
+    # comparing against a non-integer reference.
+    if onnx_tensor.dtype == torch.uint16 and reference_dtype != torch.uint16:
         onnx_tensor = onnx_tensor.view(torch.bfloat16)
     return onnx_tensor
 

--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -85,6 +85,15 @@ def _onnx_dtype_to_torch(onnx_dtype):
     return mapping.get(onnx_dtype)
 
 
+def _onnx_output_to_torch(onnx_output, reference_dtype):
+    import torch
+
+    onnx_tensor = torch.as_tensor(onnx_output)
+    if onnx_tensor.dtype == torch.uint16 and reference_dtype == torch.bfloat16:
+        onnx_tensor = onnx_tensor.view(torch.bfloat16)
+    return onnx_tensor
+
+
 def _longest_common_token_sequence(seq_a: list[int], seq_b: list[int]) -> int:
     """Compute the length of the longest common token sequence starting from the beginning.
 
@@ -320,7 +329,7 @@ class OnnxDiscrepancyCheck(Pass):
                 # Run ONNX inference
                 onnx_input_feed = format_data(input_data, io_config)
                 onnx_outputs = session.run(None, onnx_input_feed)
-                onnx_logits = torch.as_tensor(onnx_outputs[0])
+                onnx_logits = _onnx_output_to_torch(onnx_outputs[0], torch_logits.dtype)
 
                 # Compute element-wise differences using torch in double precision
                 torch_logits = torch_logits.to(torch.float64).cpu()

--- a/test/passes/onnx/test_discrepancy_check.py
+++ b/test/passes/onnx/test_discrepancy_check.py
@@ -181,9 +181,7 @@ class TestWeightDtypeInference:
         hidden = 4
         vocab = 8
 
-        embed_weight = helper.make_tensor(
-            "embed.weight", onnx_float_dtype, [vocab, hidden], [0.1] * (vocab * hidden)
-        )
+        embed_weight = helper.make_tensor("embed.weight", onnx_float_dtype, [vocab, hidden], [0.1] * (vocab * hidden))
         lm_head_weight = helper.make_tensor(
             "lm_head.weight", onnx_float_dtype, [hidden, vocab], [0.2] * (hidden * vocab)
         )

--- a/test/passes/onnx/test_discrepancy_check.py
+++ b/test/passes/onnx/test_discrepancy_check.py
@@ -256,13 +256,13 @@ class TestWeightDtypeInference:
         assert actual.dtype == torch.bfloat16
         assert torch.equal(actual, expected)
 
-    def test_onnx_output_to_torch_keeps_uint16_for_non_bfloat16_reference(self):
+    def test_onnx_output_to_torch_keeps_uint16_for_integer_reference(self):
         import torch
 
         from olive.passes.onnx.discrepancy_check import _onnx_output_to_torch
 
         expected = torch.tensor([[123, 456]], dtype=torch.uint16)
-        actual = _onnx_output_to_torch(expected.cpu().numpy(), torch.float32)
+        actual = _onnx_output_to_torch(expected.cpu().numpy(), torch.uint16)
         assert actual.dtype == torch.uint16
         assert torch.equal(actual, expected)
 

--- a/test/passes/onnx/test_discrepancy_check.py
+++ b/test/passes/onnx/test_discrepancy_check.py
@@ -188,7 +188,7 @@ class TestWeightDtypeInference:
         # Non-float buffer that must be ignored when inferring the weight dtype.
         position_ids = helper.make_tensor("position_ids", TensorProto.INT64, [hidden], [0, 1, 2, 3])
 
-        input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, hidden])
+        input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1])
         logits = helper.make_tensor_value_info("logits", onnx_float_dtype, [1, vocab])
 
         gather = helper.make_node("Gather", ["embed.weight", "input_ids"], ["hidden_states"])

--- a/test/passes/onnx/test_discrepancy_check.py
+++ b/test/passes/onnx/test_discrepancy_check.py
@@ -165,6 +165,108 @@ class TestCompareGeneration:
         assert result == 5
 
 
+class TestWeightDtypeInference:
+    """Unit tests for ONNX weight dtype inference used to match the reference model precision."""
+
+    @staticmethod
+    def _build_tiny_llm_onnx(onnx_float_dtype):
+        """Build a tiny-llm-like ONNX model whose float weights use the given dtype.
+
+        The graph mimics a minimal language-model head: an embedding weight and a
+        linear (lm_head) weight, plus an int64 buffer that must be ignored by the
+        float dtype inference.
+        """
+        from onnx import TensorProto, helper
+
+        hidden = 4
+        vocab = 8
+
+        embed_weight = helper.make_tensor(
+            "embed.weight", onnx_float_dtype, [vocab, hidden], [0.1] * (vocab * hidden)
+        )
+        lm_head_weight = helper.make_tensor(
+            "lm_head.weight", onnx_float_dtype, [hidden, vocab], [0.2] * (hidden * vocab)
+        )
+        # Non-float buffer that must be ignored when inferring the weight dtype.
+        position_ids = helper.make_tensor("position_ids", TensorProto.INT64, [hidden], [0, 1, 2, 3])
+
+        input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, hidden])
+        logits = helper.make_tensor_value_info("logits", onnx_float_dtype, [1, vocab])
+
+        gather = helper.make_node("Gather", ["embed.weight", "input_ids"], ["hidden_states"])
+        matmul = helper.make_node("MatMul", ["hidden_states", "lm_head.weight"], ["logits"])
+
+        graph = helper.make_graph(
+            [gather, matmul],
+            "tiny_llm",
+            [input_ids],
+            [logits],
+            initializer=[embed_weight, lm_head_weight, position_ids],
+        )
+        return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+    def test_infer_onnx_weight_dtype_float32(self):
+        import onnx
+
+        from olive.passes.onnx.discrepancy_check import _infer_onnx_weight_dtype
+
+        model = self._build_tiny_llm_onnx(onnx.TensorProto.FLOAT)
+        assert _infer_onnx_weight_dtype(model) == onnx.TensorProto.FLOAT
+
+    def test_infer_onnx_weight_dtype_bfloat16(self):
+        import onnx
+
+        from olive.passes.onnx.discrepancy_check import _infer_onnx_weight_dtype
+
+        model = self._build_tiny_llm_onnx(onnx.TensorProto.BFLOAT16)
+        assert _infer_onnx_weight_dtype(model) == onnx.TensorProto.BFLOAT16
+
+    def test_infer_onnx_weight_dtype_returns_none_without_float_weights(self):
+        from onnx import TensorProto, helper
+
+        from olive.passes.onnx.discrepancy_check import _infer_onnx_weight_dtype
+
+        only_int = helper.make_tensor("buffer", TensorProto.INT64, [2], [1, 2])
+        graph = helper.make_graph([], "no_float", [], [], initializer=[only_int])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        assert _infer_onnx_weight_dtype(model) is None
+
+    def test_onnx_dtype_to_torch_float32(self):
+        import onnx
+        import torch
+
+        from olive.passes.onnx.discrepancy_check import _onnx_dtype_to_torch
+
+        assert _onnx_dtype_to_torch(onnx.TensorProto.FLOAT) == torch.float32
+
+    def test_onnx_dtype_to_torch_bfloat16(self):
+        import onnx
+        import torch
+
+        from olive.passes.onnx.discrepancy_check import _onnx_dtype_to_torch
+
+        assert _onnx_dtype_to_torch(onnx.TensorProto.BFLOAT16) == torch.bfloat16
+
+    def test_tiny_llm_reference_model_cast_to_weight_dtype(self):
+        """End-to-end check that the reference model is cast to the ONNX weight dtype.
+
+        Builds a tiny-llm ONNX model in float32 and bfloat16, then verifies the
+        inferred torch dtype matches what the pass would cast the reference model to.
+        """
+        import onnx
+        import torch
+
+        from olive.passes.onnx.discrepancy_check import _infer_onnx_weight_dtype, _onnx_dtype_to_torch
+
+        for onnx_dtype, expected_torch_dtype in (
+            (onnx.TensorProto.FLOAT, torch.float32),
+            (onnx.TensorProto.BFLOAT16, torch.bfloat16),
+        ):
+            model = self._build_tiny_llm_onnx(onnx_dtype)
+            inferred = _infer_onnx_weight_dtype(model)
+            assert _onnx_dtype_to_torch(inferred) == expected_torch_dtype
+
+
 class TestSpeedupSettings:
     def test_timing_iterations_default_is_5(self):
         from olive.passes.onnx.discrepancy_check import OnnxDiscrepancyCheck

--- a/test/passes/onnx/test_discrepancy_check.py
+++ b/test/passes/onnx/test_discrepancy_check.py
@@ -245,6 +245,27 @@ class TestWeightDtypeInference:
 
         assert _onnx_dtype_to_torch(onnx.TensorProto.BFLOAT16) == torch.bfloat16
 
+    def test_onnx_output_to_torch_bfloat16_from_uint16(self):
+        import torch
+
+        from olive.passes.onnx.discrepancy_check import _onnx_output_to_torch
+
+        expected = torch.tensor([[1.5, -2.0]], dtype=torch.bfloat16)
+        onnx_output = expected.view(torch.uint16).cpu().numpy()
+        actual = _onnx_output_to_torch(onnx_output, torch.bfloat16)
+        assert actual.dtype == torch.bfloat16
+        assert torch.equal(actual, expected)
+
+    def test_onnx_output_to_torch_keeps_uint16_for_non_bfloat16_reference(self):
+        import torch
+
+        from olive.passes.onnx.discrepancy_check import _onnx_output_to_torch
+
+        expected = torch.tensor([[123, 456]], dtype=torch.uint16)
+        actual = _onnx_output_to_torch(expected.cpu().numpy(), torch.float32)
+        assert actual.dtype == torch.uint16
+        assert torch.equal(actual, expected)
+
     def test_tiny_llm_reference_model_cast_to_weight_dtype(self):
         """End-to-end check that the reference model is cast to the ONNX weight dtype.
 


### PR DESCRIPTION
## Describe your changes
OnnxDiscrepancyCheck is using numpy to compute discrepancies, it must be switched to torch for bfloat16.

