### PR TITLE
Suppress CodeQL [SM02167]

### DIFF
--- a/olive/passes/diffusers/lora.py
+++ b/olive/passes/diffusers/lora.py
@@ -941,7 +941,8 @@ class SDLoRA(Pass):
             output_dir = Path(class_data_dir)
         else:
             cache = OliveCache.from_cache_env()
-            prompt_hash = hashlib.md5(class_prompt.encode()).hexdigest()[:8]
+            # Used solely for creating unique directory names in cache, not a security-sensitive usage.
+            prompt_hash = hashlib.md5(class_prompt.encode()).hexdigest()[:8]  # CodeQL [SM02167] Justification above
             output_dir = cache.get_cache_dir() / "class_images" / prompt_hash
 
         output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Suppress CodeQL [SM02167]

Computed hash is used solely for creating uniques directory names in cache, not a security-sensitive usage.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
