### PR TITLE
Rename SelectiveMixedPrecision heuristic algorithms

### DIFF
--- a/docs/source/blogs/quant-slms.md
+++ b/docs/source/blogs/quant-slms.md
@@ -24,9 +24,9 @@ Among these, **mixed precision** was of particular interest. Full INT4 quantizat
 Olive provides simple configuration options for these strategies:
 
 * **No mixed precision:** all layers in INT4
-* **`k_quant_down`:** LM head in INT8
-* **`k_quant_down` (extended):** LM head + MLP down-projection for first 1/8, last 1/8, and every third middle layer in INT8
-* **`k_quant_mixed`:** LM head + MLP down and attention QKV projections for first 1/8, last 1/8, and every third middle layer in INT8
+* **`high_precision_lm_head`:** LM head in INT8
+* **`high_precision_mlp`:** LM head + MLP down-projection for first 1/8, last 1/8, and every third middle layer in INT8
+* **`high_precision_mlp_qkv`:** LM head + MLP down and attention QKV projections for first 1/8, last 1/8, and every third middle layer in INT8
 
 ---
 
@@ -63,18 +63,18 @@ We ran the sweeps on the following SLMs using these recipes:
 
 | Base model                                | Best schema                                                 | Δ mean quality vs Original (%) | Δ mean quality vs Baseline (%) | Size (GB) | Size vs Original (%) | Size vs Baseline (%) |
 | ----------------------------------------- | ----------------------------------------------------------- | -----------------------------: | -----------------------------: | --------: | -------------------: | -------------------: |
-| deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | block=128, symmetric=False, smp=k_quant_mixed, quarot=False |                         +2.724 |                         +7.624 |     1.434 |              −57.087 |               +0.005 |
-| meta-llama/Llama-3.2-1B-Instruct          | block=32, symmetric=False, smp=k_quant_down, quarot=True    |                         −0.096 |                         +7.342 |     1.361 |              −51.505 |              +18.112 |
-| microsoft/Phi-3.5-mini-instruct           | block=32, symmetric=False, smp=k_quant_down, quarot=False   |                         +0.924 |                         +1.042 |     2.453 |              −65.650 |              +13.666 |
-| microsoft/Phi-4-mini-instruct             | block=32, symmetric=False, smp=k_quant_mixed, quarot=True   |                         −0.348 |                         +0.929 |     3.884 |              −53.762 |               +6.169 |
-| Qwen/Qwen2.5-1.5B-Instruct                | block=32, symmetric=True, smp=k_quant_down, quarot=False    |                         +0.547 |                         +1.636 |     1.479 |              −55.432 |              +18.155 |
+| deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | block=128, symmetric=False, smp=high_precision_mlp_qkv, quarot=False |                         +2.724 |                         +7.624 |     1.434 |              −57.087 |               +0.005 |
+| meta-llama/Llama-3.2-1B-Instruct          | block=32, symmetric=False, smp=high_precision_mlp, quarot=True      |                         −0.096 |                         +7.342 |     1.361 |              −51.505 |              +18.112 |
+| microsoft/Phi-3.5-mini-instruct           | block=32, symmetric=False, smp=high_precision_mlp, quarot=False     |                         +0.924 |                         +1.042 |     2.453 |              −65.650 |              +13.666 |
+| microsoft/Phi-4-mini-instruct             | block=32, symmetric=False, smp=high_precision_mlp_qkv, quarot=True  |                         −0.348 |                         +0.929 |     3.884 |              −53.762 |               +6.169 |
+| Qwen/Qwen2.5-1.5B-Instruct                | block=32, symmetric=True, smp=high_precision_mlp, quarot=False      |                         +0.547 |                         +1.636 |     1.479 |              −55.432 |              +18.155 |
 
 ---
 
 ### Key Takeaways
 
 * **Block size:** Smaller block sizes (32) consistently yielded better results than larger ones (128), likely due to finer granularity during quantization.
-* **Mixed precision:** The `k_quant_down` configuration provided the best trade-off between quality and model size, performing strongly across most models.
+* **Mixed precision:** The `high_precision_mlp` configuration provided the best trade-off between quality and model size, performing strongly across most models.
 * **Symmetric vs asymmetric:** Asymmetric quantization (`symmetric=False`) performed better for most models, as it captures asymmetric weight distributions more effectively.
 * **QuaRot:** The QuaRot pass benefited certain models (e.g., Llama-1B, Phi-4-mini) but not others, indicating model-specific sensitivity.
 

--- a/docs/source/blogs/quant-slms.md
+++ b/docs/source/blogs/quant-slms.md
@@ -25,8 +25,8 @@ Olive provides simple configuration options for these strategies:
 
 * **No mixed precision:** all layers in INT4
 * **`high_precision_lm_head`:** LM head in INT8
-* **`high_precision_mlp`:** LM head + MLP down-projection for first 1/8, last 1/8, and every third middle layer in INT8
-* **`high_precision_mlp_qkv`:** LM head + MLP down and attention QKV projections for first 1/8, last 1/8, and every third middle layer in INT8
+* **`high_precision_mlp_down`:** LM head + MLP down-projection for first 1/8, last 1/8, and every third middle layer in INT8
+* **`high_precision_mlp_down_qkv`:** LM head + MLP down and attention QKV projections for first 1/8, last 1/8, and every third middle layer in INT8
 
 ---
 
@@ -63,18 +63,18 @@ We ran the sweeps on the following SLMs using these recipes:
 
 | Base model                                | Best schema                                                 | Δ mean quality vs Original (%) | Δ mean quality vs Baseline (%) | Size (GB) | Size vs Original (%) | Size vs Baseline (%) |
 | ----------------------------------------- | ----------------------------------------------------------- | -----------------------------: | -----------------------------: | --------: | -------------------: | -------------------: |
-| deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | block=128, symmetric=False, smp=high_precision_mlp_qkv, quarot=False |                         +2.724 |                         +7.624 |     1.434 |              −57.087 |               +0.005 |
-| meta-llama/Llama-3.2-1B-Instruct          | block=32, symmetric=False, smp=high_precision_mlp, quarot=True      |                         −0.096 |                         +7.342 |     1.361 |              −51.505 |              +18.112 |
-| microsoft/Phi-3.5-mini-instruct           | block=32, symmetric=False, smp=high_precision_mlp, quarot=False     |                         +0.924 |                         +1.042 |     2.453 |              −65.650 |              +13.666 |
-| microsoft/Phi-4-mini-instruct             | block=32, symmetric=False, smp=high_precision_mlp_qkv, quarot=True  |                         −0.348 |                         +0.929 |     3.884 |              −53.762 |               +6.169 |
-| Qwen/Qwen2.5-1.5B-Instruct                | block=32, symmetric=True, smp=high_precision_mlp, quarot=False      |                         +0.547 |                         +1.636 |     1.479 |              −55.432 |              +18.155 |
+| deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | block=128, symmetric=False, smp=high_precision_mlp_down_qkv, quarot=False |                         +2.724 |                         +7.624 |     1.434 |              −57.087 |               +0.005 |
+| meta-llama/Llama-3.2-1B-Instruct          | block=32, symmetric=False, smp=high_precision_mlp_down, quarot=True      |                         −0.096 |                         +7.342 |     1.361 |              −51.505 |              +18.112 |
+| microsoft/Phi-3.5-mini-instruct           | block=32, symmetric=False, smp=high_precision_mlp_down, quarot=False     |                         +0.924 |                         +1.042 |     2.453 |              −65.650 |              +13.666 |
+| microsoft/Phi-4-mini-instruct             | block=32, symmetric=False, smp=high_precision_mlp_down_qkv, quarot=True  |                         −0.348 |                         +0.929 |     3.884 |              −53.762 |               +6.169 |
+| Qwen/Qwen2.5-1.5B-Instruct                | block=32, symmetric=True, smp=high_precision_mlp_down, quarot=False      |                         +0.547 |                         +1.636 |     1.479 |              −55.432 |              +18.155 |
 
 ---
 
 ### Key Takeaways
 
 * **Block size:** Smaller block sizes (32) consistently yielded better results than larger ones (128), likely due to finer granularity during quantization.
-* **Mixed precision:** The `high_precision_mlp` configuration provided the best trade-off between quality and model size, performing strongly across most models.
+* **Mixed precision:** The `high_precision_mlp_down` configuration provided the best trade-off between quality and model size, performing strongly across most models.
 * **Symmetric vs asymmetric:** Asymmetric quantization (`symmetric=False`) performed better for most models, as it captures asymmetric weight distributions more effectively.
 * **QuaRot:** The QuaRot pass benefited certain models (e.g., Llama-1B, Phi-4-mini) but not others, indicating model-specific sensitivity.
 

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -119,6 +119,7 @@ class ModelBuilder(Pass):
                 required=False,
                 description="Specify when you want to exclude certain nodes from int4 quantization.",
             ),
+            # These values are forwarded to ORT GenAI ModelBuilder and are unrelated to SelectiveMixedPrecision.Algorithm.
             "int4_algo_config": PassConfigParam(
                 type_=str,
                 required=False,

--- a/olive/passes/pytorch/selective_mixed_precision.py
+++ b/olive/passes/pytorch/selective_mixed_precision.py
@@ -618,9 +618,9 @@ class SelectiveMixedPrecision(Pass):
     The supported algorithms are:
     - Layer id based heuristic:
         - high_precision_lm_head: LM head in high precision.
-        - high_precision_mlp: LM head + down projection from first 1/8 and last 1/8 layers, and every 3rd
+        - high_precision_mlp_down: LM head + down projection from first 1/8 and last 1/8 layers, and every 3rd
           layer in between in high precision.
-        - high_precision_mlp_qkv: LM head + QKV and down projection from first 1/8 and last 1/8 layers,
+        - high_precision_mlp_down_qkv: LM head + QKV and down projection from first 1/8 and last 1/8 layers,
           and every 3rd layer in between in high precision.
     - Sensitivity score based:
         - snr: Signal-to-Noise Ratio based selection.
@@ -630,8 +630,8 @@ class SelectiveMixedPrecision(Pass):
         - kld_gradient: KL Divergence gradient based selection.
 
     Deprecated algorithm strings ``k_quant_last``, ``k_quant_down``, and ``k_quant_mixed`` map to
-    ``high_precision_lm_head``, ``high_precision_mlp``, and ``high_precision_mlp_qkv``, respectively,
-    and remain accepted with a ``FutureWarning``.
+    ``high_precision_lm_head``, ``high_precision_mlp_down``, and ``high_precision_mlp_down_qkv``,
+    respectively, and remain accepted with a ``FutureWarning``.
 
     For ``kld_gradient`` the peak memory required for KL Divergence scoring can be tuned via
     ``kld_memory_mode``, which supports ``auto`` (default; picks based on the model size and free
@@ -649,18 +649,18 @@ class SelectiveMixedPrecision(Pass):
 
         IQE = "iqe"
         IQE_RELATIVE = "iqe_relative"
-        HIGH_PRECISION_MLP = "high_precision_mlp"
-        HIGH_PRECISION_MLP_QKV = "high_precision_mlp_qkv"
+        HIGH_PRECISION_MLP_DOWN = "high_precision_mlp_down"
+        HIGH_PRECISION_MLP_DOWN_QKV = "high_precision_mlp_down_qkv"
         HIGH_PRECISION_LM_HEAD = "high_precision_lm_head"
         KLD_GRADIENT = "kld_gradient"
         SNR = "snr"
         SNR_RELATIVE = "snr_relative"
 
-        # Deprecated Python API names. Their canonical values make these Enum aliases, so normal
-        # iteration (and consequently schema/search generation) only exposes the canonical names.
+        # Deprecated Python Enum names are silently retained compatibility aliases. Their canonical
+        # values keep normal iteration (and consequently schema/search generation) focused on the new names.
         K_QUANT_LAST = "high_precision_lm_head"
-        K_QUANT_DOWN = "high_precision_mlp"
-        K_QUANT_MIXED = "high_precision_mlp_qkv"
+        K_QUANT_DOWN = "high_precision_mlp_down"
+        K_QUANT_MIXED = "high_precision_mlp_down_qkv"
 
         @classmethod
         def __get_pydantic_json_schema__(cls, core_schema, handler):
@@ -673,8 +673,8 @@ class SelectiveMixedPrecision(Pass):
         def _missing_(cls, value):
             legacy_aliases = {
                 "k_quant_last": cls.HIGH_PRECISION_LM_HEAD,
-                "k_quant_down": cls.HIGH_PRECISION_MLP,
-                "k_quant_mixed": cls.HIGH_PRECISION_MLP_QKV,
+                "k_quant_down": cls.HIGH_PRECISION_MLP_DOWN,
+                "k_quant_mixed": cls.HIGH_PRECISION_MLP_DOWN_QKV,
             }
             canonical = legacy_aliases.get(value) if isinstance(value, str) else None
             if canonical is not None:
@@ -790,8 +790,8 @@ class SelectiveMixedPrecision(Pass):
     def _is_heuristic_algorithm(algorithm: SelectiveMixedPrecision.Algorithm) -> bool:
         return algorithm in {
             SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD,
-            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP,
-            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV,
         }
 
     def _run_for_config(
@@ -868,7 +868,7 @@ class SelectiveMixedPrecision(Pass):
                     continue
 
                 # Add qkv
-                if algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV:
+                if algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV:
                     for attn_input_name in layer_wrapper.get_attention_inputs(return_name=True)[1]:
                         overrides[f"{layer_prefix}.{layer_idx}.{attn_input_name}"] = override_config
 

--- a/olive/passes/pytorch/selective_mixed_precision.py
+++ b/olive/passes/pytorch/selective_mixed_precision.py
@@ -9,6 +9,7 @@ import math
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import TYPE_CHECKING
+from warnings import warn
 
 import torch
 
@@ -616,15 +617,21 @@ class SelectiveMixedPrecision(Pass):
 
     The supported algorithms are:
     - Layer id based heuristic:
-        - k_quant_last: LM head in high precision.
-        - k_quant_down: LM head + Down projection from first 1/8 and last 1/8 layers, and every 3rd layer in between in high precision.
-        - k_quant_mixed: LM head + QKV and Down projection from first 1/8 and last 1/8 layers, and every 3rd layer in between in high precision.
+        - high_precision_lm_head: LM head in high precision.
+        - high_precision_mlp: LM head + down projection from first 1/8 and last 1/8 layers, and every 3rd
+          layer in between in high precision.
+        - high_precision_mlp_qkv: LM head + QKV and down projection from first 1/8 and last 1/8 layers,
+          and every 3rd layer in between in high precision.
     - Sensitivity score based:
         - snr: Signal-to-Noise Ratio based selection.
         - snr_relative: Relative SNR (between low and high precision) based selection.
         - iqe: Inverse of Integer Quantization Error based selection.
         - iqe_relative: Relative IQE (between low and high precision) based selection.
         - kld_gradient: KL Divergence gradient based selection.
+
+    Deprecated algorithm strings ``k_quant_last``, ``k_quant_down``, and ``k_quant_mixed`` map to
+    ``high_precision_lm_head``, ``high_precision_mlp``, and ``high_precision_mlp_qkv``, respectively,
+    and remain accepted with a ``FutureWarning``.
 
     For ``kld_gradient`` the peak memory required for KL Divergence scoring can be tuned via
     ``kld_memory_mode``, which supports ``auto`` (default; picks based on the model size and free
@@ -642,12 +649,45 @@ class SelectiveMixedPrecision(Pass):
 
         IQE = "iqe"
         IQE_RELATIVE = "iqe_relative"
-        K_QUANT_DOWN = "k_quant_down"
-        K_QUANT_MIXED = "k_quant_mixed"
-        K_QUANT_LAST = "k_quant_last"
+        HIGH_PRECISION_MLP = "high_precision_mlp"
+        HIGH_PRECISION_MLP_QKV = "high_precision_mlp_qkv"
+        HIGH_PRECISION_LM_HEAD = "high_precision_lm_head"
         KLD_GRADIENT = "kld_gradient"
         SNR = "snr"
         SNR_RELATIVE = "snr_relative"
+
+        # Deprecated Python API names. Their canonical values make these Enum aliases, so normal
+        # iteration (and consequently schema/search generation) only exposes the canonical names.
+        K_QUANT_LAST = "high_precision_lm_head"
+        K_QUANT_DOWN = "high_precision_mlp"
+        K_QUANT_MIXED = "high_precision_mlp_qkv"
+
+        @classmethod
+        def __get_pydantic_json_schema__(cls, core_schema, handler):
+            json_schema = handler(core_schema)
+            # Pydantic includes Enum aliases as duplicate values by default.
+            json_schema["enum"] = list(dict.fromkeys(json_schema["enum"]))
+            return json_schema
+
+        @classmethod
+        def _missing_(cls, value):
+            legacy_aliases = {
+                "k_quant_last": cls.HIGH_PRECISION_LM_HEAD,
+                "k_quant_down": cls.HIGH_PRECISION_MLP,
+                "k_quant_mixed": cls.HIGH_PRECISION_MLP_QKV,
+            }
+            canonical = legacy_aliases.get(value) if isinstance(value, str) else None
+            if canonical is not None:
+                warn(
+                    f"SelectiveMixedPrecision config field 'algorithm' value '{value}' is deprecated; "
+                    f"use '{canonical.value}' instead.",
+                    FutureWarning,
+                    # This points to direct Enum callers. Pydantic adds a variable number of internal frames,
+                    # so the complete field/value/replacement context is also included in the message.
+                    stacklevel=4,
+                )
+                return canonical
+            return None
 
     @classmethod
     def _default_config(cls, accelerator_spec: AcceleratorSpec) -> dict[str, PassConfigParam]:
@@ -736,16 +776,31 @@ class SelectiveMixedPrecision(Pass):
         if not super().validate_config(config, accelerator_spec):
             return False
 
-        if not config.algorithm.startswith("k_quant") and (config.ratio is None or not (0 < config.ratio < 1)):
+        if config.algorithm is None:
+            logger.error("SelectiveMixedPrecision config field 'algorithm' must be specified.")
+            return False
+
+        if not cls._is_heuristic_algorithm(config.algorithm) and (config.ratio is None or not (0 < config.ratio < 1)):
             logger.error("When using %s algorithm, ratio must be provided and between 0 and 1.", config.algorithm)
             return False
 
         return True
 
+    @staticmethod
+    def _is_heuristic_algorithm(algorithm: SelectiveMixedPrecision.Algorithm) -> bool:
+        return algorithm in {
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV,
+        }
+
     def _run_for_config(
         self, model: HfModelHandler, config: type[BasePassConfig], output_model_path: str
     ) -> HfModelHandler:
         """Run the selective mixed precision pass."""
+        if config.algorithm is None:
+            raise ValueError("SelectiveMixedPrecision config field 'algorithm' must be specified.")
+
         if not isinstance(model, HfModelHandler):
             raise ValueError("SelectiveMixedPrecision pass currently only supports HfModelHandler.")
 
@@ -753,8 +808,10 @@ class SelectiveMixedPrecision(Pass):
         model.model = None
         model_wrapper = ModelWrapper.from_model(load_hf_base_model(model))
 
-        if config.algorithm.startswith("k_quant"):
-            default, overrides = self.get_k_quant_config(model_wrapper, config.algorithm, config.bits, config.high_bits)
+        if self._is_heuristic_algorithm(config.algorithm):
+            default, overrides = self.get_high_precision_config(
+                model_wrapper, config.algorithm, config.bits, config.high_bits
+            )
         else:
             default, overrides = self.get_scored_config(
                 model,
@@ -788,17 +845,18 @@ class SelectiveMixedPrecision(Pass):
         return output_model
 
     @staticmethod
-    def get_k_quant_config(
+    def get_high_precision_config(
         model_wrapper: ModelWrapper,
-        algorithm: SelectiveMixedPrecision.Algorithm,
+        algorithm: SelectiveMixedPrecision.Algorithm | str,
         bits: PrecisionBits,
         high_bits: PrecisionBits,
     ) -> tuple[dict, dict[str, dict]]:
-        """Get mixed precision config for k-quant algorithms."""
+        """Get mixed precision config for layer-based high-precision heuristics."""
+        algorithm = SelectiveMixedPrecision.Algorithm(algorithm)
         override_config = {"bits": high_bits}
         overrides = {model_wrapper.get_lm_head()[1]: override_config}
 
-        if algorithm != SelectiveMixedPrecision.Algorithm.K_QUANT_LAST:
+        if algorithm != SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD:
             layer_prefix = model_wrapper.get_layers()[1]
             num_layers = model_wrapper.num_hidden_layers
             for layer_idx, layer_wrapper in enumerate(model_wrapper.get_layer_wrappers()):
@@ -810,7 +868,7 @@ class SelectiveMixedPrecision(Pass):
                     continue
 
                 # Add qkv
-                if algorithm == SelectiveMixedPrecision.Algorithm.K_QUANT_MIXED:
+                if algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV:
                     for attn_input_name in layer_wrapper.get_attention_inputs(return_name=True)[1]:
                         overrides[f"{layer_prefix}.{layer_idx}.{attn_input_name}"] = override_config
 
@@ -819,6 +877,21 @@ class SelectiveMixedPrecision(Pass):
                     overrides[f"{layer_prefix}.{layer_idx}.{attn_output_name}"] = override_config
 
         return {"bits": bits}, overrides
+
+    @staticmethod
+    def get_k_quant_config(
+        model_wrapper: ModelWrapper,
+        algorithm: SelectiveMixedPrecision.Algorithm | str,
+        bits: PrecisionBits,
+        high_bits: PrecisionBits,
+    ) -> tuple[dict, dict[str, dict]]:
+        """Get a layer-based mixed precision config using the deprecated helper name."""
+        warn(
+            "SelectiveMixedPrecision.get_k_quant_config is deprecated; use get_high_precision_config instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return SelectiveMixedPrecision.get_high_precision_config(model_wrapper, algorithm, bits, high_bits)
 
     @staticmethod
     def get_overrides_from_scores(

--- a/test/passes/pytorch/test_selective_mixed_precision.py
+++ b/test/passes/pytorch/test_selective_mixed_precision.py
@@ -196,13 +196,13 @@ def input_model_fixture(tmp_path_factory):
 @pytest.mark.parametrize(
     ("algorithm", "expected_layer_indices", "include_qkv"),
     [
-        ("k_quant_down", [0, 3, 6, 7], False),  # first 1/8, every 3rd, and last 1/8
-        ("k_quant_mixed", [0, 3, 6, 7], True),
-        ("k_quant_last", [], False),
+        ("high_precision_mlp", [0, 3, 6, 7], False),  # first 1/8, every 3rd, and last 1/8
+        ("high_precision_mlp_qkv", [0, 3, 6, 7], True),
+        ("high_precision_lm_head", [], False),
     ],
 )
-def test_selective_mixed_precision_k_quant(algorithm, expected_layer_indices, include_qkv, input_model, tmp_path):
-    """End-to-end: rule-based k_quant_* algorithms write the expected mixed_precision_info."""
+def test_selective_mixed_precision_heuristic(algorithm, expected_layer_indices, include_qkv, input_model, tmp_path):
+    """End-to-end: layer-based heuristics write the expected mixed_precision_info."""
     config = {"algorithm": algorithm}
     p = create_pass_from_dict(SelectiveMixedPrecision, config, disable_search=True)
 
@@ -231,6 +231,220 @@ def test_selective_mixed_precision_k_quant(algorithm, expected_layer_indices, in
             }
         )
     assert output_model.model_attributes["mixed_precision_info"] == expected_mp_info
+
+
+@pytest.mark.parametrize(
+    ("legacy_algorithm", "canonical_algorithm"),
+    [
+        ("k_quant_last", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD),
+        ("k_quant_down", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP),
+        ("k_quant_mixed", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV),
+    ],
+)
+def test_selective_mixed_precision_legacy_algorithm_warns_and_normalizes(legacy_algorithm, canonical_algorithm):
+    expected_message = (
+        f"SelectiveMixedPrecision config field 'algorithm' value '{legacy_algorithm}' is deprecated; "
+        f"use '{canonical_algorithm.value}' instead."
+    )
+    with pytest.warns(FutureWarning) as warning_records:
+        pass_instance = create_pass_from_dict(
+            SelectiveMixedPrecision, {"algorithm": legacy_algorithm}, disable_search=True
+        )
+
+    assert str(warning_records[0].message) == expected_message
+    assert pass_instance.config.algorithm is canonical_algorithm
+
+
+def test_selective_mixed_precision_unknown_algorithm_is_rejected():
+    with pytest.raises(ValueError, match="algorithm"):
+        create_pass_from_dict(SelectiveMixedPrecision, {"algorithm": "unknown"}, disable_search=True)
+
+
+def test_selective_mixed_precision_algorithm_aliases_are_excluded_from_iteration_schema_and_search():
+    algorithm = SelectiveMixedPrecision.Algorithm
+    canonical_algorithms = [
+        algorithm.IQE,
+        algorithm.IQE_RELATIVE,
+        algorithm.HIGH_PRECISION_MLP,
+        algorithm.HIGH_PRECISION_MLP_QKV,
+        algorithm.HIGH_PRECISION_LM_HEAD,
+        algorithm.KLD_GRADIENT,
+        algorithm.SNR,
+        algorithm.SNR_RELATIVE,
+    ]
+    deprecated_names = {"K_QUANT_LAST", "K_QUANT_DOWN", "K_QUANT_MIXED"}
+
+    assert algorithm.K_QUANT_LAST is algorithm.HIGH_PRECISION_LM_HEAD
+    assert algorithm.K_QUANT_DOWN is algorithm.HIGH_PRECISION_MLP
+    assert algorithm.K_QUANT_MIXED is algorithm.HIGH_PRECISION_MLP_QKV
+    assert list(algorithm) == canonical_algorithms
+    assert deprecated_names.isdisjoint(member.name for member in algorithm)
+
+    algorithm_values = [algorithm.value for algorithm in SelectiveMixedPrecision.Algorithm]
+    search_defaults = SelectiveMixedPrecision._default_config(None)["algorithm"].search_defaults.get_support()
+    pass_instance = create_pass_from_dict(
+        SelectiveMixedPrecision, {"algorithm": "high_precision_mlp"}, disable_search=True
+    )
+    schema_values = pass_instance.config.__class__.model_json_schema()["$defs"]["Algorithm"]["enum"]
+
+    assert algorithm_values == [member.value for member in canonical_algorithms]
+    assert not {"k_quant_last", "k_quant_down", "k_quant_mixed"}.intersection(algorithm_values)
+    assert search_defaults == canonical_algorithms
+    assert deprecated_names.isdisjoint(member.name for member in search_defaults)
+    assert schema_values == algorithm_values
+
+
+def test_selective_mixed_precision_requires_algorithm_even_when_ratio_is_set(monkeypatch):
+    pass_instance = create_pass_from_dict(SelectiveMixedPrecision, {"ratio": 0.5}, disable_search=True)
+    errors = []
+    monkeypatch.setattr(smp_module.logger, "error", lambda message, *args: errors.append(message % args))
+
+    is_valid = SelectiveMixedPrecision.validate_config(
+        pass_instance.config,
+        pass_instance.accelerator_spec,
+    )
+
+    assert not is_valid
+    assert errors == ["SelectiveMixedPrecision config field 'algorithm' must be specified."]
+
+
+def test_selective_mixed_precision_run_requires_algorithm_before_loading_or_scoring(monkeypatch):
+    pass_instance = create_pass_from_dict(SelectiveMixedPrecision, {}, disable_search=True)
+    input_model = object.__new__(HfModelHandler)
+
+    monkeypatch.setattr(
+        smp_module,
+        "load_hf_base_model",
+        lambda *_args, **_kwargs: pytest.fail("model loading must not be reached"),
+    )
+    monkeypatch.setattr(
+        pass_instance,
+        "get_scored_config",
+        lambda *_args, **_kwargs: pytest.fail("scoring must not be reached"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"^SelectiveMixedPrecision config field 'algorithm' must be specified\.$",
+    ):
+        pass_instance.run(input_model, "unused")
+
+
+def test_get_k_quant_config_warns_and_delegates(monkeypatch):
+    model_wrapper = object()
+    expected = ({"bits": PrecisionBits.BITS4}, {"lm_head": {"bits": PrecisionBits.BITS8}})
+    calls = []
+
+    def fake_get_high_precision_config(received_wrapper, algorithm, bits, high_bits):
+        calls.append((received_wrapper, algorithm, bits, high_bits))
+        return expected
+
+    monkeypatch.setattr(SelectiveMixedPrecision, "get_high_precision_config", fake_get_high_precision_config)
+
+    with pytest.warns(
+        FutureWarning,
+        match=r"SelectiveMixedPrecision\.get_k_quant_config is deprecated; use get_high_precision_config instead\.",
+    ):
+        actual = SelectiveMixedPrecision.get_k_quant_config(
+            model_wrapper,
+            SelectiveMixedPrecision.Algorithm.K_QUANT_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+        )
+
+    assert actual is expected
+    assert calls == [
+        (
+            model_wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("legacy_algorithm", "canonical_algorithm", "expected_override_names"),
+    [
+        (
+            "k_quant_last",
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD,
+            {"lm_head"},
+        ),
+        (
+            "k_quant_down",
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP,
+            {
+                "lm_head",
+                "model.layers.0.mlp.down_proj",
+                "model.layers.3.mlp.down_proj",
+                "model.layers.6.mlp.down_proj",
+                "model.layers.7.mlp.down_proj",
+            },
+        ),
+        (
+            "k_quant_mixed",
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV,
+            {
+                "lm_head",
+                *{
+                    f"model.layers.{layer_idx}.{module_name}"
+                    for layer_idx in (0, 3, 6, 7)
+                    for module_name in (
+                        "self_attn.q_proj",
+                        "self_attn.k_proj",
+                        "self_attn.v_proj",
+                        "mlp.down_proj",
+                    )
+                },
+            },
+        ),
+    ],
+)
+def test_get_k_quant_config_normalizes_raw_legacy_algorithms(
+    legacy_algorithm,
+    canonical_algorithm,
+    expected_override_names,
+):
+    layer_wrapper = SimpleNamespace(
+        get_attention_inputs=lambda return_name=True: (
+            None,
+            ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ),
+        get_mlp_outputs=lambda return_name=True: (None, ["mlp.down_proj"]),
+    )
+    model_wrapper = SimpleNamespace(
+        num_hidden_layers=8,
+        get_lm_head=lambda: (None, "lm_head"),
+        get_layers=lambda: (None, "model.layers"),
+        get_layer_wrappers=lambda: [layer_wrapper] * 8,
+    )
+
+    with pytest.warns(FutureWarning) as warning_records:
+        actual = SelectiveMixedPrecision.get_k_quant_config(
+            model_wrapper,
+            legacy_algorithm,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+        )
+
+    expected = SelectiveMixedPrecision.get_high_precision_config(
+        model_wrapper,
+        canonical_algorithm,
+        PrecisionBits.BITS4,
+        PrecisionBits.BITS8,
+    )
+    assert actual == expected
+    assert actual[0] == {"bits": PrecisionBits.BITS4}
+    assert set(actual[1]) == expected_override_names
+    assert all(config == {"bits": PrecisionBits.BITS8} for config in actual[1].values())
+    assert [str(record.message) for record in warning_records] == [
+        "SelectiveMixedPrecision.get_k_quant_config is deprecated; use get_high_precision_config instead.",
+        (
+            f"SelectiveMixedPrecision config field 'algorithm' value '{legacy_algorithm}' is deprecated; "
+            f"use '{canonical_algorithm.value}' instead."
+        ),
+    ]
 
 
 @pytest.mark.parametrize("algorithm", ["snr", "snr_relative", "iqe", "iqe_relative", "kld_gradient"])

--- a/test/passes/pytorch/test_selective_mixed_precision.py
+++ b/test/passes/pytorch/test_selective_mixed_precision.py
@@ -6,6 +6,7 @@
 import importlib.util
 import math
 import sys
+import warnings
 from copy import deepcopy
 from types import ModuleType, SimpleNamespace
 
@@ -196,8 +197,8 @@ def input_model_fixture(tmp_path_factory):
 @pytest.mark.parametrize(
     ("algorithm", "expected_layer_indices", "include_qkv"),
     [
-        ("high_precision_mlp", [0, 3, 6, 7], False),  # first 1/8, every 3rd, and last 1/8
-        ("high_precision_mlp_qkv", [0, 3, 6, 7], True),
+        ("high_precision_mlp_down", [0, 3, 6, 7], False),  # first 1/8, every 3rd, and last 1/8
+        ("high_precision_mlp_down_qkv", [0, 3, 6, 7], True),
         ("high_precision_lm_head", [], False),
     ],
 )
@@ -237,8 +238,8 @@ def test_selective_mixed_precision_heuristic(algorithm, expected_layer_indices, 
     ("legacy_algorithm", "canonical_algorithm"),
     [
         ("k_quant_last", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD),
-        ("k_quant_down", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP),
-        ("k_quant_mixed", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV),
+        ("k_quant_down", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN),
+        ("k_quant_mixed", SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV),
     ],
 )
 def test_selective_mixed_precision_legacy_algorithm_warns_and_normalizes(legacy_algorithm, canonical_algorithm):
@@ -255,9 +256,10 @@ def test_selective_mixed_precision_legacy_algorithm_warns_and_normalizes(legacy_
     assert pass_instance.config.algorithm is canonical_algorithm
 
 
-def test_selective_mixed_precision_unknown_algorithm_is_rejected():
+@pytest.mark.parametrize("algorithm", ["high_precision_mlp", "high_precision_mlp_qkv", "unknown"])
+def test_selective_mixed_precision_unsupported_algorithm_is_rejected(algorithm):
     with pytest.raises(ValueError, match="algorithm"):
-        create_pass_from_dict(SelectiveMixedPrecision, {"algorithm": "unknown"}, disable_search=True)
+        create_pass_from_dict(SelectiveMixedPrecision, {"algorithm": algorithm}, disable_search=True)
 
 
 def test_selective_mixed_precision_algorithm_aliases_are_excluded_from_iteration_schema_and_search():
@@ -265,8 +267,8 @@ def test_selective_mixed_precision_algorithm_aliases_are_excluded_from_iteration
     canonical_algorithms = [
         algorithm.IQE,
         algorithm.IQE_RELATIVE,
-        algorithm.HIGH_PRECISION_MLP,
-        algorithm.HIGH_PRECISION_MLP_QKV,
+        algorithm.HIGH_PRECISION_MLP_DOWN,
+        algorithm.HIGH_PRECISION_MLP_DOWN_QKV,
         algorithm.HIGH_PRECISION_LM_HEAD,
         algorithm.KLD_GRADIENT,
         algorithm.SNR,
@@ -274,16 +276,19 @@ def test_selective_mixed_precision_algorithm_aliases_are_excluded_from_iteration
     ]
     deprecated_names = {"K_QUANT_LAST", "K_QUANT_DOWN", "K_QUANT_MIXED"}
 
-    assert algorithm.K_QUANT_LAST is algorithm.HIGH_PRECISION_LM_HEAD
-    assert algorithm.K_QUANT_DOWN is algorithm.HIGH_PRECISION_MLP
-    assert algorithm.K_QUANT_MIXED is algorithm.HIGH_PRECISION_MLP_QKV
+    with warnings.catch_warnings(record=True) as warning_records:
+        warnings.simplefilter("always")
+        assert algorithm.K_QUANT_LAST is algorithm.HIGH_PRECISION_LM_HEAD
+        assert algorithm.K_QUANT_DOWN is algorithm.HIGH_PRECISION_MLP_DOWN
+        assert algorithm.K_QUANT_MIXED is algorithm.HIGH_PRECISION_MLP_DOWN_QKV
+    assert not warning_records
     assert list(algorithm) == canonical_algorithms
     assert deprecated_names.isdisjoint(member.name for member in algorithm)
 
     algorithm_values = [algorithm.value for algorithm in SelectiveMixedPrecision.Algorithm]
     search_defaults = SelectiveMixedPrecision._default_config(None)["algorithm"].search_defaults.get_support()
     pass_instance = create_pass_from_dict(
-        SelectiveMixedPrecision, {"algorithm": "high_precision_mlp"}, disable_search=True
+        SelectiveMixedPrecision, {"algorithm": "high_precision_mlp_down"}, disable_search=True
     )
     schema_values = pass_instance.config.__class__.model_json_schema()["$defs"]["Algorithm"]["enum"]
 
@@ -356,7 +361,7 @@ def test_get_k_quant_config_warns_and_delegates(monkeypatch):
     assert calls == [
         (
             model_wrapper,
-            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
             PrecisionBits.BITS4,
             PrecisionBits.BITS8,
         )
@@ -373,7 +378,7 @@ def test_get_k_quant_config_warns_and_delegates(monkeypatch):
         ),
         (
             "k_quant_down",
-            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
             {
                 "lm_head",
                 "model.layers.0.mlp.down_proj",
@@ -384,7 +389,7 @@ def test_get_k_quant_config_warns_and_delegates(monkeypatch):
         ),
         (
             "k_quant_mixed",
-            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_QKV,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV,
             {
                 "lm_head",
                 *{
@@ -1077,11 +1082,11 @@ def test_kld_strategy_explicit_multi_gpu_falls_back_without_multiple_cuda_device
     patch_kld_calibration_data(monkeypatch, data)
     quantizer, high_quantizer = get_kld_gradient_quantizers()
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
-    warnings = []
+    warning_messages = []
     monkeypatch.setattr(
         smp_module.logger,
         "warning",
-        lambda message, *args: warnings.append(message % args if args else message),
+        lambda message, *args: warning_messages.append(message % args if args else message),
     )
 
     unit_numels, unit_scores = _kld_unit_scores(
@@ -1090,7 +1095,7 @@ def test_kld_strategy_explicit_multi_gpu_falls_back_without_multiple_cuda_device
 
     assert unit_numels
     assert unit_scores
-    assert any("requires at least two visible CUDA devices" in warning for warning in warnings)
+    assert any("requires at least two visible CUDA devices" in message for message in warning_messages)
 
 
 def test_kld_strategy_multi_gpu_uses_constrained_device_map(monkeypatch):


### PR DESCRIPTION
## Describe your changes

Rename the misleading `k_quant_*` SelectiveMixedPrecision heuristic names to describe which layers are promoted to high precision:

- `k_quant_last` -> `high_precision_lm_head`
- `k_quant_down` -> `high_precision_mlp_down`
- `k_quant_mixed` -> `high_precision_mlp_down_qkv`

Legacy configuration strings remain available and emit `FutureWarning`. Deprecated Python enum names remain available as silent aliases, while `get_k_quant_config` remains available and emits `FutureWarning`. The independent ORT GenAI ModelBuilder `int4_algo_config` values remain unchanged. Tests and quantization documentation are updated accordingly.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

Release note: SelectiveMixedPrecision now exposes descriptive `high_precision_*` names for its layer-based heuristics. Existing `k_quant_*` configuration strings continue to work with deprecation warnings.

## (Optional) Issue link

Related to #2638.