### PR TITLE
MobiusBuilder: route OpenVINO EP to mobius openvino build

### DIFF
--- a/olive/hardware/constants.py
+++ b/olive/hardware/constants.py
@@ -43,7 +43,7 @@ EXECUTION_PROVIDER_TO_MOBIUS_EP = {
     ExecutionProvider.DmlExecutionProvider: "webgpu",
     ExecutionProvider.MIGraphXExecutionProvider: "onnx-standard",
     ExecutionProvider.NvTensorRTRTXExecutionProvider: "trt-rtx",
-    ExecutionProvider.OpenVINOExecutionProvider: "default",
+    ExecutionProvider.OpenVINOExecutionProvider: "openvino",
     ExecutionProvider.QNNExecutionProvider: "onnx-standard",
     ExecutionProvider.ROCMExecutionProvider: "onnx-standard",
     ExecutionProvider.VitisAIExecutionProvider: "onnx-standard",

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -156,6 +156,14 @@ def test_ep_map_covers_common_providers():
     assert MobiusBuilder.EP_MAP[ExecutionProvider.WebGpuExecutionProvider] == "webgpu"
 
 
+def test_openvino_ep_maps_to_openvino_mobius_ep():
+    # OpenVINO routes to the mobius "openvino" EP (which emits the OpenVINO
+    # provider options in genai_config); the graph itself is device-agnostic.
+    from olive.hardware.constants import EXECUTION_PROVIDER_TO_MOBIUS_EP
+
+    assert EXECUTION_PROVIDER_TO_MOBIUS_EP[ExecutionProvider.OpenVINOExecutionProvider] == "openvino"
+
+
 # ---------------------------------------------------------------------------
 # Single-component model tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Maps `OpenVINOExecutionProvider` to the mobius `openvino` EP in `EXECUTION_PROVIDER_TO_MOBIUS_EP` (previously `"default"`), so the generated `genai_config.json` targets the OpenVINO EP with its provider options instead of emitting empty (CPU) provider options.

The OpenVINO graph is device-independent, so **no `device_type` logic is needed in MobiusBuilder** — mobius emits a default OpenVINO `device_type`, overridable downstream in genai_config.

## Changes
- `olive/hardware/constants.py`: `EXECUTION_PROVIDER_TO_MOBIUS_EP[OpenVINOExecutionProvider] = "openvino"`.
- Test for the mapping.

Requires the mobius `openvino` EP (onnxruntime/mobius#388).