### PR TITLE
Support chat-style multimodal audio LMs in speech WER evaluation

### DIFF
--- a/olive/evaluator/accuracy.py
+++ b/olive/evaluator/accuracy.py
@@ -171,7 +171,24 @@ class WordErrorRate(AccuracyBase):
 
     @classmethod
     def _default_config(cls) -> dict[str, ConfigParam]:
-        return {}
+        return {
+            "normalize": ConfigParam(type_=bool, default_value=True),
+        }
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        """Normalize text for WER: lowercase, strip punctuation, collapse whitespace.
+
+        Word Error Rate is conventionally reported on normalized text so that casing and
+        punctuation (which ASR models emit but references often omit) are not counted as
+        errors. Without this, e.g. FLEURS references (already lowercased, de-punctuated)
+        compared against a chat-style model's cased/punctuated output roughly doubles the WER.
+        """
+        import re
+
+        text = str(text).lower()
+        text = re.sub(r"[^\w\s]", " ", text)
+        return re.sub(r"\s+", " ", text).strip()
 
     def measure(self, model_output, target):
         preds = model_output.preds
@@ -186,7 +203,12 @@ class WordErrorRate(AccuracyBase):
         elif not isinstance(refs, list):
             refs = list(refs)
 
-        wer = torchmetrics.text.WordErrorRate(**self.config_dict)
+        config = dict(self.config_dict)
+        if config.pop("normalize", True):
+            preds = [self._normalize(p) for p in preds]
+            refs = [self._normalize(r) for r in refs]
+
+        wer = torchmetrics.text.WordErrorRate(**config)
         result = wer(preds, refs)
         return result.item()
 

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -627,6 +627,8 @@ def _is_multimodal_lm_genai(genai_cfg: Optional[dict]) -> bool:
     if not genai_cfg:
         return False
     model_cfg = genai_cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return False
     return any(key in model_cfg for key in ("speech", "audio"))
 
 
@@ -1345,7 +1347,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             {"role": "user", "content": [{"type": "audio"}, {"type": "text", "text": instruction}]},
         ]
         prompt = tokenizer.apply_chat_template(
-            messages=json.dumps(messages), tools="", add_generation_prompt=True, template_str=template_str
+            json.dumps(messages), template_str=template_str, tools="", add_generation_prompt=True
         )
 
         def _transcribe(audio_arr: np.ndarray) -> str:

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -1148,6 +1148,76 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
         return OliveModelOutput(preds=all_preds, logits=None, extras=all_extras), all_targets
 
+    def _load_genai_speech_model(self, model: ONNXModelHandler, device: Device):
+        """Load an ORT GenAI model for speech evaluation.
+
+        Returns ``(og, og_model, genai_config, model_dir)`` where ``og`` is the imported
+        ``onnxruntime_genai`` module. Shared by the whisper, streaming, and multimodal-LM
+        speech inference paths to avoid duplicating the import guard, genai_config load, and
+        execution-provider selection.
+        """
+        try:
+            import onnxruntime_genai as og
+        except ImportError:
+            raise ImportError(
+                "onnxruntime-genai is required for genai-based speech evaluation. "
+                "Install it with: pip install onnxruntime-genai"
+            ) from None
+
+        model_dir = _get_genai_model_dir(model)
+        with (Path(model_dir) / "genai_config.json").open() as f:
+            genai_config = json.load(f)
+
+        config = og.Config(model_dir)
+        config.clear_providers()
+        if device == Device.GPU:
+            config.append_provider("cuda")
+        og_model = og.Model(config)
+        return og, og_model, genai_config, model_dir
+
+    @staticmethod
+    def _run_speech_inference_loop(dataloader, sample_rate, transcribe_fn):
+        """Run the shared speech-eval batch loop.
+
+        Iterates batches, normalizes audio, times inference, transcribes each clip via
+        ``transcribe_fn(audio_array) -> str``, and collects predictions, per-sample audio
+        names, and reference texts. Returns ``(OliveModelOutput, targets)`` with RTFx timing
+        metadata in ``logits``. Only the per-clip ``transcribe_fn`` differs between the
+        whisper, streaming, and multimodal-LM speech paths.
+        """
+        all_preds = []
+        all_targets = []
+        all_extras = []
+        total_audio_duration = 0.0
+        total_inference_time = 0.0
+
+        for batch in dataloader:
+            input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
+
+            # Convert input to list of audio arrays (with optional file names)
+            audio_arrays, audio_names = _normalize_audio_batch(input_data)
+            if not audio_arrays:
+                continue
+
+            start_time = time.perf_counter()
+            for arr, name in zip(audio_arrays, audio_names):
+                total_audio_duration += len(arr) / sample_rate
+                all_preds.append(transcribe_fn(arr))
+                all_extras.append({"audio": name if name is not None else str(len(all_extras))})
+            total_inference_time += time.perf_counter() - start_time
+
+            # Collect reference texts
+            if isinstance(labels, (list, tuple)):
+                all_targets.extend(labels)
+            else:
+                all_targets.append(labels)
+
+        timing_metadata = {
+            "total_audio_duration": total_audio_duration,
+            "total_inference_time": total_inference_time,
+        }
+        return OliveModelOutput(preds=all_preds, logits=timing_metadata, extras=all_extras), all_targets
+
     def _inference_text_genai(
         self,
         model: ONNXModelHandler,
@@ -1162,30 +1232,11 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         Uses og.Model with multimodal processor for Whisper-style models.
         Automatically chunks audio longer than 30 seconds.
         """
-        try:
-            import onnxruntime_genai as og
-        except ImportError:
-            raise ImportError(
-                "onnxruntime-genai is required for genai-based speech evaluation. "
-                "Install it with: pip install onnxruntime-genai"
-            ) from None
-
         import io
 
         import soundfile as sf
 
-        model_dir = _get_genai_model_dir(model)
-
-        # Read genai_config to determine model properties
-        with (Path(model_dir) / "genai_config.json").open() as f:
-            genai_config = json.load(f)
-
-        # Build og.Model with appropriate execution provider
-        config = og.Config(model_dir)
-        config.clear_providers()
-        if device == Device.GPU:
-            config.append_provider("cuda")
-        og_model = og.Model(config)
+        og, og_model, genai_config, _ = self._load_genai_speech_model(model, device)
         processor = og_model.create_multimodal_processor()
 
         # Determine decoder prompt tokens from model config
@@ -1210,7 +1261,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
         prompt = "".join(decoder_prompt_tokens)
 
-        def _transcribe_chunks(audio_arr: np.ndarray, genai_model) -> str:
+        def _transcribe_chunks(audio_arr: np.ndarray) -> str:
             """Transcribe a single audio array, chunking if longer than 30s."""
             if len(audio_arr) <= max_chunk_samples:
                 chunks = [audio_arr]
@@ -1227,10 +1278,10 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
                 audios = og.Audios.open_bytes(buffer.getvalue())
                 inputs = processor([prompt], audios=audios)
 
-                params = og.GeneratorParams(genai_model)
+                params = og.GeneratorParams(og_model)
                 params.set_search_options(do_sample=False, max_length=max_length, min_length=0, batch_size=1)
 
-                generator = og.Generator(genai_model, params)
+                generator = og.Generator(og_model, params)
                 generator.set_inputs(inputs)
 
                 while not generator.is_done():
@@ -1241,42 +1292,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
             return " ".join(transcriptions)
 
-        all_preds = []
-        all_targets = []
-        all_extras = []
-        total_audio_duration = 0.0
-        total_inference_time = 0.0
-
-        for batch in dataloader:
-            input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
-
-            # Convert input to list of audio arrays (with optional file names)
-            audio_arrays, audio_names = _normalize_audio_batch(input_data)
-
-            if not audio_arrays:
-                continue
-
-            start_time = time.perf_counter()
-            for arr, name in zip(audio_arrays, audio_names):
-                total_audio_duration += len(arr) / sample_rate
-                transcription = _transcribe_chunks(arr, og_model)
-                all_preds.append(transcription)
-                all_extras.append({"audio": name if name is not None else str(len(all_extras))})
-            total_inference_time += time.perf_counter() - start_time
-
-            # Collect reference texts
-            if isinstance(labels, (list, tuple)):
-                all_targets.extend(labels)
-            else:
-                all_targets.append(labels)
-
-        del og_model
-
-        timing_metadata = {
-            "total_audio_duration": total_audio_duration,
-            "total_inference_time": total_inference_time,
-        }
-        return OliveModelOutput(preds=all_preds, logits=timing_metadata, extras=all_extras), all_targets
+        return self._run_speech_inference_loop(dataloader, sample_rate, _transcribe_chunks)
 
     def _inference_text_genai_multimodal(
         self,
@@ -1297,28 +1313,11 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         (``system_prompt`` / ``instruction``); they default to a strict ASR prompt that suppresses
         chat-style refusals which would otherwise inflate WER.
         """
-        try:
-            import onnxruntime_genai as og
-        except ImportError:
-            raise ImportError(
-                "onnxruntime-genai is required for genai-based speech evaluation. "
-                "Install it with: pip install onnxruntime-genai"
-            ) from None
-
         import io
 
         import soundfile as sf
 
-        model_dir = _get_genai_model_dir(model)
-
-        with (Path(model_dir) / "genai_config.json").open() as f:
-            genai_config = json.load(f)
-
-        config = og.Config(model_dir)
-        config.clear_providers()
-        if device == Device.GPU:
-            config.append_provider("cuda")
-        og_model = og.Model(config)
+        og, og_model, genai_config, model_dir = self._load_genai_speech_model(model, device)
         processor = og_model.create_multimodal_processor()
         tokenizer = og.Tokenizer(og_model)
 
@@ -1349,17 +1348,17 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             messages=json.dumps(messages), tools="", add_generation_prompt=True, template_str=template_str
         )
 
-        def _transcribe(audio_arr: np.ndarray, genai_model) -> str:
+        def _transcribe(audio_arr: np.ndarray) -> str:
             buffer = io.BytesIO()
-            sf.write(buffer, audio_arr, samplerate=sample_rate, format="WAV")
+            sf.write(buffer, np.asarray(audio_arr, dtype=np.float32), samplerate=sample_rate, format="WAV")
             audios = og.Audios.open_bytes(buffer.getvalue())
             inputs = processor(prompt, audios=audios)
 
-            params = og.GeneratorParams(genai_model)
+            params = og.GeneratorParams(og_model)
             params.set_search_options(
                 do_sample=False, max_length=max_length, min_length=0, past_present_share_buffer=False
             )
-            generator = og.Generator(genai_model, params)
+            generator = og.Generator(og_model, params)
             generator.set_inputs(inputs)
 
             prompt_len = generator.token_count()
@@ -1369,38 +1368,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             new_tokens = list(generator.get_sequence(0)[prompt_len:])
             return tokenizer.decode(new_tokens).strip()
 
-        all_preds = []
-        all_targets = []
-        all_extras = []
-        total_audio_duration = 0.0
-        total_inference_time = 0.0
-
-        for batch in dataloader:
-            input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
-
-            audio_arrays, audio_names = _normalize_audio_batch(input_data)
-            if not audio_arrays:
-                continue
-
-            start_time = time.perf_counter()
-            for arr, name in zip(audio_arrays, audio_names):
-                total_audio_duration += len(arr) / sample_rate
-                all_preds.append(_transcribe(np.asarray(arr, dtype=np.float32), og_model))
-                all_extras.append({"audio": name if name is not None else str(len(all_extras))})
-            total_inference_time += time.perf_counter() - start_time
-
-            if isinstance(labels, (list, tuple)):
-                all_targets.extend(labels)
-            else:
-                all_targets.append(labels)
-
-        del og_model
-
-        timing_metadata = {
-            "total_audio_duration": total_audio_duration,
-            "total_inference_time": total_inference_time,
-        }
-        return OliveModelOutput(preds=all_preds, logits=timing_metadata, extras=all_extras), all_targets
+        return self._run_speech_inference_loop(dataloader, sample_rate, _transcribe)
 
     def _inference_text_genai_streaming(
         self,
@@ -1416,40 +1384,22 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
         Uses og.StreamingProcessor for stateful chunked inference with silence padding
         for right-context flushing.
         """
-        try:
-            import onnxruntime_genai as og
-        except ImportError:
-            raise ImportError(
-                "onnxruntime-genai is required for genai-based speech evaluation. "
-                "Install it with: pip install onnxruntime-genai"
-            ) from None
-
-        model_dir = _get_genai_model_dir(model)
-
-        with (Path(model_dir) / "genai_config.json").open() as f:
-            genai_config = json.load(f)
+        og, og_model, genai_config, _ = self._load_genai_speech_model(model, device)
+        tokenizer = og.Tokenizer(og_model)
 
         sample_rate = genai_config["model"].get("sample_rate", 16000)
         chunk_samples = genai_config["model"].get("chunk_samples", 8960)
 
-        # Build og.Model with appropriate execution provider
-        config = og.Config(model_dir)
-        config.clear_providers()
-        if device == Device.GPU:
-            config.append_provider("cuda")
-        og_model = og.Model(config)
-        tokenizer = og.Tokenizer(og_model)
-
         # Number of silence chunks for right-context flushing
         num_silence_chunks = 4
 
-        def _transcribe_streaming(audio_arr: np.ndarray, genai_model) -> str:
+        def _transcribe_streaming(audio_arr: np.ndarray) -> str:
             """Transcribe audio using stateful streaming processor."""
             audio = audio_arr.astype(np.float32)
-            stream_processor = og.StreamingProcessor(genai_model)
+            stream_processor = og.StreamingProcessor(og_model)
             tokenizer_stream = tokenizer.create_stream()
-            params = og.GeneratorParams(genai_model)
-            generator = og.Generator(genai_model, params)
+            params = og.GeneratorParams(og_model)
+            generator = og.Generator(og_model, params)
 
             transcript = ""
 
@@ -1487,42 +1437,7 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
 
             return transcript
 
-        all_preds = []
-        all_targets = []
-        all_extras = []
-        total_audio_duration = 0.0
-        total_inference_time = 0.0
-
-        for batch in dataloader:
-            input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
-
-            # Convert input to list of audio arrays (with optional file names)
-            audio_arrays, audio_names = _normalize_audio_batch(input_data)
-
-            if not audio_arrays:
-                continue
-
-            start_time = time.perf_counter()
-            for arr, name in zip(audio_arrays, audio_names):
-                total_audio_duration += len(arr) / sample_rate
-                transcription = _transcribe_streaming(arr, og_model)
-                all_preds.append(transcription)
-                all_extras.append({"audio": name if name is not None else str(len(all_extras))})
-            total_inference_time += time.perf_counter() - start_time
-
-            # Collect reference texts
-            if isinstance(labels, (list, tuple)):
-                all_targets.extend(labels)
-            else:
-                all_targets.append(labels)
-
-        del og_model
-
-        timing_metadata = {
-            "total_audio_duration": total_audio_duration,
-            "total_inference_time": total_inference_time,
-        }
-        return OliveModelOutput(preds=all_preds, logits=timing_metadata, extras=all_extras), all_targets
+        return self._run_speech_inference_loop(dataloader, sample_rate, _transcribe_streaming)
 
     def _evaluate_onnx_latency(
         self,

--- a/olive/evaluator/olive_evaluator.py
+++ b/olive/evaluator/olive_evaluator.py
@@ -616,6 +616,20 @@ def _normalize_audio_batch(input_data) -> tuple[list, list]:
     return arrays, names
 
 
+def _is_multimodal_lm_genai(genai_cfg: Optional[dict]) -> bool:
+    """Return True for chat-style multimodal LMs that accept an audio input (e.g. gemma4).
+
+    These models are not dedicated ASR heads like whisper/nemotron_speech; they are
+    instruction-tuned decoders prompted with an ``<|audio|>`` chat turn. They are detected
+    by the presence of an audio component (``speech``/``audio``) in the genai config's
+    ``model`` section.
+    """
+    if not genai_cfg:
+        return False
+    model_cfg = genai_cfg.get("model", {})
+    return any(key in model_cfg for key in ("speech", "audio"))
+
+
 def _unwrap_audio_input(input_data):
     """Strip the speech metadata dict down to the raw audio array(s).
 
@@ -783,10 +797,15 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
                     inference_output, targets = self._inference_text_genai_streaming(
                         model, metric, dataloader, device, execution_providers
                     )
+                elif _is_multimodal_lm_genai(genai_cfg):
+                    inference_output, targets = self._inference_text_genai_multimodal(
+                        model, metric, dataloader, device, execution_providers
+                    )
                 else:
                     raise ValueError(
                         f"Unsupported genai model type '{model_type}' for speech evaluation. "
-                        f"Supported types: 'whisper' (offline), 'nemotron_speech' (streaming). "
+                        f"Supported types: 'whisper' (offline), 'nemotron_speech' (streaming), "
+                        f"and chat-style multimodal LMs with an audio input (e.g. 'gemma4'). "
                         f"For unsupported model types, use a custom evaluation script."
                     )
             else:
@@ -1246,6 +1265,130 @@ class OnnxEvaluator(_OliveEvaluator, OnnxEvaluatorMixin):
             total_inference_time += time.perf_counter() - start_time
 
             # Collect reference texts
+            if isinstance(labels, (list, tuple)):
+                all_targets.extend(labels)
+            else:
+                all_targets.append(labels)
+
+        del og_model
+
+        timing_metadata = {
+            "total_audio_duration": total_audio_duration,
+            "total_inference_time": total_inference_time,
+        }
+        return OliveModelOutput(preds=all_preds, logits=timing_metadata, extras=all_extras), all_targets
+
+    def _inference_text_genai_multimodal(
+        self,
+        model: ONNXModelHandler,
+        metric: Metric,
+        dataloader: "DataLoader",
+        device: Device = Device.CPU,
+        execution_providers: Optional[Union[str, list[str]]] = None,
+    ) -> tuple[OliveModelOutput, Any]:
+        """Text-based ASR inference for chat-style multimodal LMs (e.g. gemma4) via onnxruntime-genai.
+
+        Unlike whisper/nemotron_speech, these models are instruction-tuned decoders: the audio is
+        wrapped in an ``<|audio|>`` chat turn built from the model's ``chat_template.jinja`` and a
+        configurable system prompt + instruction, then decoded greedily. Only the newly generated
+        tokens (after the prompt) are returned as the transcription.
+
+        The system prompt and instruction can be overridden via the metric's pre-process params
+        (``system_prompt`` / ``instruction``); they default to a strict ASR prompt that suppresses
+        chat-style refusals which would otherwise inflate WER.
+        """
+        try:
+            import onnxruntime_genai as og
+        except ImportError:
+            raise ImportError(
+                "onnxruntime-genai is required for genai-based speech evaluation. "
+                "Install it with: pip install onnxruntime-genai"
+            ) from None
+
+        import io
+
+        import soundfile as sf
+
+        model_dir = _get_genai_model_dir(model)
+
+        with (Path(model_dir) / "genai_config.json").open() as f:
+            genai_config = json.load(f)
+
+        config = og.Config(model_dir)
+        config.clear_providers()
+        if device == Device.GPU:
+            config.append_provider("cuda")
+        og_model = og.Model(config)
+        processor = og_model.create_multimodal_processor()
+        tokenizer = og.Tokenizer(og_model)
+
+        pre_process_params = (
+            metric.data_config.pre_process_data_config.params
+            if (metric.data_config and metric.data_config.pre_process_data_config)
+            else {}
+        )
+        sample_rate = pre_process_params.get("sample_rate", 16000)
+        default_system = (
+            "You are an automatic speech recognition (ASR) system. "
+            "Output only the exact verbatim transcript of the speech in the audio. "
+            "Do not add commentary, explanations, or apologies. "
+            "If unsure, output your best guess."
+        )
+        system_prompt = pre_process_params.get("system_prompt", default_system)
+        instruction = pre_process_params.get("instruction", "Transcribe the audio verbatim.")
+        max_length = genai_config.get("search", {}).get("max_length", 1024)
+
+        # Build the chat prompt once (audio is injected per-sample via the processor).
+        chat_template_path = Path(model_dir) / "chat_template.jinja"
+        template_str = chat_template_path.read_text(encoding="utf-8") if chat_template_path.exists() else None
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": [{"type": "audio"}, {"type": "text", "text": instruction}]},
+        ]
+        prompt = tokenizer.apply_chat_template(
+            messages=json.dumps(messages), tools="", add_generation_prompt=True, template_str=template_str
+        )
+
+        def _transcribe(audio_arr: np.ndarray, genai_model) -> str:
+            buffer = io.BytesIO()
+            sf.write(buffer, audio_arr, samplerate=sample_rate, format="WAV")
+            audios = og.Audios.open_bytes(buffer.getvalue())
+            inputs = processor(prompt, audios=audios)
+
+            params = og.GeneratorParams(genai_model)
+            params.set_search_options(
+                do_sample=False, max_length=max_length, min_length=0, past_present_share_buffer=False
+            )
+            generator = og.Generator(genai_model, params)
+            generator.set_inputs(inputs)
+
+            prompt_len = generator.token_count()
+            while not generator.is_done():
+                generator.generate_next_token()
+
+            new_tokens = list(generator.get_sequence(0)[prompt_len:])
+            return tokenizer.decode(new_tokens).strip()
+
+        all_preds = []
+        all_targets = []
+        all_extras = []
+        total_audio_duration = 0.0
+        total_inference_time = 0.0
+
+        for batch in dataloader:
+            input_data, labels = OliveEvaluator.unpack_batch_for_accuracy(batch)
+
+            audio_arrays, audio_names = _normalize_audio_batch(input_data)
+            if not audio_arrays:
+                continue
+
+            start_time = time.perf_counter()
+            for arr, name in zip(audio_arrays, audio_names):
+                total_audio_duration += len(arr) / sample_rate
+                all_preds.append(_transcribe(np.asarray(arr, dtype=np.float32), og_model))
+                all_extras.append({"audio": name if name is not None else str(len(all_extras))})
+            total_inference_time += time.perf_counter() - start_time
+
             if isinstance(labels, (list, tuple)):
                 all_targets.extend(labels)
             else:

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -1023,6 +1023,12 @@ class TestIsMultimodalLmGenai:
 
         assert _is_multimodal_lm_genai(None) is False
 
+    def test_is_multimodal_lm_genai_false_when_model_not_dict(self):
+        """A malformed config with a non-dict model section does not raise."""
+        from olive.evaluator.olive_evaluator import _is_multimodal_lm_genai
+
+        assert _is_multimodal_lm_genai({"model": None}) is False
+
 
 class TestWordErrorRateNormalization:
     """Tests for WordErrorRate ASR text normalization."""

--- a/test/evaluator/test_olive_evaluator.py
+++ b/test/evaluator/test_olive_evaluator.py
@@ -996,6 +996,62 @@ class TestFindGenaiConfig:
         assert result is None
 
 
+class TestIsMultimodalLmGenai:
+    """Tests for _is_multimodal_lm_genai audio-LM detection."""
+
+    def test_is_multimodal_lm_genai_true_when_speech_field(self):
+        """Detect a chat-style audio LM (e.g. gemma4) via the speech component."""
+        from olive.evaluator.olive_evaluator import _is_multimodal_lm_genai
+
+        assert _is_multimodal_lm_genai({"model": {"type": "gemma4", "speech": {}}}) is True
+
+    def test_is_multimodal_lm_genai_true_when_audio_field(self):
+        """Detect an audio LM via an audio component."""
+        from olive.evaluator.olive_evaluator import _is_multimodal_lm_genai
+
+        assert _is_multimodal_lm_genai({"model": {"type": "some_lm", "audio": {}}}) is True
+
+    def test_is_multimodal_lm_genai_false_when_no_audio(self):
+        """A text/vision-only genai config is not an audio LM."""
+        from olive.evaluator.olive_evaluator import _is_multimodal_lm_genai
+
+        assert _is_multimodal_lm_genai({"model": {"type": "gemma4", "vision": {}}}) is False
+
+    def test_is_multimodal_lm_genai_false_when_none(self):
+        """A missing genai config is not an audio LM."""
+        from olive.evaluator.olive_evaluator import _is_multimodal_lm_genai
+
+        assert _is_multimodal_lm_genai(None) is False
+
+
+class TestWordErrorRateNormalization:
+    """Tests for WordErrorRate ASR text normalization."""
+
+    @staticmethod
+    def _wer(preds, refs, **config):
+        from olive.evaluator.accuracy import WordErrorRate
+        from olive.evaluator.olive_evaluator import OliveModelOutput
+
+        metric = WordErrorRate(config=config or None)
+        return metric.measure(OliveModelOutput(preds=preds, logits=None), refs)
+
+    def test_measure_ignores_case_and_punctuation_by_default(self):
+        """Casing and punctuation should not be counted as word errors by default."""
+        wer = self._wer(["Hello, World!"], ["hello world"])
+        assert wer == 0.0
+
+    def test_measure_counts_real_word_errors(self):
+        """A genuine substitution is still counted after normalization."""
+        # one substitution out of three reference words -> 1/3
+        wer = self._wer(["the quick fox"], ["the slow fox"])
+        assert abs(wer - (1.0 / 3.0)) < 1e-6
+
+    def test_measure_respects_normalize_false(self):
+        """With normalize disabled, casing/punctuation differences count as errors."""
+        wer = self._wer(["Hello, World!"], ["hello world"], normalize=False)
+        assert wer > 0.0
+
+
 class TestSaveSampleLog:
     """Tests for OliveEvaluator.save_sample_log."""
 


### PR DESCRIPTION
## Describe your changes

The genai speech evaluator (`_evaluate_onnx_accuracy` → text-based/WER path) only routed `whisper` and `nemotron_speech` genai model types and raised `ValueError` for anything else. Chat-style multimodal LMs that accept an audio input (e.g. `gemma4`, and other audio-instruction models) therefore could not be evaluated for WER/RTFx through Olive without a custom script.

This PR adds first-class support for those models, plus a correctness fix to WER scoring:

**1. Generic chat-style audio-LM inference path**
- `_is_multimodal_lm_genai()` detects these models generically by the presence of a `speech`/`audio` component in `genai_config.json` — **not** a hard-coded model type — so any current/future chat-style audio LM is covered.
- New `_inference_text_genai_multimodal()`: builds the `<|audio|>` chat prompt from the model's `chat_template.jinja` with a configurable **system prompt + instruction**, greedy-decodes, and returns only the newly generated tokens as the transcription.
- The system prompt defaults to a **strict ASR prompt** that suppresses chat-style refusals ("I'm sorry, I can't transcribe…") which otherwise severely inflate WER. Both `system_prompt` and `instruction` are overridable via the metric's pre-process params.
- Dedicated ASR heads (`whisper`, `nemotron_speech`) are intentionally **unaffected** — they use decoder-token prompts and cannot emit chat-style refusals, so a system prompt does not apply to them.

**2. Standard WER text normalization**
- `WordErrorRate.measure` now normalizes text by default (lowercase, strip punctuation, collapse whitespace), matching standard ASR WER practice. Previously raw strings were passed straight to `torchmetrics.WordErrorRate`, so casing and punctuation the model emits — but references omit (e.g. FLEURS references are already lowercased/de-punctuated) — were counted as word errors. Toggleable via a new `normalize` config option (default `True`).

### Validation
End-to-end `olive run` on a `gemma4` int4 export over FLEURS `en_us` (64 samples) reports **WER 0.0926**, exactly matching the reference standalone script. Without normalization the same run scored 0.2171, confirming the normalization gap was purely casing/punctuation.

## Checklist before requesting a review
- [x] Add unit tests for this change. (audio-LM detection + WER normalization behavior in `test/evaluator/test_olive_evaluator.py`)
- [x] Make sure all tests can pass. (`test/evaluator/test_olive_evaluator.py`: 125 passed)
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a` (ruff check + format clean on changed files)
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes. **Speech/ASR WER evaluation now supports chat-style multimodal audio LMs (e.g. gemma4), and WER is normalized (case/punctuation-insensitive) by default.**

## (Optional) Issue link