### PR TITLE
ci: show environment (pip list) before running tests

### DIFF
--- a/.azure_pipelines/job_templates/olive-test-cpu-template.yaml
+++ b/.azure_pipelines/job_templates/olive-test-cpu-template.yaml
@@ -42,7 +42,13 @@ jobs:
   - script: |
         python -m pip install pytest
         python -m pip install -r $(Build.SourcesDirectory)/test/$(requirements_file)
+    displayName: Install test dependencies
+
+  - script: |
         python -m pip list
+    displayName: Show environment (pip list)
+
+  - script: |
         coverage run --source=$(Build.SourcesDirectory)/olive -m pytest -v -s -p no:warnings --disable-warnings --log-cli-level=WARNING --junitxml=$(Build.SourcesDirectory)/logs/test-TestOlive.xml -m "$(pytest_marker)" $(Build.SourcesDirectory)/$(test_path) --basetemp $(PYTEST_BASETEMP)
         coverage xml
     displayName: Test Olive

--- a/.azure_pipelines/scripts/run_test.sh
+++ b/.azure_pipelines/scripts/run_test.sh
@@ -42,7 +42,9 @@ BUILD_CUDA_EXT=0 pip install --no-build-isolation "git+https://github.com/PanQiW
 pip install huggingface-hub
 hf auth login --token "$7"
 
+echo "===== Environment (pip list) ====="
 pip list
+echo "==================================="
 
 # Step 4: Run tests with or without coverage tracking
 XML_PATH="/logs/TestOlive.xml"


### PR DESCRIPTION
## Describe your changes

CI environment can currently be hard to diagnose because installed package
versions aren't clearly visible before the test run. This adds an explicit
environment-visibility step ahead of test execution:

- `olive-test-cpu-template.yaml` (Azure Pipelines CPU CI, Linux & Windows):
  split the combined "Test Olive" step into three steps: `Install test
  dependencies`, `Show environment (pip list)`, and `Test Olive`, so the
  installed package list is visible as its own step in the pipeline UI/logs.
- `run_test.sh` (Linux GPU docker test script): added clear log markers
  around the existing `pip list` call (kept as part of the same script
  since it runs as a single `docker run` invocation) to make the environment
  dump easy to find in logs.

GitHub Actions (`test-model-fast.yml`) already has an independent `pip
freeze` step, so no change was needed there.

## Checklist before requesting a review
- [x] Add unit tests for this change. (N/A - CI pipeline config only)
- [ ] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [ ] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link