### PR TITLE
docs: document eager experts_implementation requirement for MoE-quantized inference

### DIFF
--- a/docs/source/features/quantization.md
+++ b/docs/source/features/quantization.md
@@ -103,6 +103,27 @@ Attempting to `torch.onnx.export` a model with 3D-quantized experts raises a cle
 Mobius / ORT GenAI `ModelBuilder` for the experts. Non-MoE parts (attention projections, router/gate,
 embeddings, lm_head) still export through the existing `MatMulNBits` / `GatherBlockQuantized` path.
 
+### `moe` and native PyTorch inference: force the `"eager"` experts implementation
+
+`transformers` lets a loaded MoE model pick its runtime forward strategy independently of the
+checkpoint's on-disk layout, via `model.set_experts_implementation(...)` / `config._experts_implementation`
+(`"eager"`, `"grouped_mm"`, `"batched_mm"`, ...). Some non-`"eager"` strategies (e.g. `"grouped_mm"`, which
+`transformers` may auto-select even on CPU) call `weight.transpose(-2, -1)` on the fused-experts weight
+before dispatching to their matmul kernel. Because Olive's 3D fused-expert `QuantTensor` is storage-only
+(see above) and cannot represent a transpose without a lossy unpack/re-quantize round trip, this raises a
+`RuntimeError` at inference time -- even for architectures whose checkpoint layout (`is_transposed=False`)
+is fully supported for quantization.
+
+**Workaround**: after loading a `moe=True`-quantized checkpoint for native PyTorch inference (as opposed to
+consuming it via Mobius / ORT GenAI `ModelBuilder`), force the eager path once, before running any forward
+pass:
+
+```python
+model.set_experts_implementation("eager")
+```
+
+This is tracked as a follow-up in [#2619](https://github.com/microsoft/Olive/issues/2619).
+
 ### `modules_to_not_convert` and `overrides`
 
 `modules_to_not_convert` lists module-name patterns to exclude entirely, and `overrides` maps module-name


### PR DESCRIPTION
## Describe your changes

Documents a limitation surfaced while validating KQuant/RTN MoE quantization on a real (locally-constructed) `Qwen3MoeForCausalLM` model: `transformers` may auto-select the `"grouped_mm"` experts implementation at inference time (even on CPU), which internally calls `weight.transpose(-2, -1)` on the fused-experts weight before its matmul kernel. Olive's 3D fused-expert `QuantTensor` is storage-only and cannot represent a transpose without a lossy dequantize/re-quantize round trip, so this raises a `RuntimeError` at inference time -- even for architectures whose checkpoint layout (`is_transposed=False`) is already fully supported for quantization by `Rtn`/`Gptq`/`KQuant`.

This reproduces identically for both `Rtn` (merged, #2616) and `KQuant` (#2618), confirming it's a shared `QuantTensor` limitation rather than a pass-specific bug.

Adds a short doc section next to the existing "`moe` and ONNX export" note, documenting the workaround (`model.set_experts_implementation("eager")` before running inference) and linking the follow-up issue.

Follow-up issue: #2619 (tracks whether the deferred "transposed layout" (`is_transposed=True`) `QuantTensor` design work could also resolve this as a side effect, or whether it needs separate design).

Doc-only change, no code/test changes.