### PR TITLE
Refactor warmup logic and generator mock in OnnxDiscrepancyCheck

### DIFF
--- a/olive/passes/onnx/discrepancy_check.py
+++ b/olive/passes/onnx/discrepancy_check.py
@@ -1007,14 +1007,15 @@ class OnnxDiscrepancyCheck(Pass):
         genai_ttfn = None
         num_generated = 0
 
-        # warmup
+        # warmup — throwaway list so genai_tokens is never polluted
+        warmup_tokens = list(genai_input_ids)
         generator = og.Generator(genai_model, params)
         generator.append_tokens([genai_input_ids])
         start = time.perf_counter()
         while not generator.is_done():
             generator.generate_next_token()
-            genai_tokens.append(generator.get_next_tokens()[0])
-            if len(genai_tokens) >= 3:
+            warmup_tokens.append(generator.get_next_tokens()[0])
+            if len(warmup_tokens) >= genai_prompt_token_count + 1:
                 break
         genai_warmup_time = time.perf_counter() - start
 

--- a/test/passes/onnx/test_discrepancy_check.py
+++ b/test/passes/onnx/test_discrepancy_check.py
@@ -84,22 +84,30 @@ class TestCompareGeneration:
         mock_params = MagicMock()
         mock_og.GeneratorParams.return_value = mock_params
 
-        # Simulate generator producing tokens: 10, 11, 99, 99 then done
-        mock_generator = MagicMock()
+        # Each og.Generator (warmup + real run) replays the same deterministic token
+        # stream 10, 11, 99, 99 from the start, so the warmup never consumes tokens from
+        # the real generation run.
         genai_new_tokens = [10, 11, 99, 99]
-        call_count = [0]
+        shared_append_tokens = MagicMock()
 
-        def is_done_side_effect():
-            return call_count[0] >= len(genai_new_tokens)
+        def make_generator(*args, **kwargs):
+            generator = MagicMock()
+            generator.append_tokens = shared_append_tokens
+            counter = [0]
 
-        def get_next_tokens_side_effect():
-            token = genai_new_tokens[call_count[0]]
-            call_count[0] += 1
-            return [token]
+            def is_done_side_effect():
+                return counter[0] >= len(genai_new_tokens)
 
-        mock_generator.is_done = is_done_side_effect
-        mock_generator.get_next_tokens = get_next_tokens_side_effect
-        mock_og.Generator.return_value = mock_generator
+            def get_next_tokens_side_effect():
+                token = genai_new_tokens[counter[0]]
+                counter[0] += 1
+                return [token]
+
+            generator.is_done = is_done_side_effect
+            generator.get_next_tokens = get_next_tokens_side_effect
+            return generator
+
+        mock_og.Generator.side_effect = make_generator
 
         with (
             patch.dict(sys.modules, {"onnxruntime_genai": mock_og}),
@@ -110,8 +118,8 @@ class TestCompareGeneration:
                 config, mock_ref_model, ref_model_path=config.reference_model_path
             )
 
-        assert mock_generator.append_tokens.call_count == 2
-        mock_generator.append_tokens.assert_has_calls([call([[1, 2, 3]]), call([[1, 2, 3]])])
+        assert shared_append_tokens.call_count == 2
+        shared_append_tokens.assert_has_calls([call([[1, 2, 3]]), call([[1, 2, 3]])])
         # Generated-only common prefix: transformers [10, 11, 12, 13] vs genai [10, 11, 99, 99]
         # matches on [10, 11] = 2 tokens before divergence (shared prompt is excluded).
         assert result["longest_common_token_sequence"] == 2
@@ -155,21 +163,30 @@ class TestCompareGeneration:
         mock_params = MagicMock()
         mock_og.GeneratorParams.return_value = mock_params
 
-        mock_generator = MagicMock()
+        # Each og.Generator (warmup + real run) replays the same deterministic token
+        # stream 30, 40, 50 from the start, so the warmup never consumes tokens from the
+        # real generation run.
         genai_new_tokens = [30, 40, 50]
-        call_count = [0]
+        shared_append_tokens = MagicMock()
 
-        def is_done_side_effect():
-            return call_count[0] >= len(genai_new_tokens)
+        def make_generator(*args, **kwargs):
+            generator = MagicMock()
+            generator.append_tokens = shared_append_tokens
+            counter = [0]
 
-        def get_next_tokens_side_effect():
-            token = genai_new_tokens[call_count[0]]
-            call_count[0] += 1
-            return [token]
+            def is_done_side_effect():
+                return counter[0] >= len(genai_new_tokens)
 
-        mock_generator.is_done = is_done_side_effect
-        mock_generator.get_next_tokens = get_next_tokens_side_effect
-        mock_og.Generator.return_value = mock_generator
+            def get_next_tokens_side_effect():
+                token = genai_new_tokens[counter[0]]
+                counter[0] += 1
+                return [token]
+
+            generator.is_done = is_done_side_effect
+            generator.get_next_tokens = get_next_tokens_side_effect
+            return generator
+
+        mock_og.Generator.side_effect = make_generator
 
         with (
             patch.dict(sys.modules, {"onnxruntime_genai": mock_og}),
@@ -180,8 +197,8 @@ class TestCompareGeneration:
                 config, mock_ref_model, ref_model_path=config.reference_model_path
             )
 
-        assert mock_generator.append_tokens.call_count == 2
-        mock_generator.append_tokens.assert_has_calls([call([[10, 20]]), call([[10, 20]])])
+        assert shared_append_tokens.call_count == 2
+        shared_append_tokens.assert_has_calls([call([[10, 20]]), call([[10, 20]])])
         # All 3 generated tokens match (shared prompt is excluded)
         assert result["longest_common_token_sequence"] == 3
         assert result["first_n_tokens_timed"] == 5
@@ -270,22 +287,27 @@ class TestCompareGeneration:
         mock_genai_tokenizer.encode.return_value = [1, 2, 3]
         mock_og.GeneratorParams.return_value = MagicMock()
 
-        mock_generator = MagicMock()
-        # GenAI first generated token is also 10 -> match.
+        # GenAI first generated token is also 10 -> match. Each og.Generator (warmup +
+        # real run) replays the same deterministic stream 10, 99, 99 from the start.
         genai_new_tokens = [10, 99, 99]
-        call_count = [0]
 
-        def is_done_side_effect():
-            return call_count[0] >= len(genai_new_tokens)
+        def make_generator(*args, **kwargs):
+            generator = MagicMock()
+            counter = [0]
 
-        def get_next_tokens_side_effect():
-            token = genai_new_tokens[call_count[0]]
-            call_count[0] += 1
-            return [token]
+            def is_done_side_effect():
+                return counter[0] >= len(genai_new_tokens)
 
-        mock_generator.is_done = is_done_side_effect
-        mock_generator.get_next_tokens = get_next_tokens_side_effect
-        mock_og.Generator.return_value = mock_generator
+            def get_next_tokens_side_effect():
+                token = genai_new_tokens[counter[0]]
+                counter[0] += 1
+                return [token]
+
+            generator.is_done = is_done_side_effect
+            generator.get_next_tokens = get_next_tokens_side_effect
+            return generator
+
+        mock_og.Generator.side_effect = make_generator
 
         with (
             patch.dict(sys.modules, {"onnxruntime_genai": mock_og}),
@@ -340,21 +362,27 @@ class TestCompareGeneration:
         mock_genai_tokenizer.encode.return_value = [1, 2]
         mock_og.GeneratorParams.return_value = MagicMock()
 
-        mock_generator = MagicMock()
+        # Each og.Generator (warmup + real run) replays the same deterministic stream
+        # 40, 41 from the start, so the warmup never consumes tokens from the real run.
         genai_new_tokens = [40, 41]
-        call_count = [0]
 
-        def is_done_side_effect():
-            return call_count[0] >= len(genai_new_tokens)
+        def make_generator(*args, **kwargs):
+            generator = MagicMock()
+            counter = [0]
 
-        def get_next_tokens_side_effect():
-            token = genai_new_tokens[call_count[0]]
-            call_count[0] += 1
-            return [token]
+            def is_done_side_effect():
+                return counter[0] >= len(genai_new_tokens)
 
-        mock_generator.is_done = is_done_side_effect
-        mock_generator.get_next_tokens = get_next_tokens_side_effect
-        mock_og.Generator.return_value = mock_generator
+            def get_next_tokens_side_effect():
+                token = genai_new_tokens[counter[0]]
+                counter[0] += 1
+                return [token]
+
+            generator.is_done = is_done_side_effect
+            generator.get_next_tokens = get_next_tokens_side_effect
+            return generator
+
+        mock_og.Generator.side_effect = make_generator
 
         with (
             patch.dict(sys.modules, {"onnxruntime_genai": mock_og}),


### PR DESCRIPTION
### Summary
Fix a warmup pollution bug in `OnnxDiscrepancyCheck.compare_generation`
(`olive/passes/onnx/discrepancy_check.py`) that caused a systematic off-by-one
misalignment in the ONNX Runtime GenAI generated-token list.

### Bug
The GenAI warmup loop (introduced in `fe69db6`) reused the `genai_tokens`
accumulator across both the warmup and the real generation run. The generator
is correctly re-created for the real run, but the accumulator was not reset, so
warmup-generated tokens were already present in `genai_tokens` when the real run
started.

Because generation is deterministic, this shifted every generated token by one
position and produced misleading metrics:

- `first_token_matches` → `True` (warmup token equals the real first token)
- `second_token_matches` → `False` (real first token lands in the second slot)
- `longest_common_token_sequence` → collapsed to `1`

The warmup break condition (`len(genai_tokens) >= 3`) also counted prompt tokens,
under-warming on prompts of 3 or more tokens.

### Fix
- Use a throwaway `warmup_tokens` accumulator during warmup so `genai_tokens` is
  never touched until the real run — structurally mirroring how the transformers
  side already discards its warmup output.
- Change the warmup break condition to `len(warmup_tokens) >= genai_prompt_token_count + 1`
  so it counts only generated tokens.

The real generation block immediately following was already correct and is
unchanged.

### Tests
- Updated `test/passes/onnx/test_discrepancy_check.py` `TestCompareGeneration`
  mocks so each `og.Generator` call (warmup + real run) replays the token stream
  from the start via an `og.Generator.side_effect` factory. This models real
  deterministic re-generation, where warmup and the real run produce the same
  tokens and the warmup output is discarded. Previously the mocks shared a single
  `call_count` across both generators, which encoded the buggy behavior.
- The two `append_tokens` assertions now target a shared mock so the "prompt is
  seeded for both warmup and real run" checks still hold.
- `test_compare_generation_with_zero_max_new_tokens` was left unchanged — its
  generator reports `is_done` immediately and never appended warmup tokens, so it
  was unaffected by the bug.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

### Release notes
Fixed a bug in the `OnnxDiscrepancyCheck` pass where GenAI warmup tokens polluted
the generated-token comparison, causing incorrect `first_token_matches`,
`second_token_matches`, and `longest_common_token_sequence` results.

## (Optional) Issue link