### PR TITLE
OpenVINOEncapsulation: map float16/bfloat16/bool (char) OV dtypes

### DIFF
--- a/olive/passes/openvino/encapsulation.py
+++ b/olive/passes/openvino/encapsulation.py
@@ -29,7 +29,9 @@ class OpenVINOEncapsulation(Pass):
         "f64": TensorProto.DOUBLE,
         "float64": TensorProto.DOUBLE,
         "f16": TensorProto.FLOAT16,
+        "float16": TensorProto.FLOAT16,
         "bf16": TensorProto.BFLOAT16,
+        "bfloat16": TensorProto.BFLOAT16,
         "i8": TensorProto.INT8,
         "int8_t": TensorProto.INT8,
         "i16": TensorProto.INT16,
@@ -48,6 +50,7 @@ class OpenVINOEncapsulation(Pass):
         "uint64_t": TensorProto.UINT64,
         "bool": TensorProto.BOOL,
         "boolean": TensorProto.BOOL,
+        "char": TensorProto.BOOL,
         # Add more if needed
     }
 


### PR DESCRIPTION
## Problem

`OpenVINOEncapsulation` builds the `EPContext` ONNX by mapping each OpenVINO model input/output element type to an ONNX `TensorProto` dtype via `openvino_to_onnx_dtype[str(element_type)...]`. The map was missing the OpenVINO string spellings for several common types:

- fp16 stringifies as `float16` (only `f16` was mapped)
- bf16 as `bfloat16` (only `bf16`)
- ONNX `BOOL` round-trips through OpenVINO as `char`

As a result, encapsulating an **fp16 model** (e.g. an LLM decoder) or any model with a **boolean mask** input crashes:

```
File ".../openvino/encapsulation.py", line 181, in _run_single_target
    inputs.append(helper.make_tensor_value_info(name, onnx_dtype, shape_list))
TypeError: 'NoneType' object cannot be interpreted as an integer
```

(`onnx_dtype` is `None` because the lookup missed.)

## Fix

Add the missing aliases: `float16` → `FLOAT16`, `bfloat16` → `BFLOAT16`, `char` → `BOOL`.

## Validation

With this fix, `OpenVINOConversion` → `OpenVINOEncapsulation` successfully produces `EPContext` ONNX models for all four components of a multimodal fp16 INT4 decoder+encoders package (Gemma 4 E2B, built via `MobiusBuilder` → `OnnxKQuantQuantization` → `MatMulNBitsToQDQ` → OpenVINO 2026.3), including the audio encoder's boolean `input_features_mask`. Before the fix, fp16 inputs failed immediately and the boolean-mask encoder failed with the same `NoneType` error.