### PR TITLE
Use the full calibration split and surface sample shortfalls

### DIFF
--- a/olive/data/component/text_generation.py
+++ b/olive/data/component/text_generation.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import logging
 from pathlib import Path
 from random import Random
 from typing import Callable, Optional, Union
@@ -15,6 +16,8 @@ from olive.common.user_module_loader import UserModuleLoader
 from olive.common.utils import StrEnumBase
 from olive.data.component.dataset import ClassificationDataset
 from olive.data.constants import IGNORE_INDEX
+
+logger = logging.getLogger(__name__)
 
 
 class TextGenStrategy(StrEnumBase):
@@ -253,8 +256,10 @@ def text_gen_pre_process(dataset, tokenizer, all_kwargs):
                     joined_input_ids += input_ids + joiner_tokens
 
                 end_loc = 0  # position of unused token in joined_input_ids
-                # '- args.max_seq_len ' is used to make sure we don't get a sequence that is too short
-                for begin_loc in range(0, len(joined_input_ids) - args.max_seq_len, step):
+                # '- args.max_seq_len' is used to make sure we don't get a sequence that is too short
+                # '+ 1' since range is exclusive at the end: a block starting exactly at
+                # len(joined_input_ids) - max_seq_len is still a full length block
+                for begin_loc in range(0, len(joined_input_ids) - args.max_seq_len + 1, step):
                     # end_loc is the beginning of the next sequence
                     end_loc = begin_loc + args.max_seq_len
                     # get the input sequence
@@ -358,10 +363,23 @@ def text_gen_pre_process(dataset, tokenizer, all_kwargs):
                         # found a good sample
                         break
                     resamples += 1
-                if not encodings:
-                    # could not find a good sample after resampling
+                if encodings is None or (args.drop_short_sequences and encodings.input_ids.shape[1] < args.max_seq_len):
+                    # could not find a good sample after resampling. `encodings` holds the last rejected
+                    # row once the retries are exhausted, and a non-empty BatchEncoding is truthy, so the
+                    # length has to be re-checked explicitly to honor drop_short_sequences.
                     continue
                 append_text_gen_input_ids(tokenized_inputs, encodings.input_ids[0], encodings.attention_mask[0])
+
+    # every strategy can stop early and silently deliver fewer samples than requested, for reasons that
+    # depend on the strategy. Warn so that the shortfall is visible to the user.
+    num_delivered = len(tokenized_inputs["input_ids"])
+    if args.max_samples is not None and num_delivered < args.max_samples:
+        logger.warning(
+            "Only %d samples were generated but max_samples=%d was requested. %s",
+            num_delivered,
+            args.max_samples,
+            get_sample_shortfall_hint(args, total_examples),
+        )
 
     if not args.use_attention_mask:
         # remove attention_mask
@@ -373,6 +391,55 @@ def text_gen_pre_process(dataset, tokenizer, all_kwargs):
 
     # return ClassificationDataset
     return ClassificationDataset(hf_dataset, "labels", max_samples=args.max_samples)
+
+
+def get_sample_shortfall_hint(args: TextGenParams, total_examples: int) -> str:
+    """Explain why a strategy delivered fewer samples than max_samples and how to get more.
+
+    The cause and the effective remedies are different for each strategy, so the hint is strategy specific.
+    """
+    if args.strategy == TextGenStrategy.JOIN_RANDOM:
+        # samples are drawn from random start positions and may overlap, so the corpus only ever needs
+        # max_seq_len tokens in total, i.e. max_samples does not change the requirement
+        return (
+            f"The '{args.strategy}' strategy samples random start positions, so it only needs"
+            f" max_seq_len={args.max_seq_len} tokens after a start position and max_samples does not increase that"
+            f" requirement. All random_retries={args.random_retries} attempts for the missing samples started too"
+            " close to the end of the split. Use a larger dataset split, lower max_seq_len, or raise random_retries."
+        )
+
+    if "join" in args.strategy:
+        # JOIN and JOIN_SLIDING_WINDOW walk the joined corpus in blocks of max_seq_len taken every `step` tokens
+        step = args.stride if args.strategy == TextGenStrategy.JOIN_SLIDING_WINDOW else args.max_seq_len
+        required = args.max_seq_len + (args.max_samples - 1) * step
+        remedy = "Use a larger dataset split, or lower max_samples/max_seq_len."
+        if args.strategy == TextGenStrategy.JOIN_SLIDING_WINDOW:
+            remedy = "Use a larger dataset split, raise stride, or lower max_samples/max_seq_len."
+        return (
+            f"The '{args.strategy}' strategy takes a block of max_seq_len={args.max_seq_len} tokens every"
+            f" step={step} tokens of the joined corpus, so it needs at least max_seq_len + (max_samples - 1) * step"
+            f" = {required} tokens and the split provides fewer. {remedy}"
+        )
+
+    if args.strategy == TextGenStrategy.LINE_BY_LINE_RANDOM:
+        return (
+            f"The '{args.strategy}' strategy produces at most one sample per sampled row and no acceptable row was"
+            f" found for the missing samples within random_retries={args.random_retries} attempts"
+            f" (drop_short_sequences={args.drop_short_sequences} discards rows shorter than"
+            f" max_seq_len={args.max_seq_len}). Use a larger dataset split, lower max_seq_len, or raise"
+            " random_retries."
+        )
+
+    # LINE_BY_LINE
+    dropped_note = (
+        f" and drop_short_sequences=True discards rows shorter than max_seq_len={args.max_seq_len}"
+        if args.drop_short_sequences
+        else ""
+    )
+    return (
+        f"The '{args.strategy}' strategy produces at most one sample per non-empty row, the split provides"
+        f" {total_examples} non-empty rows{dropped_note}. Use a larger dataset split, or lower max_samples."
+    )
 
 
 def get_text(

--- a/olive/passes/pytorch/train_utils.py
+++ b/olive/passes/pytorch/train_utils.py
@@ -255,7 +255,7 @@ DEFAULT_DEEPSPEED_CONFIG = {
 def get_calibration_dataset(
     model: HfModelHandler | PyTorchModelHandler,
     data_config: DataConfig | dict | None = None,
-    split: str = "train[:1000]",
+    split: str = "train",
     batch_size: int = 1,
     max_seq_len: int = 2048,
     max_samples: int = 128,
@@ -265,7 +265,7 @@ def get_calibration_dataset(
     Args:
         model: The HuggingFace or PyTorch model to get dataset for.
         data_config: Configuration object or dictionary containing data settings.
-        split: The dataset split to use for default data config. Default is 'train[:1000]'.
+        split: The dataset split to use for default data config. Default is 'train'.
         batch_size: The batch size to use for default data config. Default is 1.
         max_seq_len: Maximum sequence length for default data config. Default is 2048.
         max_samples: Maximum number of samples for default data config. Default is 128.
@@ -312,7 +312,7 @@ def get_calibration_data_config(
     trust_remote_code: bool = False,
     data_name: str = "Salesforce/wikitext",
     subset: str = "wikitext-2-raw-v1",
-    split: str = "train[:1000]",
+    split: str = "train",
     batch_size: int = 1,
     max_seq_len: int = 2048,
     max_samples: int = 128,
@@ -324,7 +324,7 @@ def get_calibration_data_config(
         trust_remote_code: Whether to trust remote code when loading data.
         data_name: The name of the dataset to use from Hugging Face Datasets. Default is "Salesforce/wikitext".
         subset: The subset of the dataset to use. Default is "wikitext-2-raw-v1".
-        split: The dataset split to use. Default is 'train[:1000]'.
+        split: The dataset split to use. Default is 'train'.
         batch_size: The batch size to use. Default is 1.
         max_seq_len: Maximum sequence length. Default is 2048.
         max_samples: Maximum number of samples. Default is 128.

--- a/test/data_container/test_text_generation.py
+++ b/test/data_container/test_text_generation.py
@@ -1,0 +1,315 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import logging
+
+import pytest
+import torch
+from datasets import Dataset
+
+from olive.data.component.text_generation import TextGenStrategy, text_gen_pre_process
+
+
+@pytest.fixture(name="propagate_olive_logs", autouse=True)
+def propagate_olive_logs_fixture():
+    """Olive disables propagation on its root logger, so caplog cannot see the records without this.
+
+    This mirrors the inline propagation toggling already used elsewhere in the suite, e.g. in
+    test/engine/test_engine.py, test/common/test_copy_dir.py and test/hardware/test_accelerator.py.
+    """
+    logger = logging.getLogger("olive")
+    original = logger.propagate
+    logger.propagate = True
+    yield
+    logger.propagate = original
+
+
+class FakeEncoding(dict):
+    """Dict that also supports attribute access, like transformers' BatchEncoding."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+class FakeTokenizer:
+    """Minimal word level tokenizer so the tests don't need to download a real tokenizer."""
+
+    def __init__(self, pad_token_id: int = 0):
+        self.padding_side = "right"
+        self.pad_token_id = pad_token_id
+
+    def encode(self, text, add_special_tokens=False):
+        # only the number of tokens matters for these tests, the token ids themselves are arbitrary
+        return [len(word) for word in text.split()]
+
+    def __call__(
+        self,
+        text,
+        add_special_tokens=False,
+        truncation=False,
+        max_length=None,
+        padding=False,
+        return_tensors=None,
+        **kwargs,
+    ):
+        texts = [text] if isinstance(text, str) else text
+        input_ids = [self.encode(single_text) for single_text in texts]
+        if truncation and max_length is not None:
+            input_ids = [ids[:max_length] for ids in input_ids]
+        attention_mask = [[1] * len(ids) for ids in input_ids]
+        if padding == "max_length" and max_length is not None:
+            attention_mask = [mask + [0] * (max_length - len(mask)) for mask in attention_mask]
+            input_ids = [ids + [self.pad_token_id] * (max_length - len(ids)) for ids in input_ids]
+        if return_tensors == "pt":
+            return FakeEncoding(input_ids=torch.tensor(input_ids), attention_mask=torch.tensor(attention_mask))
+        if isinstance(text, str):
+            return FakeEncoding(input_ids=input_ids[0], attention_mask=attention_mask[0])
+        return FakeEncoding(input_ids=input_ids, attention_mask=attention_mask)
+
+
+def make_dataset(num_rows: int, words_per_row: int) -> Dataset:
+    return Dataset.from_dict({"text": [" ".join(["word"] * words_per_row) for _ in range(num_rows)]})
+
+
+def get_kwargs(max_samples, max_seq_len: int = 8, **kwargs) -> dict:
+    return {
+        "strategy": TextGenStrategy.JOIN,
+        "add_special_tokens": False,
+        "max_samples": max_samples,
+        "max_seq_len": max_seq_len,
+        "joiner": "",
+        **kwargs,
+    }
+
+
+@pytest.mark.parametrize(
+    ("strategy", "expected_step", "expected_required", "expected_samples"),
+    [
+        # JOIN: step is max_seq_len, so 8 + (10 - 1) * 8 = 80 tokens are needed, 16 tokens give 2 samples
+        (TextGenStrategy.JOIN, 8, 80, 2),
+        # JOIN_SLIDING_WINDOW: step is stride, so 8 + (10 - 1) * 4 = 44 tokens are needed, 16 tokens give 3 samples
+        (TextGenStrategy.JOIN_SLIDING_WINDOW, 4, 44, 3),
+    ],
+)
+def test_text_gen_pre_process_warns_when_join_corpus_exhausted_before_max_samples(
+    strategy, expected_step, expected_required, expected_samples, caplog
+):
+    # setup
+    # 4 rows x 4 tokens = 16 tokens
+    dataset = make_dataset(num_rows=4, words_per_row=4)
+    kwargs = get_kwargs(max_samples=10, strategy=strategy, stride=4)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == expected_samples
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert f"Only {expected_samples} samples were generated" in message
+    assert "max_samples=10" in message
+    assert f"step={expected_step}" in message
+    assert f"= {expected_required} tokens" in message
+
+
+def test_text_gen_pre_process_warns_with_stride_remedy_when_strategy_is_sliding_window(caplog):
+    # setup
+    dataset = make_dataset(num_rows=4, words_per_row=4)
+    kwargs = get_kwargs(max_samples=10, strategy=TextGenStrategy.JOIN_SLIDING_WINDOW, stride=4)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert "raise stride" in caplog.records[0].getMessage()
+
+
+def test_text_gen_pre_process_delivers_max_samples_when_corpus_is_an_exact_fit(caplog):
+    # setup
+    # 4 rows x 8 tokens = 32 tokens, exactly max_samples x max_seq_len = 4 x 8
+    dataset = make_dataset(num_rows=4, words_per_row=8)
+    kwargs = get_kwargs(max_samples=4)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 4
+    assert all(len(sample[0]["input_ids"]) == 8 for sample in result)
+    assert not caplog.records
+
+
+def test_text_gen_pre_process_warns_when_random_strategy_cannot_fill_max_samples(caplog):
+    # setup
+    # each row is shorter than max_seq_len and there is only one row, so no sample can be built
+    dataset = make_dataset(num_rows=1, words_per_row=2)
+    kwargs = get_kwargs(max_samples=3, strategy=TextGenStrategy.JOIN_RANDOM, random_seed=0, random_retries=5)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 0
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "max_samples=3" in message
+    assert "random_retries=5" in message
+    # max_samples must not be presented as part of the token requirement for the random strategy
+    assert "max_samples does not increase that requirement" in message
+    assert "lower max_samples" not in message
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [TextGenStrategy.JOIN, TextGenStrategy.JOIN_SLIDING_WINDOW],
+)
+def test_text_gen_pre_process_does_not_warn_when_max_samples_delivered(strategy, caplog):
+    # setup
+    # 20 rows x 8 tokens = 160 tokens, more than enough for 4 samples with either step
+    dataset = make_dataset(num_rows=20, words_per_row=8)
+    kwargs = get_kwargs(max_samples=4, strategy=strategy, stride=4)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 4
+    assert not caplog.records
+
+
+def test_text_gen_pre_process_does_not_warn_when_max_samples_is_none(caplog):
+    # setup
+    dataset = make_dataset(num_rows=4, words_per_row=4)
+    kwargs = get_kwargs(max_samples=None)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert not caplog.records
+
+
+def test_text_gen_pre_process_warns_when_line_by_line_has_too_few_rows(caplog):
+    # setup
+    # only 3 usable rows for 5 requested samples
+    dataset = make_dataset(num_rows=3, words_per_row=8)
+    kwargs = get_kwargs(max_samples=5, strategy=TextGenStrategy.LINE_BY_LINE)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 3
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "Only 3 samples were generated" in message
+    assert "3 non-empty rows" in message
+    assert "lower max_samples" in message
+
+
+def test_text_gen_pre_process_warns_when_line_by_line_drops_short_rows(caplog):
+    # setup
+    # every row is shorter than max_seq_len and drop_short_sequences filters them all out
+    dataset = make_dataset(num_rows=5, words_per_row=2)
+    kwargs = get_kwargs(
+        max_samples=5,
+        strategy=TextGenStrategy.LINE_BY_LINE,
+        pad_to_max_len=False,
+        drop_short_sequences=True,
+    )
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 0
+    assert "drop_short_sequences=True" in caplog.records[0].getMessage()
+
+
+def test_text_gen_pre_process_does_not_warn_when_line_by_line_delivers_max_samples(caplog):
+    # setup
+    dataset = make_dataset(num_rows=5, words_per_row=8)
+    kwargs = get_kwargs(max_samples=5, strategy=TextGenStrategy.LINE_BY_LINE)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 5
+    assert not caplog.records
+
+
+def test_text_gen_pre_process_warns_when_line_by_line_random_finds_no_sample(caplog):
+    # setup
+    # random_retries=0 means no row is ever accepted, so every sample is skipped
+    dataset = make_dataset(num_rows=5, words_per_row=2)
+    kwargs = get_kwargs(
+        max_samples=4,
+        strategy=TextGenStrategy.LINE_BY_LINE_RANDOM,
+        random_seed=0,
+        random_retries=0,
+        pad_to_max_len=False,
+        drop_short_sequences=True,
+    )
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 0
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "max_samples=4" in message
+    assert "random_retries=0" in message
+
+
+def test_text_gen_pre_process_drops_short_rows_when_line_by_line_random_exhausts_retries(caplog):
+    # setup
+    # every row is shorter than max_seq_len, so all random_retries attempts are rejected. The loop variable
+    # still holds the last rejected row, which used to be emitted because a BatchEncoding is always truthy.
+    dataset = make_dataset(num_rows=5, words_per_row=2)
+    kwargs = get_kwargs(
+        max_samples=4,
+        strategy=TextGenStrategy.LINE_BY_LINE_RANDOM,
+        random_seed=0,
+        random_retries=3,
+        pad_to_max_len=False,
+        drop_short_sequences=True,
+    )
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 0
+    assert len(caplog.records) == 1
+    assert "drop_short_sequences=True" in caplog.records[0].getMessage()
+
+
+def test_text_gen_pre_process_does_not_warn_when_line_by_line_random_delivers_max_samples(caplog):
+    # setup
+    dataset = make_dataset(num_rows=5, words_per_row=8)
+    kwargs = get_kwargs(max_samples=4, strategy=TextGenStrategy.LINE_BY_LINE_RANDOM, random_seed=0)
+
+    # execute
+    with caplog.at_level(logging.WARNING, logger="olive.data.component.text_generation"):
+        result = text_gen_pre_process(dataset, FakeTokenizer(), kwargs)
+
+    # assert
+    assert len(result) == 4
+    assert not caplog.records

--- a/test/passes/pytorch/test_train_utils.py
+++ b/test/passes/pytorch/test_train_utils.py
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import inspect
+
+import pytest
+
+from olive.passes.pytorch.train_utils import get_calibration_data_config, get_calibration_dataset
+
+
+@pytest.mark.parametrize("func", [get_calibration_dataset, get_calibration_data_config])
+def test_calibration_helpers_default_split_is_full_train(func):
+    # execute
+    default_split = inspect.signature(func).parameters["split"].default
+
+    # assert
+    # measured with the gpt2 tokenizer: wikitext-2-raw-v1 'train[:1000]' is only 61,816 tokens (353 of the
+    # first 1000 rows are blank lines or headers) which is ~30 blocks of 2048 tokens, silently
+    # under-delivering the requested max_samples. The full 'train' split gives ~1,167 blocks.
+    assert default_split == "train"
+
+
+def test_get_calibration_data_config_uses_default_split():
+    # execute
+    data_config = get_calibration_data_config("dummy-model")
+
+    # assert
+    assert data_config.load_dataset_config.params["split"] == "train"

--- a/test/utils.py
+++ b/test/utils.py
@@ -398,6 +398,8 @@ def get_wikitext_data_config(
         load_dataset_config={
             "data_name": "Salesforce/wikitext",
             "subset": "wikitext-2-raw-v1",
+            # intentionally a small slice: these tests only need max_samples=1, so reading the full
+            # split would just slow them down
             "split": "train[:1000]",
         },
         pre_process_data_config={


### PR DESCRIPTION
## Describe your changes

`get_calibration_dataset` / `get_calibration_data_config` in `olive/passes/pytorch/train_utils.py` defaulted the dataset split to `train[:1000]`. That slice is far too small for the default `max_samples=128`, so calibration silently ran on a fraction of the requested data. This changes the default to the full `train` split and makes any remaining shortfall visible.

### The shortfall

Measured locally against the cached wikitext-2-raw-v1 (gpt2 tokenizer, `max_seq_len=2048`):

| split | tokens | blocks available | blocks requested |
|---|---|---|---|
| `train[:1000]` | 61,816 | **~30** | 128 |
| `train` | 2,391,884 | ~1,167 | 128 |

Of the 1000 sliced rows, 353 are blank or section headers and get filtered out, leaving 647 usable rows. The result was that a pass asking for 128 calibration samples received roughly 30, with no indication that anything was wrong.

128 blocks x 2048 tokens is ~10-11% of the full split, so the new default is not "read everything" — it is "have enough to satisfy `max_samples`".

### Affected passes

Four passes take the default and are therefore affected:

- `Gptq` (via `quant_utils.py`)
- `AutoGPTQ`
- `GPTQModel`
- `SelectiveMixedPrecision`

Explicitly **not** affected: `Rotate` already passes `split="train"`, `AutoClip` uses `mit-han-lab/pile-val-backup` `validation[:1000]` explicitly, and `Rtn` needs no calibration data at all.

`test/utils.py` keeps its own `train[:1000]` slice — that one is a deliberate test-speed choice with `max_samples=1` and is left alone (a comment now says so).

### Accuracy impact

Qwen2.5-0.5B / 1.5B / 3B, 4-bit GPTQ, wikitext-2 test perplexity and pile-val perplexity, at 32 / 128 / 512 calibration blocks. 11 of the 12 comparisons improve over the 32-block baseline.

Caveats that should be read alongside that number:

- The absolute deltas are small.
- It is **not** monotone in block count everywhere. 1.5B on pile-val goes 0% -> **-2.7%** at 128 blocks -> +6.9% at 512, i.e. 128 blocks is worse than 32 for that one series.
- All of the evidence is from **dense** models. No MoE model was measured.
- 128 blocks costs roughly 25% more calibration wall-clock than 32; 512 costs about 2.3x. The default `max_samples` is unchanged, so this PR does not change wall-clock by itself — it only changes whether `max_samples` is actually met.

### This is a reproducibility break

Any workflow that relied on the old default will now calibrate on more data and produce different (bit-wise non-identical) quantized weights. Pinning `split="train[:1000]"` in the data config restores the previous behaviour exactly.

### Network footprint is unchanged

`datasets` downloads the full parquet shard regardless of a `[:N]` slice — the slicing happens in memory after the download. Moving from `train[:1000]` to `train` therefore does not download more data.

## Making the shortfall observable

Every tokenization strategy in `text_generation.py` can stop early and deliver fewer than `max_samples` without saying anything. A single check after all strategy branches now warns when that happens, with a strategy-specific explanation, because the cause and the useful remedy differ per strategy:

- `join` / `join-sliding-window`: the corpus needs `max_seq_len + (max_samples - 1) * step` tokens, where `step` is `max_seq_len` for `join` and `stride` for `join-sliding-window`. Raising `stride` is an effective remedy for the latter and not for the former.
- `join-random`: start positions are random and may overlap, so the corpus only ever needs `max_seq_len` tokens and lowering `max_samples` does not help. The real cause is `random_retries` exhaustion.
- `line-by-line` / `line-by-line-random`: at most one sample per row.

## Two latent bugs found along the way

Both were pre-existing and are fixed here because the new warning interacts directly with them.

**1. Off-by-one in the join strategies.** The block loop was `range(0, len(joined_input_ids) - args.max_seq_len, step)`. `range` is exclusive at the end, so a block starting exactly at `len - max_seq_len` was never emitted even though it is a full-length block. A corpus that was an exact fit for `max_samples` always came up one block short:

| tokens | required | delivered (before) | delivered (after) |
|---|---|---|---|
| 8 | 8 | 0 | 1 |
| 16 | 16 | 1 | 2 |
| 32 | 32 | 3 | 4 |
| 72 | 64 | 7 | 8 |

The new maximum `begin_loc` is `len - max_seq_len`, so `end_loc <= len` and every emitted sequence is still exactly `max_seq_len` long. Without the fix the new warning would have fired as a false alarm on exact-fit corpora.

**2. `drop_short_sequences` had no effect in `line-by-line-random`.** The resampling loop reassigns `encodings` on every attempt and was guarded by `if not encodings: continue`. Once the retries are exhausted, `encodings` still holds the last *rejected* (too-short) row, and a non-empty `BatchEncoding` is truthy, so the rejected row was appended anyway. `drop_short_sequences=True` therefore emitted short sequences instead of dropping them — silently producing wrong-length calibration data rather than less of it. The length is now re-checked explicitly, matching what `line-by-line` already did via an explicit `filter`.

Blast radius of bug 2 is essentially zero: `drop_short_sequences` defaults to `False` and is mutually exclusive with `pad_to_max_len` (which defaults to `True`), so triggering it required explicitly setting both. No recipe in the repository does.

### Known follow-up, not fixed here

In `line-by-line-random`, `cache[i] = encodings` means resampling an already-seen index returns the cached (short) row while still incrementing `resamples`. On a small dataset the retries burn on repeated rows, so far fewer distinct rows are explored than `random_retries` suggests. This is an efficiency issue rather than a correctness one now that bug 2 is fixed — the worst case is a shortfall, which is now reported.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

**Release note:** Calibration data for the `Gptq`, `AutoGPTQ`, `GPTQModel` and `SelectiveMixedPrecision` passes now defaults to the full `train` split instead of `train[:1000]`, which was too small to satisfy the default `max_samples=128`. Quantized weights produced by these passes will differ from previous releases; set `split` explicitly in the data config to restore the old behaviour. Data preprocessing now warns when fewer samples than `max_samples` could be produced, and two pre-existing bugs were fixed: the `join` strategies dropped the last full block on exact-fit corpora, and `drop_short_sequences` was ignored by `line-by-line-random`.

### Tests

`test/data_container/test_text_generation.py` (14 tests) and `test/passes/pytorch/test_train_utils.py` (3 tests), both network-free. Includes a regression test for each of the two bugs above — the off-by-one test asserts an exact-fit corpus delivers all `max_samples`, and the `drop_short_sequences` test was verified to fail (4 short samples emitted instead of 0) with the fix reverted.

```
python -m pytest test/data_container test/passes/pytorch/test_train_utils.py -q
-> 1 failed, 94 passed, 1 skipped
```

The one failure is `test_dataloader.py::test_llm_augmented_dataloader[True]` (`TypeError: check_extra_options() takes 2 positional arguments but 7 were given`), which fails identically on `main` and is unrelated to this change.
