### PR TITLE
Use onnx-shape-inference's infer_symbolic_shapes

### DIFF
--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -581,8 +581,8 @@ def model_has_adapters(model_path: Union[str, Path], adapter_type: AdapterType =
 
 def _fix_output_shapes(model_proto: onnx.ModelProto):
     """Run shape inference on the model and update the output shapes to make them fixed."""
-    from onnxruntime.tools.onnx_model_utils import is_fixed_size_tensor
     from onnx_shape_inference import infer_symbolic_shapes
+    from onnxruntime.tools.onnx_model_utils import is_fixed_size_tensor
 
     ir_model = ir.serde.deserialize_model(model_proto)
     infer_symbolic_shapes(ir_model, warn_on_missing=False)

--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -582,10 +582,11 @@ def model_has_adapters(model_path: Union[str, Path], adapter_type: AdapterType =
 def _fix_output_shapes(model_proto: onnx.ModelProto):
     """Run shape inference on the model and update the output shapes to make them fixed."""
     from onnxruntime.tools.onnx_model_utils import is_fixed_size_tensor
-    from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+    from onnx_shape_inference import infer_symbolic_shapes
 
-    # use the onnxruntime shape inference tool since it can handle large models as well as contrib ops
-    inferred_proto = SymbolicShapeInference.infer_shapes(model_proto, auto_merge=True, guess_output_rank=True)
+    ir_model = ir.serde.deserialize_model(model_proto)
+    infer_symbolic_shapes(ir_model, warn_on_missing=False)
+    inferred_proto = ir.serde.serialize_model(ir_model)
 
     for idx, o in enumerate(model_proto.graph.output):
         if not is_fixed_size_tensor(o):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ hf-xet
 numpy
 onnx
 onnx_ir>=0.1.2
+onnx-shape-inference>=0.3.1
 onnxscript>=0.5.3
 opentelemetry-sdk>=1.39.1
 optuna

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 hf-xet
 numpy
 onnx
-onnx_ir>=0.1.2
 onnx-shape-inference>=0.3.1
+onnx_ir>=0.1.2
 onnxscript>=0.5.3
 opentelemetry-sdk>=1.39.1
 optuna

--- a/test/passes/onnx/test_dynamic_to_fixed_shape.py
+++ b/test/passes/onnx/test_dynamic_to_fixed_shape.py
@@ -1,4 +1,6 @@
+import onnx
 import pytest
+from onnx import TensorProto, helper
 
 from olive.model import ONNXModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
@@ -71,6 +73,32 @@ def test_dynamic_to_fixed_shape(pass_config, tmp_path):
     p = create_pass_from_dict(DynamicToFixedShape, pass_config, disable_search=True)
     out = p.run(input_model, tmp_path)
     output_model = out.load_model()
+
+    assert output_model.graph.input[0].type.tensor_type.shape.dim[0].dim_value == 1
+    assert output_model.graph.output[0].type.tensor_type.shape.dim[0].dim_value == 1
+
+
+def test_dynamic_to_fixed_shape_with_scalar_constant_attribute(tmp_path):
+    input_value = helper.make_tensor_value_info("input", TensorProto.FLOAT, ["batch_size", 1])
+    output_value = helper.make_tensor_value_info("output", TensorProto.FLOAT, ["batch_size", 1])
+    graph = helper.make_graph(
+        [
+            helper.make_node("Identity", ["input"], ["output"]),
+            helper.make_node("Constant", [], ["unused"], value_int=1),
+        ],
+        "scalar_constant_attribute",
+        [input_value],
+        [output_value],
+    )
+    model_path = tmp_path / "input_model.onnx"
+    onnx.save(helper.make_model(graph), model_path)
+
+    p = create_pass_from_dict(
+        DynamicToFixedShape,
+        {"dim_param": ["batch_size"], "dim_value": [1]},
+        disable_search=True,
+    )
+    output_model = p.run(ONNXModelHandler(model_path), tmp_path).load_model()
 
     assert output_model.graph.input[0].type.tensor_type.shape.dim[0].dim_value == 1
     assert output_model.graph.output[0].type.tensor_type.shape.dim[0].dim_value == 1


### PR DESCRIPTION
- Replaced ORT shape inference with  onnx-shape-inference  and added a test for scalar  Constant  attributes.
- ORT crashes on valid  Constant(value_int=...)  nodes, while  onnx-shape-inference  handles them correctly.