### PR TITLE
skip ci for mcp and skills

### DIFF
--- a/.azure_pipelines/olive-ci.yaml
+++ b/.azure_pipelines/olive-ci.yaml
@@ -12,6 +12,7 @@ trigger:
     - mcp/**
     - notebooks/**
     - scripts/**
+    - skills/**
 pr:
   branches:
     include:
@@ -27,6 +28,7 @@ pr:
     - mcp/**
     - notebooks/**
     - scripts/**
+    - skills/**
 
 variables:
   runCodesignValidationInjection: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,15 +16,11 @@ on:
     branches: [ "main" ]
     paths-ignore:
       - '**/*.cs'
-      - 'mcp/**'
-      - 'skills/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
     paths-ignore:
       - '**/*.cs'
-      - 'mcp/**'
-      - 'skills/**'
   schedule:
     - cron: '00 08 * * 2'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,15 +12,9 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "mcp/**"
-      - "skills/**"
   pull_request:
     branches:
       - "main"
-    paths-ignore:
-      - "mcp/**"
-      - "skills/**"
 
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,13 +5,7 @@ on:
     branches:
       - main
       - rel-*
-    paths-ignore:
-      - "mcp/**"
-      - "skills/**"
   pull_request:
-    paths-ignore:
-      - "mcp/**"
-      - "skills/**"
 
 jobs:
   optional-lint:

--- a/.github/workflows/test-model-fast.yml
+++ b/.github/workflows/test-model-fast.yml
@@ -7,15 +7,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "mcp/**"
-      - "skills/**"
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "mcp/**"
-      - "skills/**"
 
 jobs:
   ubuntu-test-model-fast:

--- a/.github/workflows/test-model-fast.yml
+++ b/.github/workflows/test-model-fast.yml
@@ -7,9 +7,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "mcp/**"
+      - "skills/**"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "mcp/**"
+      - "skills/**"
 
 jobs:
   ubuntu-test-model-fast:


### PR DESCRIPTION
## Describe your changes
Fix ci skip issue. Github action CI seems required for Olive repo. Skip tests for mcp and skills instead.
## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
