### PR TITLE
Emit ORT-spec-compliant model packages from generate-model-package

### DIFF
--- a/olive/cli/model_package.py
+++ b/olive/cli/model_package.py
@@ -16,11 +16,12 @@ Output layout (per the ONNX Runtime model-package specification)::
     <output>/
     ├── manifest.json
     ├── models/
-    │   └── <component>/
+    │   └── model/                             # the one component
     │       ├── component.json
     │       └── <variant>/
     │           ├── genai_config.json          # complete, self-contained
-    │           ├── model.onnx
+    │           ├── text.onnx                  # every role's graph
+    │           ├── vision.onnx
     │           └── ...                        # external-data blobs (inline)
     └── shared_assets/
         └── sha256-<hex>/                      # content-addressed tokenizer assets
@@ -28,15 +29,25 @@ Output layout (per the ONNX Runtime model-package specification)::
             └── ...
 
 Notes:
+- The package declares exactly **one** component. ORT-GenAI selects a single
+  component and loads the complete ``genai_config.json`` from the variant
+  directory it picks, resolving every role's ``filename`` against that one
+  directory; it rejects a package declaring more than one component. So all
+  of a model's roles (``decoder``, ``embedding``, ``vision``, ...) live in
+  one variant directory even though each is a separate ORT session at
+  runtime. Variants are the per-hardware builds of that same model.
 - ``manifest.json`` maps component name -> component directory. ORT reads
   ``component.json`` from that directory; the file is selection-only. Each
   variant declares a single execution provider inline (``ep``) plus optional
   ``device`` and opaque ``compatibility_string``.
-- Each variant directory is self-contained: the ONNX file, any external-data
-  blobs it references, and a **complete** ``genai_config.json`` are placed
+- Each variant directory is self-contained: the ONNX files, any external-data
+  blobs they reference, and a **complete** ``genai_config.json`` are placed
   inline so stock ORT and ORT-GenAI can load the variant directly. ORT-GenAI
   loads ``<selected_variant_dir>/genai_config.json`` and has no notion of a
   package-level base config or a merge-patch overlay.
+- Role graphs keep the relative path their source declared
+  (``vision_encoder/model.onnx``), so producers that name every role's graph
+  ``model.onnx`` don't collide inside the shared variant directory.
 - Tokenizer assets are shared across variants through a content-addressed
   ``shared_assets/sha256-<hex>/`` directory; each variant config points at it
   with ``model.tokenizer_dir = "sha256:<hex>"``. Processor configs stay inside
@@ -96,6 +107,14 @@ _TOKENIZER_SENTINEL = "tokenizer_config.json"
 # The manifest maps each component name to ``models/<component>``; ORT reads
 # ``component.json`` from that directory.
 _MODELS_DIR = "models"
+
+# Name of the single component every generated package declares. ORT-GenAI
+# opens a package by selecting "the" component and requires the package to
+# declare exactly one ("declares N components; onnxruntime-genai requires
+# exactly one"), so every genai_config role must live in one component whose
+# variant directory holds a complete genai_config.json. ``model`` is the name
+# used by the ORT-GenAI model-package documentation.
+_GENAI_COMPONENT_NAME = "model"
 
 # Conventional directory suffix for an ORT model package. Not enforced by
 # ORT/ORT-GenAI loaders (they probe structure, not filenames), but matches
@@ -253,38 +272,50 @@ class ModelPackageCommand(BaseOliveCLICommand):
     def _build_variants(self, targets: list[tuple[str, Path, dict]]) -> list["VariantSpec"]:
         variants: list[VariantSpec] = []
         for target_name, source_path, source_genai in targets:
-            # Each role under ``genai_config.model`` is an independent ORT
-            # inference session at runtime, so each role becomes its own
-            # package component. A text-only model has one role (``decoder``)
-            # → one component. A VLM has three roles (``vision``,
-            # ``embedding``, ``decoder``) → three components. A QNN
-            # pipeline-shaped role becomes ONE component whose variant
-            # directory holds every stage's ONNX flat.
+            # Every role under ``genai_config.model`` (``vision``,
+            # ``embedding``, ``decoder``, ...) is a separate ORT inference
+            # session at runtime, but they all belong to ONE package
+            # component: ORT-GenAI selects a single component and loads the
+            # complete ``genai_config.json`` from that component's variant
+            # directory, resolving every role's ``filename`` against it.
+            # Splitting roles across components would leave each component's
+            # config missing its siblings' graphs, and ORT-GenAI rejects a
+            # multi-component package outright. So one source = one variant
+            # holding all of its roles' ONNX files.
             artifacts_by_role = _collect_artifacts_per_role(source_path, source_genai)
+
+            onnx_files: list[Path] = []
+            onnx_rel_paths: list[str] = []
+            onnx_rel_paths_by_role: dict[str, list[str]] = {}
             for role_name, role_artifacts in artifacts_by_role.items():
-                onnx_files = [a.source_path for a in role_artifacts]
-                onnx_rel_paths = [a.package_rel_path for a in role_artifacts]
+                onnx_rel_paths_by_role[role_name] = [a.package_rel_path for a in role_artifacts]
+                onnx_files.extend(a.source_path for a in role_artifacts)
+                onnx_rel_paths.extend(a.package_rel_path for a in role_artifacts)
 
-                ep = _resolve_ep_for_role(source_genai, role_name)
-                # ``ep_compatibility_info`` metadata is conventionally
-                # written on the role's first ONNX (the primary stage for
-                # a pipeline role); probe that file for the EP-scoped
-                # compatibility string.
-                raw_compat = _extract_ep_compatibility_from_onnx(onnx_files[0], ep) if onnx_files else None
-                compatibility_string = raw_compat.strip() if raw_compat and raw_compat.strip() else None
+            ep = _resolve_ep_for_variant(source_path, source_genai, artifacts_by_role)
+            # ``ep_compatibility_info`` metadata is conventionally written on
+            # the ONNX compiled for the EP. With every role in one variant the
+            # producer may tag only the role that actually targets the EP, so
+            # probe each graph and take the first declaration.
+            compatibility_string = None
+            for onnx_file in onnx_files:
+                raw_compat = _extract_ep_compatibility_from_onnx(onnx_file, ep)
+                if raw_compat and raw_compat.strip():
+                    compatibility_string = raw_compat.strip()
+                    break
 
-                variants.append(
-                    VariantSpec(
-                        component_name=role_name,
-                        variant_name=target_name,
-                        role_name=role_name,
-                        onnx_files=onnx_files,
-                        onnx_rel_paths=onnx_rel_paths,
-                        ep=ep,
-                        compatibility_string=compatibility_string,
-                        source_genai=source_genai,
-                    )
+            variants.append(
+                VariantSpec(
+                    component_name=_GENAI_COMPONENT_NAME,
+                    variant_name=target_name,
+                    onnx_files=onnx_files,
+                    onnx_rel_paths=onnx_rel_paths,
+                    onnx_rel_paths_by_role=onnx_rel_paths_by_role,
+                    ep=ep,
+                    compatibility_string=compatibility_string,
+                    source_genai=source_genai,
                 )
+            )
         return variants
 
     # ------------------------------------------------------------------
@@ -431,16 +462,25 @@ class VariantSpec:
     # supplied, must be index-aligned with ``onnx_files`` and contain a
     # safe relative path for every ONNX. When empty, the writer falls back
     # to the legacy flat layout (each ONNX placed at
-    # ``<variant_dir>/<basename>``) — kept for direct callers and tests that
-    # predate multi-component sources.
+    # ``<variant_dir>/<basename>``) — kept for direct callers that supply
+    # only ``onnx_files``.
     onnx_rel_paths: list[str] = field(default_factory=list)
+    # Per-role view of ``onnx_rel_paths``, keyed by genai_config role
+    # (``decoder``, ``vision``, ...). The overlay writer needs to know which
+    # in-package paths belong to which role so each role's ``filename`` /
+    # pipeline stage filenames point at the files actually written for it.
+    # Empty for direct callers that supply only ``onnx_files``.
+    onnx_rel_paths_by_role: dict[str, list[str]] = field(default_factory=dict)
     # The genai_config role this variant represents (e.g. ``decoder``,
     # ``vision``, ``embedding``). When set, the overlay writer scopes its
     # lift to just this role rather than the whole ``model`` block, so a
-    # multi-role source (Mobius VLM) produces one VariantSpec per role
-    # under one component per role. When unset, the writer falls back to
-    # the legacy multi-role lift for direct callers / tests that predate
-    # per-role components.
+    # caller can split a multi-role model across one component per role.
+    # The ``generate-model-package`` CLI never sets this: ORT-GenAI opens
+    # exactly one component per package and resolves every role's
+    # ``filename`` against that component's selected variant directory, so
+    # a per-role split would be unloadable. It stays available for direct
+    # ``write_model_package`` callers targeting non-GenAI consumers, which
+    # the plain ORT model-package spec does allow.
     role_name: Optional[str] = None
 
     def __post_init__(self) -> None:
@@ -552,18 +592,18 @@ def write_model_package(
                 "belong to exactly one package component."
             )
 
-    # Preferred path: per-role variants (each VariantSpec carries the role
-    # it represents). One variant = one role = one component, so the
-    # mapping is direct and conflicts are easy to surface.
+    # Per-role variants (each VariantSpec carries the role it represents).
+    # One variant = one role = one component, so the mapping is direct and
+    # conflicts are easy to surface. Only direct ``write_model_package``
+    # callers take this path; the CLI packs every role into one component.
     for v in variants:
         if v.role_name:
             _assign_role(v.role_name, v.component_name)
-    # Legacy / multi-role path: variants without ``role_name`` aggregate
-    # several roles under one component. Seed from each variant's source
-    # genai_config so every role that appears under ``model.<role>``
-    # (vision, embedding, decoder, ...) still points back at that
-    # variant's component_name. Preserves backward compatibility for
-    # direct ``write_model_package`` callers and tests.
+    # Multi-role path (the CLI default): variants without ``role_name``
+    # aggregate several roles under one component. Seed from each variant's
+    # source genai_config so every role that appears under ``model.<role>``
+    # (vision, embedding, decoder, ...) points back at that variant's
+    # component_name.
     for v in variants:
         if v.role_name:
             continue
@@ -830,11 +870,11 @@ def _write_variant_genai_config(
     The merge replaces values rather than appending, so list-valued fields
     such as ``eos_token_id`` and ``pipeline`` keep the variant's exact value.
 
-    When the variant was built per-role (``v.role_name`` is set, the default
-    CLI path) only that role's body is lifted; other roles live in their own
-    components. When the variant carries every role at once (no ``role_name``,
-    legacy multi-role-per-component callers) every role's per-variant body is
-    lifted together.
+    When the variant carries every role at once (no ``role_name`` — the CLI
+    path) every role's per-variant body is lifted together, producing one
+    complete config for the single component. When a direct caller built the
+    variant per-role (``v.role_name`` set) only that role's body is lifted;
+    other roles live in their own components.
 
     Direct ``write_model_package`` callers that don't pass ``source_genai``
     fall back to the legacy ``inference_settings``-driven shape so existing
@@ -847,22 +887,22 @@ def _write_variant_genai_config(
 
     if isinstance(src_model, dict):
         if v.role_name:
-            # Preferred path: per-role variant. Only lift this role's body.
-            # Other roles end up in their own components (one component
-            # per role), each with their own overlay.
+            # Direct-caller path: per-role variant. Only lift this role's
+            # body. Other roles end up in their own components (one
+            # component per role), each with their own overlay.
             role_body = src_model.get(v.role_name)
             if isinstance(role_body, dict):
                 role_patch = _lift_role_overlay_body(role_body, v.onnx_rel_paths)
                 if role_patch:
                     model_patch[v.role_name] = role_patch
         else:
-            # Legacy multi-role-per-component path: lift every role's
-            # per-variant fields. Used by direct ``write_model_package``
-            # callers / tests that predate per-role components.
+            # Multi-role path: this variant holds every role of the source
+            # model, so lift each role's per-variant fields together into
+            # one complete config.
             for role_name, role_body in src_model.items():
                 if not isinstance(role_body, dict):
                     continue
-                role_patch = _lift_role_overlay_body(role_body)
+                role_patch = _lift_role_overlay_body(role_body, v.onnx_rel_paths_by_role.get(role_name))
                 if role_patch:
                     model_patch[role_name] = role_patch
     else:
@@ -952,24 +992,20 @@ def _lift_role_overlay_body(role_body: dict, onnx_rel_paths: Optional[list[str]]
     EP knobs). All three are stripped from the base genai_config; this
     helper recovers them as the role's overlay patch.
 
-    Filenames are normalised to their basenames. In the per-role-component
-    layout each role gets its own variant directory under
-    ``models/<role>/<variant>/`` and the writer places the ONNX(s) there
-    flat — the original source-side ``decoder/`` / ``vision_encoder/`` /
-    ``embedding/`` subdirectory prefixes (Mobius VLM convention) are no
-    longer needed to disambiguate sibling roles inside one variant dir.
-    When ``onnx_rel_paths`` is supplied (preferred), the role's
-    ``filename`` is replaced by the writer-known package-relative path so
-    the overlay matches the on-disk layout exactly even if the source
-    diverged. Pipeline-stage filenames are likewise rewritten to their
-    basenames so the per-stage references resolve inside the flat variant
-    directory.
+    When ``onnx_rel_paths`` is supplied (the CLI path), each filename is
+    replaced by the writer-known package-relative path so the overlay
+    matches the on-disk layout exactly. Those paths preserve the source's
+    directory structure (``vision_encoder/model.onnx``), which is what keeps
+    sibling roles from colliding inside the shared variant directory.
+    Without them the filename falls back to its basename, matching the flat
+    layout ``_variant_artifacts`` writes for direct callers that supply only
+    ``onnx_files``.
 
     Every filename — top-level role and pipeline stages alike — is
-    validated as a safe relative path before basename normalisation;
-    absolute paths or upward traversal raise rather than silently
-    propagate into a generated overlay. Pipeline and session_options are
-    deep-copied to avoid aliasing with the caller's dict.
+    validated as a safe relative path before normalisation; absolute paths
+    or upward traversal raise rather than silently propagate into a
+    generated overlay. Pipeline and session_options are deep-copied to
+    avoid aliasing with the caller's dict.
     """
     patch: dict[str, Any] = {}
     pipeline = role_body.get("pipeline")
@@ -1497,13 +1533,13 @@ def _collect_artifacts_per_role(source_path: Path, source_genai: Optional[dict])
     The role's value is the ordered list of artifacts that belong to it —
     one for a flat role, one per stage for a pipeline role.
 
-    Every artifact's ``package_rel_path`` is the source filename's basename:
-    in the per-role-component layout, each role gets its own variant
-    directory under ``models/<role>/<variant>/``, so files don't need
-    subdirectory prefixes to disambiguate from sibling roles' ONNXes
-    (they no longer share a directory). The source filename's subdirectory
-    is used only to locate the file on disk in the source — it does not
-    propagate into the package.
+    Every artifact's ``package_rel_path`` preserves the source's declared
+    relative location (e.g. ``vision_encoder/model.onnx``). All roles share
+    one variant directory, so basenames alone would collide whenever a
+    producer names every role's graph ``model.onnx`` (the Mobius VLM
+    convention). Keeping the declared path is inherently collision-free —
+    the files already coexisted under one source directory — and lets each
+    role's ``filename`` stay exactly as the source declared it.
 
     Filenames are validated as safe relative paths; absolute or
     upward-traversing entries raise ``ValueError``. A source with no
@@ -1523,7 +1559,7 @@ def _collect_artifacts_per_role(source_path: Path, source_genai: Optional[dict])
                 f"Source {source_path} role {role!r} {kind} {filename!r} is not a safe "
                 "relative path (absolute paths and '..' segments are rejected)."
             )
-        return OnnxArtifact(source_path=source_path / filename, package_rel_path=Path(filename).name)
+        return OnnxArtifact(source_path=source_path / filename, package_rel_path=filename)
 
     for role_name, role_body in model_block.items():
         if not isinstance(role_body, dict):
@@ -1592,6 +1628,44 @@ def _resolve_ep_for_role(source_genai: Optional[dict], role_name: str) -> str:
                 if ep and ep != "CPUExecutionProvider":
                     return ep
     return "CPUExecutionProvider"
+
+
+def _resolve_ep_for_variant(
+    source_path: Path,
+    source_genai: Optional[dict],
+    artifacts_by_role: dict[str, list[OnnxArtifact]],
+) -> str:
+    """Pick the single ORT EP for a variant holding every role of a model.
+
+    A variant declares one ``ep`` in the manifest, and ORT-GenAI builds all
+    of a model's sessions against one device: a role whose provider resolves
+    to a different non-CPU device makes the model fail to load with "Running
+    a model with multiple providers is not supported". CPU roles are exempt —
+    ORT-GenAI registers CPU implicitly and a CPU role never claims the
+    device — so a package mixing, say, a CPU vision encoder with a QNN
+    decoder is legitimate and takes the decoder's EP.
+
+    Raises when two roles demand different non-CPU EPs, since the resulting
+    package would be unloadable.
+    """
+    cpu_ep = "CPUExecutionProvider"
+    eps_by_role: dict[str, str] = {}
+    for role_name in artifacts_by_role:
+        ep = _resolve_ep_for_role(source_genai, role_name)
+        if ep != cpu_ep:
+            eps_by_role[role_name] = ep
+
+    distinct = sorted(set(eps_by_role.values()))
+    if len(distinct) > 1:
+        detail = ", ".join(f"{role}={ep}" for role, ep in sorted(eps_by_role.items()))
+        raise ValueError(
+            f"Source {source_path} declares more than one non-CPU execution provider across its "
+            f"genai_config roles ({detail}). All roles of a model share one package variant and "
+            "ORT-GenAI runs them on a single device, so they must target the same execution "
+            "provider (roles left on CPU are fine). Split the roles into separate per-EP sources "
+            "or align their session_options.provider_options."
+        )
+    return distinct[0] if distinct else cpu_ep
 
 
 def _select_base_config_source(

--- a/olive/cli/model_package.py
+++ b/olive/cli/model_package.py
@@ -86,6 +86,12 @@ _COMPONENT_FILENAME = "component.json"
 # must be copied into every variant directory instead of a shared asset.
 _VARIANT_LOCAL_CONFIG_NAMES = frozenset({"processor_config.json", "audio_processor_config.json"})
 
+# The one file onnxruntime-extensions requires to exist under
+# ``model.tokenizer_dir``; its absence is a hard tokenizer-load failure. Used to
+# decide whether the shared asset directory is worth pointing ``tokenizer_dir``
+# at in the first place.
+_TOKENIZER_SENTINEL = "tokenizer_config.json"
+
 # Directory under the package root that holds per-component subdirectories.
 # The manifest maps each component name to ``models/<component>``; ORT reads
 # ``component.json`` from that directory.
@@ -1200,7 +1206,24 @@ def _write_shared_assets(output_dir: Path, config_files: dict[str, Path]) -> "Sh
         shutil.rmtree(tmp_dir)
     else:
         tmp_dir.rename(asset_dir)
-    shared.tokenizer_asset_uri = f"sha256:{digest}"
+
+    # ``model.tokenizer_dir`` is only meaningful when the asset actually holds a
+    # tokenizer. ORT-GenAI delegates tokenizer loading to onnxruntime-extensions,
+    # which unconditionally opens ``<tokenizer_dir>/tokenizer_config.json`` and
+    # hard-fails when it is missing; every other file it reads is optional or
+    # named by that config (``tokenizer.json``, ``chat_template.jinja``,
+    # ``tokenizer_module.json``, an arbitrary ``tiktoken_file``). So the presence
+    # of ``tokenizer_config.json`` is the one reliable signal — pointing
+    # ``tokenizer_dir`` at a shared asset without it would only misdirect the
+    # error message for a package that has no tokenizer either way.
+    if _TOKENIZER_SENTINEL in staged:
+        shared.tokenizer_asset_uri = f"sha256:{digest}"
+    elif staged:
+        logger.warning(
+            "Shared assets contain no %s; leaving model.tokenizer_dir unset. Files staged: %s.",
+            _TOKENIZER_SENTINEL,
+            ", ".join(sorted(staged)),
+        )
     return shared
 
 

--- a/olive/cli/model_package.py
+++ b/olive/cli/model_package.py
@@ -11,32 +11,37 @@ Each ``--source`` directory is one Olive output (an ``ONNXModel`` or a
 ``CompositeModel`` with ONNX components). Single-source packages are
 allowed: a single variant under one component is a normal, valid package.
 
-Output layout (per the ORT model-package proposal)::
+Output layout (per the ONNX Runtime model-package specification)::
 
     <output>/
     ├── manifest.json
-    ├── configs/
-    │   └── <consumer-shared assets>           # tokenizer, genai_config, ...
-    └── models/
-        └── <component>/
-            ├── metadata.json
-            └── <variant>/
-                ├── genai_config_overlay.json      # optional: per-variant runtime fields
-                ├── model.onnx
-                └── ...                            # external-data blobs (inline)
+    ├── models/
+    │   └── <component>/
+    │       ├── component.json
+    │       └── <variant>/
+    │           ├── genai_config.json          # complete, self-contained
+    │           ├── model.onnx
+    │           └── ...                        # external-data blobs (inline)
+    └── shared_assets/
+        └── sha256-<hex>/                      # content-addressed tokenizer assets
+            ├── tokenizer.json
+            └── ...
 
 Notes:
-- ``metadata.json`` is selection-only. Each variant declares a single
-  execution provider inline (``ep``) plus optional ``device`` and opaque
-  ``compatibility_string``.
-- Each variant directory is self-contained: the ONNX file and any external-data
-  blobs it references are copied inline so stock ORT can load it directly.
-- ``genai_config.json`` is canonicalized into ``<output>/configs/``: variant-
-  specific runtime fields (``filename``, ``session_options``) are stripped from
-  the base and each role gets a ``component`` pointer so ORT GenAI can map
-  roles to ``models/<component>/`` at load time. The stripped fields are
-  re-injected per variant as a ``genai_config_overlay.json`` (an RFC 7386 JSON
-  Merge Patch applied on top of ``configs/genai_config.json``).
+- ``manifest.json`` maps component name -> component directory. ORT reads
+  ``component.json`` from that directory; the file is selection-only. Each
+  variant declares a single execution provider inline (``ep``) plus optional
+  ``device`` and opaque ``compatibility_string``.
+- Each variant directory is self-contained: the ONNX file, any external-data
+  blobs it references, and a **complete** ``genai_config.json`` are placed
+  inline so stock ORT and ORT-GenAI can load the variant directly. ORT-GenAI
+  loads ``<selected_variant_dir>/genai_config.json`` and has no notion of a
+  package-level base config or a merge-patch overlay.
+- Tokenizer assets are shared across variants through a content-addressed
+  ``shared_assets/sha256-<hex>/`` directory; each variant config points at it
+  with ``model.tokenizer_dir = "sha256:<hex>"``. Processor configs stay inside
+  the variant directory because ORT-GenAI resolves those relative to
+  ``genai_config.json`` rather than through the package resolver.
 
 """
 
@@ -60,21 +65,30 @@ from olive.telemetry import action
 logger = logging.getLogger(__name__)
 
 # Files inside an Olive output dir that always belong next to the ONNX model
-# rather than under <package>/configs/.
+# rather than in a shared asset.
 _MODEL_SUFFIXES = {".onnx", ".bin", ".data", ".xml"}
 
-# Schema versions emitted in the package JSON files. Keep in sync with the
-# ORT model-package schema.
-_MANIFEST_SCHEMA_VERSION = 1
-_METADATA_SCHEMA_VERSION = 1
+# Schema version emitted in manifest.json. The ORT model-package schema
+# expects a "<major>.<minor>" string; the major gates compatibility.
+_MANIFEST_SCHEMA_VERSION = "1.0"
 
-# Directory under the package root that holds consumer-shared config assets
-# (genai_config base, tokenizer, processor configs, chat templates).
-_CONFIGS_DIR = "configs"
+# Directory under the package root that holds content-addressed shared assets.
+# ORT discovers ``<package>/shared_assets/sha256-<hex>/`` at open time; variants
+# reference them with the ``sha256:<hex>`` scheme.
+_SHARED_ASSETS_DIR = "shared_assets"
+
+# Filename ORT reads when a manifest component entry points at a directory.
+# The name is fixed by the ORT model-package specification.
+_COMPONENT_FILENAME = "component.json"
+
+# Config files ORT-GenAI resolves relative to ``genai_config.json`` (via
+# ``config_path / filename``) rather than through the package resolver. These
+# must be copied into every variant directory instead of a shared asset.
+_VARIANT_LOCAL_CONFIG_NAMES = frozenset({"processor_config.json", "audio_processor_config.json"})
 
 # Directory under the package root that holds per-component subdirectories.
-# Required by the ORT model-package schema; ORT's model-package loader
-# discovers components via ``<package>/models/<component>/metadata.json``.
+# The manifest maps each component name to ``models/<component>``; ORT reads
+# ``component.json`` from that directory.
 _MODELS_DIR = "models"
 
 # Conventional directory suffix for an ORT model package. Not enforced by
@@ -381,7 +395,7 @@ class OnnxArtifact:
     to disambiguate against. Direct callers that construct a VariantSpec
     by hand may supply a nested subpath when the variant truly needs a
     multi-file layout under one component. The rel path is the same
-    string the variant's ``genai_config_overlay.json`` emits under
+    string the variant's ``genai_config.json`` emits under
     ``model.<role>.filename``, so the on-disk layout and the loader's
     view stay aligned.
     """
@@ -469,13 +483,16 @@ def write_model_package(
         previous run.
     :param variants: Ordered list of variants. Component insertion order is
         the order each component first appears in this list.
-    :param config_files: Map from filename (basename) to source path; copied
-        into ``<output_dir>/configs/``. Same-named files contributed by
-        different sources should be byte-identical; the first wins on
-        conflict and a warning is logged.
+    :param config_files: Map from filename (basename) to source path. Tokenizer
+        assets land in a content-addressed ``shared_assets/sha256-<hex>/``
+        directory; processor configs are copied into every variant directory;
+        ``genai_config.json`` becomes the base each variant's complete config
+        is derived from. Same-named files contributed by different sources
+        should be byte-identical; the first wins on conflict and a warning is
+        logged.
     :param producer_info: Olive-specific provenance recorded under
-        ``manifest.producer``. Schema-tolerated extra field; producers may add
-        namespaced extras.
+        ``manifest.additional_metadata.producer``. The ORT schema rejects
+        unknown top-level manifest keys, so provenance is namespaced there.
     :param package_name: Name recorded under ``manifest.package_name``.
         Defaults to the output directory name.
     :param package_version: Version recorded under ``manifest.package_version``.
@@ -512,14 +529,10 @@ def write_model_package(
                 )
             seen.add(v.variant_name)
 
-    for comp_name, comp_variants in components.items():
-        _write_component(output_dir, comp_name, comp_variants, component_to_role.get(comp_name, comp_name))
-
-    # Build the role -> component map needed by _copy_config_files so it can
-    # inject ``model.<role>.component`` markers into the base genai_config. ORT
-    # requires every role-block to declare which package component it loads;
-    # without those markers ORT-GenAI's variant auto-selection fails with
-    # "the genai config does not reference any package components".
+    # Role -> component mapping. Kept as a consistency check: a genai_config
+    # role must belong to exactly one package component, otherwise the
+    # per-variant configs derived below would disagree about which variant
+    # directory serves that role.
     role_to_component: dict[str, str] = {}
 
     def _assign_role(role: str, component: str) -> None:
@@ -562,12 +575,48 @@ def write_model_package(
         if explicit_role not in role_to_component:
             role_to_component[explicit_role] = comp_name
 
-    if config_files:
-        _copy_config_files(output_dir, config_files, role_to_component)
+    # Shared assets and the base genai_config must exist before the variants
+    # are written: each variant embeds a complete genai_config.json derived
+    # from the base, pointing at the tokenizer asset by URI.
+    shared = _write_shared_assets(output_dir, config_files or {})
+
+    for comp_name, comp_variants in components.items():
+        _write_component(
+            output_dir,
+            comp_name,
+            comp_variants,
+            component_to_role.get(comp_name, comp_name),
+            shared,
+        )
 
     _write_manifest(
         output_dir, list(components.keys()), producer_info, package_name or output_dir.name, package_version
     )
+
+
+@dataclass
+class SharedConfigAssets:
+    """Package-level config material resolved before variants are written.
+
+    :param base_genai: The package's base ``genai_config.json`` (parsed) with
+        variant-specific keys stripped. Each variant's complete config is this
+        merged with that variant's own fields. Empty when no source supplied a
+        ``genai_config.json``.
+    :param model_level_defaults: The model-level scalars in
+        ``_VARIANT_LEVEL_MODEL_KEYS`` as declared by the base source. Applied
+        under a variant's own values so a variant that does not declare them
+        still ends up with a complete config. Per-role keys are deliberately
+        excluded: a variant must never inherit another role's ``filename``.
+    :param tokenizer_asset_uri: ``sha256:<hex>`` URI of the shared tokenizer
+        asset directory, or ``None`` when no tokenizer files were contributed.
+    :param variant_local_files: Config files ORT-GenAI resolves relative to
+        ``genai_config.json``; copied into every variant directory.
+    """
+
+    base_genai: dict[str, Any] = field(default_factory=dict)
+    model_level_defaults: dict[str, Any] = field(default_factory=dict)
+    tokenizer_asset_uri: Optional[str] = None
+    variant_local_files: dict[str, Path] = field(default_factory=dict)
 
 
 def _write_component(
@@ -575,6 +624,7 @@ def _write_component(
     component_name: str,
     comp_variants: list[VariantSpec],
     component_role: str,
+    shared: "SharedConfigAssets",
 ) -> None:
     component_dir = output_dir / _MODELS_DIR / component_name
     component_dir.mkdir(parents=True, exist_ok=True)
@@ -677,10 +727,23 @@ def _write_component(
                 dst = dst_dir / entry_name
                 _copy_with_collision_check(entry, dst, skip_if_identical=True)
 
-        # Per-variant runtime fields flow through genai_config_overlay.json.
-        _write_genai_config_overlay(variant_dir, component_role, v)
+        # Config files ORT-GenAI resolves relative to genai_config.json must
+        # sit next to it inside the variant directory.
+        for name, src in shared.variant_local_files.items():
+            src_path = Path(src)
+            if src_path.is_dir():
+                dst = variant_dir / name
+                if not dst.exists():
+                    shutil.copytree(str(src_path), str(dst))
+            elif src_path.is_file():
+                _copy_with_collision_check(src_path, variant_dir / name, skip_if_identical=True)
 
-    _write_metadata(component_dir, component_name, comp_variants)
+        # Each variant carries a complete, self-contained genai_config.json:
+        # ORT-GenAI loads <selected_variant_dir>/genai_config.json directly and
+        # never merges a package-level base config.
+        _write_variant_genai_config(variant_dir, component_role, v, shared)
+
+    _write_component_json(component_dir, component_name, comp_variants)
 
 
 def _copy_with_collision_check(src: Path, dst: Path, *, skip_if_identical: bool = False) -> None:
@@ -709,7 +772,7 @@ def _copy_with_collision_check(src: Path, dst: Path, *, skip_if_identical: bool 
     shutil.copy2(str(src), str(dst))
 
 
-def _write_metadata(component_dir: Path, component_name: str, comp_variants: list[VariantSpec]) -> None:
+def _write_component_json(component_dir: Path, component_name: str, comp_variants: list[VariantSpec]) -> None:
     variants_payload: dict[str, Any] = {}
     for v in comp_variants:
         # EP fields are inline on the variant object; a variant targets a
@@ -720,10 +783,11 @@ def _write_metadata(component_dir: Path, component_name: str, comp_variants: lis
         if v.compatibility_string:
             variant_obj["compatibility_string"] = v.compatibility_string
         variants_payload[v.variant_name] = variant_obj
+    # The ORT schema allows only component_name / variants / additional_metadata
+    # here; any other key (a schema_version, for instance) fails the parse.
     _write_json(
-        component_dir / "metadata.json",
+        component_dir / _COMPONENT_FILENAME,
         {
-            "schema_version": _METADATA_SCHEMA_VERSION,
             "component_name": component_name,
             "variants": variants_payload,
         },
@@ -738,33 +802,33 @@ def _genai_provider_name(ep: str) -> str:
     return ep[: -len("ExecutionProvider")].lower() if ep.endswith("ExecutionProvider") else ep
 
 
-def _write_genai_config_overlay(variant_dir: Path, component_role: str, v: VariantSpec) -> None:
-    """Emit a per-variant ``genai_config_overlay.json`` (RFC 7386 merge patch).
+def _write_variant_genai_config(
+    variant_dir: Path, component_role: str, v: VariantSpec, shared: "SharedConfigAssets"
+) -> None:
+    """Write a complete, self-contained ``genai_config.json`` into a variant dir.
 
-    Per-variant runtime fields flow through a JSON Merge Patch applied on top
-    of the package's base ``configs/genai_config.json``. The base has every
-    role's ``filename`` / ``session_options`` / ``pipeline`` stripped (see
-    ``_strip_variant_specific``); this overlay restores them.
+    ORT-GenAI loads ``<selected_variant_dir>/genai_config.json`` and knows
+    nothing about a package-level base config or an RFC 7386 merge patch, so
+    each variant must carry a full config.
+
+    The config is built as ``merge(base, per-variant fields)``. ``base`` is the
+    package's shared ``genai_config.json`` with every variant-specific key
+    stripped (see ``_strip_variant_specific``); the per-variant fields are
+    lifted from the variant's own source config and restore ``filename``,
+    ``session_options``, ``pipeline`` and the model-level scalars in
+    ``_VARIANT_LEVEL_MODEL_KEYS`` (``context_length``, ``eos_token_id``,
+    ``pad_token_id``, ``bos_token_id``, ``type``) — values that legitimately
+    differ across variants, e.g. an NPU build capping ``context_length`` at
+    4224 while CPU/CUDA use the full 131072.
+
+    The merge replaces values rather than appending, so list-valued fields
+    such as ``eos_token_id`` and ``pipeline`` keep the variant's exact value.
 
     When the variant was built per-role (``v.role_name`` is set, the default
-    CLI path) the overlay lifts only that role's body — each role gets its
-    own component / variant directory, so each overlay scopes to exactly the
-    role it represents. The model-level scalars in
-    ``_VARIANT_LEVEL_MODEL_KEYS`` (``context_length``, ``eos_token_id``,
-    ``pad_token_id``, ``bos_token_id``, ``type``) are written into the
-    overlay of only the source's primary role (``_pick_primary_role``).
-    Writing them on every per-role overlay would corrupt the merged config
-    because GenAI's overlay parser appends arrays rather than replacing
-    them — ``eos_token_id`` is commonly a list, and a three-role VLM
-    overlay set would triple every entry.
-
-    When the variant carries every role at once (no ``role_name``, legacy
-    multi-role-per-component callers) every role's per-variant body is
-    lifted into the overlay together with the variant-level scalars.
-
-    Pipeline-shaped roles (multi-stage exports, e.g. QNN) are covered by
-    the same lift: ``pipeline`` is in the strip set so the base loses it,
-    the overlay restores it.
+    CLI path) only that role's body is lifted; other roles live in their own
+    components. When the variant carries every role at once (no ``role_name``,
+    legacy multi-role-per-component callers) every role's per-variant body is
+    lifted together.
 
     Direct ``write_model_package`` callers that don't pass ``source_genai``
     fall back to the legacy ``inference_settings``-driven shape so existing
@@ -834,24 +898,44 @@ def _write_genai_config_overlay(variant_dir: Path, component_role: str, v: Varia
     # legitimately differ across variants (e.g. NPU runtime caps
     # ``context_length`` at 4224 while CPU/CUDA use the full 131072;
     # pad_token_id can differ when one exporter uses the EOS as PAD and
-    # another uses the sentinel). Without this lift the merged config
+    # another uses the sentinel). Without this lift the variant config
     # would silently use whichever variant happened to win the base
-    # selection. For per-role variants only the primary role's overlay
-    # carries these so the same scalar isn't append-merged once per
-    # component (critical for list-valued ``eos_token_id``).
+    # selection. Every variant carries them: the merge below replaces
+    # values, so a list-valued ``eos_token_id`` keeps this variant's
+    # exact value instead of accumulating entries.
     if isinstance(src_model, dict):
-        is_primary = (not v.role_name) or (v.role_name == _pick_primary_role(src_genai))
-        if is_primary:
-            for k in _VARIANT_LEVEL_MODEL_KEYS:
-                if k in src_model:
-                    # Deep-copy via JSON round-trip so we never share refs with
-                    # the caller's dict; arrays in particular must be
-                    # independent because GenAI's overlay parser treats arrays
-                    # as append-merge.
-                    model_patch[k] = json.loads(json.dumps(src_model[k]))
+        for k in _VARIANT_LEVEL_MODEL_KEYS:
+            if k in src_model:
+                model_patch[k] = src_model[k]
 
-    overlay = {"model": model_patch}
-    _write_json(variant_dir / "genai_config_overlay.json", overlay)
+    # Model-level scalars the variant did not declare fall back to the base
+    # source's values. Without this a variant carrying no source config would
+    # lose them entirely: the base strips them, and nothing would restore them.
+    config = _json_merge(shared.base_genai, {"model": dict(shared.model_level_defaults)})
+    config = _json_merge(config, {"model": model_patch})
+
+    # Point at the shared tokenizer asset. ORT resolves ``sha256:<hex>`` to the
+    # content-addressed directory; without this the tokenizer would be looked
+    # up next to genai_config.json, where it deliberately does not live.
+    if shared.tokenizer_asset_uri:
+        config.setdefault("model", {})["tokenizer_dir"] = shared.tokenizer_asset_uri
+
+    _write_json(variant_dir / "genai_config.json", config)
+
+
+def _json_merge(base: Any, patch: Any) -> Any:
+    """Recursively merge ``patch`` onto ``base``, returning a fresh deep copy.
+
+    Objects merge key-by-key; every other value (including lists) is replaced
+    outright. Deep-copied via a JSON round-trip so the result never shares
+    references with either input.
+    """
+    if isinstance(base, dict) and isinstance(patch, dict):
+        merged = dict(base)
+        for k, v in patch.items():
+            merged[k] = _json_merge(merged[k], v) if k in merged else v
+        return json.loads(json.dumps(merged))
+    return json.loads(json.dumps(patch))
 
 
 def _lift_role_overlay_body(role_body: dict, onnx_rel_paths: Optional[list[str]] = None) -> dict:
@@ -961,15 +1045,13 @@ def _strip_variant_specific(
 ) -> Any:
     """Recursively drop variant-specific keys from a genai_config-shaped dict.
 
-    ``filename`` and ``session_options`` are intrinsically variant-specific and
-    must not live in the package's base ``configs/genai_config.json``; per-variant
-    ``genai_config_overlay.json`` files patch them back in. ``pipeline`` is
-    also stripped because GenAI's overlay parser appends arrays rather than
-    replacing them — a pipeline present in both base and overlay would
-    duplicate every stage on merge. The same logic applies to per-variant
-    model-level scalars listed in ``_VARIANT_LEVEL_MODEL_KEYS`` (e.g.
-    ``context_length`` differs between NPU and GPU variants of the same
-    model). Returns a deep copy.
+    ``filename``, ``session_options`` and ``pipeline`` are intrinsically
+    variant-specific and must not leak from one variant's config into another,
+    so they are stripped from the shared base and re-applied per variant from
+    that variant's own source config. The same applies to the model-level
+    scalars listed in ``_VARIANT_LEVEL_MODEL_KEYS`` (e.g. ``context_length``
+    differs between NPU and GPU variants of the same model). Returns a deep
+    copy.
     """
     if isinstance(node, dict):
         return {k: _strip_variant_specific(v, keys) for k, v in node.items() if k not in keys}
@@ -1037,108 +1119,104 @@ def _write_manifest(
         "schema_version": _MANIFEST_SCHEMA_VERSION,
         "package_name": package_name,
         "package_version": package_version,
-        "components": components,
-        "configs_dir": _CONFIGS_DIR,
+        # ORT requires an object mapping component name -> component location.
+        # Pointing at the directory makes ORT read ``component.json`` from it.
+        "components": {name: f"{_MODELS_DIR}/{name}" for name in components},
     }
     if producer_info:
-        # Olive-specific provenance under a namespaced key so future schema
-        # evolution can't collide with it.
-        manifest["producer"] = producer_info
+        # The ORT schema rejects unknown top-level manifest keys, so Olive
+        # provenance is namespaced inside the free-form additional_metadata.
+        manifest["additional_metadata"] = {"producer": producer_info}
     _write_json(output_dir / "manifest.json", manifest)
 
 
 # ---------------------------------------------------------------------------
-# configs/ handling
+# shared asset handling
 # ---------------------------------------------------------------------------
 
 
-def _copy_config_files(
-    output_dir: Path,
-    config_files: dict[str, Path],
-    role_to_component: Optional[dict[str, str]] = None,
-) -> None:
-    configs_dir = output_dir / _CONFIGS_DIR
-    configs_dir.mkdir(parents=True, exist_ok=True)
-    configs_root = configs_dir.resolve()
+def _write_shared_assets(output_dir: Path, config_files: dict[str, Path]) -> "SharedConfigAssets":
+    """Materialize package-level config material and describe it to the writer.
+
+    ``genai_config.json`` is not copied verbatim: it becomes the base every
+    variant's complete config is merged from, with variant-specific keys
+    stripped. Processor configs are handed back for per-variant copying because
+    ORT-GenAI resolves those relative to ``genai_config.json``. Everything else
+    (tokenizer assets) is written once into a content-addressed
+    ``shared_assets/sha256-<hex>/`` directory that variants reference by URI.
+    """
+    shared = SharedConfigAssets()
+    if not config_files:
+        return shared
+
+    staged: dict[str, Path] = {}
     for name, src in config_files.items():
         if "/" in name or "\\" in name or name in ("", ".", ".."):
             logger.warning("Skipping config file with unsafe name %r.", name)
             continue
         src_path = Path(src)
-        dest = configs_dir / name
-        # Belt-and-suspenders: even with the name check above, refuse a dest
-        # that doesn't land directly under configs/.
-        if dest.resolve().parent != configs_root:
-            logger.warning("Skipping config file %r: resolved path escapes configs/.", name)
+        if not src_path.exists():
+            logger.warning("Config source %s does not exist; skipping.", src_path)
             continue
-        if dest.exists():
-            if not _paths_equal(src_path, dest):
-                logger.warning(
-                    "configs/%s already present and differs from %s; keeping the existing copy. "
-                    "Per-variant config differences belong in genai_config_overlay.json, "
-                    "not in the shared configs/ directory.",
-                    name,
-                    src_path,
-                )
+        if name == "genai_config.json":
+            if src_path.is_file():
+                try:
+                    with src_path.open(encoding="utf-8") as fh:
+                        base = json.load(fh)
+                    shared.base_genai = _strip_variant_specific(base)
+                    base_model = base.get("model")
+                    if isinstance(base_model, dict):
+                        shared.model_level_defaults = {
+                            k: base_model[k] for k in _VARIANT_LEVEL_MODEL_KEYS if k in base_model
+                        }
+                except Exception:
+                    logger.debug("Failed to read base genai_config from %s.", src_path, exc_info=True)
             continue
-        if name == "genai_config.json" and src_path.is_file():
-            # Strip variant-specific keys from the base genai_config and inject
-            # ``model.<role>.component`` markers so ORT-GenAI can resolve each
-            # role to a package component (and apply the right per-variant
-            # overlay). Each variant's genai_config_overlay.json patches the
-            # stripped keys back in.
-            try:
-                with src_path.open(encoding="utf-8") as fh:
-                    base_genai = json.load(fh)
-                stripped = _strip_variant_specific(base_genai)
-                if role_to_component:
-                    _inject_role_components(stripped, role_to_component)
-                _write_json(dest, stripped)
-                continue
-            except Exception:
-                logger.debug(
-                    "Failed to strip variant-specific keys from %s; falling back to verbatim copy.",
-                    src_path,
-                    exc_info=True,
-                )
+        if name in _VARIANT_LOCAL_CONFIG_NAMES:
+            shared.variant_local_files[name] = src_path
+            continue
+        staged[name] = src_path
+
+    if not staged:
+        return shared
+
+    # Content-address the asset so two packages shipping the same tokenizer
+    # resolve to the same URI and can share one on-disk copy once installed.
+    asset_root = output_dir / _SHARED_ASSETS_DIR
+    tmp_dir = asset_root / "_staging"
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True)
+    for name, src_path in staged.items():
+        dest = tmp_dir / name
         if src_path.is_dir():
             shutil.copytree(str(src_path), str(dest))
-        elif src_path.is_file():
-            shutil.copy2(str(src_path), str(dest))
         else:
-            logger.warning("Config source %s does not exist; skipping.", src_path)
+            shutil.copy2(str(src_path), str(dest))
+
+    digest = _compute_directory_hash(tmp_dir)
+    asset_dir = asset_root / f"sha256-{digest}"
+    if asset_dir.exists():
+        shutil.rmtree(tmp_dir)
+    else:
+        tmp_dir.rename(asset_dir)
+    shared.tokenizer_asset_uri = f"sha256:{digest}"
+    return shared
 
 
-def _inject_role_components(genai: dict, role_to_component: dict[str, str]) -> None:
-    """Inject ``model.<role>.component = <component>`` markers in-place.
+def _compute_directory_hash(source_dir: Path) -> str:
+    r"""Return the canonical shared-asset digest for ``source_dir``.
 
-    ORT-GenAI's model-package variant selection requires every role block in
-    the base ``configs/genai_config.json`` to declare which package component
-    serves it. Olive-generated source ``genai_config.json`` typically lacks
-    these markers because the source is a flat-directory build, not a package.
+    Mirrors ORT's ``ModelPackage_ComputeDirectoryHash``: hash every regular
+    file, build ``"<sha256>  <relative/posix/path>\n"`` lines sorted by path,
+    and hash that manifest text. Hashing names as well as contents means
+    renaming a file inside the asset changes its URI.
     """
-    model_block = genai.get("model")
-    if not isinstance(model_block, dict):
-        return
-    for role, component in role_to_component.items():
-        role_block = model_block.get(role)
-        if isinstance(role_block, dict):
-            role_block["component"] = component
-
-
-def _paths_equal(a: Path, b: Path) -> bool:
-    """Return True if a and b have identical content (file or directory)."""
-    if a.is_file() and b.is_file():
-        if a.stat().st_size != b.stat().st_size:
-            return False
-        return _sha256_file(a) == _sha256_file(b)
-    if a.is_dir() and b.is_dir():
-        a_entries = sorted(p.name for p in a.iterdir())
-        b_entries = sorted(p.name for p in b.iterdir())
-        if a_entries != b_entries:
-            return False
-        return all(_paths_equal(a / name, b / name) for name in a_entries)
-    return False
+    files = sorted(
+        (p for p in source_dir.rglob("*") if p.is_file()), key=lambda p: p.relative_to(source_dir).as_posix()
+    )
+    manifest = "".join(f"{_sha256_file(p)}  {p.relative_to(source_dir).as_posix()}\n" for p in files)
+    return hashlib.sha256(manifest.encode("utf-8")).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -1336,29 +1414,6 @@ def _load_source_genai(source_path: Path) -> Optional[dict]:
     except Exception:
         logger.debug("Could not parse %s; skipping per-variant model-field lift.", path, exc_info=True)
         return None
-
-
-def _pick_primary_role(source_genai: Optional[dict]) -> Optional[str]:
-    """Pick the genai_config role that names the model's primary component.
-
-    A genai_config's ``model`` block keys mix per-role objects (``decoder``,
-    ``embedding``, ...) with model-level scalars (``vocab_size``,
-    ``context_length``, ...). The primary role is the first key whose value
-    is an object carrying either a ``filename`` (flat variant) or a
-    ``pipeline`` (multi-stage variant). Returns ``None`` when no such role
-    is found (e.g. genai_config missing or malformed).
-    """
-    if not isinstance(source_genai, dict):
-        return None
-    model_block = source_genai.get("model")
-    if not isinstance(model_block, dict):
-        return None
-    for role, body in model_block.items():
-        if not isinstance(body, dict):
-            continue
-        if "pipeline" in body or "filename" in body:
-            return role
-    return None
 
 
 def _model_artifact_dirs(source_genai: Optional[dict]) -> set[str]:

--- a/test/cli/test_model_package.py
+++ b/test/cli/test_model_package.py
@@ -796,6 +796,8 @@ class TestConfigsAndSafety:
         cfg_a.write_text("{}")
         cfg_b = tmp_path / "configs_src" / "genai_config.json"
         cfg_b.write_text("{}")
+        cfg_c = tmp_path / "configs_src" / "tokenizer_config.json"
+        cfg_c.write_text("{}")
         out = tmp_path / "package"
 
         write_model_package(
@@ -808,11 +810,12 @@ class TestConfigsAndSafety:
                     ep="CPUExecutionProvider",
                 )
             ],
-            config_files={"tokenizer.json": cfg_a, "genai_config.json": cfg_b},
+            config_files={"tokenizer.json": cfg_a, "tokenizer_config.json": cfg_c, "genai_config.json": cfg_b},
         )
 
         asset_dir = _shared_asset_dir(out)
         assert (asset_dir / "tokenizer.json").is_file()
+        assert (asset_dir / "tokenizer_config.json").is_file()
         # genai_config.json is the base each variant config is derived from,
         # never a shared asset of its own.
         assert not (asset_dir / "genai_config.json").exists()
@@ -820,6 +823,37 @@ class TestConfigsAndSafety:
 
         config = json.loads((out / "models" / "decoder" / "cpu" / "genai_config.json").read_text())
         assert config["model"]["tokenizer_dir"] == f"sha256:{asset_dir.name.removeprefix('sha256-')}"
+
+    def test_no_tokenizer_dir_without_tokenizer_config(self, tmp_path):
+        """Shared assets that hold no tokenizer must not be advertised as one.
+
+        onnxruntime-extensions unconditionally opens
+        ``<tokenizer_dir>/tokenizer_config.json``, so pointing ``tokenizer_dir``
+        at an asset without it cannot help and only misreports where the
+        tokenizer was expected.
+        """
+        onnx_path = _make_onnx_inline(tmp_path / "src" / "model.onnx")
+        stray = tmp_path / "src" / "notes.txt"
+        stray.write_text("not a tokenizer")
+        out = tmp_path / "package"
+
+        write_model_package(
+            output_dir=out,
+            variants=[
+                VariantSpec(
+                    component_name="decoder",
+                    variant_name="cpu",
+                    onnx_files=[onnx_path],
+                    ep="CPUExecutionProvider",
+                )
+            ],
+            config_files={"notes.txt": stray},
+        )
+
+        # The file is still staged; only the tokenizer_dir pointer is withheld.
+        assert (_shared_asset_dir(out) / "notes.txt").is_file()
+        config = json.loads((out / "models" / "decoder" / "cpu" / "genai_config.json").read_text())
+        assert "tokenizer_dir" not in config.get("model", {})
 
     def test_rejects_non_empty_output_dir(self, tmp_path):
         onnx_path = _make_onnx_inline(tmp_path / "src" / "model.onnx")

--- a/test/cli/test_model_package.py
+++ b/test/cli/test_model_package.py
@@ -251,16 +251,16 @@ class TestGeneratePackageMultiVariant:
 
         manifest = json.loads((out / "manifest.json").read_text())
         assert manifest["schema_version"] == "1.0"
-        # ``decoder`` (not ``model``) — the genai_config role is ``decoder``,
-        # so _extract_task -> ``text_generation`` -> component dir ``decoder``.
-        assert manifest["components"] == {"decoder": "models/decoder"}
+        # One component holds every genai_config role, because ORT-GenAI
+        # selects a single component and loads one complete config from it.
+        assert manifest["components"] == {"model": "models/model"}
         assert manifest["additional_metadata"]["producer"]["model_name"] == "test_model"
         assert manifest["additional_metadata"]["producer"]["model_version"] == "2.0"
 
         # metadata uses inline EP
-        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
+        metadata = json.loads((out / "models" / "model" / "component.json").read_text())
         assert "schema_version" not in metadata
-        assert metadata["component_name"] == "decoder"
+        assert metadata["component_name"] == "model"
         assert set(metadata["variants"]) == {"soc_60", "soc_73"}
         for variant_payload in metadata["variants"].values():
             assert variant_payload == {"ep": "QNNExecutionProvider"}
@@ -268,8 +268,8 @@ class TestGeneratePackageMultiVariant:
         # No variant.json is emitted; the ONNX file lands in the variant
         # directory.
         for v in ("soc_60", "soc_73"):
-            assert not (out / "models" / "decoder" / v / "variant.json").exists()
-            assert (out / "models" / "decoder" / v / "model.onnx").is_file()
+            assert not (out / "models" / "model" / v / "variant.json").exists()
+            assert (out / "models" / "model" / v / "model.onnx").is_file()
 
 
 class TestGeneratePackageSingleSource:
@@ -281,12 +281,12 @@ class TestGeneratePackageSingleSource:
         cmd.run()
 
         manifest = json.loads((out / "manifest.json").read_text())
-        assert manifest["components"] == {"decoder": "models/decoder"}
-        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
+        assert manifest["components"] == {"model": "models/model"}
+        metadata = json.loads((out / "models" / "model" / "component.json").read_text())
         assert "cpu_x64" in metadata["variants"]
         assert metadata["variants"]["cpu_x64"] == {"ep": "CPUExecutionProvider"}
         # No shared_weights because nothing to dedup.
-        assert not (out / "models" / "decoder" / "shared_weights").exists()
+        assert not (out / "models" / "model" / "shared_weights").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -1017,7 +1017,7 @@ class TestCompatibilityFromOnnxMetadata:
         cmd.run()
 
         # assert: compatibility_string passes the raw opaque string through verbatim
-        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
+        metadata = json.loads((out / "models" / "model" / "component.json").read_text())
         variant = metadata["variants"]["soc_60"]
         assert variant["ep"] == "QNNExecutionProvider"
         assert variant["compatibility_string"] == "soc_60,soc_69,soc_73"
@@ -1155,7 +1155,7 @@ class TestPipelineSources:
 
         cmd.run()
 
-        variant_dir = out.with_suffix(".ortpackage") / "models" / "decoder" / "qnn_npu"
+        variant_dir = out.with_suffix(".ortpackage") / "models" / "model" / "qnn_npu"
         assert variant_dir.is_dir()
         for fname in stage_files:
             assert (variant_dir / fname).is_file(), f"missing stage file {fname}"
@@ -1181,7 +1181,7 @@ class TestPipelineSources:
 
         cmd.run()
 
-        overlay_path = out.with_suffix(".ortpackage") / "models" / "decoder" / "qnn_npu" / "genai_config.json"
+        overlay_path = out.with_suffix(".ortpackage") / "models" / "model" / "qnn_npu" / "genai_config.json"
         overlay = json.loads(overlay_path.read_text())
         decoder = overlay["model"]["decoder"]
         assert "pipeline" in decoder
@@ -1215,7 +1215,7 @@ class TestPipelineSources:
         cmd.run()
 
         pkg = out.with_suffix(".ortpackage")
-        config = json.loads((pkg / "models" / "decoder" / "qnn_npu" / "genai_config.json").read_text())
+        config = json.loads((pkg / "models" / "model" / "qnn_npu" / "genai_config.json").read_text())
         decoder = config["model"]["decoder"]
         stage_files = [next(iter(stage.values()))["filename"] for stage in decoder["pipeline"]]
         assert stage_files == ["e.onnx", "c.onnx", "i.onnx", "h.onnx"]
@@ -1252,10 +1252,10 @@ class TestPipelineSources:
 
         cmd.run()
 
-        metadata = json.loads((out.with_suffix(".ortpackage") / "models" / "decoder" / "component.json").read_text())
+        metadata = json.loads((out.with_suffix(".ortpackage") / "models" / "model" / "component.json").read_text())
         assert metadata["variants"]["vitia_npu"]["ep"] == "VitisAIExecutionProvider"
         overlay = json.loads(
-            (out.with_suffix(".ortpackage") / "models" / "decoder" / "vitia_npu" / "genai_config.json").read_text()
+            (out.with_suffix(".ortpackage") / "models" / "model" / "vitia_npu" / "genai_config.json").read_text()
         )
         assert overlay["model"]["decoder"]["session_options"]["provider_options"] == [{"VitisAI": {}}]
 
@@ -1309,32 +1309,37 @@ class TestVLMMultiRoleOverlay:
     """Multi-role (vision + embedding + decoder) VLM packaging.
 
     A flat VLM source dir packs >1 ONNX file referenced by >1 role in the
-    same ``genai_config.json``. Each role becomes its own component
-    (``models/vision/``, ``models/embedding/``, ``models/decoder/``); each
-    component's overlay restores only that role's ``filename`` /
-    ``session_options``. The base genai_config strips every role's
-    filename / session_options and injects a ``component=<role>`` marker
-    so the loader can map each role back to its on-disk directory.
+    same ``genai_config.json``. All of those roles land in ONE component
+    (``models/model/``) because ORT-GenAI selects exactly one component
+    per package and then resolves every role's ``filename`` against that
+    single selected variant directory (``src/models/multi_modal.cpp``
+    builds the vision / embedding / decoder sessions from one
+    ``config_path``). Splitting roles across components would produce a
+    package ORT-GenAI refuses to open ("declares N components;
+    onnxruntime-genai requires exactly one").
     """
 
-    def test_each_role_becomes_its_own_component(self, tmp_path):
+    def test_all_roles_share_one_component(self, tmp_path):
         src = _create_vlm_source(tmp_path, "cpu_and_mobile")
         out = tmp_path / "out"
         cmd = _make_command(["generate-model-package", "-s", str(src), "-o", str(out)])
 
         cmd.run()
 
-        models_dir = out.with_suffix(".ortpackage") / "models"
-        assert (models_dir / "vision" / "component.json").is_file()
-        assert (models_dir / "embedding" / "component.json").is_file()
-        assert (models_dir / "decoder" / "component.json").is_file()
+        pkg = out.with_suffix(".ortpackage")
+        manifest = json.loads((pkg / "manifest.json").read_text())
+        assert manifest["components"] == {"model": "models/model"}
+        assert (pkg / "models" / "model" / "component.json").is_file()
+        # No per-role components: those would make the package unloadable.
+        for role in ("vision", "embedding", "decoder"):
+            assert not (pkg / "models" / role).exists(), f"role {role} leaked into its own component"
 
-    def test_each_components_config_restores_only_its_role(self, tmp_path):
-        """Each per-role variant config restores exactly that role's filename.
+    def test_single_config_restores_every_role_filename(self, tmp_path):
+        """The one variant config restores EVERY role's filename.
 
-        The shared base strips every role's ``filename``, and a variant only
-        re-applies its own, so a role's ONNX is never claimed by a component
-        that does not hold it.
+        The shared base strips per-role ``filename`` / ``session_options``;
+        the variant re-applies all of them, because the single component
+        owns every role and GenAI reads one complete config from it.
         """
         src = _create_vlm_source(tmp_path, "cpu_and_mobile")
         out = tmp_path / "out"
@@ -1343,26 +1348,21 @@ class TestVLMMultiRoleOverlay:
         cmd.run()
 
         models = out.with_suffix(".ortpackage") / "models"
-        decoder_cfg = json.loads((models / "decoder" / "cpu_and_mobile" / "genai_config.json").read_text())
-        vision_cfg = json.loads((models / "vision" / "cpu_and_mobile" / "genai_config.json").read_text())
-        embedding_cfg = json.loads((models / "embedding" / "cpu_and_mobile" / "genai_config.json").read_text())
+        cfg = json.loads((models / "model" / "cpu_and_mobile" / "genai_config.json").read_text())
 
-        for role, cfg in (("decoder", decoder_cfg), ("vision", vision_cfg), ("embedding", embedding_cfg)):
-            with_filename = {
-                name for name, body in cfg["model"].items() if isinstance(body, dict) and "filename" in body
-            }
-            assert with_filename == {role}, f"{role} config restored filenames for {with_filename}"
+        with_filename = {name for name, body in cfg["model"].items() if isinstance(body, dict) and "filename" in body}
+        assert with_filename == {"vision", "embedding", "decoder"}
 
-        assert decoder_cfg["model"]["decoder"]["filename"] == "text.onnx"
-        assert vision_cfg["model"]["vision"]["filename"] == "vision.onnx"
-        assert embedding_cfg["model"]["embedding"]["filename"] == "embedding.onnx"
+        assert cfg["model"]["decoder"]["filename"] == "text.onnx"
+        assert cfg["model"]["vision"]["filename"] == "vision.onnx"
+        assert cfg["model"]["embedding"]["filename"] == "embedding.onnx"
 
-    def test_variant_dirs_are_flat_one_onnx_per_role(self, tmp_path):
-        """Each per-role variant dir holds exactly its own ONNX, flat.
+    def test_variant_dir_holds_every_roles_onnx(self, tmp_path):
+        """The single variant dir holds all three roles' ONNX files, flat.
 
-        With one role per component there's no sibling-role disambiguation
-        to do, so the writer drops any subdir prefixes from the source
-        layout and writes each ONNX at the variant root.
+        GenAI resolves each role's ``filename`` relative to the selected
+        variant directory, so every role's graph must be reachable from
+        that one directory.
         """
         src = _create_vlm_source(tmp_path, "cpu_and_mobile")
         out = tmp_path / "out"
@@ -1370,11 +1370,10 @@ class TestVLMMultiRoleOverlay:
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        assert (models / "decoder" / "cpu_and_mobile" / "text.onnx").is_file()
-        assert not (models / "decoder" / "cpu_and_mobile" / "vision.onnx").exists()
-        assert (models / "vision" / "cpu_and_mobile" / "vision.onnx").is_file()
-        assert (models / "embedding" / "cpu_and_mobile" / "embedding.onnx").is_file()
+        variant = out.with_suffix(".ortpackage") / "models" / "model" / "cpu_and_mobile"
+        assert (variant / "text.onnx").is_file()
+        assert (variant / "vision.onnx").is_file()
+        assert (variant / "embedding.onnx").is_file()
 
     def test_variant_config_omits_unknown_component_marker(self, tmp_path):
         """No ``component`` marker is emitted into any role block.
@@ -1390,12 +1389,48 @@ class TestVLMMultiRoleOverlay:
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        for role in ("vision", "embedding", "decoder"):
-            config = json.loads((models / role / "cpu_and_mobile" / "genai_config.json").read_text())
-            for name, body in config["model"].items():
-                if isinstance(body, dict):
-                    assert "component" not in body, f"{role} config leaked a component marker under {name!r}"
+        config = json.loads(
+            (out.with_suffix(".ortpackage") / "models" / "model" / "cpu_and_mobile" / "genai_config.json").read_text()
+        )
+        for name, body in config["model"].items():
+            if isinstance(body, dict):
+                assert "component" not in body, f"config leaked a component marker under {name!r}"
+
+    def test_conflicting_non_cpu_eps_across_roles_raises(self, tmp_path):
+        """Two roles demanding different non-CPU EPs is rejected up front.
+
+        All roles share one component and therefore one variant EP.
+        ORT-GenAI additionally has a single model-level device
+        (``src/models/model.cpp``: "Running a model with multiple
+        providers is not supported"), so such a package could never load.
+        Failing during packaging gives a far clearer diagnostic.
+        """
+        src = tmp_path / "mixed"
+        src.mkdir()
+        for fname in ("vision.onnx", "text.onnx"):
+            _make_onnx_inline(src / fname)
+        (src / "genai_config.json").write_text(
+            json.dumps(
+                {
+                    "model": {
+                        "type": "qwen3vl",
+                        "vision": {
+                            "filename": "vision.onnx",
+                            "session_options": {"provider_options": [{"qnn": {}}]},
+                        },
+                        "decoder": {
+                            "head_size": 128,
+                            "filename": "text.onnx",
+                            "session_options": {"provider_options": [{"cuda": {}}]},
+                        },
+                    }
+                }
+            )
+        )
+        cmd = _make_command(["generate-model-package", "-s", str(src), "-o", str(tmp_path / "out")])
+
+        with pytest.raises(ValueError, match="more than one non-CPU execution provider"):
+            cmd.run()
 
 
 # ---------------------------------------------------------------------------
@@ -1420,13 +1455,13 @@ def _create_mobius_vlm_source(
     references each role by its full subdirectory-prefixed path
     (``"filename": "decoder/model.onnx"``).
 
-    With per-role components each role gets its own
-    ``models/<role>/<variant>/`` directory, so the packager safely
-    flattens the packaged filename to the basename (``model.onnx``) and
-    rewrites the overlay to match the on-disk layout — no sibling-role
-    disambiguation is needed inside any one variant dir. The source-side
-    subdirectory prefix is used only to locate the file on disk in the
-    source and does not propagate into the package.
+    All roles land in ONE package component and therefore share one
+    variant directory, so the packager preserves each role's source-side
+    subdirectory prefix verbatim. Flattening to the basename would make
+    all three roles collide at ``<variant>/model.onnx``; keeping the
+    prefix is inherently collision-free (the files already coexisted in
+    the source) and means the genai_config ``filename`` values need no
+    rewriting at all.
     """
     source_dir = tmp_path / name
     source_dir.mkdir(parents=True)
@@ -1492,54 +1527,52 @@ def _create_mobius_vlm_source(
 
 
 class TestMobiusHierarchicalLayout:
-    """End-to-end packaging of Mobius-style multi-component VLM sources.
+    """End-to-end packaging of Mobius-style multi-role VLM sources.
 
-    Each Mobius role (``decoder``/``embedding``/``vision``) becomes its
-    own component in the package (``models/decoder/``,
-    ``models/embedding/``, ``models/vision/``). Per the ORT model-package
-    proposal, ``models/<component>/`` is the top-level grouping where one
-    component == one inference session. Each component's variant
-    directory is flat: the source-side subdir prefix is dropped because
-    there's no longer a sibling role to disambiguate against.
+    Every Mobius role (``decoder``/``embedding``/``vision``) goes into the
+    single package component ``models/model/``, because ORT-GenAI opens
+    exactly one component and resolves all of a model's role filenames
+    against that component's selected variant directory. The variant
+    directory therefore mirrors the source layout, keeping each role's
+    subdirectory (``decoder/model.onnx`` etc.) so same-named graphs don't
+    collide.
     """
 
-    def test_each_role_becomes_top_level_component(self, tmp_path):
+    def test_all_roles_share_one_component(self, tmp_path):
         src = _create_mobius_vlm_source(tmp_path, "cpu")
         out = tmp_path / "out"
         cmd = _make_command(["generate-model-package", "-s", str(src), "-o", str(out)])
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
+        pkg = out.with_suffix(".ortpackage")
+        manifest = json.loads((pkg / "manifest.json").read_text())
+        assert manifest["components"] == {"model": "models/model"}
+        assert (pkg / "models" / "model" / "component.json").is_file()
         for role in ("decoder", "embedding", "vision"):
-            assert (models / role / "component.json").is_file(), f"missing component dir for role {role}"
+            assert not (pkg / "models" / role).exists(), f"role {role} leaked into its own component"
 
-    def test_variant_dir_is_flat_under_each_component(self, tmp_path):
+    def test_variant_dir_preserves_source_role_subdirs(self, tmp_path):
         src = _create_mobius_vlm_source(tmp_path, "cpu")
         out = tmp_path / "out"
         cmd = _make_command(["generate-model-package", "-s", str(src), "-o", str(out)])
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        # Each per-role variant dir holds the ONNX flat (basename only).
-        for role in ("decoder", "embedding", "vision"):
-            assert (models / role / "cpu" / "model.onnx").is_file(), (
-                f"missing flat model.onnx under models/{role}/cpu (writer kept subdir?)"
-            )
-            # The source-side subdir should NOT propagate into the
-            # variant dir — there's only one role here, no sibling to
-            # disambiguate against.
-            assert not (models / role / "cpu" / role / "model.onnx").exists()
+        variant = out.with_suffix(".ortpackage") / "models" / "model" / "cpu"
+        # Sibling roles share one variant dir, so the source-side subdir
+        # must survive — flattening to the basename would collide.
+        for subdir in ("decoder", "embedding", "vision_encoder"):
+            assert (variant / subdir / "model.onnx").is_file(), f"missing {subdir}/model.onnx under the variant dir"
 
-    def test_external_data_lands_next_to_its_onnx_in_flat_layout(self, tmp_path):
-        """Each role's external-data blob lives flat next to its ONNX in that role's variant dir.
+    def test_external_data_lands_next_to_its_onnx_in_role_subdir(self, tmp_path):
+        """Each role's external-data blob lives next to its own ONNX.
 
         The ONNX file references ``model.onnx.data`` relative to its own
-        directory; the loader resolves the same way. With one role per
-        component each role's blob has its own dedicated directory, so
-        no collision is possible even when sibling source-side roles
-        shared the same basename.
+        directory and the loader resolves the same way, so the blob must
+        follow the ONNX into its role subdirectory. Routing blobs to the
+        variant root would collide all three at
+        ``<variant>/model.onnx.data``.
         """
         src = _create_mobius_vlm_source(tmp_path, "cpu", with_external_data=True)
         out = tmp_path / "out"
@@ -1547,18 +1580,23 @@ class TestMobiusHierarchicalLayout:
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        for role in ("decoder", "embedding", "vision"):
-            blob = models / role / "cpu" / "model.onnx.data"
-            assert blob.is_file(), f"external-data blob missing under models/{role}/cpu/"
+        variant = out.with_suffix(".ortpackage") / "models" / "model" / "cpu"
+        seen = set()
+        for subdir, role in (("decoder", "decoder"), ("embedding", "embedding"), ("vision_encoder", "vision_encoder")):
+            blob = variant / subdir / "model.onnx.data"
+            assert blob.is_file(), f"external-data blob missing under {subdir}/"
+            payload = blob.read_bytes()
+            assert payload == f"role-{role}".encode() * 16, f"{subdir} blob holds another role's weights"
+            seen.add(payload)
+        assert len(seen) == 3, "role blobs were deduped/overwritten into each other"
 
-    def test_overlay_filename_is_basename(self, tmp_path):
-        """The overlay's ``filename`` is the basename, not the source subdir-prefixed path.
+    def test_overlay_filename_keeps_role_subdir_prefix(self, tmp_path):
+        """The overlay's ``filename`` keeps the source's subdir-prefixed path.
 
-        Per-role variant dirs are flat; the overlay must match the on-disk
-        layout. The source-side ``decoder/model.onnx`` prefix is purely a
-        sibling-disambiguation device that no longer applies once the
-        roles are separated into top-level components.
+        All roles share one variant dir, whose layout mirrors the source,
+        so the packaged filenames are byte-identical to the source's. That
+        also means GenAI's ``config_path / filename`` resolution finds each
+        graph without any rewriting.
         """
         src = _create_mobius_vlm_source(tmp_path, "cpu")
         out = tmp_path / "out"
@@ -1566,13 +1604,12 @@ class TestMobiusHierarchicalLayout:
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        decoder = json.loads((models / "decoder" / "cpu" / "genai_config.json").read_text())
-        embedding = json.loads((models / "embedding" / "cpu" / "genai_config.json").read_text())
-        vision = json.loads((models / "vision" / "cpu" / "genai_config.json").read_text())
-        assert decoder["model"]["decoder"]["filename"] == "model.onnx"
-        assert embedding["model"]["embedding"]["filename"] == "model.onnx"
-        assert vision["model"]["vision"]["filename"] == "model.onnx"
+        model = json.loads(
+            (out.with_suffix(".ortpackage") / "models" / "model" / "cpu" / "genai_config.json").read_text()
+        )["model"]
+        assert model["decoder"]["filename"] == "decoder/model.onnx"
+        assert model["embedding"]["filename"] == "embedding/model.onnx"
+        assert model["vision"]["filename"] == "vision_encoder/model.onnx"
 
     def test_shared_assets_exclude_model_artifact_subdirs(self, tmp_path):
         """``decoder/``/``embedding/``/``vision_encoder/`` must not leak into shared assets.
@@ -1599,12 +1636,12 @@ class TestMobiusHierarchicalLayout:
         assert not (asset_dir / "genai_config.json").exists()
         assert not (pkg / "configs").exists()
 
-    def test_variant_configs_restore_filename_and_omit_component_marker(self, tmp_path):
-        """Every role's variant config restores its own ``filename`` and adds no marker.
+    def test_variant_config_restores_every_filename_and_omits_component_marker(self, tmp_path):
+        """The variant config restores every role's ``filename`` and adds no marker.
 
-        The shared base strips per-role ``filename``; each variant re-applies
-        exactly its own. No ``component`` field is emitted because ORT-GenAI's
-        config parser rejects unknown fields.
+        The shared base strips per-role ``filename``; the single variant
+        re-applies all of them. No ``component`` field is emitted because
+        ORT-GenAI's config parser rejects unknown fields.
         """
         src = _create_mobius_vlm_source(tmp_path, "cpu")
         out = tmp_path / "out"
@@ -1612,25 +1649,23 @@ class TestMobiusHierarchicalLayout:
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        for role in ("decoder", "embedding", "vision"):
-            config = json.loads((models / role / "cpu" / "genai_config.json").read_text())
-            model = config["model"]
-            assert model[role]["filename"] == "model.onnx"
-            with_filename = {name for name, body in model.items() if isinstance(body, dict) and "filename" in body}
-            assert with_filename == {role}, f"{role} config restored filenames for {with_filename}"
-            for name, body in model.items():
-                if isinstance(body, dict):
-                    assert "component" not in body, f"{role} config leaked a component marker under {name!r}"
+        model = json.loads(
+            (out.with_suffix(".ortpackage") / "models" / "model" / "cpu" / "genai_config.json").read_text()
+        )["model"]
+        with_filename = {name for name, body in model.items() if isinstance(body, dict) and "filename" in body}
+        assert with_filename == {"decoder", "embedding", "vision"}
+        for name, body in model.items():
+            if isinstance(body, dict):
+                assert "component" not in body, f"config leaked a component marker under {name!r}"
 
-    def test_two_sources_each_produce_per_role_variants(self, tmp_path):
-        """CPU + GPU Mobius sources both contribute one variant per role to each component.
+    def test_two_sources_become_two_variants_of_one_component(self, tmp_path):
+        """CPU + GPU Mobius sources contribute one variant each to the single component.
 
         This is the user-reported scenario:
-        ``olive generate-model-package -s cpu -s gpu -o cpu_gpu``. Each
-        role component (``decoder``/``embedding``/``vision``) ends up
-        with two variants — ``cpu`` (CPUExecutionProvider) and ``gpu``
-        (CUDAExecutionProvider).
+        ``olive generate-model-package -s cpu -s gpu -o cpu_gpu``. The
+        package holds one component with two variants — ``cpu``
+        (CPUExecutionProvider) and ``gpu`` (CUDAExecutionProvider) — each
+        carrying the full three-role model.
         """
         cpu = _create_mobius_vlm_source(tmp_path, "cpu", ep="CPUExecutionProvider")
         gpu = _create_mobius_vlm_source(tmp_path, "gpu", ep="CUDAExecutionProvider")
@@ -1639,13 +1674,15 @@ class TestMobiusHierarchicalLayout:
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        for role in ("decoder", "embedding", "vision"):
-            for variant in ("cpu", "gpu"):
-                assert (models / role / variant / "model.onnx").is_file(), f"missing models/{role}/{variant}/model.onnx"
-            metadata = json.loads((models / role / "component.json").read_text())
-            assert metadata["variants"]["cpu"]["ep"] == "CPUExecutionProvider"
-            assert metadata["variants"]["gpu"]["ep"] == "CUDAExecutionProvider"
+        component = out.with_suffix(".ortpackage") / "models" / "model"
+        for variant in ("cpu", "gpu"):
+            for subdir in ("decoder", "embedding", "vision_encoder"):
+                assert (component / variant / subdir / "model.onnx").is_file(), (
+                    f"missing models/model/{variant}/{subdir}/model.onnx"
+                )
+        metadata = json.loads((component / "component.json").read_text())
+        assert metadata["variants"]["cpu"]["ep"] == "CPUExecutionProvider"
+        assert metadata["variants"]["gpu"]["ep"] == "CUDAExecutionProvider"
 
     def test_variant_level_scalars_present_in_every_variant_config(self, tmp_path):
         """Variant-level scalars appear in every variant config, at their exact value.
@@ -1655,27 +1692,29 @@ class TestMobiusHierarchicalLayout:
         a list-valued ``eos_token_id`` keeps exactly the source's entries
         instead of accumulating copies.
         """
-        src = _create_mobius_vlm_source(tmp_path, "cpu")
+        cpu = _create_mobius_vlm_source(tmp_path, "cpu", ep="CPUExecutionProvider")
+        gpu = _create_mobius_vlm_source(tmp_path, "gpu", ep="CUDAExecutionProvider")
         out = tmp_path / "out"
-        cmd = _make_command(["generate-model-package", "-s", str(src), "-o", str(out)])
+        cmd = _make_command(["generate-model-package", "-s", str(cpu), "-s", str(gpu), "-o", str(out)])
 
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        source_model = json.loads((src / "genai_config.json").read_text())["model"]
-        for role in ("decoder", "embedding", "vision"):
-            model = json.loads((models / role / "cpu" / "genai_config.json").read_text())["model"]
+        component = out.with_suffix(".ortpackage") / "models" / "model"
+        source_model = json.loads((cpu / "genai_config.json").read_text())["model"]
+        for variant in ("cpu", "gpu"):
+            model = json.loads((component / variant / "genai_config.json").read_text())["model"]
             for key in ("context_length", "type", "eos_token_id", "pad_token_id", "bos_token_id"):
                 if key in source_model:
-                    assert model[key] == source_model[key], f"{role}/{key} diverged from the source"
+                    assert model[key] == source_model[key], f"{variant}/{key} diverged from the source"
 
-    def test_explicit_cpu_role_in_gpu_source_kept_as_cpu(self, tmp_path):
-        """A role with explicit CPU ``provider_options`` keeps CPU even when the source dir is named like a GPU build.
+    def test_explicit_cpu_role_keeps_cpu_provider_options(self, tmp_path):
+        """A role with explicit CPU ``provider_options`` keeps them, and doesn't sway the variant EP.
 
-        Variant-name heuristics must not override a producer's explicit
-        per-role provider choice — Mobius outputs sometimes mark a
-        helper role (e.g. ``embedding``) as CPU even inside a
-        predominantly-GPU build.
+        Mobius outputs sometimes mark a helper role (e.g. ``embedding``) as
+        CPU even inside a predominantly-GPU build. The variant EP is the
+        single non-CPU EP across roles (CUDA here) — CPU roles are exempt
+        because ORT-GenAI registers CPU implicitly and a CPU role never
+        claims the model's device.
         """
         src = tmp_path / "gpu"
         src.mkdir()
@@ -1710,21 +1749,16 @@ class TestMobiusHierarchicalLayout:
         cmd = _make_command(["generate-model-package", "-s", str(src), "-o", str(out)])
         cmd.run()
 
-        models = out.with_suffix(".ortpackage") / "models"
-        assert (
-            json.loads((models / "decoder" / "component.json").read_text())["variants"]["gpu"]["ep"]
-            == "CUDAExecutionProvider"
+        component = out.with_suffix(".ortpackage") / "models" / "model"
+        assert json.loads((component / "component.json").read_text())["variants"]["gpu"]["ep"] == (
+            "CUDAExecutionProvider"
         )
-        assert (
-            json.loads((models / "vision" / "component.json").read_text())["variants"]["gpu"]["ep"]
-            == "CUDAExecutionProvider"
-        )
-        # Critical: explicit CPU role must NOT be promoted to CUDA via
-        # the variant-name "gpu" heuristic.
-        assert (
-            json.loads((models / "embedding" / "component.json").read_text())["variants"]["gpu"]["ep"]
-            == "CPUExecutionProvider"
-        )
+        model = json.loads((component / "gpu" / "genai_config.json").read_text())["model"]
+        # Critical: the CPU role's explicit (empty) provider_options survive
+        # so the loader doesn't put the embedding on CUDA.
+        assert model["embedding"]["session_options"]["provider_options"] == []
+        assert model["decoder"]["session_options"]["provider_options"] == [{"cuda": {}}]
+        assert model["vision"]["session_options"]["provider_options"] == [{"cuda": {}}]
 
     def test_base_config_source_picks_richest_role_set(self, tmp_path):
         """When sources expose different role sets, the base config is taken from the source with the most roles.
@@ -1762,7 +1796,7 @@ class TestMobiusHierarchicalLayout:
         # from the richest base). If first-source-wins ran, only decoder
         # would appear.
         config = json.loads(
-            (out.with_suffix(".ortpackage") / "models" / "decoder" / "cpu" / "genai_config.json").read_text()
+            (out.with_suffix(".ortpackage") / "models" / "model" / "cpu" / "genai_config.json").read_text()
         )
         for role in ("decoder", "embedding", "vision"):
             assert role in config["model"], f"variant config missing {role} block; wrong source selected"
@@ -1912,12 +1946,13 @@ class TestCopyWithCollisionCheck:
 class TestRoleToComponentConflictDetection:
     """Two variants mapping the same role to different components must raise.
 
-    Per the per-role-component layout, each genai_config role belongs to
-    exactly one package component. A direct caller that constructs
-    variants by hand could violate this invariant (e.g. by reusing the
-    same source_genai under two component names); ``write_model_package``
-    detects the conflict at the role_to_component build step and raises
-    rather than silently keep one mapping and drop the other.
+    A direct ``write_model_package`` caller may split roles across
+    components (the plain ORT model-package spec allows it), but each
+    genai_config role must still belong to exactly one component. A caller
+    could violate that by hand (e.g. by reusing the same source_genai under
+    two component names); ``write_model_package`` detects the conflict at
+    the role_to_component build step and raises rather than silently keep
+    one mapping and drop the other.
     """
 
     def test_same_role_mapped_to_two_components_raises(self, tmp_path):

--- a/test/cli/test_model_package.py
+++ b/test/cli/test_model_package.py
@@ -31,6 +31,13 @@ from olive.cli.model_package import (
 # ---------------------------------------------------------------------------
 
 
+def _shared_asset_dir(package_root: Path) -> Path:
+    """Return the package's single ``shared_assets/sha256-<hex>/`` directory."""
+    assets = sorted((package_root / "shared_assets").glob("sha256-*"))
+    assert len(assets) == 1, f"expected exactly one shared asset, found {[p.name for p in assets]}"
+    return assets[0]
+
+
 def _make_onnx_inline(onnx_path: Path, metadata_props: dict[str, str] | None = None) -> Path:
     """Write a minimal ONNX file with no external data."""
     onnx_path.parent.mkdir(parents=True, exist_ok=True)
@@ -243,16 +250,16 @@ class TestGeneratePackageMultiVariant:
         assert (out / "models").is_dir()
 
         manifest = json.loads((out / "manifest.json").read_text())
-        assert manifest["schema_version"] == 1
+        assert manifest["schema_version"] == "1.0"
         # ``decoder`` (not ``model``) — the genai_config role is ``decoder``,
         # so _extract_task -> ``text_generation`` -> component dir ``decoder``.
-        assert manifest["components"] == ["decoder"]
-        assert manifest["producer"]["model_name"] == "test_model"
-        assert manifest["producer"]["model_version"] == "2.0"
+        assert manifest["components"] == {"decoder": "models/decoder"}
+        assert manifest["additional_metadata"]["producer"]["model_name"] == "test_model"
+        assert manifest["additional_metadata"]["producer"]["model_version"] == "2.0"
 
         # metadata uses inline EP
-        metadata = json.loads((out / "models" / "decoder" / "metadata.json").read_text())
-        assert metadata["schema_version"] == 1
+        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
+        assert "schema_version" not in metadata
         assert metadata["component_name"] == "decoder"
         assert set(metadata["variants"]) == {"soc_60", "soc_73"}
         for variant_payload in metadata["variants"].values():
@@ -274,8 +281,8 @@ class TestGeneratePackageSingleSource:
         cmd.run()
 
         manifest = json.loads((out / "manifest.json").read_text())
-        assert manifest["components"] == ["decoder"]
-        metadata = json.loads((out / "models" / "decoder" / "metadata.json").read_text())
+        assert manifest["components"] == {"decoder": "models/decoder"}
+        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
         assert "cpu_x64" in metadata["variants"]
         assert metadata["variants"]["cpu_x64"] == {"ep": "CPUExecutionProvider"}
         # No shared_weights because nothing to dedup.
@@ -307,7 +314,7 @@ class TestWriteModelPackageLayout:
         )
 
         assert (out / "manifest.json").is_file()
-        assert (out / "models" / "decoder" / "metadata.json").is_file()
+        assert (out / "models" / "decoder" / "component.json").is_file()
         # No variant.json is emitted.
         assert not (out / "models" / "decoder" / "cpu" / "variant.json").exists()
         assert (out / "models" / "decoder" / "cpu" / "model.onnx").is_file()
@@ -330,15 +337,26 @@ class TestWriteModelPackageLayout:
         )
 
         manifest = json.loads((out / "manifest.json").read_text())
-        assert manifest["schema_version"] == 1
-        assert manifest["components"] == ["decoder"]
+        assert manifest["schema_version"] == "1.0"
+        assert manifest["components"] == {"decoder": "models/decoder"}
         assert manifest["package_name"] == "package"
         assert manifest["package_version"] == "1.0"
-        assert manifest["configs_dir"] == "configs"
-        assert manifest["producer"] == {
+        assert manifest["additional_metadata"]["producer"] == {
             "tool": "olive-ai",
             "tool_version": "1.2.3",
             "model_name": "demo",
+        }
+        # The ORT schema rejects unknown top-level manifest keys, so nothing
+        # outside its vocabulary may be emitted.
+        assert set(manifest) <= {
+            "schema_version",
+            "package_name",
+            "package_version",
+            "description",
+            "layout",
+            "components",
+            "shared_assets",
+            "additional_metadata",
         }
         # No legacy fields
         assert "name" not in manifest
@@ -363,8 +381,8 @@ class TestWriteModelPackageLayout:
             ],
         )
 
-        metadata = json.loads((out / "models" / "decoder" / "metadata.json").read_text())
-        assert metadata["schema_version"] == 1
+        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
+        assert "schema_version" not in metadata
         assert metadata["component_name"] == "decoder"
         assert metadata["variants"]["qnn-npu"] == {
             "ep": "QNNExecutionProvider",
@@ -389,7 +407,7 @@ class TestWriteModelPackageLayout:
             ],
         )
 
-        metadata = json.loads((out / "models" / "decoder" / "metadata.json").read_text())
+        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
         assert metadata["variants"]["cpu"] == {"ep": "CPUExecutionProvider"}
 
     def test_overlay_carries_session_and_provider_options(self, tmp_path):
@@ -415,10 +433,10 @@ class TestWriteModelPackageLayout:
             ],
         )
 
-        # Runtime fields go to genai_config_overlay.json, not variant.json.
+        # Runtime fields live in the variant's own genai_config.json.
         assert not (out / "models" / "decoder" / "cuda" / "variant.json").exists()
-        overlay = json.loads((out / "models" / "decoder" / "cuda" / "genai_config_overlay.json").read_text())
-        assert overlay == {
+        config = json.loads((out / "models" / "decoder" / "cuda" / "genai_config.json").read_text())
+        assert config == {
             "model": {
                 "decoder": {
                     "filename": "model.onnx",
@@ -454,8 +472,8 @@ class TestWriteModelPackageLayout:
             ],
         )
 
-        overlay = json.loads((out / "models" / "decoder" / "qnn" / "genai_config_overlay.json").read_text())
-        assert overlay["model"]["decoder"]["session_options"]["provider_options"] == [
+        config = json.loads((out / "models" / "decoder" / "qnn" / "genai_config.json").read_text())
+        assert config["model"]["decoder"]["session_options"]["provider_options"] == [
             {"qnn": {"backend_path": "QnnHtp.so"}}
         ]
 
@@ -484,8 +502,8 @@ class TestWriteModelPackageLayout:
             ],
         )
 
-        overlay = json.loads((out / "models" / "decoder" / "cpu" / "genai_config_overlay.json").read_text())
-        assert overlay == {
+        config = json.loads((out / "models" / "decoder" / "cpu" / "genai_config.json").read_text())
+        assert config == {
             "model": {
                 "decoder": {
                     "filename": "model.onnx",
@@ -532,7 +550,7 @@ class TestWriteModelPackageLayout:
             ],
         )
 
-        overlay = json.loads((out / "models" / "decoder" / "npu" / "genai_config_overlay.json").read_text())
+        overlay = json.loads((out / "models" / "decoder" / "npu" / "genai_config.json").read_text())
         model_patch = overlay["model"]
         assert model_patch["context_length"] == 4224
         assert model_patch["pad_token_id"] == 200020
@@ -544,15 +562,14 @@ class TestWriteModelPackageLayout:
         # the overlay — otherwise it would duplicate the base copy.
         assert "vocab_size" not in model_patch
 
-    def test_base_genai_strips_per_variant_model_fields(self, tmp_path):
-        """The base ``configs/genai_config.json`` must not carry per-variant fields.
+    def test_variant_config_is_complete_and_self_contained(self, tmp_path):
+        """Each variant carries a full ``genai_config.json``, not a merge patch.
 
-        If ``context_length`` (or similar) lived in the base, GenAI's overlay
-        merge would still honor the per-variant value (overlay scalar wins),
-        but ``_VARIANT_LEVEL_MODEL_KEYS`` includes arrays (``eos_token_id``)
-        whose presence in the base would trigger GenAI's array-append merge
-        semantics — the merged result would duplicate the array. So the base
-        must be free of every variant-level model key.
+        ORT-GenAI loads ``<selected_variant_dir>/genai_config.json`` directly
+        and never merges a package-level base, so every field it needs —
+        structural (``vocab_size``) and per-variant (``context_length``,
+        ``eos_token_id``, ``filename``) alike — must be present in that one
+        file.
         """
         onnx_path = _make_onnx_inline(tmp_path / "src" / "model.onnx")
         out = tmp_path / "package"
@@ -591,16 +608,23 @@ class TestWriteModelPackageLayout:
             config_files={"genai_config.json": cfg},
         )
 
-        base = json.loads((out / "configs" / "genai_config.json").read_text())
-        model = base["model"]
-        for stripped in ("context_length", "pad_token_id", "eos_token_id", "bos_token_id", "type"):
-            assert stripped not in model, f"base genai_config must not contain {stripped!r}"
-        # Variant-specific decoder fields also stripped.
-        assert "filename" not in model["decoder"]
-        assert "session_options" not in model["decoder"]
-        # Structural shared fields remain.
+        config = json.loads((out / "models" / "decoder" / "cpu" / "genai_config.json").read_text())
+        model = config["model"]
+        # The variant config is complete: variant-level keys come from this
+        # variant's own source rather than leaking in from a shared base.
+        assert model["context_length"] == 131072
+        assert model["pad_token_id"] == 199999
+        assert model["eos_token_id"] == [200020, 199999]
+        assert model["bos_token_id"] == 199999
+        assert model["type"] == "phi3"
+        assert model["decoder"]["filename"] == "model.onnx"
+        # Structural shared fields survive the base strip.
         assert model["vocab_size"] == 200064
         assert model["decoder"]["head_size"] == 128
+        # No package-level base config is emitted; ORT-GenAI only ever reads
+        # the selected variant's genai_config.json.
+        assert not (out / "configs").exists()
+        assert not (out / "genai_config.json").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -765,7 +789,7 @@ class TestExternalDataInline:
 
 
 class TestConfigsAndSafety:
-    def test_copies_config_files_into_configs_dir(self, tmp_path):
+    def test_shares_tokenizer_assets_by_content_address(self, tmp_path):
         onnx_path = _make_onnx_inline(tmp_path / "src" / "model.onnx")
         cfg_a = tmp_path / "configs_src" / "tokenizer.json"
         cfg_a.parent.mkdir(parents=True)
@@ -787,8 +811,15 @@ class TestConfigsAndSafety:
             config_files={"tokenizer.json": cfg_a, "genai_config.json": cfg_b},
         )
 
-        assert (out / "configs" / "tokenizer.json").is_file()
-        assert (out / "configs" / "genai_config.json").is_file()
+        asset_dir = _shared_asset_dir(out)
+        assert (asset_dir / "tokenizer.json").is_file()
+        # genai_config.json is the base each variant config is derived from,
+        # never a shared asset of its own.
+        assert not (asset_dir / "genai_config.json").exists()
+        assert not (out / "configs").exists()
+
+        config = json.loads((out / "models" / "decoder" / "cpu" / "genai_config.json").read_text())
+        assert config["model"]["tokenizer_dir"] == f"sha256:{asset_dir.name.removeprefix('sha256-')}"
 
     def test_rejects_non_empty_output_dir(self, tmp_path):
         onnx_path = _make_onnx_inline(tmp_path / "src" / "model.onnx")
@@ -893,12 +924,12 @@ class TestConfigsAndSafety:
         )
 
         # assert: unsafe keys are dropped, safe key copied
+        asset_dir = _shared_asset_dir(out)
         assert not (out.parent / "escape.txt").exists()
-        assert not (out / "configs" / "subdir").exists()
-        assert not (out / "configs" / "..").is_dir() or not (out / ".." / "escape.txt").exists()
-        assert (out / "configs" / "ok.txt").exists()
-        # configs/ should contain only the one safe entry
-        assert sorted(p.name for p in (out / "configs").iterdir()) == ["ok.txt"]
+        assert not (asset_dir / "subdir").exists()
+        assert (asset_dir / "ok.txt").exists()
+        # the shared asset should contain only the one safe entry
+        assert sorted(p.name for p in asset_dir.iterdir()) == ["ok.txt"]
 
 
 # ---------------------------------------------------------------------------
@@ -952,7 +983,7 @@ class TestCompatibilityFromOnnxMetadata:
         cmd.run()
 
         # assert: compatibility_string passes the raw opaque string through verbatim
-        metadata = json.loads((out / "models" / "decoder" / "metadata.json").read_text())
+        metadata = json.loads((out / "models" / "decoder" / "component.json").read_text())
         variant = metadata["variants"]["soc_60"]
         assert variant["ep"] == "QNNExecutionProvider"
         assert variant["compatibility_string"] == "soc_60,soc_69,soc_73"
@@ -1116,7 +1147,7 @@ class TestPipelineSources:
 
         cmd.run()
 
-        overlay_path = out.with_suffix(".ortpackage") / "models" / "decoder" / "qnn_npu" / "genai_config_overlay.json"
+        overlay_path = out.with_suffix(".ortpackage") / "models" / "decoder" / "qnn_npu" / "genai_config.json"
         overlay = json.loads(overlay_path.read_text())
         decoder = overlay["model"]["decoder"]
         assert "pipeline" in decoder
@@ -1130,13 +1161,11 @@ class TestPipelineSources:
         # decoder-level session_options also lifted from source so log_id etc. survive.
         assert decoder["session_options"]["log_id"] == "onnxruntime-genai"
 
-    def test_base_genai_strips_pipeline_field(self, tmp_path):
-        """``pipeline`` lives only in the overlay; base must not duplicate it.
+    def test_variant_config_carries_pipeline_exactly_once(self, tmp_path):
+        """The variant config holds the pipeline array exactly once.
 
-        GenAI's overlay parser appends arrays rather than replacing them
-        (``src/config.cpp:PipelineModelObject_Element``), so a ``pipeline``
-        in both base and overlay would double every stage. The strip is the
-        guard.
+        The shared base strips ``pipeline`` and each variant re-applies its
+        own, so the stage list can never be duplicated by a merge.
         """
         src = _create_pipeline_source(
             tmp_path,
@@ -1151,9 +1180,12 @@ class TestPipelineSources:
 
         cmd.run()
 
-        base = json.loads((out.with_suffix(".ortpackage") / "configs" / "genai_config.json").read_text())
-        decoder = base["model"]["decoder"]
-        assert "pipeline" not in decoder, "base genai_config must not retain the pipeline array"
+        pkg = out.with_suffix(".ortpackage")
+        config = json.loads((pkg / "models" / "decoder" / "qnn_npu" / "genai_config.json").read_text())
+        decoder = config["model"]["decoder"]
+        stage_files = [next(iter(stage.values()))["filename"] for stage in decoder["pipeline"]]
+        assert stage_files == ["e.onnx", "c.onnx", "i.onnx", "h.onnx"]
+        assert not (pkg / "configs").exists()
 
     def test_flat_source_ep_derived_from_source_genai_when_attrs_missing(self, tmp_path):
         """For flat sources, source genai's ``provider_options`` overrules name guess.
@@ -1186,12 +1218,10 @@ class TestPipelineSources:
 
         cmd.run()
 
-        metadata = json.loads((out.with_suffix(".ortpackage") / "models" / "decoder" / "metadata.json").read_text())
+        metadata = json.loads((out.with_suffix(".ortpackage") / "models" / "decoder" / "component.json").read_text())
         assert metadata["variants"]["vitia_npu"]["ep"] == "VitisAIExecutionProvider"
         overlay = json.loads(
-            (
-                out.with_suffix(".ortpackage") / "models" / "decoder" / "vitia_npu" / "genai_config_overlay.json"
-            ).read_text()
+            (out.with_suffix(".ortpackage") / "models" / "decoder" / "vitia_npu" / "genai_config.json").read_text()
         )
         assert overlay["model"]["decoder"]["session_options"]["provider_options"] == [{"VitisAI": {}}]
 
@@ -1261,17 +1291,16 @@ class TestVLMMultiRoleOverlay:
         cmd.run()
 
         models_dir = out.with_suffix(".ortpackage") / "models"
-        assert (models_dir / "vision" / "metadata.json").is_file()
-        assert (models_dir / "embedding" / "metadata.json").is_file()
-        assert (models_dir / "decoder" / "metadata.json").is_file()
+        assert (models_dir / "vision" / "component.json").is_file()
+        assert (models_dir / "embedding" / "component.json").is_file()
+        assert (models_dir / "decoder" / "component.json").is_file()
 
-    def test_each_components_overlay_lifts_only_its_role(self, tmp_path):
-        """Each per-role overlay carries exactly that role's filename, no others.
+    def test_each_components_config_restores_only_its_role(self, tmp_path):
+        """Each per-role variant config restores exactly that role's filename.
 
-        The base config strips every role's filename, but each per-role
-        overlay should only restore its own — duplicating the lift across
-        all overlays would corrupt the loader's view (and trigger array
-        append-merge problems for list-valued scalars).
+        The shared base strips every role's ``filename``, and a variant only
+        re-applies its own, so a role's ONNX is never claimed by a component
+        that does not hold it.
         """
         src = _create_vlm_source(tmp_path, "cpu_and_mobile")
         out = tmp_path / "out"
@@ -1280,26 +1309,19 @@ class TestVLMMultiRoleOverlay:
         cmd.run()
 
         models = out.with_suffix(".ortpackage") / "models"
-        decoder_overlay = json.loads((models / "decoder" / "cpu_and_mobile" / "genai_config_overlay.json").read_text())
-        vision_overlay = json.loads((models / "vision" / "cpu_and_mobile" / "genai_config_overlay.json").read_text())
-        embedding_overlay = json.loads(
-            (models / "embedding" / "cpu_and_mobile" / "genai_config_overlay.json").read_text()
-        )
+        decoder_cfg = json.loads((models / "decoder" / "cpu_and_mobile" / "genai_config.json").read_text())
+        vision_cfg = json.loads((models / "vision" / "cpu_and_mobile" / "genai_config.json").read_text())
+        embedding_cfg = json.loads((models / "embedding" / "cpu_and_mobile" / "genai_config.json").read_text())
 
-        assert "decoder" in decoder_overlay["model"]
-        assert decoder_overlay["model"]["decoder"]["filename"] == "text.onnx"
-        assert "vision" not in decoder_overlay["model"]
-        assert "embedding" not in decoder_overlay["model"]
+        for role, cfg in (("decoder", decoder_cfg), ("vision", vision_cfg), ("embedding", embedding_cfg)):
+            with_filename = {
+                name for name, body in cfg["model"].items() if isinstance(body, dict) and "filename" in body
+            }
+            assert with_filename == {role}, f"{role} config restored filenames for {with_filename}"
 
-        assert "vision" in vision_overlay["model"]
-        assert vision_overlay["model"]["vision"]["filename"] == "vision.onnx"
-        assert "decoder" not in vision_overlay["model"]
-        assert "embedding" not in vision_overlay["model"]
-
-        assert "embedding" in embedding_overlay["model"]
-        assert embedding_overlay["model"]["embedding"]["filename"] == "embedding.onnx"
-        assert "decoder" not in embedding_overlay["model"]
-        assert "vision" not in embedding_overlay["model"]
+        assert decoder_cfg["model"]["decoder"]["filename"] == "text.onnx"
+        assert vision_cfg["model"]["vision"]["filename"] == "vision.onnx"
+        assert embedding_cfg["model"]["embedding"]["filename"] == "embedding.onnx"
 
     def test_variant_dirs_are_flat_one_onnx_per_role(self, tmp_path):
         """Each per-role variant dir holds exactly its own ONNX, flat.
@@ -1320,12 +1342,13 @@ class TestVLMMultiRoleOverlay:
         assert (models / "vision" / "cpu_and_mobile" / "vision.onnx").is_file()
         assert (models / "embedding" / "cpu_and_mobile" / "embedding.onnx").is_file()
 
-    def test_base_genai_injects_component_marker_for_every_role(self, tmp_path):
-        """Every role gets a ``component=<role>`` marker in the base config.
+    def test_variant_config_omits_unknown_component_marker(self, tmp_path):
+        """No ``component`` marker is emitted into any role block.
 
-        The merged config the loader sees must know which component
-        directory each role lives in. With per-role components the
-        component name equals the role name.
+        ORT-GenAI's config parser rejects unknown fields
+        (``src/config.cpp`` throws ``JSON::unknown_value_error``) and has no
+        ``component`` field, so emitting one would make the package
+        unloadable.
         """
         src = _create_vlm_source(tmp_path, "cpu_and_mobile")
         out = tmp_path / "out"
@@ -1333,10 +1356,12 @@ class TestVLMMultiRoleOverlay:
 
         cmd.run()
 
-        base = json.loads((out.with_suffix(".ortpackage") / "configs" / "genai_config.json").read_text())
-        model = base["model"]
+        models = out.with_suffix(".ortpackage") / "models"
         for role in ("vision", "embedding", "decoder"):
-            assert model[role]["component"] == role, f"role {role} missing self-named component marker"
+            config = json.loads((models / role / "cpu_and_mobile" / "genai_config.json").read_text())
+            for name, body in config["model"].items():
+                if isinstance(body, dict):
+                    assert "component" not in body, f"{role} config leaked a component marker under {name!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -1453,7 +1478,7 @@ class TestMobiusHierarchicalLayout:
 
         models = out.with_suffix(".ortpackage") / "models"
         for role in ("decoder", "embedding", "vision"):
-            assert (models / role / "metadata.json").is_file(), f"missing component dir for role {role}"
+            assert (models / role / "component.json").is_file(), f"missing component dir for role {role}"
 
     def test_variant_dir_is_flat_under_each_component(self, tmp_path):
         src = _create_mobius_vlm_source(tmp_path, "cpu")
@@ -1508,19 +1533,19 @@ class TestMobiusHierarchicalLayout:
         cmd.run()
 
         models = out.with_suffix(".ortpackage") / "models"
-        decoder = json.loads((models / "decoder" / "cpu" / "genai_config_overlay.json").read_text())
-        embedding = json.loads((models / "embedding" / "cpu" / "genai_config_overlay.json").read_text())
-        vision = json.loads((models / "vision" / "cpu" / "genai_config_overlay.json").read_text())
+        decoder = json.loads((models / "decoder" / "cpu" / "genai_config.json").read_text())
+        embedding = json.loads((models / "embedding" / "cpu" / "genai_config.json").read_text())
+        vision = json.loads((models / "vision" / "cpu" / "genai_config.json").read_text())
         assert decoder["model"]["decoder"]["filename"] == "model.onnx"
         assert embedding["model"]["embedding"]["filename"] == "model.onnx"
         assert vision["model"]["vision"]["filename"] == "model.onnx"
 
-    def test_configs_dir_excludes_model_artifact_subdirs(self, tmp_path):
-        """``decoder/``/``embedding/``/``vision_encoder/`` must not leak into ``configs/``.
+    def test_shared_assets_exclude_model_artifact_subdirs(self, tmp_path):
+        """``decoder/``/``embedding/``/``vision_encoder/`` must not leak into shared assets.
 
         Without explicit exclusion the config-file sweep would copy every
         source-root directory (including the model-artifact subdirs), so the
-        package would carry duplicate ONNXs under ``configs/`` and bloat
+        package would carry duplicate ONNXs in the shared asset and bloat
         the deliverable. The sweep recognizes model-artifact subdirs via
         the genai_config's role filenames and skips them.
         """
@@ -1530,18 +1555,22 @@ class TestMobiusHierarchicalLayout:
 
         cmd.run()
 
-        configs_dir = out.with_suffix(".ortpackage") / "configs"
+        pkg = out.with_suffix(".ortpackage")
+        asset_dir = _shared_asset_dir(pkg)
         for excluded in ("decoder", "embedding", "vision_encoder"):
-            assert not (configs_dir / excluded).exists(), f"{excluded}/ leaked into configs/"
-        assert (configs_dir / "tokenizer_config.json").is_file()
-        assert (configs_dir / "model_config.json").is_file()
-        assert (configs_dir / "genai_config.json").is_file()
+            assert not (asset_dir / excluded).exists(), f"{excluded}/ leaked into the shared asset"
+        assert (asset_dir / "tokenizer_config.json").is_file()
+        assert (asset_dir / "model_config.json").is_file()
+        # genai_config.json is never a shared asset: each variant owns a copy.
+        assert not (asset_dir / "genai_config.json").exists()
+        assert not (pkg / "configs").exists()
 
-    def test_base_genai_strips_filename_and_marks_self_named_components(self, tmp_path):
-        """Base genai_config strips per-role ``filename`` and injects a self-named ``component`` marker.
+    def test_variant_configs_restore_filename_and_omit_component_marker(self, tmp_path):
+        """Every role's variant config restores its own ``filename`` and adds no marker.
 
-        With per-role components the role name equals the component name,
-        so every role's ``component`` field is its own name.
+        The shared base strips per-role ``filename``; each variant re-applies
+        exactly its own. No ``component`` field is emitted because ORT-GenAI's
+        config parser rejects unknown fields.
         """
         src = _create_mobius_vlm_source(tmp_path, "cpu")
         out = tmp_path / "out"
@@ -1549,11 +1578,16 @@ class TestMobiusHierarchicalLayout:
 
         cmd.run()
 
-        base = json.loads((out.with_suffix(".ortpackage") / "configs" / "genai_config.json").read_text())
-        model = base["model"]
+        models = out.with_suffix(".ortpackage") / "models"
         for role in ("decoder", "embedding", "vision"):
-            assert "filename" not in model[role], f"{role}.filename should be stripped from base"
-            assert model[role]["component"] == role, f"{role} component marker should equal role name"
+            config = json.loads((models / role / "cpu" / "genai_config.json").read_text())
+            model = config["model"]
+            assert model[role]["filename"] == "model.onnx"
+            with_filename = {name for name, body in model.items() if isinstance(body, dict) and "filename" in body}
+            assert with_filename == {role}, f"{role} config restored filenames for {with_filename}"
+            for name, body in model.items():
+                if isinstance(body, dict):
+                    assert "component" not in body, f"{role} config leaked a component marker under {name!r}"
 
     def test_two_sources_each_produce_per_role_variants(self, tmp_path):
         """CPU + GPU Mobius sources both contribute one variant per role to each component.
@@ -1575,18 +1609,17 @@ class TestMobiusHierarchicalLayout:
         for role in ("decoder", "embedding", "vision"):
             for variant in ("cpu", "gpu"):
                 assert (models / role / variant / "model.onnx").is_file(), f"missing models/{role}/{variant}/model.onnx"
-            metadata = json.loads((models / role / "metadata.json").read_text())
+            metadata = json.loads((models / role / "component.json").read_text())
             assert metadata["variants"]["cpu"]["ep"] == "CPUExecutionProvider"
             assert metadata["variants"]["gpu"]["ep"] == "CUDAExecutionProvider"
 
-    def test_variant_level_scalars_lift_only_into_primary_role_overlay(self, tmp_path):
-        """Variant-level scalars (eos_token_id, context_length, ...) appear in exactly one overlay.
+    def test_variant_level_scalars_present_in_every_variant_config(self, tmp_path):
+        """Variant-level scalars appear in every variant config, at their exact value.
 
-        GenAI's overlay parser append-merges arrays. If
-        ``eos_token_id`` (often a list) ended up in three different
-        per-role overlays the merged config would triple every entry.
-        Only the primary role per source (``_pick_primary_role`` —
-        ``decoder`` here) carries these scalars.
+        Each variant config is standalone, so it must carry the model-level
+        scalars in full. Because the writer replaces rather than appends,
+        a list-valued ``eos_token_id`` keeps exactly the source's entries
+        instead of accumulating copies.
         """
         src = _create_mobius_vlm_source(tmp_path, "cpu")
         out = tmp_path / "out"
@@ -1595,16 +1628,12 @@ class TestMobiusHierarchicalLayout:
         cmd.run()
 
         models = out.with_suffix(".ortpackage") / "models"
-        decoder_model = json.loads((models / "decoder" / "cpu" / "genai_config_overlay.json").read_text())["model"]
-        embedding_model = json.loads((models / "embedding" / "cpu" / "genai_config_overlay.json").read_text())["model"]
-        vision_model = json.loads((models / "vision" / "cpu" / "genai_config_overlay.json").read_text())["model"]
-        # context_length and type are seeded on the Mobius fixture under
-        # ``model``; they belong only to the primary role's overlay.
-        assert "context_length" in decoder_model
-        assert "type" in decoder_model
-        for non_primary in (embedding_model, vision_model):
-            assert "context_length" not in non_primary
-            assert "type" not in non_primary
+        source_model = json.loads((src / "genai_config.json").read_text())["model"]
+        for role in ("decoder", "embedding", "vision"):
+            model = json.loads((models / role / "cpu" / "genai_config.json").read_text())["model"]
+            for key in ("context_length", "type", "eos_token_id", "pad_token_id", "bos_token_id"):
+                if key in source_model:
+                    assert model[key] == source_model[key], f"{role}/{key} diverged from the source"
 
     def test_explicit_cpu_role_in_gpu_source_kept_as_cpu(self, tmp_path):
         """A role with explicit CPU ``provider_options`` keeps CPU even when the source dir is named like a GPU build.
@@ -1649,28 +1678,28 @@ class TestMobiusHierarchicalLayout:
 
         models = out.with_suffix(".ortpackage") / "models"
         assert (
-            json.loads((models / "decoder" / "metadata.json").read_text())["variants"]["gpu"]["ep"]
+            json.loads((models / "decoder" / "component.json").read_text())["variants"]["gpu"]["ep"]
             == "CUDAExecutionProvider"
         )
         assert (
-            json.loads((models / "vision" / "metadata.json").read_text())["variants"]["gpu"]["ep"]
+            json.loads((models / "vision" / "component.json").read_text())["variants"]["gpu"]["ep"]
             == "CUDAExecutionProvider"
         )
         # Critical: explicit CPU role must NOT be promoted to CUDA via
         # the variant-name "gpu" heuristic.
         assert (
-            json.loads((models / "embedding" / "metadata.json").read_text())["variants"]["gpu"]["ep"]
+            json.loads((models / "embedding" / "component.json").read_text())["variants"]["gpu"]["ep"]
             == "CPUExecutionProvider"
         )
 
     def test_base_config_source_picks_richest_role_set(self, tmp_path):
         """When sources expose different role sets, the base config is taken from the source with the most roles.
 
-        Otherwise the package's base ``configs/genai_config.json`` could
-        miss role blocks that downstream components rely on. Example:
-        gpu source only has decoder; cpu source has all three. The base
-        must come from cpu so embedding/vision components have role
-        markers in the base config.
+        Every variant config is derived from that base, so a base missing
+        role blocks would produce variant configs that cannot describe the
+        whole model. Example: gpu source only has decoder; cpu source has
+        all three. The base must come from cpu so each variant config
+        still carries embedding/vision.
         """
         # cpu source: full three-role VLM.
         cpu = _create_mobius_vlm_source(tmp_path, "cpu")
@@ -1695,12 +1724,14 @@ class TestMobiusHierarchicalLayout:
         cmd = _make_command(["generate-model-package", "-s", str(gpu_dir), "-s", str(cpu), "-o", str(out)])
         cmd.run()
 
-        # Base must carry all three role blocks (so the embedding/vision
-        # components are findable). If first-source-wins ran, only
-        # decoder would appear.
-        base = json.loads((out.with_suffix(".ortpackage") / "configs" / "genai_config.json").read_text())
+        # Every variant config must carry all three role blocks (inherited
+        # from the richest base). If first-source-wins ran, only decoder
+        # would appear.
+        config = json.loads(
+            (out.with_suffix(".ortpackage") / "models" / "decoder" / "cpu" / "genai_config.json").read_text()
+        )
         for role in ("decoder", "embedding", "vision"):
-            assert role in base["model"], f"base config missing {role} block; wrong source selected"
+            assert role in config["model"], f"variant config missing {role} block; wrong source selected"
 
 
 class TestUnsafeGenaiFilenamesRejected:


### PR DESCRIPTION
The packages produced by `olive generate-model-package` could not be opened by ONNX Runtime or loaded by ORT-GenAI. Verified against ORT 1.29 and a local onnxruntime-genai build, the previous output failed at the very first step: `OrtModelPackageApi_CreateModelPackageContext` rejected the manifest with "unknown field 'configs_dir'".

The directory layout was already fine. Four things were not:

1. `manifest.json` used a schema ORT rejects. ORT enforces a strict top-level whitelist, so `configs_dir` and `producer` were hard errors; `components` must be an object mapping name -> path, not an array; and `schema_version` must be a "<major>.<minor>" string, not an integer. Provenance now lives under `additional_metadata.producer`.

2. `metadata.json` is now `component.json`. When a manifest component entry points at a directory, ORT reads that fixed filename and nothing else.

3. `genai_config_overlay.json` is now a complete `genai_config.json`. ORT-GenAI loads `Config(variant_dir, "")` and explicitly refuses runtime overlays on the package path, so it has no notion of a package-level base config or an RFC 7386 merge patch. Each variant now carries a self-contained config, merged from the base, the model-level defaults, and the variant's own fields.

4. Shared config assets move from `configs/` to a content-addressed `shared_assets/sha256-<hex>/` directory, computed with ORT's `ModelPackage_ComputeDirectoryHash` algorithm. Variants reference tokenizer assets via `model.tokenizer_dir = "sha256:<hex>"`, which is one of the few fields ORT-GenAI routes through the package resolver. Processor configs are resolved as `config_path / filename` instead, so they are copied into each variant directory rather than shared.

Also drops the injected `model.<role>.component` markers. The ORT-GenAI config parser has no `component` field and throws `unknown_value_error` on unknown keys, so those markers made every package unloadable. The comment justifying them cited a GenAI error string that does not exist in GenAI.

Fixes a latent bug along the way: a variant with no `source_genai` used to lose the model-level scalars that were stripped from the base. Those are now restored from a `model_level_defaults` fallback layer, scoped to `_VARIANT_LEVEL_MODEL_KEYS` so per-role `filename` / `session_options` / `pipeline` never leak across roles in multi-component (VLM) packages.

Verified end to end: a CPU+CUDA package generated by the CLI now opens in ORT and loads in ORT-GenAI.

## Describe your changes

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
