### PR TITLE
Fix Mobius test-model export and llama.cpp discrepancy checks

### DIFF
--- a/olive/cli/run.py
+++ b/olive/cli/run.py
@@ -75,7 +75,9 @@ class WorkflowRunCommand(BaseOliveCLICommand):
             validate_test_output_path(output_path, self.args.test)
             run_config["input_model"] = add_hf_test_model_config(input_model, self.args.test, output_path)
             test_metrics = _flatten_test_metrics(getattr(self.args, "test_metrics", None))
-            run_config = add_discrepancy_check_pass(run_config, test_metrics)
+            run_config = add_discrepancy_check_pass(
+                run_config, test_metrics, getattr(self.args, "test_llama_path", None)
+            )
 
         for arg_key, rc_key in [("output_path", "output_dir"), ("log_level", "log_severity_level")]:
             if (arg_value := getattr(self.args, arg_key)) is not None:

--- a/olive/passes/onnx/mobius_model_builder.py
+++ b/olive/passes/onnx/mobius_model_builder.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
+from olive.common.hf.utils import has_test_model_weights, is_test_model_dir
 from olive.common.utils import StrEnumBase
 from olive.constants import Precision
 from olive.hardware.constants import EXECUTION_PROVIDER_TO_MOBIUS_EP, ExecutionProvider
@@ -122,6 +123,15 @@ class MobiusBuilder(Pass):
 
         dtype_str: str = _PRECISION_TO_DTYPE.get(config.precision, "f32")
         model_id: str = model.model_name_or_path
+        if model.test_model_config:
+            if not model.test_model_path:
+                raise ValueError(
+                    "MobiusBuilder requires test_model_path to be set when test_model_config is provided. "
+                    "Please specify the path where the test model should be saved."
+                )
+            if not is_test_model_dir(model.test_model_path) or not has_test_model_weights(model.test_model_path):
+                model.load_model(cache_model=False)
+            model_id = str(Path(model.test_model_path).resolve())
 
         # Read trust_remote_code from the model's HuggingFace load kwargs.
         trust_remote_code: bool = model.get_load_kwargs().get("trust_remote_code", False)

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -156,6 +156,7 @@ def test_workflow_run_command_with_overrides(mock_repo_exists, mock_run, tmp_pat
 @patch("olive.workflows.run")
 def test_workflow_run_command_with_test_override(mock_run, tmp_path):
     mock_run.return_value = None
+    llama_env_path = str(tmp_path / "llama_env")
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(
@@ -169,7 +170,14 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
             }
         )
     )
-    command_args = ["run", "--run-config", str(config_path), "--test"]
+    command_args = [
+        "run",
+        "--run-config",
+        str(config_path),
+        "--test",
+        "--test_llama_path",
+        llama_env_path,
+    ]
 
     cli_main(command_args)
 
@@ -187,6 +195,11 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
             "output_dir": output_dir,
             "passes": {
                 "save_test_model_config": {"type": "SaveTestModelConfig"},
+                "convert_hf_to_gguf": {
+                    "type": "ConvertHfToGGUF",
+                    "llama_cpp_env_path": llama_env_path,
+                    "reference_model_path": test_model_path,
+                },
                 "discrepancy_check": {
                     "type": "OnnxDiscrepancyCheck",
                     "reference_model_path": test_model_path,
@@ -194,6 +207,8 @@ def test_workflow_run_command_with_test_override(mock_run, tmp_path):
                     "test_metrics": ["mae"],
                     "max_mae": 0.1,
                     "timing_iterations": 0,
+                    "llama_cpp": True,
+                    "llama_cpp_env_path": llama_env_path,
                 },
             },
         },

--- a/test/passes/onnx/test_mobius_model_builder.py
+++ b/test/passes/onnx/test_mobius_model_builder.py
@@ -55,8 +55,13 @@ def mock_hf_config():
         yield
 
 
-def _make_hf_model(model_path: str, load_kwargs: dict | None = None) -> HfModelHandler:
-    model = HfModelHandler(model_path=model_path)
+def _make_hf_model(
+    model_path: str,
+    load_kwargs: dict | None = None,
+    test_model_config: dict | None = None,
+    test_model_path: str | None = None,
+) -> HfModelHandler:
+    model = HfModelHandler(model_path=model_path, test_model_config=test_model_config, test_model_path=test_model_path)
     if load_kwargs:
         # Patch get_load_kwargs on the instance to return the given kwargs.
         model.get_load_kwargs = lambda: load_kwargs
@@ -185,6 +190,66 @@ def test_single_component_returns_onnx_handler(tmp_path):
     call_kwargs = mock_build.call_args.kwargs
     assert call_kwargs["execution_provider"] == "cpu"
     assert call_kwargs["dtype"] == "f32"
+
+
+def test_mobius_builder_uses_saved_test_model_path(tmp_path):
+    test_model_path = tmp_path / "saved_test_model"
+    test_model_path.mkdir()
+    model = _make_hf_model(
+        "org/full-model", test_model_config={"hidden_layers": 2}, test_model_path=str(test_model_path)
+    )
+    pkg = _fake_pkg(["model"], tmp_path / "out")
+
+    with (
+        _patch_build(pkg) as mock_build,
+        patch("olive.passes.onnx.mobius_model_builder.is_test_model_dir", return_value=True),
+        patch("olive.passes.onnx.mobius_model_builder.has_test_model_weights", return_value=True),
+        patch.object(model, "load_model") as mock_load_model,
+        patch.object(MobiusBuilder, "_write_genai_config") as mock_write_genai_config,
+    ):
+        _make_pass().run(model, tmp_path / "out")
+
+    resolved_test_model_path = str(test_model_path.resolve())
+    assert mock_build.call_args.args[0] == resolved_test_model_path
+    assert mock_write_genai_config.call_args.args[2] == resolved_test_model_path
+    mock_load_model.assert_not_called()
+
+
+def test_mobius_builder_materializes_missing_test_weights(tmp_path):
+    test_model_path = tmp_path / "config_only_test_model"
+    test_model_path.mkdir()
+    model = _make_hf_model(
+        "org/full-model", test_model_config={"hidden_layers": 2}, test_model_path=str(test_model_path)
+    )
+    pkg = _fake_pkg(["model"], tmp_path / "out")
+
+    with (
+        _patch_build(pkg) as mock_build,
+        patch("olive.passes.onnx.mobius_model_builder.is_test_model_dir", return_value=True),
+        patch("olive.passes.onnx.mobius_model_builder.has_test_model_weights", return_value=False),
+        patch.object(model, "load_model") as mock_load_model,
+    ):
+        _make_pass().run(model, tmp_path / "out")
+
+    mock_load_model.assert_called_once_with(cache_model=False)
+    assert mock_build.call_args.args[0] == str(test_model_path.resolve())
+
+
+def test_mobius_builder_requires_test_model_path(tmp_path):
+    model = _make_hf_model("org/full-model", test_model_config={"hidden_layers": 2})
+
+    with pytest.raises(ValueError, match="requires test_model_path"):
+        _make_pass().run(model, tmp_path / "out")
+
+
+def test_mobius_builder_uses_huggingface_id_for_normal_export(tmp_path):
+    model_id = "org/full-model"
+    pkg = _fake_pkg(["model"], tmp_path / "out")
+
+    with _patch_build(pkg) as mock_build:
+        _make_pass().run(_make_hf_model(model_id), tmp_path / "out")
+
+    assert mock_build.call_args.args[0] == model_id
 
 
 def test_model_onnx_exists_after_run(tmp_path):


### PR DESCRIPTION
## Describe your changes

Fix `olive run --test` for workflows using `MobiusBuilder`.

- Export the saved reduced test model instead of the original Hugging Face model.
- Honor the two-layer model generated for discrepancy checks, avoiding full-model downloads and exports.
- Materialize test weights when the test-model directory contains only configuration.
- Raise a clear error when `test_model_config` is set without `test_model_path`.
- Preserve the original Hugging Face model ID for normal exports.
- Forward `--test_llama_path` to enable llama.cpp conversion and benchmarking.
- Add regression tests for both fixes.

## Checklist before requesting a review

- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary. No documentation changes required.
- [x] Lint and apply fixes to your code by running `lintrunner -a`.
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

Release note: Fixed `olive run --test` to honor reduced two-layer models used by discrepancy checks when exporting with Mobius, and to honor `--test_llama_path` for llama.cpp benchmarking.

## (Optional) Issue link

N/A