### PR TITLE
Fix OnnxDiscrepancyCheck crash on BF16 models — format_data cannot convert bfloat16 to NumPy

### DIFF
--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -305,11 +305,7 @@ def format_data(data, io_config):
             return value.cpu().numpy()
         return value
 
-    return {
-        k: np.ascontiguousarray(_to_numpy(data[k]), dtype=name_to_type[k])
-        for k in data
-        if k in input_names
-    }
+    return {k: np.ascontiguousarray(_to_numpy(data[k]), dtype=name_to_type[k]) for k in data if k in input_names}
 
 
 def resolve_torch_dtype(dtype):

--- a/olive/common/utils.py
+++ b/olive/common/utils.py
@@ -294,11 +294,19 @@ def format_data(data, io_config):
         data = dict(zip(input_names, [data]))
     elif not isinstance(data, dict):
         raise ValueError(f"Invalid input data format: {data}")
+
+    def _to_numpy(value):
+        if isinstance(value, torch.Tensor):
+            # NumPy has no native bfloat16 dtype, so torch.Tensor.numpy() raises for bf16 tensors.
+            # Upcast to fp32 first (lossless for bf16) and let the np.ascontiguousarray dtype cast
+            # below emit the target ONNX dtype.
+            if value.dtype == torch.bfloat16:
+                value = value.to(torch.float32)
+            return value.cpu().numpy()
+        return value
+
     return {
-        k: np.ascontiguousarray(
-            data[k].cpu().numpy() if isinstance(data[k], torch.Tensor) else data[k],
-            dtype=name_to_type[k],
-        )
+        k: np.ascontiguousarray(_to_numpy(data[k]), dtype=name_to_type[k])
         for k in data
         if k in input_names
     }

--- a/test/common/test_format_data.py
+++ b/test/common/test_format_data.py
@@ -1,0 +1,67 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import numpy as np
+import pytest
+import torch
+
+from olive.common.utils import format_data
+
+
+def _io_config(input_names, input_types):
+    return {"input_names": list(input_names), "input_types": list(input_types)}
+
+
+@pytest.mark.parametrize("target_type", ["bfloat16", "float16", "float32"])
+def test_format_data_returns_correct_values_when_bfloat16_input(target_type):
+    # bf16 -> fp32 is lossless, so the expected values are the fp32 upcast cast to the target dtype.
+    tensor = torch.tensor([[1.5, -2.25], [0.0, 3.75]], dtype=torch.bfloat16)
+    io_config = _io_config(["past_key"], [target_type])
+
+    result = format_data({"past_key": tensor}, io_config)
+
+    expected = np.ascontiguousarray(tensor.to(torch.float32).cpu().numpy(), dtype=target_type)
+    assert result["past_key"].dtype == np.dtype(target_type)
+    np.testing.assert_array_equal(result["past_key"], expected)
+
+
+def test_format_data_does_not_raise_when_bfloat16_input():
+    # Regression: torch.Tensor.numpy() on a bfloat16 tensor previously raised
+    # "TypeError: Got unsupported ScalarType BFloat16".
+    tensor = torch.ones((2, 3), dtype=torch.bfloat16)
+    io_config = _io_config(["past_value"], ["bfloat16"])
+
+    result = format_data({"past_value": tensor}, io_config)
+
+    assert result["past_value"].shape == (2, 3)
+
+
+@pytest.mark.parametrize(
+    ("torch_dtype", "target_type"),
+    [
+        (torch.float16, "float16"),
+        (torch.float32, "float32"),
+        (torch.int64, "int64"),
+        (torch.int32, "int32"),
+    ],
+)
+def test_format_data_is_byte_identical_when_non_bfloat16_tensor(torch_dtype, target_type):
+    tensor = torch.arange(6, dtype=torch_dtype).reshape(2, 3)
+    io_config = _io_config(["input"], [target_type])
+
+    result = format_data({"input": tensor}, io_config)
+
+    expected = np.ascontiguousarray(tensor.cpu().numpy(), dtype=target_type)
+    assert result["input"].dtype == np.dtype(target_type)
+    assert result["input"].tobytes() == expected.tobytes()
+
+
+def test_format_data_is_byte_identical_when_numpy_array_input():
+    array = np.arange(6, dtype=np.float32).reshape(2, 3)
+    io_config = _io_config(["input"], ["float32"])
+
+    result = format_data({"input": array}, io_config)
+
+    expected = np.ascontiguousarray(array, dtype="float32")
+    assert result["input"].tobytes() == expected.tobytes()


### PR DESCRIPTION
## Describe your changes

### Summary
Fix `OnnxDiscrepancyCheck` (and any other consumer of `format_data`) crashing on
**BF16** models with `TypeError: Got unsupported ScalarType BFloat16`.

### Background / previous logic
`olive/common/utils.py::format_data` builds the ONNX input feed by calling
`torch.Tensor.numpy()` directly on each input tensor and then value-casting to the
target ONNX dtype:

```python
return {
    k: np.ascontiguousarray(
        data[k].cpu().numpy() if isinstance(data[k], torch.Tensor) else data[k],
        dtype=name_to_type[k],
    )
    for k in data
    if k in input_names
}
```

NumPy has **no native bfloat16 dtype**, so `torch.Tensor.numpy()` raises for a
`torch.bfloat16` tensor **before** the trailing `dtype=name_to_type[k]` cast can run.
For a BF16 model, `OnnxDiscrepancyCheck._prepare_dataloader` generates dummy inputs at
the ONNX graph's input dtypes, so float inputs (e.g. `past_key_values.*.key/value`)
arrive as `torch.bfloat16` and trip this path. The identical flow with FP16 succeeds,
which is the key signal that this is an input-feed-only gap.

BF16 is already handled correctly everywhere else in the pass:
- `discrepancy_check.py::_onnx_output_to_torch` reinterprets ORT's `uint16` output back
  to `torch.bfloat16`.
- `discrepancy_check.py::_onnx_dtype_to_torch` maps `onnx.TensorProto.BFLOAT16 →
  torch.bfloat16`.
- `common/utils.py::tensor_data_to_dtype` already includes `torch.bfloat16`.

So `format_data` was the sole remaining gap.

### Change
`format_data` now upcasts `torch.bfloat16` tensors to `float32` before `.numpy()`, then
lets the existing `np.ascontiguousarray(..., dtype=name_to_type[k])` value-cast emit the
correct target dtype (bf16 via `ml_dtypes`, or fp16/fp32):

```python
def _to_numpy(value):
    if isinstance(value, torch.Tensor):
        if value.dtype == torch.bfloat16:
            value = value.to(torch.float32)
        return value.cpu().numpy()
    return value

return {
    k: np.ascontiguousarray(_to_numpy(data[k]), dtype=name_to_type[k])
    for k in data
    if k in input_names
}
```

**Why fp32 (not a `uint16` bit-reinterpret like the output side):** the trailing `dtype=`
is a *value-preserving* cast, so it needs an array whose values are correct. bf16 → fp32
is lossless (bf16 shares fp32's 8 exponent bits and has only 7 mantissa bits), so casting
back to bf16 returns the identical value. A `uint16` `.view()` reinterpret would feed
integer bit-patterns into the value-cast and corrupt the data.

FP16/FP32/int and numpy-array inputs are untouched (no upcast branch taken), so their
feeds stay byte-identical.

### Files changed
- `olive/common/utils.py` — `format_data`: upcast bf16 → fp32 before `.numpy()`.
- `test/common/test_format_data.py` — new unit tests.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

### Release note
Fixed a crash (`TypeError: Got unsupported ScalarType BFloat16`) when running the ONNX
discrepancy check / evaluation input feed on BF16 models.

## (Optional) Issue link
