### PR TITLE
Derive layer names from ONNX node and CaptureSplitInfo emit assignmen…

### DIFF
--- a/olive/passes/onnx/split.py
+++ b/olive/passes/onnx/split.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
+import onnx
 import onnx_ir as ir
 from onnx_ir.passes.common import IdentityEliminationPass, TopologicalSortPass
 
@@ -19,6 +20,32 @@ from olive.passes.onnx.common import get_external_data_config, model_proto_to_ol
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_constant_attributes(model_proto: onnx.ModelProto) -> None:
+    """Rewrite Constant nodes to carry their data in the "value" attribute.
+
+    The value_int(s)/value_float(s) attributes are equivalent to a scalar/1-D "value" tensor but
+    are not understood by every consumer, so normalize them in place.
+    """
+    for node in model_proto.graph.node:
+        if node.op_type != "Constant":
+            continue
+        for attribute in list(node.attribute):
+            if attribute.name == "value_int":
+                elem_type, dims, vals = onnx.TensorProto.INT64, [], [attribute.i]
+            elif attribute.name == "value_ints":
+                elem_type, dims, vals = onnx.TensorProto.INT64, [len(attribute.ints)], list(attribute.ints)
+            elif attribute.name == "value_float":
+                elem_type, dims, vals = onnx.TensorProto.FLOAT, [], [attribute.f]
+            elif attribute.name == "value_floats":
+                elem_type, dims, vals = onnx.TensorProto.FLOAT, [len(attribute.floats)], list(attribute.floats)
+            else:
+                continue
+
+            tensor = onnx.helper.make_tensor(node.output[0], elem_type, dims, vals)
+            node.attribute.remove(attribute)
+            node.attribute.append(onnx.helper.make_attribute("value", tensor))
 
 
 class SplitModel(Pass):
@@ -49,7 +76,9 @@ class SplitModel(Pass):
                 if metadata_prop.key == "split_assignments":
                     split_assignments = metadata_prop.value
                     break
-        # TODO(jambayk): Should we allow split assignments in the model attributes too?
+        if split_assignments is None:
+            # CaptureSplitInfo stores the assignments here when it runs on an ONNX model
+            split_assignments = (model.model_attributes or {}).get("split_assignments")
         if not split_assignments:
             raise ValueError("No split assignments found in the model metadata")
 
@@ -238,7 +267,15 @@ class SplitModel(Pass):
 
             # should we just use the same model proto? might modify dynamic shapes of existing value infos
             # if this becomes an issue replace with a newly loaded model proto
-            shape_inferred_proto = SymbolicShapeInference.infer_shapes(model_proto, auto_merge=True)
+            try:
+                shape_inferred_proto = SymbolicShapeInference.infer_shapes(model_proto, auto_merge=True)
+            except AttributeError:
+                # onnxruntime's symbolic shape inference only reads the "value" attribute of Constant nodes.
+                # Exporters are free to use the equivalent value_int(s)/value_float(s)/value_string(s) forms,
+                # which make it fail. Normalize them to "value" and retry.
+                logger.debug("Symbolic shape inference failed. Retrying with normalized Constant nodes.")
+                _normalize_constant_attributes(model_proto)
+                shape_inferred_proto = SymbolicShapeInference.infer_shapes(model_proto, auto_merge=True)
             inferred_model = ir.from_proto(shape_inferred_proto)
             vi_map = ir.convenience.create_value_mapping(inferred_model.graph)
 

--- a/olive/passes/pytorch/capture_split_info.py
+++ b/olive/passes/pytorch/capture_split_info.py
@@ -143,7 +143,9 @@ class CaptureSplitInfo(Pass):
                 raise ValueError("block_to_split is not set and could not be inferred. Please set it manually.")
             # the transformer layer block is the namespace with the most numbered children
             block_to_split = max(blocks, key=lambda name: len(blocks[name]))
-            logger.debug("Inferred block_to_split as '%s' with %d members.", block_to_split, len(blocks[block_to_split]))
+            logger.debug(
+                "Inferred block_to_split as '%s' with %d members.", block_to_split, len(blocks[block_to_split])
+            )
 
         block_to_splits = block_to_split if isinstance(block_to_split, list) else [block_to_split]
 

--- a/olive/passes/pytorch/capture_split_info.py
+++ b/olive/passes/pytorch/capture_split_info.py
@@ -4,16 +4,18 @@
 # --------------------------------------------------------------------------
 import csv
 import logging
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
+import onnx
 
 from olive.common.hf.wrapper import ModelWrapper
 from olive.common.utils import get_attr
 from olive.hardware.accelerator import AcceleratorSpec
-from olive.model import HfModelHandler, PyTorchModelHandler
+from olive.model import HfModelHandler, ONNXModelHandler, PyTorchModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, ParamCategory, PassConfigParam
 
@@ -82,10 +84,17 @@ class CaptureSplitInfo(Pass):
         return False
 
     def _run_for_config(
-        self, model: Union[HfModelHandler, PyTorchModelHandler], config: type[BasePassConfig], output_model_path: str
-    ) -> Union[HfModelHandler, PyTorchModelHandler]:
+        self,
+        model: Union[HfModelHandler, PyTorchModelHandler, ONNXModelHandler],
+        config: type[BasePassConfig],
+        output_model_path: str,
+    ) -> Union[HfModelHandler, PyTorchModelHandler, ONNXModelHandler]:
         split_assignments = None
-        if config.num_splits:
+        if isinstance(model, ONNXModelHandler):
+            if not config.num_splits:
+                raise ValueError("num_splits is required to split an ONNX model. cost_model is not supported.")
+            split_assignments = self.split_using_num_splits_onnx(model, config)
+        elif config.num_splits:
             split_assignments = self.split_using_num_splits(model, config)
         elif config.cost_model:
             split_assignments = self.split_using_cost_model(model, config)
@@ -99,6 +108,67 @@ class CaptureSplitInfo(Pass):
         model_attributes["split_assignments"] = split_assignments
 
         return output_model
+
+    @staticmethod
+    def _to_module_name(node_name: str) -> str:
+        """Normalize an ONNX node name into a dotted module namespace.
+
+        ONNX exporters commonly name nodes after the originating module using ``/`` as the
+        separator, for example ``model/layers.0/self_attn/q_proj/MatMul``. SplitModel already
+        normalizes the same way when matching assignments to nodes.
+        """
+        return node_name.replace("/", ".").lstrip(".")
+
+    @classmethod
+    def _get_indexed_blocks(cls, node_names: list[str]) -> dict[str, set[int]]:
+        """Map each candidate block namespace to the set of numeric child indices seen under it."""
+        blocks = defaultdict(set)
+        for node_name in node_names:
+            components = cls._to_module_name(node_name).split(".")
+            for idx, component in enumerate(components[1:], start=1):
+                if component.isdigit():
+                    blocks[".".join(components[:idx])].add(int(component))
+        return blocks
+
+    def split_using_num_splits_onnx(self, model: ONNXModelHandler, config: type[BasePassConfig]) -> dict[str, int]:
+        # node names carry the module namespace, so the weights are never needed here
+        model_proto = onnx.load(model.model_path, load_external_data=False)
+        node_names = [node.name for node in model_proto.graph.node if node.name]
+
+        blocks = self._get_indexed_blocks(node_names)
+        block_to_split = config.block_to_split
+        # check for None specifically since "" is a valid value
+        if block_to_split is None:
+            if not blocks:
+                raise ValueError("block_to_split is not set and could not be inferred. Please set it manually.")
+            # the transformer layer block is the namespace with the most numbered children
+            block_to_split = max(blocks, key=lambda name: len(blocks[name]))
+            logger.debug("Inferred block_to_split as '%s' with %d members.", block_to_split, len(blocks[block_to_split]))
+
+        block_to_splits = block_to_split if isinstance(block_to_split, list) else [block_to_split]
+
+        block_members = []
+        for block_name in block_to_splits:
+            member_indices = blocks.get(block_name)
+            if not member_indices:
+                raise ValueError(f"Could not find any members for block '{block_name}' in the ONNX model.")
+            block_members.extend(f"{block_name}.{index}".lstrip(".") for index in sorted(member_indices))
+
+        split_assignments, used_splits, modules_to_exclude = self._init_split_assignments(
+            model, None, config.unique_embeds_lm_head_splits
+        )
+
+        for split_idx, split_members in enumerate(np.array_split(block_members, config.num_splits)):
+            for member_name in split_members:
+                if member_name in modules_to_exclude:
+                    continue
+                split_assignments[member_name] = split_idx + used_splits
+
+        if config.unique_embeds_lm_head_splits:
+            # assign lm_head layer to its own split
+            split_assignments["lm_head"] = config.num_splits + used_splits
+
+        return split_assignments
 
     def split_using_num_splits(
         self, model: Union[HfModelHandler, PyTorchModelHandler], config: type[BasePassConfig]
@@ -200,14 +270,14 @@ class CaptureSplitInfo(Pass):
 
     def _init_split_assignments(
         self,
-        model: Union[HfModelHandler, PyTorchModelHandler],
-        pytorch_model: "nn.Module",
+        model: Union[HfModelHandler, PyTorchModelHandler, ONNXModelHandler],
+        pytorch_model: Optional["nn.Module"],
         unique_embeds_lm_head_splits: bool,
     ) -> tuple[dict[str, int], int, set]:
         """Initialize the split assignments for the model.
 
         :param model: The input model to split.
-        :param pytorch_model: The loaded input model.
+        :param pytorch_model: The loaded input model. None for ONNX models.
         :param unique_embeds_lm_head_splits: Whether to assign embedding and lm_head layers to their own splits.
         :return: A dictionary of split assignments, next split index, and set of modules to exclude.
         """


### PR DESCRIPTION

## Describe your changes
What the two changes do

1.  capture_split_info.py : make the pass work on ONNX

Instead of a torch module tree, derive the layer list from ONNX node names. Mobius names nodes after their originating module ( model/layers.0/self_attn/q_proj/MatMul ), so the structure is already there. The pass normalizes  / → . , groups by namespace, and picks the one with the most numbered children →  model.layers , indices 0–34.

This is safe rather than a guess:  SplitModel.get_assignment  ( split.py:255 ) already normalizes node names the exact same way to match assignments back to nodes. I'm just reading the naming convention the consumer side already assumes.

2.  split.py : let the two passes hand off

 CaptureSplitInfo  writes assignments to  model_attributes ;  SplitModel  didn't look there. Without this the passes can't chain. The file carried an explicit  TODO(jambayk): Should we allow split assignments in the model attributes too? So this closes a sanctioned gap.
