### PR TITLE
[AMD] Add algo-config option in Quark

### DIFF
--- a/olive/passes/quark_quantizer/quark_quantization.py
+++ b/olive/passes/quark_quantizer/quark_quantization.py
@@ -127,6 +127,11 @@ class QuarkQuantization(Pass):
                 default_value=True,
                 description="[Torch] Trust remote code from HuggingFace",
             ),
+            "algo_configs": PassConfigParam(
+                type_=Optional[dict],
+                default_value=None,
+                description="[Torch] Custom algorithm configs by name, e.g. {'awq': {'scaling_layers': [...], 'model_decoder_layers': 'model.layers'}}. Used for architectures Quark lacks a built-in config for.",
+            ),
             # ── ONNX-specific configs ────────────────────────────────────
             "quant_mode": PassConfigParam(
                 type_=str,

--- a/olive/passes/quark_quantizer/torch/quark_torch_quantization.py
+++ b/olive/passes/quark_quantizer/torch/quark_torch_quantization.py
@@ -120,16 +120,7 @@ def run_quark_torch_quantization(
     # Build custom algo_configs from the recipe JSON (for architectures Quark
     # lacks a built-in config for, e.g. qwen3). Remove per-arch entries once
     # Quark ships them upstream in AWQ_MAP.
-    algo_configs = None
-    if getattr(config, "algo_configs", None):
-        from quark.torch.quantization.config.config import AWQConfig
-
-        algo_configs = {}
-        for algo_name, algo_dict in config.algo_configs.items():
-            if algo_name.lower() == "awq":
-                algo_configs["awq"] = AWQConfig(**algo_dict)
-            else:
-                raise ValueError(f"algo_configs for '{algo_name}' is not supported by this pass yet")
+    algo_configs = _build_algo_configs(getattr(config, "algo_configs", None))
 
     quant_config = template.get_config(
         scheme=config.quant_scheme,
@@ -228,6 +219,26 @@ def _parse_quant_algo(quant_algo):
     if isinstance(quant_algo, str):
         return quant_algo.split(",") if "," in quant_algo else [quant_algo]
     return None
+
+
+def _build_algo_configs(algo_configs):
+    """Convert recipe-supplied algo_configs dicts into Quark AlgoConfig objects.
+
+    For architectures Quark has no built-in algorithm config for (e.g. qwen3),
+    the recipe supplies the config; this builds the AlgoConfig to forward to
+    LLMTemplate.get_config(algo_configs=...). Returns None if nothing supplied.
+    """
+    if not algo_configs:
+        return None
+    from quark.torch.quantization.config.config import AWQConfig
+
+    result = {}
+    for algo_name, algo_dict in algo_configs.items():
+        if algo_name.lower() == "awq":
+            result["awq"] = AWQConfig(**algo_dict)
+        else:
+            raise ValueError(f"algo_configs for '{algo_name}' is not supported by this pass yet")
+    return result
 
 
 def _strip_auto_map(output_dir: Path):

--- a/olive/passes/quark_quantizer/torch/quark_torch_quantization.py
+++ b/olive/passes/quark_quantizer/torch/quark_torch_quantization.py
@@ -94,7 +94,6 @@ def run_quark_torch_quantization(
     main_device = torch_model.device
     calib_dataloader = get_calib_dataloader(
         dataset_name=config.dataset,
-        processor=None,
         tokenizer=tokenizer,
         batch_size=config.batch_size,
         num_calib_data=config.num_calib_data,
@@ -118,6 +117,20 @@ def run_quark_torch_quantization(
     # Build layer-specific config
     layer_config = dict(config.layer_quant_scheme) if config.layer_quant_scheme else {}
 
+    # Build custom algo_configs from the recipe JSON (for architectures Quark
+    # lacks a built-in config for, e.g. qwen3). Remove per-arch entries once
+    # Quark ships them upstream in AWQ_MAP.
+    algo_configs = None
+    if getattr(config, "algo_configs", None):
+        from quark.torch.quantization.config.config import AWQConfig
+
+        algo_configs = {}
+        for algo_name, algo_dict in config.algo_configs.items():
+            if algo_name.lower() == "awq":
+                algo_configs["awq"] = AWQConfig(**algo_dict)
+            else:
+                raise ValueError(f"algo_configs for '{algo_name}' is not supported by this pass yet")
+
     quant_config = template.get_config(
         scheme=config.quant_scheme,
         algorithm=quant_algo_list,
@@ -126,6 +139,7 @@ def run_quark_torch_quantization(
         layer_config=layer_config if layer_config else None,
         attention_scheme=config.attention_dtype,
         exclude_layers=config.exclude_layers,
+        algo_configs=algo_configs,
     )
 
     # Handle kv_cache_post_rope flag

--- a/test/passes/quark_quantizer/test_quark_torch_quantization.py
+++ b/test/passes/quark_quantizer/test_quark_torch_quantization.py
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import pytest
+
+pytestmark = pytest.mark.amd
+
+
+def test_build_algo_configs_awq_builds_awqconfig():
+    """A recipe-supplied AWQ dict is converted into an AWQConfig for get_config(algo_configs=...)."""
+    from quark.torch.quantization.config.config import AWQConfig
+
+    from olive.passes.quark_quantizer.torch.quark_torch_quantization import _build_algo_configs
+
+    result = _build_algo_configs({"awq": {"scaling_layers": [], "model_decoder_layers": "model.layers"}})
+    assert isinstance(result["awq"], AWQConfig)
+    assert result["awq"].model_decoder_layers == "model.layers"
+
+
+def test_build_algo_configs_rejects_unsupported_algo():
+    """Only 'awq' is supported today; other algorithms raise a clear ValueError."""
+    from olive.passes.quark_quantizer.torch.quark_torch_quantization import _build_algo_configs
+
+    with pytest.raises(ValueError, match=r"algo_configs for 'gptq'"):
+        _build_algo_configs({"gptq": {"scaling_layers": []}})
+
+
+def test_build_algo_configs_none_when_empty():
+    """No algo_configs supplied → None (built-in Quark config path unchanged)."""
+    from olive.passes.quark_quantizer.torch.quark_torch_quantization import _build_algo_configs
+
+    assert _build_algo_configs(None) is None
+    assert _build_algo_configs({}) is None


### PR DESCRIPTION
- Adds an algo_configs parameter to the QuarkQuantization pass (torch path), letting a recipe pass a custom quantization algorithm config (e.g. AWQ scaling_layers / model_decoder_layers) through to LLMTemplate.get_config(algo_configs=...).

- This is needed for architectures that Quark 0.12.post1 does not ship a built-in algorithm config for, e.g. qwen3, which is absent from Quark's AWQ_MAP and otherwise raises NotImplementedError: No built-in awq configuration is available for the 'qwen3' architecture. With this change, the recipe can supply the config (including scaling_layers: [] for auto-detection), unblocking AWQ quantization for such models.

- The parameter is optional and defaults to None; existing recipes and architectures with built-in configs are unaffected.
