### PR TITLE
Support Qwen3.5/3.6-MoE VL checkpoints in PyTorch-side quantization

### DIFF
--- a/olive/assets/io_configs/defaults.yaml
+++ b/olive/assets/io_configs/defaults.yaml
@@ -3,12 +3,18 @@
 
 # Attribute aliases (same concept, different naming across models)
 aliases:
-  # Layer count
-  num_layers: [num_hidden_layers, n_layer, n_layers]
-  # Hidden dimensions
-  hidden_size: [dim, d_model, n_embd]
-  num_attention_heads: [num_heads, n_head, n_heads, encoder_attention_heads]
-  num_kv_heads: [num_key_value_heads]
+  # Layer count. ``text_config.num_hidden_layers`` covers composite VL configs (e.g.
+  # Qwen3.5/3.6-MoE-VL, GLM4V-MoE) whose top level only has ``vision_config``/``text_config``
+  # and no flat decoder attributes of its own.
+  num_layers: [num_hidden_layers, n_layer, n_layers, text_config.num_hidden_layers]
+  # Hidden dimensions. See ``num_layers`` above for why the ``text_config.*`` fallbacks exist.
+  hidden_size: [dim, d_model, n_embd, text_config.hidden_size]
+  num_attention_heads: [num_heads, n_head, n_heads, encoder_attention_heads, text_config.num_attention_heads]
+  num_kv_heads: [num_key_value_heads, text_config.num_key_value_heads]
+  # Explicit head_dim, so composite VL configs whose head_dim doesn't equal
+  # hidden_size // num_attention_heads (e.g. Qwen3.5/3.6-MoE-VL) resolve correctly instead of
+  # falling back to that derived (and here incorrect) value.
+  head_dim: [text_config.head_dim]
   # MoE expert count. Covers flat configs (Mixtral / gpt-oss / PhiMoE
   # ``num_local_experts``, DeepSeek ``n_routed_experts``, Ernie4.5 / Aria
   # ``moe_num_experts``) and nested sub-configs (DBRX ``ffn_config``, Llama4 /

--- a/olive/common/hf/io_config/io_resolver.py
+++ b/olive/common/hf/io_config/io_resolver.py
@@ -113,10 +113,23 @@ def get_aliases() -> dict[str, list[str]]:
 
 
 def _get_nested_attr(obj, attr_path: str):
-    """Get nested attribute using dot notation (e.g., 'vision_config.image_size')."""
-    parts = attr_path.split(".")
-    for part in parts:
-        obj = getattr(obj, part, None)
+    """Get nested attribute using dot notation (e.g., 'vision_config.image_size').
+
+    Attribute access is guarded with a broad ``except Exception`` (rather than relying on
+    ``getattr``'s default, which only swallows ``AttributeError``) because transformers 5.x
+    heterogeneous / per-layer configs raise their own exception types on ambiguous access.
+    For example Gemma4-family configs raise
+    ``transformers.integrations.heterogeneity.configuration_utils.AmbiguousGlobalPerLayerAttributeError``
+    when a per-layer attribute such as ``head_dim`` is read off the top-level config without a
+    layer index. That exception type is not importable across every transformers version Olive
+    supports, so it is caught structurally instead of by type: an attribute Olive cannot read
+    unambiguously is simply "not resolvable here", and the caller falls back to the next alias.
+    """
+    for part in attr_path.split("."):
+        try:
+            obj = getattr(obj, part, None)
+        except Exception:  # pylint: disable=broad-except
+            return None
         if obj is None:
             return None
     return obj

--- a/olive/common/hf/io_config/io_resolver.py
+++ b/olive/common/hf/io_config/io_resolver.py
@@ -145,6 +145,12 @@ def resolve_alias(config, name: str, aliases: dict[str, list[str]] | None = None
 
     Supports nested attribute paths (e.g., 'vision_config.image_size').
 
+    Resolution order: the canonical ``name`` on the config itself wins, and the aliases are
+    only consulted as fallbacks. This matters for composite (VL) configs that carry *both* a
+    top-level value and a nested ``text_config.<name>`` alias with a different value -- the
+    model's own top-level attribute is authoritative and must not be silently overridden by
+    the nested fallback.
+
     Args:
         config: The config object to query.
         name: The canonical name to look up (e.g., 'hidden_size', 'num_layers').
@@ -157,17 +163,18 @@ def resolve_alias(config, name: str, aliases: dict[str, list[str]] | None = None
     if aliases is None:
         aliases = get_aliases()
 
-    # Check aliases first
+    # Direct lookup of the canonical name takes precedence over any alias.
+    value = _get_nested_attr(config, name)
+    if value is not None and _is_valid_config_value(value):
+        return value
+
+    # Fall back to aliases, in declaration order.
     if name in aliases:
         for attr in aliases[name]:
             value = _get_nested_attr(config, attr)
-            if _is_valid_config_value(value) and value is not None:
+            if value is not None and _is_valid_config_value(value):
                 return value
 
-    # Try direct lookup
-    value = _get_nested_attr(config, name)
-    if _is_valid_config_value(value):
-        return value
     return None
 
 

--- a/olive/common/hf/wrapper.py
+++ b/olive/common/hf/wrapper.py
@@ -394,6 +394,7 @@ class ModelWrapper:
         "qwen": ["transformer.wte"],
         # VL checkpoint: decoder lives under ``model.language_model`` alongside
         # ``model.visual``, rather than directly under ``model`` -- see ``LAYERS`` below.
+        # Flat text-only ``qwen3_5_moe`` configs are routed to ``qwen3_5_moe_text`` instead.
         "qwen3_5_moe": ["model.language_model.embed_tokens"],
     }
     # in newer transformers versions, there is one rotary embedding per model
@@ -421,18 +422,28 @@ class ModelWrapper:
         "gptj": "transformer.h",
         "opt": "model.decoder.layers",
         "qwen": "transformer.h",
-        # ``Qwen3_5MoeForConditionalGeneration`` (VL, ``model_type == "qwen3_5_moe"``) nests
-        # the decoder under ``model.language_model`` next to ``model.visual`` (the vision
-        # tower). The text-only ``Qwen3_5MoeForCausalLM`` uses ``Qwen3_5MoeTextConfig``
-        # (``model_type == "qwen3_5_moe_text"``), which is flat and already matches
-        # ``"default"`` -- so this entry is scoped to the VL ``model_type`` only and does not
-        # affect the text-only path.
+        # ``Qwen3_5MoeForConditionalGeneration`` (VL) nests the decoder under
+        # ``model.language_model`` next to ``model.visual`` (the vision tower). Flat text-only
+        # ``qwen3_5_moe`` checkpoints report the same ``model_type`` but use the default
+        # ``model.layers`` layout -- they are routed to ``qwen3_5_moe_text`` by
+        # ``_resolve_model_type`` (see ``TEXT_ONLY_MODEL_TYPES``), so this entry only applies
+        # to configs that actually carry a ``vision_config``.
         "qwen3_5_moe": "model.language_model.layers",
     }
+    # Some ``model_type``s are shared by a composite (vision-language) checkpoint and a flat
+    # text-only checkpoint. ``qwen3_5_moe`` is one: ``Qwen3_5MoeForConditionalGeneration``
+    # nests the decoder under ``model.language_model`` (next to ``model.visual``), while
+    # text-only ``Qwen3_5MoeForCausalLM`` checkpoints keep the flat ``model.layers`` layout
+    # even though their config still reports ``model_type == "qwen3_5_moe"``. Mobius
+    # disambiguates the two exactly this way -- ``config.vision_config is None`` means
+    # text-only -- so a text-only config is normalized to the ``*_text`` model_type, which has
+    # no entries in the module-path mappings above and therefore uses the flat "default"
+    # paths. Maps ``VL model_type -> text-only model_type``.
+    TEXT_ONLY_MODEL_TYPES = {"qwen3_5_moe": "qwen3_5_moe_text"}
 
     def __init__(self, config: Union[PretrainedConfig, dict]):
         self.config = config if isinstance(config, PretrainedConfig) else PretrainedConfig.from_dict(config)
-        self.model_type = getattr(self.config, "model_type", None)
+        self.model_type = self._resolve_model_type(self.config)
 
         # model attributes (using unified aliases from defaults.yaml)
         self.hidden_size = resolve_alias(self.config, "hidden_size")
@@ -445,6 +456,25 @@ class ModelWrapper:
 
         self._model = None
         self._layer_wrappers = None
+
+    @classmethod
+    def _resolve_model_type(cls, config: PretrainedConfig) -> Union[str, None]:
+        """Return the model_type used to look up module paths in the mappings above.
+
+        Normalizes a flat text-only checkpoint whose ``model_type`` is shared with a composite
+        VL architecture to the corresponding text-only ``model_type`` -- see
+        ``TEXT_ONLY_MODEL_TYPES``.
+        """
+        model_type = getattr(config, "model_type", None)
+        if model_type in cls.TEXT_ONLY_MODEL_TYPES and getattr(config, "vision_config", None) is None:
+            text_only_model_type = cls.TEXT_ONLY_MODEL_TYPES[model_type]
+            logger.debug(
+                "Config for model_type %r has no vision_config; treating it as the text-only %r layout.",
+                model_type,
+                text_only_model_type,
+            )
+            return text_only_model_type
+        return model_type
 
     @property
     def model(self) -> "PreTrainedModel":

--- a/olive/common/hf/wrapper.py
+++ b/olive/common/hf/wrapper.py
@@ -184,6 +184,17 @@ class LayerWrapper:
         "jamba": "router",
         "phimoe": "router",
     }
+    # ``SHARED_EXPERT_GATE`` is the sigmoid gate that scales a layer's always-active shared
+    # expert branch (``F.sigmoid(self.shared_expert_gate(x)) * shared_expert_output``), used
+    # alongside a normal top-k ``ROUTER`` by qwen2_moe, qwen3_5_moe, qwen3_next, and
+    # qwen3_omni_moe. Like the router, it directly controls how much the shared expert
+    # contributes and is a single-row ``nn.Linear`` (out_features=1) -- quantizing it to a
+    # handful of bits is both undesirable (routing-like signal) and disproportionately lossy
+    # (one output row). Resolved (when present) purely so ``iter_quant_targets`` can exclude
+    # it, the same way it excludes ``ROUTER``.
+    SHARED_EXPERT_GATE = {
+        "default": "shared_expert_gate",
+    }
     # ``MAMBA`` is a decoder layer's state-space-model (SSM) sub-module, when present --
     # e.g. Jamba interleaves ``JambaMambaDecoderLayer`` (has ``.mamba``) with
     # ``JambaAttentionDecoderLayer`` (has ``.self_attn`` instead). A Mamba block's
@@ -191,8 +202,13 @@ class LayerWrapper:
     # state-space recursion rather than a plain matmul, so they were never intentionally
     # supported by the generic 2D quantization walk -- resolved (when present) purely so
     # ``iter_quant_targets`` can exclude them, the same way it excludes routers.
+    #
+    # ``qwen3_5_moe``/``qwen3_5_moe_text`` interleave full attention with GatedDeltaNet
+    # linear-attention layers under ``.linear_attn`` instead of ``.mamba``.
     MAMBA = {
         "default": "mamba",
+        "qwen3_5_moe": "linear_attn",
+        "qwen3_5_moe_text": "linear_attn",
     }
 
     def __init__(self, layer: nn.Module, model_type: str):
@@ -326,6 +342,22 @@ class LayerWrapper:
         name = f"{self.mlp_name}.{self.ROUTER.get(self.model_type, self.ROUTER['default'])}"
         return (module, name) if return_name else module
 
+    def get_shared_expert_gate(self, return_name: bool = True):
+        """Return this layer's shared-expert gate sub-module (or ``None`` if not present).
+
+        See ``SHARED_EXPERT_GATE``'s docstring for why this is excluded from quantization the
+        same way ``ROUTER`` is.
+        """
+        if self.mlp is None:
+            return (None, "") if return_name else None
+        module = get_submodules(
+            self.mlp, self.SHARED_EXPERT_GATE, self.model_type, return_name=False, fail_on_not_found=False
+        )
+        if module is None:
+            return (None, "") if return_name else None
+        name = f"{self.mlp_name}.{self.SHARED_EXPERT_GATE.get(self.model_type, self.SHARED_EXPERT_GATE['default'])}"
+        return (module, name) if return_name else module
+
     def get_mamba(self, return_name: bool = True):
         """Return this layer's Mamba/SSM sub-module (or ``None`` for a non-Mamba layer).
 
@@ -360,6 +392,9 @@ class ModelWrapper:
         "gptj": ["transformer.wte"],
         "opt": ["model.decoder.embed_tokens", "model.decoder.embed_positions"],
         "qwen": ["transformer.wte"],
+        # VL checkpoint: decoder lives under ``model.language_model`` alongside
+        # ``model.visual``, rather than directly under ``model`` -- see ``LAYERS`` below.
+        "qwen3_5_moe": ["model.language_model.embed_tokens"],
     }
     # in newer transformers versions, there is one rotary embedding per model
     ROTARY_EMBEDDING = {
@@ -367,6 +402,7 @@ class ModelWrapper:
         "falcon": "transformer.rotary_emb",
         "gpt_neox": "gpt_neox.rotary_emb",
         "qwen": "transformer.rotary_emb",
+        "qwen3_5_moe": "model.language_model.rotary_emb",
     }
     LM_HEAD = {"default": "lm_head"}
     PRE_HEAD_LAYERNORM = {
@@ -374,6 +410,7 @@ class ModelWrapper:
         "gpt2": "transformer.ln_f",
         "lfm2": "model.embedding_norm",
         "qwen": "transformer.ln_f",
+        "qwen3_5_moe": "model.language_model.norm",
     }
     LAYERS = {
         "default": "model.layers",
@@ -384,6 +421,13 @@ class ModelWrapper:
         "gptj": "transformer.h",
         "opt": "model.decoder.layers",
         "qwen": "transformer.h",
+        # ``Qwen3_5MoeForConditionalGeneration`` (VL, ``model_type == "qwen3_5_moe"``) nests
+        # the decoder under ``model.language_model`` next to ``model.visual`` (the vision
+        # tower). The text-only ``Qwen3_5MoeForCausalLM`` uses ``Qwen3_5MoeTextConfig``
+        # (``model_type == "qwen3_5_moe_text"``), which is flat and already matches
+        # ``"default"`` -- so this entry is scoped to the VL ``model_type`` only and does not
+        # affect the text-only path.
+        "qwen3_5_moe": "model.language_model.layers",
     }
 
     def __init__(self, config: Union[PretrainedConfig, dict]):

--- a/olive/common/quant/selection.py
+++ b/olive/common/quant/selection.py
@@ -83,6 +83,32 @@ def _collect_moe_routers(wrapper: ModelWrapper | None) -> list[nn.Module]:
     return routers
 
 
+def _collect_shared_expert_gates(wrapper: ModelWrapper | None) -> list[nn.Module]:
+    """Return the shared-expert gate module of every layer that also resolves an experts subtree.
+
+    A shared-expert gate (``qwen2_moe``, ``qwen3_5_moe``, ``qwen3_next``, ``qwen3_omni_moe``)
+    is a single-row ``nn.Linear`` sigmoid gate that scales an always-active "shared expert"
+    branch, alongside the normal top-k ``ROUTER``. Like the router, it directly controls
+    routing-like behavior and is disproportionately lossy to quantize (one output row), so it
+    is excluded the same way ``ROUTER`` is -- see ``LayerWrapper.SHARED_EXPERT_GATE``.
+
+    Only gates of layers with resolvable experts are excluded, so a dense layer that happens
+    to own an attribute named ``shared_expert_gate`` is never silently skipped.
+    """
+    if wrapper is None:
+        return []
+    gates: list[nn.Module] = []
+    for lw in wrapper.get_layer_wrappers():
+        get_gate = getattr(lw, "get_shared_expert_gate", None)
+        if get_gate is None:
+            continue
+        gate = get_gate(return_name=False)
+        if gate is None or lw.get_experts(return_name=False) is None:
+            continue
+        gates.append(gate)
+    return gates
+
+
 def _collect_mamba_modules(wrapper: ModelWrapper | None) -> list[nn.Module]:
     """Return every layer's Mamba/SSM sub-module (state-space model), when present.
 
@@ -313,6 +339,11 @@ def iter_quant_targets(
     # :func:`_collect_moe_routers`.
     for router in _collect_moe_routers(wrapper):
         for sub in router.modules():
+            skip_ids.add(id(sub))
+    # Shared-expert gates stay full precision regardless of ``quantize_moe``, same reasoning
+    # as routers -- see :func:`_collect_shared_expert_gates`.
+    for gate in _collect_shared_expert_gates(wrapper):
+        for sub in gate.modules():
             skip_ids.add(id(sub))
     # Mamba/SSM blocks stay full precision unconditionally -- see :func:`_collect_mamba_modules`.
     for mamba in _collect_mamba_modules(wrapper):

--- a/olive/common/quant/selection.py
+++ b/olive/common/quant/selection.py
@@ -131,6 +131,36 @@ def _collect_mamba_modules(wrapper: ModelWrapper | None) -> list[nn.Module]:
     return mamba_modules
 
 
+# Attribute names under which multimodal checkpoints hang their vision tower. Matched against
+# a module's own attribute name (the last component of its dotted ``named_modules`` name).
+_VISION_TOWER_ATTR_NAMES = ("visual", "vision_tower", "vision_model", "vision_encoder")
+
+
+def _collect_vision_towers(model: nn.Module) -> list[nn.Module]:
+    """Return the vision-tower sub-modules of a composite vision-language model.
+
+    Olive's PyTorch-side (RTN/GPTQ) quantization targets the *text decoder* only; a VL
+    checkpoint's vision encoder is quantized separately (int8) on the ONNX side. Without this
+    exclusion the generic ``named_modules`` walk also sweeps in ``model.visual.*`` (patch
+    embeddings, attention/MLP projections, merger, ...), which would then be quantized twice —
+    once to int4 here and once by the later ONNX pass.
+
+    Detection is deliberately conservative: only applied when the model's config declares a
+    ``vision_config`` (i.e. it really is a composite multimodal model), so a standalone vision
+    model — whose root module may itself be named ``vision_model`` — is never emptied of
+    targets. Users can still exclude additional subtrees via ``modules_to_not_convert``.
+    """
+    config = getattr(model, "config", None)
+    if config is None or getattr(config, "vision_config", None) is None:
+        return []
+    towers: list[nn.Module] = []
+    for name, module in model.named_modules():
+        # skip the root module (name == "") -- never treat the model itself as a vision tower
+        if name and name.rsplit(".", 1)[-1] in _VISION_TOWER_ATTR_NAMES:
+            towers.append(module)
+    return towers
+
+
 def _layers_missing_experts(wrapper: ModelWrapper | None) -> list[int]:
     """Return indices of layers that look structurally MoE but whose experts couldn't be resolved.
 
@@ -252,6 +282,11 @@ def iter_quant_targets(
     * the router module of every MoE layer is always skipped (routers
       stay in full precision), including bare ``nn.Linear`` routers such
       as Jamba's.
+    * for a composite vision-language model (config declares a
+      ``vision_config``), every module under the vision tower
+      (``visual`` / ``vision_tower`` / ``vision_model`` / ``vision_encoder``)
+      is skipped: PyTorch-side quantization covers the text decoder only,
+      the vision encoder is quantized separately downstream.
     * ``skip_patterns`` matches the parameter's ``full_name`` via the
       shared HF-style substring / ``re:``-prefixed regex matcher.
     * When ``skip_already_quantized=True`` (default), parameters whose
@@ -348,6 +383,11 @@ def iter_quant_targets(
     # Mamba/SSM blocks stay full precision unconditionally -- see :func:`_collect_mamba_modules`.
     for mamba in _collect_mamba_modules(wrapper):
         for sub in mamba.modules():
+            skip_ids.add(id(sub))
+    # A composite VL model's vision tower is never a PyTorch-side quantization target -- see
+    # :func:`_collect_vision_towers`.
+    for tower in _collect_vision_towers(model):
+        for sub in tower.modules():
             skip_ids.add(id(sub))
     if not quantize_moe:
         for experts, _ in expert_modules:

--- a/olive/model/handler/mixin/hf.py
+++ b/olive/model/handler/mixin/hf.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
+import shutil
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -124,22 +126,69 @@ class HfMixin:
         # defaults. Only applicable to multimodal models (e.g. VL checkpoints); text-only
         # models have no processor and are already covered by the tokenizer save above.
         if not (output_dir / "preprocessor_config.json").exists():
-            try:
-                from transformers import AutoProcessor
-                from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-
-                processor = AutoProcessor.from_pretrained(
-                    self.model_name_or_path, **self.get_load_kwargs(exclude_load_keys=exclude_load_keys)
-                )
-                if not isinstance(processor, PreTrainedTokenizerBase):
-                    processor_filepaths = processor.save_pretrained(str(output_dir), **kwargs)
-                    saved_filepaths.extend([fp for fp in processor_filepaths if Path(fp).exists()])
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug("No processor/image processor saved for %r: %s", self.model_name_or_path, e)
+            saved_filepaths.extend(self._save_processor(output_dir, exclude_load_keys=exclude_load_keys, **kwargs))
 
         logger.debug("Save metadata files to %s: %s", output_dir, saved_filepaths)
 
         return saved_filepaths
+
+    def _save_processor(self, output_dir: Path, exclude_load_keys: Optional[list[str]] = None, **kwargs) -> list[str]:
+        """Save the model's processor files (preprocessor_config.json, ...) to output_dir.
+
+        Never overwrites a file that already exists in ``output_dir``:
+        ``ProcessorMixin.save_pretrained`` also re-saves the processor's tokenizer, which would
+        clobber a tokenizer that an earlier step intentionally customized and saved. The
+        processor is therefore saved to a temporary directory first and only its new files are
+        copied over.
+
+        :param output_dir: output directory to save the processor files in
+        :param exclude_load_keys: list of keys to exclude from load_kwargs
+        :param kwargs: additional keyword arguments to pass to `save_pretrained` method
+        :return: list of file paths that were written
+        """
+        from transformers import AutoProcessor
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+        try:
+            processor = AutoProcessor.from_pretrained(
+                self.model_name_or_path, **self.get_load_kwargs(exclude_load_keys=exclude_load_keys)
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            # unexpected: loading failed for a reason other than "this model has no processor"
+            # (network / auth / incompatible config). Surface it -- VL models genuinely need
+            # preprocessor_config.json downstream.
+            logger.warning("Failed to load processor for %r, no processor files saved: %s", self.model_name_or_path, e)
+            return []
+
+        if isinstance(processor, PreTrainedTokenizerBase):
+            # expected for text-only models: AutoProcessor falls back to returning the
+            # tokenizer, which the tokenizer save above already handled.
+            logger.debug("No processor for %r (AutoProcessor returned a tokenizer).", self.model_name_or_path)
+            return []
+
+        try:
+            with tempfile.TemporaryDirectory(prefix="olive_processor_") as temp_dir:
+                processor.save_pretrained(temp_dir, **kwargs)
+                return self._copy_missing_files(Path(temp_dir), output_dir)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Failed to save processor files for %r: %s", self.model_name_or_path, e)
+            return []
+
+    @staticmethod
+    def _copy_missing_files(src_dir: Path, output_dir: Path) -> list[str]:
+        """Copy files from src_dir into output_dir, keeping any file that already exists there."""
+        copied_filepaths = []
+        for src_path in sorted(src_dir.rglob("*")):
+            if not src_path.is_file():
+                continue
+            dst_path = output_dir / src_path.relative_to(src_dir)
+            if dst_path.exists():
+                logger.debug("Keeping existing %s instead of overwriting it.", dst_path)
+                continue
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(src_path, dst_path)
+            copied_filepaths.append(str(dst_path))
+        return copied_filepaths
 
     def get_hf_io_config(self) -> Optional[dict[str, Any]]:
         """Get Io config for the model."""

--- a/olive/model/handler/mixin/hf.py
+++ b/olive/model/handler/mixin/hf.py
@@ -117,6 +117,26 @@ class HfMixin:
             tokenizer_filepaths = save_tokenizer(self.get_hf_tokenizer(), output_dir, **kwargs)
             saved_filepaths.extend([fp for fp in tokenizer_filepaths if Path(fp).exists()])
 
+        # save processor / image processor, skip if one already exists
+        # this writes preprocessor_config.json (and any image processor files) so downstream
+        # tools that load from this output_dir (e.g. mobius's AutoProcessor.from_pretrained)
+        # get the model's real preprocessing config instead of silently falling back to
+        # defaults. Only applicable to multimodal models (e.g. VL checkpoints); text-only
+        # models have no processor and are already covered by the tokenizer save above.
+        if not (output_dir / "preprocessor_config.json").exists():
+            try:
+                from transformers import AutoProcessor
+                from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+                processor = AutoProcessor.from_pretrained(
+                    self.model_name_or_path, **self.get_load_kwargs(exclude_load_keys=exclude_load_keys)
+                )
+                if not isinstance(processor, PreTrainedTokenizerBase):
+                    processor_filepaths = processor.save_pretrained(str(output_dir), **kwargs)
+                    saved_filepaths.extend([fp for fp in processor_filepaths if Path(fp).exists()])
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug("No processor/image processor saved for %r: %s", self.model_name_or_path, e)
+
         logger.debug("Save metadata files to %s: %s", output_dir, saved_filepaths)
 
         return saved_filepaths

--- a/test/common/hf/io_config/test_task_config.py
+++ b/test/common/hf/io_config/test_task_config.py
@@ -35,6 +35,42 @@ class TestResolveAlias:
 
         assert resolve_alias(Config(), "num_layers") is None
 
+    def test_top_level_value_wins_over_text_config_alias(self):
+        """Regression: a composite config's own top-level value must not be overridden.
+
+        Some VL-family configs (e.g. ovis2) carry both a top-level ``hidden_size`` and a
+        differing ``text_config.hidden_size``; the top-level value is authoritative and the
+        ``text_config.*`` alias is only a fallback for configs that lack it.
+        """
+
+        class TextConfig:
+            hidden_size = 4096
+            num_hidden_layers = 32
+            num_attention_heads = 32
+
+        class Config:
+            hidden_size = 1536
+            num_hidden_layers = 24
+            num_attention_heads = 12
+            text_config = TextConfig()
+
+        config = Config()
+        assert resolve_alias(config, "hidden_size") == 1536
+        assert resolve_alias(config, "num_layers") == 24
+        assert resolve_alias(config, "num_attention_heads") == 12
+
+    def test_text_config_alias_used_when_top_level_missing(self):
+        class TextConfig:
+            hidden_size = 4096
+            num_hidden_layers = 32
+
+        class Config:
+            text_config = TextConfig()
+
+        config = Config()
+        assert resolve_alias(config, "hidden_size") == 4096
+        assert resolve_alias(config, "num_layers") == 32
+
     def test_ambiguous_per_layer_attribute_resolves_to_none(self):
         """Regression: transformers 5.x per-layer configs raise on ambiguous attribute access.
 

--- a/test/common/hf/io_config/test_task_config.py
+++ b/test/common/hf/io_config/test_task_config.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from olive.common.hf.io_config.io_resolver import get_task_template, resolve_alias
+from olive.common.hf.io_config.io_resolver import _get_nested_attr, get_task_template, resolve_alias
 from olive.common.hf.io_config.task_config import (
     _build_inputs,
     generate_dummy_inputs,
@@ -34,6 +34,47 @@ class TestResolveAlias:
             pass
 
         assert resolve_alias(Config(), "num_layers") is None
+
+    def test_ambiguous_per_layer_attribute_resolves_to_none(self):
+        """Regression: transformers 5.x per-layer configs raise on ambiguous attribute access.
+
+        Gemma4-family (heterogeneous) configs raise ``AmbiguousGlobalPerLayerAttributeError``
+        -- not ``AttributeError`` -- when a per-layer attribute such as ``head_dim`` is read
+        off the top-level config. Alias resolution must degrade to ``None`` instead of
+        propagating the error.
+        """
+
+        class AmbiguousGlobalPerLayerAttributeError(Exception):
+            pass
+
+        class Config:
+            hidden_size = 1024
+
+            def __getattr__(self, name):
+                if name == "head_dim":
+                    raise AmbiguousGlobalPerLayerAttributeError(name)
+                raise AttributeError(name)
+
+        config = Config()
+        assert _get_nested_attr(config, "head_dim") is None
+        assert resolve_alias(config, "head_dim") is None
+        # unrelated attributes still resolve normally
+        assert resolve_alias(config, "hidden_size") == 1024
+
+    def test_ambiguous_per_layer_attribute_real_transformers_exception(self):
+        """Same as above, but with the real transformers exception type when available."""
+        heterogeneity = pytest.importorskip("transformers.integrations.heterogeneity.configuration_utils")
+        error_cls = getattr(heterogeneity, "AmbiguousGlobalPerLayerAttributeError", None)
+        if error_cls is None:
+            pytest.skip("transformers version has no AmbiguousGlobalPerLayerAttributeError")
+
+        class Config:
+            def __getattr__(self, name):
+                if name == "head_dim":
+                    raise error_cls(name)
+                raise AttributeError(name)
+
+        assert resolve_alias(Config(), "head_dim") is None
 
 
 class TestGetIOConfig:

--- a/test/common/quant/test_selection.py
+++ b/test/common/quant/test_selection.py
@@ -254,6 +254,102 @@ def test_moe_enabled_yields_only_3d_weights_and_skips_2d_bias(monkeypatch):
     assert all(module._parameters[pname].dim() == 3 for module, pname, _ in targets)
 
 
+def test_shared_expert_gate_excluded_from_quantization(monkeypatch):
+    """Verify ``SHARED_EXPERT_GATE``-mapped modules are excluded from quantization.
+
+    Covers qwen2_moe/qwen3_5_moe/qwen3_next-style single-row sigmoid gates, which must be
+    excluded the same way routers are, regardless of ``quantize_moe``.
+    """
+    from olive.common.hf import wrapper as wrapper_mod
+
+    class FusedExperts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_up_proj = nn.Parameter(torch.zeros(4, 8, 16), requires_grad=False)
+
+    class _Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.experts = FusedExperts()
+            self.shared_expert_gate = nn.Linear(8, 1, bias=False)
+            self.other_linear = nn.Linear(8, 8, bias=False)
+
+    class FakeLayerWrapper:
+        def __init__(self, experts, gate):
+            self._experts = experts
+            self._gate = gate
+
+        def get_experts(self, return_name=True):
+            return (self._experts, "experts") if return_name else self._experts
+
+        def get_shared_expert_gate(self, return_name=True):
+            return (self._gate, "shared_expert_gate") if return_name else self._gate
+
+    class FakeWrapper:
+        def __init__(self, model):
+            self.model = model
+
+        def get_layer_wrappers(self):
+            return [FakeLayerWrapper(self.model.experts, self.model.shared_expert_gate)]
+
+    monkeypatch.setattr(wrapper_mod.ModelWrapper, "from_model", classmethod(lambda cls, m: FakeWrapper(m)))
+
+    m = _Model()
+    targets = list(iter_quant_targets(m, quantize_lm_head=True, quantize_embeds=True, quantize_moe=True))
+    assert _names(targets) == ["experts.gate_up_proj", "other_linear"]
+
+
+def test_mamba_linear_attn_excluded_from_quantization(monkeypatch):
+    """Verify ``MAMBA``-mapped modules are excluded from the generic 2D quantization walk.
+
+    Includes qwen3_5_moe's ``linear_attn`` GatedDeltaNet block, which must be excluded
+    unconditionally.
+    """
+    from olive.common.hf import wrapper as wrapper_mod
+
+    class FusedExperts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_up_proj = nn.Parameter(torch.zeros(4, 8, 16), requires_grad=False)
+
+    class LinearAttn(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.in_proj_qkv = nn.Linear(8, 24, bias=False)
+            self.out_proj = nn.Linear(8, 8, bias=False)
+
+    class _Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.experts = FusedExperts()
+            self.linear_attn = LinearAttn()
+            self.other_linear = nn.Linear(8, 8, bias=False)
+
+    class FakeLayerWrapper:
+        def __init__(self, experts, mamba):
+            self._experts = experts
+            self._mamba = mamba
+
+        def get_experts(self, return_name=True):
+            return (self._experts, "experts") if return_name else self._experts
+
+        def get_mamba(self, return_name=True):
+            return (self._mamba, "linear_attn") if return_name else self._mamba
+
+    class FakeWrapper:
+        def __init__(self, model):
+            self.model = model
+
+        def get_layer_wrappers(self):
+            return [FakeLayerWrapper(self.model.experts, self.model.linear_attn)]
+
+    monkeypatch.setattr(wrapper_mod.ModelWrapper, "from_model", classmethod(lambda cls, m: FakeWrapper(m)))
+
+    m = _Model()
+    targets = list(iter_quant_targets(m, quantize_lm_head=True, quantize_embeds=True, quantize_moe=True))
+    assert _names(targets) == ["experts.gate_up_proj", "other_linear"]
+
+
 def test_modulelist_experts_moe_flag_controls_selection(monkeypatch):
     """Regression (ModuleList bug): per-expert Linears are quantized iff ``moe=True``."""
     m = _ExpertList()

--- a/test/common/quant/test_selection.py
+++ b/test/common/quant/test_selection.py
@@ -695,3 +695,59 @@ def test_gptq_then_rtn_moe_composition_skips_already_quantized(monkeypatch):
     assert m.q_proj.weight.data.bits == 8
     assert isinstance(m.o_proj.weight.data, QuantTensor)
     assert m.o_proj.weight.data.bits == 8
+
+
+class _VisionTower(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.patch_embed = nn.Linear(8, 8, bias=False)
+        self.blocks = nn.ModuleList([nn.Linear(8, 8, bias=False)])
+        self.merger = nn.Linear(8, 8, bias=False)
+
+
+class _VLModel(nn.Module):
+    """Composite VL model: decoder under ``model.language_model``, tower under ``model.visual``."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.model = nn.Module()
+        self.model.language_model = nn.Module()
+        self.model.language_model.embed_tokens = nn.Embedding(16, 8)
+        self.model.language_model.linear = nn.Linear(8, 8, bias=False)
+        self.model.visual = _VisionTower()
+        self.lm_head = nn.Linear(8, 16, bias=False)
+
+    def get_input_embeddings(self):
+        return self.model.language_model.embed_tokens
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+class _FakeConfig:
+    def __init__(self, vision_config=None):
+        self.vision_config = vision_config
+
+
+def test_vision_tower_excluded_for_composite_vl_model():
+    """Regression: a VL model's vision tower must not be a PyTorch-side quantization target.
+
+    The vision encoder is quantized separately (int8) downstream; including it here would
+    double-quantize it.
+    """
+    m = _VLModel(_FakeConfig(vision_config=_FakeConfig()))
+    targets = list(iter_quant_targets(m, quantize_lm_head=True, quantize_embeds=True, quantize_moe=True))
+    assert _names(targets) == [
+        "lm_head",
+        "model.language_model.embed_tokens",
+        "model.language_model.linear",
+    ]
+    assert not any(name.startswith("model.visual") for _, _, name in targets)
+
+
+def test_vision_named_modules_kept_when_config_has_no_vision_config():
+    """Text-only models are unaffected: nothing is excluded by name alone."""
+    m = _VLModel(_FakeConfig(vision_config=None))
+    targets = list(iter_quant_targets(m, quantize_lm_head=False, quantize_embeds=False, quantize_moe=False))
+    assert "model.visual.merger" in _names(targets)

--- a/test/common/test_hf_wrapper.py
+++ b/test/common/test_hf_wrapper.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 import pytest
 from torch import nn
+from transformers import PretrainedConfig
 
 from olive.common.hf.wrapper import ModelWrapper
 from test.utils import get_tiny_phi3, make_local_tiny_llama
@@ -137,3 +138,73 @@ def test_hf_wrapper_lfm2():
     # LFM2 must have both layer types
     assert has_attn_layer, "Expected at least one attention layer"
     assert has_conv_layer, "Expected at least one conv layer"
+
+
+def test_hf_wrapper_composite_vl_config():
+    """Composite VL configs (e.g. Qwen3.5/3.6-MoE VL) nest decoder attributes under ``text_config``.
+
+    Verifies the ``text_config.*`` alias fallbacks in ``defaults.yaml`` resolve them, and the
+    ``qwen3_5_moe`` entries in ``LAYERS``/``EMBEDDINGS``/``PRE_HEAD_LAYERNORM``/
+    ``ROTARY_EMBEDDING`` point at the VL decoder's actual nested module path
+    (``model.language_model.*``), without needing to download/load any real model or weights.
+
+    ``text_config``/``vision_config`` must be actual (attribute-accessible) nested
+    ``PretrainedConfig`` objects here -- as real composite VL config classes (e.g.
+    ``Qwen3_5MoeConfig``) construct them -- not plain dicts, since ``resolve_alias``'s nested
+    path lookup uses ``getattr``, not dict indexing.
+    """
+    text_config = PretrainedConfig()
+    text_config.hidden_size = 2048
+    text_config.num_hidden_layers = 40
+    text_config.num_attention_heads = 16
+    text_config.num_key_value_heads = 2
+    text_config.head_dim = 256
+    text_config.num_experts = 256
+
+    vision_config = PretrainedConfig()
+    vision_config.hidden_size = 1152
+
+    composite_config = PretrainedConfig()
+    composite_config.model_type = "qwen3_5_moe"
+    composite_config.text_config = text_config
+    composite_config.vision_config = vision_config
+
+    model_wrapper = ModelWrapper(composite_config)
+
+    assert model_wrapper.model_type == "qwen3_5_moe"
+    assert model_wrapper.hidden_size == 2048
+    assert model_wrapper.num_attention_heads == 16
+    assert model_wrapper.num_key_value_heads == 2
+    assert model_wrapper.head_dim == 256
+    assert model_wrapper.num_hidden_layers == 40
+
+    assert model_wrapper.LAYERS[model_wrapper.model_type] == "model.language_model.layers"
+    assert model_wrapper.EMBEDDINGS[model_wrapper.model_type] == ["model.language_model.embed_tokens"]
+    assert model_wrapper.PRE_HEAD_LAYERNORM[model_wrapper.model_type] == "model.language_model.norm"
+    assert model_wrapper.ROTARY_EMBEDDING[model_wrapper.model_type] == "model.language_model.rotary_emb"
+
+
+def test_hf_wrapper_text_only_config_unaffected_by_vl_aliases():
+    """Verify the flat text-only Qwen3.5/3.6 config resolves exactly as before.
+
+    ``model_type == "qwen3_5_moe_text"`` already has flat attributes matching the "default"
+    aliases, and has no ``qwen3_5_moe`` entry in the ``LAYERS``/etc. mappings (a different
+    model_type), so the VL-specific additions must not change its resolution.
+    """
+    text_only_config = {
+        "model_type": "qwen3_5_moe_text",
+        "hidden_size": 2048,
+        "num_hidden_layers": 40,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 2,
+        "head_dim": 256,
+        "num_experts": 256,
+    }
+
+    model_wrapper = ModelWrapper(text_only_config)
+
+    assert model_wrapper.model_type == "qwen3_5_moe_text"
+    assert model_wrapper.hidden_size == 2048
+    assert model_wrapper.num_hidden_layers == 40
+    # No "qwen3_5_moe_text" entry in LAYERS/EMBEDDINGS/etc. -- falls back to "default".
+    assert model_wrapper.LAYERS.get(model_wrapper.model_type, model_wrapper.LAYERS["default"]) == "model.layers"

--- a/test/common/test_hf_wrapper.py
+++ b/test/common/test_hf_wrapper.py
@@ -208,3 +208,99 @@ def test_hf_wrapper_text_only_config_unaffected_by_vl_aliases():
     assert model_wrapper.num_hidden_layers == 40
     # No "qwen3_5_moe_text" entry in LAYERS/EMBEDDINGS/etc. -- falls back to "default".
     assert model_wrapper.LAYERS.get(model_wrapper.model_type, model_wrapper.LAYERS["default"]) == "model.layers"
+
+
+def test_hf_wrapper_flat_text_only_qwen3_5_moe_config():
+    """Regression: flat text-only checkpoints also report ``model_type == "qwen3_5_moe"``.
+
+    Only the composite VL checkpoint nests its decoder under ``model.language_model``; a
+    text-only ``Qwen3_5MoeForCausalLM`` checkpoint keeps the flat ``model.layers`` layout
+    while still reporting ``model_type == "qwen3_5_moe"``. The two are disambiguated by the
+    presence of a ``vision_config`` (same rule mobius uses), so the flat config must resolve
+    the "default" module paths instead of crashing on the VL-only paths.
+    """
+
+    class _Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.self_attn = nn.Module()
+            self.mlp = nn.Module()
+
+    class _FlatQwenMoE(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.model = nn.Module()
+            self.model.embed_tokens = nn.Embedding(16, 8)
+            self.model.layers = nn.ModuleList([_Layer(), _Layer()])
+            self.model.norm = nn.LayerNorm(8)
+            self.lm_head = nn.Linear(8, 16, bias=False)
+
+    flat_config = PretrainedConfig()
+    flat_config.model_type = "qwen3_5_moe"
+    flat_config.hidden_size = 2048
+    flat_config.num_hidden_layers = 2
+    flat_config.num_attention_heads = 16
+    flat_config.num_key_value_heads = 2
+    flat_config.head_dim = 256
+    flat_config.num_experts = 256
+
+    model_wrapper = ModelWrapper(flat_config)
+
+    # normalized to the text-only model_type, so the flat "default" paths are used
+    assert model_wrapper.model_type == "qwen3_5_moe_text"
+    assert model_wrapper.hidden_size == 2048
+    assert model_wrapper.head_dim == 256
+
+    model = _FlatQwenMoE(flat_config)
+    model_wrapper.set_model(model)
+
+    assert model_wrapper.get_layers(False) is model.model.layers
+    assert model_wrapper.get_embeds(False)[0] is model.model.embed_tokens
+    assert model_wrapper.get_pre_head_layernorm(False) is model.model.norm
+    assert model_wrapper.get_lm_head(False) is model.lm_head
+
+
+def test_hf_wrapper_vl_qwen3_5_moe_config_uses_nested_paths():
+    """The composite VL config (has ``vision_config``) keeps the nested decoder paths."""
+
+    class _Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.self_attn = nn.Module()
+            self.mlp = nn.Module()
+
+    class _VLQwenMoE(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.model = nn.Module()
+            self.model.language_model = nn.Module()
+            self.model.language_model.embed_tokens = nn.Embedding(16, 8)
+            self.model.language_model.layers = nn.ModuleList([_Layer()])
+            self.model.language_model.norm = nn.LayerNorm(8)
+            self.model.visual = nn.Module()
+            self.model.visual.proj = nn.Linear(8, 8, bias=False)
+            self.lm_head = nn.Linear(8, 16, bias=False)
+
+    text_config = PretrainedConfig()
+    text_config.hidden_size = 2048
+    text_config.num_hidden_layers = 1
+    text_config.num_attention_heads = 16
+    text_config.num_key_value_heads = 2
+    text_config.head_dim = 256
+
+    vl_config = PretrainedConfig()
+    vl_config.model_type = "qwen3_5_moe"
+    vl_config.text_config = text_config
+    vl_config.vision_config = PretrainedConfig()
+
+    model_wrapper = ModelWrapper(vl_config)
+    assert model_wrapper.model_type == "qwen3_5_moe"
+
+    model = _VLQwenMoE(vl_config)
+    model_wrapper.set_model(model)
+
+    assert model_wrapper.get_layers(False) is model.model.language_model.layers
+    assert model_wrapper.get_embeds(False)[0] is model.model.language_model.embed_tokens
+    assert model_wrapper.get_pre_head_layernorm(False) is model.model.language_model.norm

--- a/test/model/test_hf_model.py
+++ b/test/model/test_hf_model.py
@@ -100,6 +100,51 @@ class TestHFModel:
         }
 
 
+def test_save_metadata_saves_processor_for_vl_model(tmp_path):
+    """save_metadata should save preprocessor_config.json for multimodal models.
+
+    Uses a mocked AutoProcessor since there's no lightweight real VL checkpoint fixture
+    available; verifies the processor.save_pretrained output is captured and the
+    tokenizer-like AutoProcessor return value (text-only models) is correctly skipped.
+    """
+    olive_model = HfModelHandler(
+        model_path="katuni4ka/tiny-random-phi3",
+        task="text-generation-with-past",
+        load_kwargs={"revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"},
+    )
+
+    processor_config_path = tmp_path / "preprocessor_config.json"
+
+    class FakeProcessor:
+        def save_pretrained(self, output_dir, **kwargs):
+            path = Path(output_dir) / "preprocessor_config.json"
+            path.write_text("{}")
+            return [str(path)]
+
+    with patch("transformers.AutoProcessor.from_pretrained", return_value=FakeProcessor()):
+        saved_filepaths = olive_model.save_metadata(tmp_path)
+
+    assert str(processor_config_path) in saved_filepaths
+    assert processor_config_path.exists()
+
+
+def test_save_metadata_skips_processor_when_already_saved(tmp_path):
+    """save_metadata should not call AutoProcessor.from_pretrained if a processor config already exists."""
+    olive_model = HfModelHandler(
+        model_path="katuni4ka/tiny-random-phi3",
+        task="text-generation-with-past",
+        load_kwargs={"revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"},
+    )
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "preprocessor_config.json").write_text("{}")
+
+    with patch("transformers.AutoProcessor.from_pretrained") as mock_from_pretrained:
+        olive_model.save_metadata(tmp_path)
+
+    mock_from_pretrained.assert_not_called()
+
+
 @pytest.mark.parametrize("trust_remote_code", [True, False])
 def test_save_metadata_with_module_files(trust_remote_code, tmp_path):
     load_kwargs = {"trust_remote_code": trust_remote_code, "revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"}

--- a/test/model/test_hf_model.py
+++ b/test/model/test_hf_model.py
@@ -205,7 +205,7 @@ def test_save_metadata_skips_tokenizer_return_silently(tmp_path):
     ):
         olive_model.save_metadata(tmp_path)
 
-    assert warnings == []
+    assert not warnings
     assert not (tmp_path / "preprocessor_config.json").exists()
 
 

--- a/test/model/test_hf_model.py
+++ b/test/model/test_hf_model.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import json
+import logging
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import ANY, patch
 
@@ -143,6 +145,99 @@ def test_save_metadata_skips_processor_when_already_saved(tmp_path):
         olive_model.save_metadata(tmp_path)
 
     mock_from_pretrained.assert_not_called()
+
+
+@contextmanager
+def capture_warnings(logger_name: str):
+    """Collect warning-or-worse records from ``logger_name`` (Olive loggers don't propagate)."""
+    records: list[str] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    logger = logging.getLogger(logger_name)
+    handler = _Handler(level=logging.WARNING)
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+
+def test_save_metadata_warns_on_unexpected_processor_failure(tmp_path):
+    """An unexpected AutoProcessor failure must be visible, not silently swallowed at debug level."""
+    olive_model = HfModelHandler(
+        model_path="katuni4ka/tiny-random-phi3",
+        task="text-generation-with-past",
+        load_kwargs={"revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"},
+    )
+
+    with (
+        patch("transformers.AutoProcessor.from_pretrained", side_effect=RuntimeError("boom")),
+        capture_warnings("olive.model.handler.mixin.hf") as warnings,
+    ):
+        saved_filepaths = olive_model.save_metadata(tmp_path)
+
+    assert any("boom" in message for message in warnings)
+    assert not (tmp_path / "preprocessor_config.json").exists()
+    # the rest of the metadata is still saved
+    assert str(tmp_path / "config.json") in saved_filepaths
+
+
+def test_save_metadata_skips_tokenizer_return_silently(tmp_path):
+    """Text-only models: AutoProcessor returns the tokenizer -- expected, so no warning."""
+    olive_model = HfModelHandler(
+        model_path="katuni4ka/tiny-random-phi3",
+        task="text-generation-with-past",
+        load_kwargs={"revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"},
+    )
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "katuni4ka/tiny-random-phi3", revision="585361abfee667f3c63f8b2dc4ad58405c4e34e2"
+    )
+    with (
+        patch("transformers.AutoProcessor.from_pretrained", return_value=tokenizer),
+        capture_warnings("olive.model.handler.mixin.hf") as warnings,
+    ):
+        olive_model.save_metadata(tmp_path)
+
+    assert warnings == []
+    assert not (tmp_path / "preprocessor_config.json").exists()
+
+
+def test_save_metadata_processor_does_not_overwrite_custom_tokenizer(tmp_path):
+    """A processor save must not clobber a tokenizer an earlier step customized and saved."""
+    olive_model = HfModelHandler(
+        model_path="katuni4ka/tiny-random-phi3",
+        task="text-generation-with-past",
+        load_kwargs={"revision": "585361abfee667f3c63f8b2dc4ad58405c4e34e2"},
+    )
+
+    custom_tokenizer_config = '{"custom": true}'
+    (tmp_path / "tokenizer_config.json").write_text(custom_tokenizer_config)
+
+    class FakeProcessor:
+        """Mimics ProcessorMixin.save_pretrained, which also re-saves the tokenizer."""
+
+        def save_pretrained(self, output_dir, **kwargs):
+            out = Path(output_dir)
+            (out / "preprocessor_config.json").write_text('{"image_processor": true}')
+            (out / "tokenizer_config.json").write_text('{"custom": false}')
+            (out / "tokenizer.json").write_text("{}")
+            return [str(out / "preprocessor_config.json")]
+
+    with patch("transformers.AutoProcessor.from_pretrained", return_value=FakeProcessor()):
+        saved_filepaths = olive_model.save_metadata(tmp_path)
+
+    # the pre-existing tokenizer config is untouched, the processor config is new
+    assert (tmp_path / "tokenizer_config.json").read_text() == custom_tokenizer_config
+    assert (tmp_path / "preprocessor_config.json").read_text() == '{"image_processor": true}'
+    assert str(tmp_path / "preprocessor_config.json") in saved_filepaths
+    assert str(tmp_path / "tokenizer_config.json") not in saved_filepaths
 
 
 @pytest.mark.parametrize("trust_remote_code", [True, False])


### PR DESCRIPTION
## Summary

Enables Olive's PyTorch-side quantization passes (`Rtn`/`GPTQ`/`KQuant`, via `ModelWrapper`/`iter_quant_targets`) to work on a Qwen3.5/3.6-MoE checkpoint loaded as its **vision-language** class (`Qwen3_5MoeForConditionalGeneration`, `task="image-text-to-text"`), instead of only the text-only decoder class (`Qwen3_5MoeForCausalLM`) that was previously supported.

### Root cause

Two structural gaps, both purely data/mapping issues (no PyTorch quantization logic needed to change):

1. **Composite config resolution**: the VL checkpoint's top-level `config` has no flat `hidden_size`/`num_hidden_layers`/`num_attention_heads`/`num_key_value_heads`/`head_dim` — they live under `config.text_config`. `ModelWrapper.__init__` resolved these to `None` and crashed with a `TypeError`.
2. **Decoder module path**: the VL decoder is nested at `model.language_model.*` (alongside `model.visual`, the vision tower), not `model.*` directly, so `LAYERS`/`EMBEDDINGS`/`PRE_HEAD_LAYERNORM`/`ROTARY_EMBEDDING` couldn't resolve it.

### Fix

- `olive/assets/io_configs/defaults.yaml`: add `text_config.*` fallbacks for `num_layers`, `hidden_size`, `num_attention_heads`, `num_kv_heads` (mirrors the existing `num_experts` nested-fallback pattern), plus a new `head_dim` alias.
- `olive/common/hf/wrapper.py`: add a `"qwen3_5_moe"` entry to `LAYERS`/`EMBEDDINGS`/`PRE_HEAD_LAYERNORM`/`ROTARY_EMBEDDING` pointing at `model.language_model.*`. Scoped to the VL `model_type` only — the text-only checkpoint carries `model_type == "qwen3_5_moe_text"` and its flat config already matches `"default"`, so it is unaffected (see `test_hf_wrapper_text_only_config_unaffected_by_vl_aliases`).

### Two pre-existing (non-VL-specific) quantization gaps, found while validating the above

Both reproduce identically on the text-only checkpoint too, but affect Qwen3.5/3.6-MoE quantization quality generally:

- `MAMBA` mapping didn't recognize this architecture's `linear_attn` (GatedDeltaNet) attribute name, so its projections (`in_proj_qkv`/`in_proj_a`/`in_proj_b`/`in_proj_z`/`out_proj`) were swept into the generic 2D quantization walk instead of staying full precision like other Mamba/SSM blocks.
- Added a `SHARED_EXPERT_GATE` mapping + `LayerWrapper.get_shared_expert_gate()` accessor (also applicable to `qwen2_moe`/`qwen3_next`/`qwen3_omni_moe`, which use the same attribute name) and wired it into `iter_quant_targets`'s exclusion set — the single-row shared-expert sigmoid gate was being quantized like an ordinary `Linear`, despite being a routing-like signal (same reasoning as excluding the main router).

## Verification

- Confirmed against the real `Qwen/Qwen3.6-35B-A3B` checkpoint's config: alias/mapping resolution (`hidden=2048 heads=16 kv=2 head_dim=256 layers=40`, decoder path `model.language_model.layers`) now matches expectations exactly.
- Built a shape-faithful synthetic VL checkpoint (206M params, real vision tower + 4-layer MoE decoder) and ran the actual `Rtn` pass end-to-end (`bits=4, group_size=32, moe=True, modules_to_not_convert=["visual"]`):
  - `mlp.experts.*` (fused 3D MoE weights) — quantized ✅
  - `mlp.gate` (router), `mlp.shared_expert_gate`, `linear_attn.*` — full precision, untouched ✅
  - `model.visual.*` (vision tower) — 0 quant artifacts ✅
  - Reload of the quantized checkpoint via `HfModelHandler` succeeds.
- Added 5 new unit tests covering composite-config resolution, text-only-path non-regression, and `linear_attn`/`shared_expert_gate` exclusion.
- Full relevant suite: `test/common/`, `test/passes/pytorch/test_rtn.py`, `test/model/` — 622+ passed, 0 regressions (pre-existing unrelated `azure` module errors only). `lintrunner` clean (only the repo-wide `CPY001` false positive).

## Files

- `olive/assets/io_configs/defaults.yaml`
- `olive/common/hf/wrapper.py`
- `olive/common/quant/selection.py`
- `test/common/test_hf_wrapper.py`
- `test/common/quant/test_selection.py`