### PR TITLE
[QNN] Improve GPU StaticLLM pass

### DIFF
--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -809,7 +809,7 @@ def update_llm_pipeline_genai_config_gpu(
     """
     output_model_dir = Path(output_model_dir)
 
-    additional_files = model.model_attributes["additional_files"]
+    additional_files = model.model_attributes.get("additional_files") or []
     genai_config_path = None
     for file_path in additional_files:
         if Path(file_path).name == "genai_config.json":

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -860,7 +860,10 @@ def update_llm_pipeline_genai_config_gpu(
             "filename": Path(single_handler.model_path).name,
             "inputs": component_io_config["input_names"],
             "outputs": component_io_config["output_names"],
+            "inherit_session_options": True,
         }
+
+        last_model_path = single_handler.model_path
 
     else:
         # Composite case: one entry per component
@@ -870,13 +873,39 @@ def update_llm_pipeline_genai_config_gpu(
                 "filename": Path(comp_handler.model_path).name,
                 "inputs": component_io_config["input_names"],
                 "outputs": component_io_config["output_names"],
+                "inherit_session_options": True,
             }
             if comp_name.endswith("decode"):
                 pipeline_config[comp_name]["run_on_prompt"] = False
             else:
                 pipeline_config[comp_name]["run_on_token_gen"] = False
 
+            last_model_path = comp_handler.model_path
+
     decoder_config["pipeline"] = [pipeline_config]
+
+    # Update the genai_config to reflect fixed max sequence length
+    key_template = decoder_config["inputs"]["past_key_names"]
+
+    try:
+        # The template uses printf-style format specifiers with the expectation
+        # of one slot for the index. So, use the old style '%' operator which
+        # handles this out-of-the-box.
+        past_key_0_name = key_template % (0,)
+    except TypeError:
+        logger.warning("Failed to update max sequence length in genai_config.json. Unexpected key template format.")
+    else:
+        inputs = onnx.load(last_model_path, load_external_data=False).graph.input
+        past_key_0_input, *_ = [inp for inp in inputs if inp.name == past_key_0_name]
+
+        shape = past_key_0_input.type.tensor_type.shape
+
+        # Only update if the sequence length dimension is fixed (which is expected
+        # for QNN).
+        if shape.dim[2].HasField("dim_value"):
+            max_length = shape.dim[2].dim_value
+            genai_config["model"]["context_length"] = max_length
+            genai_config["search"]["max_length"] = max_length
 
     # save the updated genai_config
     new_genai_config_path = output_model_dir / "genai_config.json"

--- a/olive/passes/onnx/context_binary.py
+++ b/olive/passes/onnx/context_binary.py
@@ -61,14 +61,6 @@ class EPContextBinaryGenerator(Pass):
                 default_value=False,
                 description="Whether to disable CPU fallback.",
             ),
-            "update_genai_config": PassConfigParam(
-                type_=bool,
-                default_value=False,
-                description=(
-                    "Whether to update the genai_config.json pipeline entry for the generated context binary."
-                    " Only applicable to QNN GPU."
-                ),
-            ),
         }
 
     @staticmethod
@@ -125,7 +117,6 @@ class EPContextBinaryGenerator(Pass):
             "session_options": config.session_options,
             "embed_context": config.embed_context,
             "disable_cpu_fallback": config.disable_cpu_fallback,
-            "update_genai_config": config.update_genai_config,
             "model": model,
         }
 
@@ -282,7 +273,6 @@ class EPContextBinaryGenerator(Pass):
         share_ep_contexts: bool = False,
         stop_share_ep_contexts: bool = False,
         ignore_missing_cb_bin: bool = False,
-        update_genai_config: bool = False,
         model: Optional[Union[ONNXModelHandler, CompositeModelHandler]] = None,
         logical_name: Optional[str] = None,
     ) -> ONNXModelHandler:
@@ -297,7 +287,6 @@ class EPContextBinaryGenerator(Pass):
         :param share_ep_contexts: Whether to share EP contexts.
         :param stop_share_ep_contexts: Whether to stop sharing EP contexts.
         :param ignore_missing_cb_bin: Whether to ignore missing context binary files.
-        :param update_genai_config: Whether to update the genai_config.json pipeline entry (QNN GPU only).
         :param logical_name: Component's logical name used to update genai_config.json.
         :return: ONNXModelHandler for the generated context binary.
         """
@@ -315,13 +304,12 @@ class EPContextBinaryGenerator(Pass):
         if execution_provider == ExecutionProvider.QNNExecutionProvider:
             if str(device).lower() == "gpu":
                 provider_options["backend_path"] = "libQnnGpu.so" if platform.system() == "Linux" else "QnnGpu.dll"
-                if update_genai_config:
-                    ctxbin_path = (
-                        Path(output_model_path).with_name(f"{logical_name}.onnx")
-                        if logical_name
-                        else Path(output_model_path)
-                    )
-                    update_llm_pipeline_genai_config_gpu_ctxbin(model, ctxbin_path)
+                ctxbin_path = (
+                    Path(output_model_path).with_name(f"{logical_name}.onnx")
+                    if logical_name
+                    else Path(output_model_path)
+                )
+                update_llm_pipeline_genai_config_gpu_ctxbin(model, ctxbin_path)
             else:
                 provider_options["backend_path"] = "libQnnHtp.so" if platform.system() == "Linux" else "QnnHtp.dll"
                 if share_ep_contexts:

--- a/olive/passes/onnx/static_llm.py
+++ b/olive/passes/onnx/static_llm.py
@@ -253,7 +253,7 @@ class StaticLLM(Pass):
             # instead of a concrete dim in the KV cache shapes. Fix this dim with the
             # head size defined in genai_config.json.
             if model.model_attributes is not None:
-                additional_files = model.model_attributes["additional_files"]
+                additional_files = model.model_attributes.get("additional_files") or []
                 genai_config_path = None
                 for file_path in additional_files:
                     if Path(file_path).name == "genai_config.json":

--- a/olive/passes/onnx/static_llm.py
+++ b/olive/passes/onnx/static_llm.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+import json
 import logging
 from copy import deepcopy
 from pathlib import Path
@@ -81,14 +82,6 @@ class StaticLLM(Pass):
                 type_=dict,
                 description=(
                     "Session options for the context and iterator models. Only used for models with genai_config."
-                ),
-            ),
-            "update_genai_config": PassConfigParam(
-                type_=bool,
-                default_value=False,
-                description=(
-                    "Whether to update the genai_config.json pipeline for the generated static LLM model(s)."
-                    " Only applicable to QNN GPU."
                 ),
             ),
         }
@@ -255,6 +248,25 @@ class StaticLLM(Pass):
 
             # --- Step 3: Fix symbolic dimensions for this context length ---
             param_mapping = {batch_size: config.batch_size, sequence_length: ctx_len}
+
+            # As of onnxruntime-genai 0.15, the ModelBuilder pass uses "kv_cache_dim"
+            # instead of a concrete dim in the KV cache shapes. Fix this dim with the
+            # head size defined in genai_config.json.
+            if model.model_attributes is not None:
+                additional_files = model.model_attributes["additional_files"]
+                genai_config_path = None
+                for file_path in additional_files:
+                    if Path(file_path).name == "genai_config.json":
+                        genai_config_path = file_path
+                        break
+
+                if genai_config_path:
+                    with open(genai_config_path) as f:
+                        genai_config = json.load(f)
+
+                    head_size = genai_config["model"]["decoder"]["head_size"]
+                    param_mapping["kv_cache_dim"] = head_size
+
             self.fix_shape(model_proto, param_mapping)
 
             add_version_metadata_to_model_proto(model_proto)
@@ -316,9 +328,6 @@ class StaticLLM(Pass):
                 },
             }
 
-            if not config.update_genai_config:
-                return handler
-
             return update_llm_pipeline_genai_config_gpu(
                 model=handler,
                 output_model_dir=output_model_dir,
@@ -343,9 +352,6 @@ class StaticLLM(Pass):
         composite = CompositeModelHandler(
             model_components=components, model_component_names=component_names, model_attributes=new_model_attributes
         )
-
-        if not config.update_genai_config:
-            return composite
 
         # Build per-component sliding_window config keyed by name
         composite_decoder_extra = {

--- a/test/passes/onnx/test_static_llm.py
+++ b/test/passes/onnx/test_static_llm.py
@@ -4,10 +4,25 @@
 # --------------------------------------------------------------------------
 import json
 
+import onnx
+import pytest
+
+from olive.hardware import Device
+from olive.hardware.accelerator import AcceleratorSpec
+from olive.hardware.constants import ExecutionProvider
 from olive.model import CompositeModelHandler, ONNXModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.static_llm import StaticLLM
 from test.utils import make_local_tiny_llama
+
+
+def _assert_static_io_shapes(model: ONNXModelHandler):
+    model_proto = onnx.load(model.model_path, load_external_data=False)
+
+    for value_info in [*model_proto.graph.input, *model_proto.graph.output]:
+        shape = value_info.type.tensor_type.shape
+        dynamic_dims = [dim.dim_param or "<unknown>" for dim in shape.dim if not dim.HasField("dim_value")]
+        assert not dynamic_dims, f"{value_info.name} has dynamic dimensions: {dynamic_dims}"
 
 
 def test_static_llm(tmp_path):
@@ -64,3 +79,118 @@ def test_static_llm(tmp_path):
     assert set(genai_config["model"]["decoder"]["pipeline"][0].keys()) == set(output_model.model_component_names)
     assert not genai_config["model"]["decoder"]["pipeline"][0]["context_0"]["run_on_token_gen"]
     assert not genai_config["model"]["decoder"]["pipeline"][0]["iterator_0"]["run_on_prompt"]
+
+
+class TestStaticLlmQnnGpu:
+    @pytest.fixture(scope="class")
+    def setup_model(self, tmp_path_factory):
+        from olive.passes.onnx.dynamic_to_fixed_shape import DynamicToFixedShape
+        from olive.passes.onnx.graph_surgeries import GraphSurgeries
+        from olive.passes.onnx.model_builder import ModelBuilder
+
+        setup_path = tmp_path_factory.mktemp("static_llm_qnn_gpu")
+
+        pytorch_model = make_local_tiny_llama(setup_path / "input_model")
+        onnx_model = create_pass_from_dict(ModelBuilder, {"precision": "fp32"}, disable_search=True).run(
+            pytorch_model, setup_path / "onnx_model"
+        )
+        post_op_model = create_pass_from_dict(
+            GraphSurgeries,
+            {
+                "surgeries": [
+                    {"surgeon": "RemoveRopeMultiCache"},
+                    {"surgeon": "AttentionMaskToSequenceLengths"},
+                    {"surgeon": "SimplifiedLayerNormToRMSNorm"},
+                ]
+            },
+            disable_search=True,
+        ).run(onnx_model, setup_path / "post_op_model")
+
+        return create_pass_from_dict(
+            DynamicToFixedShape,
+            {"dim_param": ["past_sequence_length"], "dim_value": [4096]},
+            disable_search=True,
+        ).run(post_op_model, setup_path / "fixed_context_len_model")
+
+    def test_prefill_decode_models(self, setup_model, tmp_path):
+        accelerator_spec = AcceleratorSpec(
+            accelerator_type=Device.GPU,
+            execution_provider=ExecutionProvider.QNNExecutionProvider,
+        )
+
+        p = create_pass_from_dict(
+            StaticLLM,
+            {
+                "batch_size": 1,
+                "context_length": 128,
+                "prefill_decode_models": True,
+            },
+            disable_search=True,
+            accelerator_spec=accelerator_spec,
+        )
+
+        # run
+        output_model_path = tmp_path / "output_model"
+        output_model = p.run(setup_model, output_model_path)
+
+        # check
+        assert isinstance(output_model, CompositeModelHandler)
+        model_components = list(output_model.model_components)
+        assert all(isinstance(m, ONNXModelHandler) for m in model_components)
+        assert len(model_components) == 2
+        with (output_model_path / "genai_config.json").open() as f:
+            genai_config = json.load(f)
+        assert genai_config["model"]["type"] == "decoder-pipeline"
+        for i_name in ["input_ids", "past_sequence_length"]:
+            assert i_name in genai_config["model"]["decoder"]["inputs"]
+        assert genai_config["model"]["decoder"]["sliding_window"]["window_size"] == 128
+
+        pipeline_config = genai_config["model"]["decoder"]["pipeline"][0]
+        assert set(pipeline_config.keys()) == {"prefill", "decode"}
+        assert not pipeline_config["prefill"]["run_on_token_gen"]
+        assert not pipeline_config["decode"]["run_on_prompt"]
+        assert pipeline_config["prefill"]["inherit_session_options"]
+        assert pipeline_config["decode"]["inherit_session_options"]
+        assert genai_config["model"]["context_length"] == 4096
+        assert genai_config["search"]["max_length"] == 4096
+
+        for model_component in model_components:
+            _assert_static_io_shapes(model_component)
+
+    def test_single_model(self, setup_model, tmp_path):
+        accelerator_spec = AcceleratorSpec(
+            accelerator_type=Device.GPU,
+            execution_provider=ExecutionProvider.QNNExecutionProvider,
+        )
+
+        p = create_pass_from_dict(
+            StaticLLM,
+            {
+                "batch_size": 1,
+                "context_length": 128,
+                "prefill_decode_models": False,
+            },
+            disable_search=True,
+            accelerator_spec=accelerator_spec,
+        )
+
+        # run
+        output_model_path = tmp_path / "output_model"
+        output_model = p.run(setup_model, output_model_path)
+
+        # check
+        assert isinstance(output_model, ONNXModelHandler)
+        _assert_static_io_shapes(output_model)
+
+        with (output_model_path / "genai_config.json").open() as f:
+            genai_config = json.load(f)
+        assert genai_config["model"]["type"] == "decoder-pipeline"
+        for i_name in ["input_ids", "past_sequence_length"]:
+            assert i_name in genai_config["model"]["decoder"]["inputs"]
+        assert genai_config["model"]["decoder"]["sliding_window"]["window_size"] == 128
+        pipeline_config = genai_config["model"]["decoder"]["pipeline"][0]
+        assert set(pipeline_config.keys()) == {"model"}
+        assert pipeline_config["model"]["filename"] == "model.onnx"
+        assert pipeline_config["model"]["inherit_session_options"]
+        assert genai_config["model"]["context_length"] == 4096
+        assert genai_config["search"]["max_length"] == 4096


### PR DESCRIPTION
## Describe your changes
* Update search.max_length in genai_config.json to inform onnxruntime-genai when to stop decode, which is required for the QNN GPU exports with fixed max seq len.
* Remove the "update_genai_config" option.
* Handle new ModelBuilder behavior with symbolic "kv_cache_dim".
* Add "inherit_session_options" to pipeline models in the genai config.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.
