### PR TITLE
Fix docs build broken by sphinx-argparse commands domain

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,6 +96,7 @@ def setup(app):
 
     ArgParseDomain.resolve_any_xref = resolve_any_xref
 
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 html_theme = "pydata_sphinx_theme"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,7 @@ source_suffix = {
 templates_path = ["_templates"]
 exclude_patterns = []
 
-suppress_warnings = ["myst.xref_missing"]
+suppress_warnings = ["myst.xref_missing", "myst.domains"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,38 @@ source_suffix = {
 templates_path = ["_templates"]
 exclude_patterns = []
 
-suppress_warnings = ["myst.xref_missing", "myst.domains"]
+suppress_warnings = ["myst.xref_missing"]
+
+
+def setup(app):
+    # sphinx-argparse >= 0.6.0 registers a "commands" domain that does not implement
+    # resolve_any_xref. MyST then falls back to calling its resolve_xref for every
+    # markdown link, which logs "Error, no command xref target ..." for each unmatched
+    # target. Providing resolve_any_xref lets MyST resolve real command targets and
+    # skips the noisy fallback (and the "myst.domains" legacy-domain warning).
+    try:
+        from sphinxarg.ext import ArgParseDomain
+        from sphinxarg.utils import target_to_anchor_id
+    except ImportError:
+        # Older sphinx-argparse (< 0.6.0) has no "commands" domain, nothing to patch.
+        return
+
+    # Don't override a native implementation a future release might provide.
+    if "resolve_any_xref" in ArgParseDomain.__dict__:
+        return
+
+    from sphinx.util.nodes import make_refnode
+
+    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
+        anchor_id = target_to_anchor_id(target)
+        results = []
+        for _cmd, _sig, _type, docname, anchor, _prio in self.get_objects():
+            if anchor_id == anchor:
+                refnode = make_refnode(builder, fromdocname, docname, anchor, contnode, anchor)
+                results.append(("commands:command", refnode))
+        return results
+
+    ArgParseDomain.resolve_any_xref = resolve_any_xref
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output


### PR DESCRIPTION
## Describe your changes

sphinx-argparse 0.6.0 registers a `commands` domain (`ArgParseDomain`) that does not implement the standard Sphinx `Domain.resolve_any_xref` API. MyST falls back to calling the domain's `resolve_xref` for every markdown cross-reference, and that method logs `Error, no command xref target from ...` for each target it doesn't own, including links that already resolve via doc/std resolution. Under `-W`, this flood of warnings fails the docs build.

This adds a `resolve_any_xref` implementation to `ArgParseDomain` in `docs/source/conf.py`, supplying the API the extension omits so MyST resolves real command targets and skips the noisy fallback. This also removes the `myst.domains` legacy-domain warning, so the earlier `suppress_warnings` entry for it is dropped. No version pin is added to `docs/requirements.txt`.

The rendered HTML is byte-identical to before; only the spurious warnings are gone. The `sphinx-build -W` build passes.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link