### PR TITLE
Add fused MoE support to SelectiveMixedPrecision heuristics

### DIFF
--- a/docs/source/features/quantization.md
+++ b/docs/source/features/quantization.md
@@ -226,6 +226,36 @@ are quantized; expert biases remain in full precision.
 }
 ```
 
+## Selective mixed precision for MoE
+
+`SelectiveMixedPrecision` can plan higher precision for the routed fused
+`experts.down_proj` parameters on the explicitly supported Qwen3 and Qwen3.5 MoE
+families. This is available only to the fixed `high_precision_mlp_down` and
+`high_precision_mlp_down_qkv` heuristics; score-based algorithms do not support
+MoE selection. The always-active `shared_expert.down_proj` is not specially
+promoted and remains at the pass default bit width.
+
+MoE planning uses a double opt-in. Set `moe=true` on
+`SelectiveMixedPrecision`, then also set `moe=true` on the first MoE-capable
+PyTorch quantizer (`Rtn`, `KQuant`, or `Gptq`) that consumes the plan. When routed expert
+overrides are emitted, the plan records
+`mixed_precision_info.requires_moe=true`; this requirement prevents a capable
+consumer from silently skipping those overrides. A pass without a `moe` field,
+such as `AutoClip`, may carry the plan forward, and category-only follow-up
+passes may use `moe=false` after a compatible Olive checkpoint with `moe=true`
+already exists. The metadata `default` map never enables or disables the
+consumer's `moe` setting.
+
+`requires_moe` is pass-emitted metadata, not an additional return value from the
+lower-level `get_high_precision_config` or deprecated `get_k_quant_config`
+helpers; both retain their two-value return contract.
+
+This planning metadata belongs to the Hugging Face/PyTorch pass boundary.
+Plain ONNX quantization does not consume it. For Mobius / ORT GenAI
+`ModelBuilder`, first materialize the plan with a supported PyTorch quantizer so
+the resulting Olive Hugging Face `quantization_config` records the selected
+expert precisions; planner metadata alone is not a Mobius input contract.
+
 ## HQQ
 `HQQ (Half-Quadratic Quantization)` is a fast, calibration-free weight quantization method that enables low-bit quantization of large models without relying on gradient-based optimization. Unlike data-dependent approaches like GPTQ, [HQQ](https://dropbox.github.io/hqq_blog/) uses half-quadratic splitting to minimize weight quantization error efficiently.
 

--- a/docs/source/features/quantization.md
+++ b/docs/source/features/quantization.md
@@ -251,10 +251,10 @@ lower-level `get_high_precision_config` or deprecated `get_k_quant_config`
 helpers; both retain their two-value return contract.
 
 This planning metadata belongs to the Hugging Face/PyTorch pass boundary.
-Plain ONNX quantization does not consume it. For Mobius / ORT GenAI
-`ModelBuilder`, first materialize the plan with a supported PyTorch quantizer so
-the resulting Olive Hugging Face `quantization_config` records the selected
-expert precisions; planner metadata alone is not a Mobius input contract.
+Plain ONNX quantization does not consume it. This stage covers materializing the
+plan into an Olive Hugging Face/PyTorch checkpoint; export through Mobius or ORT
+GenAI `ModelBuilder` is out of scope and has not been validated. Planner
+metadata alone is not an input contract for those export paths.
 
 ## HQQ
 `HQQ (Half-Quadratic Quantization)` is a fast, calibration-free weight quantization method that enables low-bit quantization of large models without relying on gradient-based optimization. Unlike data-dependent approaches like GPTQ, [HQQ](https://dropbox.github.io/hqq_blog/) uses half-quadratic splitting to minimize weight quantization error efficiently.

--- a/olive/common/hf/wrapper.py
+++ b/olive/common/hf/wrapper.py
@@ -170,6 +170,17 @@ class LayerWrapper:
     EXPERTS = {
         "default": "experts",
     }
+    # Direct semantic output/down parameter on explicitly supported fused-experts
+    # implementations. There is intentionally no default: consumers of this mapping need
+    # proof that the architecture stores the output projection directly on ``experts`` as
+    # a K-last 3D tensor, rather than guessing from an attribute name.
+    EXPERT_OUTPUTS = {
+        "qwen3_moe": "down_proj",
+        # Both the composite and native text model types are mapped explicitly because
+        # model-type resolution can preserve either form.
+        "qwen3_5_moe": "down_proj",
+        "qwen3_5_moe_text": "down_proj",
+    }
     #
     # Router attribute names verified against transformers 5.14.1:
     #   * ``gate``   -- qwen2_moe, qwen3_moe, mixtral, deepseek_v3, olmoe (the default)
@@ -324,6 +335,41 @@ class LayerWrapper:
             return (None, "") if return_name else None
         name = f"{self.mlp_name}.{self.EXPERTS.get(self.model_type, self.EXPERTS['default'])}"
         return (module, name) if return_name else module
+
+    def get_expert_output(self, return_name: bool = True):
+        """Return the supported fused experts' direct 3D output/down parameter.
+
+        Unlike the general ``get_experts`` accessor, this semantic accessor is deliberately
+        fail-closed. It only recognizes architectures whose fused output parameter topology
+        has been verified, and it rejects per-expert modules and indirect/non-3D parameters.
+        The returned name is local to the experts owner; callers that need a canonical model
+        name must resolve ``(id(experts), parameter_name)`` through ``iter_quant_targets``.
+        """
+        parameter_name = self.EXPERT_OUTPUTS.get(self.model_type)
+        if parameter_name is None:
+            raise ValueError(
+                "Selective mixed precision does not recognize a fused expert output projection "
+                f"for model_type='{self.model_type}'."
+            )
+
+        experts = self.get_experts(return_name=False)
+        if experts is None:
+            raise ValueError("The layer has no resolved experts module.")
+        if isinstance(experts, nn.ModuleList):
+            raise ValueError(
+                "Selective mixed precision requires a fused experts module with a direct 3D "
+                "output projection; per-expert ModuleList topology is unsupported."
+            )
+
+        parameter = dict(experts.named_parameters(recurse=False)).get(parameter_name)
+        if not isinstance(parameter, nn.Parameter):
+            raise ValueError(
+                f"Experts output projection '{parameter_name}' must be a direct nn.Parameter "
+                "on the fused experts module."
+            )
+        if parameter.dim() != 3:
+            raise ValueError(f"Experts output projection '{parameter_name}' must be 3D, got {parameter.dim()}D.")
+        return parameter if not return_name else (parameter, parameter_name)
 
     def get_router(self, return_name: bool = True):
         """Return the router sub-module of this layer (or ``None`` if not MoE).

--- a/olive/passes/pytorch/quant_utils.py
+++ b/olive/passes/pytorch/quant_utils.py
@@ -9,6 +9,7 @@ import contextlib
 import inspect
 import logging
 import re
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
@@ -41,6 +42,8 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+_QUANTIZATION_CONFIG_NOT_PROVIDED = object()
 
 
 def get_quantizer_config(allow_embeds: bool = False, allow_moe: bool = False) -> dict[str, PassConfigParam]:
@@ -495,6 +498,177 @@ def _collect_already_quantized_names(model: torch.nn.Module) -> set[str]:
     return names
 
 
+def _get_hf_quantization_config_value(quantization_config, name: str, default=None):
+    """Read a field from a dict or Hugging Face quantization config object."""
+    if isinstance(quantization_config, Mapping):
+        return quantization_config.get(name, default)
+    return getattr(quantization_config, name, default)
+
+
+def _copy_existing_quantization_config(quantization_config) -> dict | None:
+    """Return a validated mutable copy of an existing HF quantization config."""
+    if quantization_config is None:
+        return None
+    if isinstance(quantization_config, Mapping):
+        copied = deepcopy(dict(quantization_config))
+    else:
+        to_dict = getattr(quantization_config, "to_dict", None)
+        if not callable(to_dict):
+            raise ValueError("Existing quantization_config must be a mapping or expose a callable to_dict().")
+        copied = to_dict()
+        if not isinstance(copied, Mapping):
+            raise ValueError("Existing quantization_config.to_dict() must return a mapping.")
+        copied = deepcopy(dict(copied))
+
+    if copied.get("quant_method") == OliveHfQuantizationMethod.OLIVE:
+        moe = copied.get("moe", False)
+        if "moe" in copied and not isinstance(moe, bool):
+            raise ValueError("Existing Olive quantization_config.moe must be a bool when present.")
+    return copied
+
+
+def _get_validated_mixed_precision_info(model: HfModelHandler) -> dict | None:
+    """Validate and copy the mixed-precision metadata consumed by quantization passes."""
+    attributes = model.model_attributes or {}
+    if "mixed_precision_info" not in attributes:
+        return None
+
+    raw_info = attributes["mixed_precision_info"]
+    if not isinstance(raw_info, Mapping):
+        raise ValueError("mixed_precision_info must be a mapping.")
+
+    requires_moe = raw_info.get("requires_moe", False)
+    if "requires_moe" in raw_info and not isinstance(requires_moe, bool):
+        raise ValueError("mixed_precision_info.requires_moe must be a bool when present.")
+
+    default = raw_info.get("default")
+    if not isinstance(default, Mapping):
+        raise ValueError("mixed_precision_info.default must be a mapping.")
+    raw_overrides = raw_info.get("overrides")
+    if not isinstance(raw_overrides, Mapping):
+        raise ValueError("mixed_precision_info.overrides must be a mapping.")
+
+    overrides = {}
+    for name, override in raw_overrides.items():
+        if not isinstance(name, str):
+            raise ValueError("Every mixed_precision_info.overrides key must be a string.")
+        if not isinstance(override, Mapping):
+            raise ValueError(f"mixed_precision_info.overrides[{name!r}] must be a mapping.")
+        overrides[name] = dict(override)
+
+    return {
+        "default": dict(default),
+        "overrides": overrides,
+        **({"requires_moe": requires_moe} if "requires_moe" in raw_info else {}),
+    }
+
+
+def validate_moe_quantization_requirement(
+    model: HfModelHandler,
+    config: type[BasePassConfig],
+    existing_quantization_config=_QUANTIZATION_CONFIG_NOT_PROVIDED,
+) -> None:
+    """Validate a mixed-precision plan's MoE consumer requirement.
+
+    Consumers without a ``moe`` field, such as AutoClip, may pass the plan through
+    unchanged. A MoE-capable consumer must opt in unless a compatible existing Olive
+    checkpoint already records ``moe=True``.
+
+    Args:
+        model: The Hugging Face model carrying mixed-precision metadata.
+        config: The consuming pass configuration.
+        existing_quantization_config: An optional previously read Hugging Face
+            quantization config.
+
+    Raises:
+        ValueError: If the plan requires MoE, the consumer explicitly disables it, and
+            no compatible MoE-enabled Olive checkpoint has already fulfilled the
+            requirement.
+
+    """
+    mp_info = _get_validated_mixed_precision_info(model)
+    if mp_info is None or mp_info.get("requires_moe") is not True:
+        return
+
+    if not hasattr(config, "moe"):
+        return
+    if not isinstance(config.moe, bool):
+        raise ValueError("The consuming quantization pass config.moe must be a bool.")
+    if config.moe is True:
+        return
+
+    if existing_quantization_config is _QUANTIZATION_CONFIG_NOT_PROVIDED:
+        existing_quantization_config = getattr(model.get_hf_model_config(), "quantization_config", None)
+    existing_quantization_config = _copy_existing_quantization_config(existing_quantization_config)
+    if (
+        existing_quantization_config is not None
+        and _get_hf_quantization_config_value(existing_quantization_config, "quant_method")
+        != OliveHfQuantizationMethod.OLIVE
+    ):
+        raise ValueError("Model has an existing quantization configuration that is not compatible with this pass.")
+    if (
+        existing_quantization_config is not None
+        and _get_hf_quantization_config_value(existing_quantization_config, "moe", False) is True
+    ):
+        # This is only a pre-load exemption. prepare_model verifies the required expert
+        # parameters are really QuantTensor-backed after loading the checkpoint.
+        return
+
+    raise ValueError(
+        "This model's mixed_precision_info requires MoE quantization, but the consuming "
+        "quantization pass explicitly disabled it. Set moe=True on a MoE-capable quantization "
+        "pass before applying follow-up category passes."
+    )
+
+
+def _get_required_fused_expert_overrides(root_model: torch.nn.Module, mp_info: dict | None) -> set[str]:
+    """Return exact SMP override names that refer to fused expert parameters."""
+    if mp_info is None or mp_info.get("requires_moe") is not True:
+        return set()
+
+    fused_expert_targets = {
+        full_name
+        for module, pname, full_name in iter_quant_targets(
+            root_model,
+            quantize_lm_head=True,
+            quantize_embeds=True,
+            quantize_moe=True,
+            quantize_vision=True,
+            skip_already_quantized=False,
+        )
+        if not isinstance(module, (torch.nn.Linear, torch.nn.Embedding)) and module._parameters[pname].dim() == 3
+    }
+    return {name for name in mp_info["overrides"] if name in fused_expert_targets}
+
+
+def _validate_required_fused_expert_targets(
+    *,
+    config: type[BasePassConfig],
+    required_names: set[str],
+    new_target_names: set[str],
+    already_quantized_names: set[str],
+    has_compatible_existing_config: bool,
+) -> None:
+    """Ensure a MoE-capable consumer really materializes every required expert override."""
+    if not hasattr(config, "moe"):
+        return
+    if not required_names:
+        raise ValueError(
+            "mixed_precision_info.requires_moe is true, but no exact fused expert overrides "
+            "could be resolved in the loaded model."
+        )
+
+    materialized_names = already_quantized_names if has_compatible_existing_config else set()
+    if config.moe is True:
+        materialized_names = materialized_names | new_target_names
+    missing = sorted(required_names - materialized_names)
+    if missing:
+        raise ValueError(
+            "The consuming quantization pass did not fulfill the required fused expert targets. "
+            f"Missing required names: {missing}"
+        )
+
+
 def prepare_model(
     model: HfModelHandler,
     config: type[BasePassConfig],
@@ -512,16 +686,24 @@ def prepare_model(
     Returns:
         A tuple containing ModelWrapper with prepared model, the quantization configuration, and a boolean indicating if the word embeddings are eligible for tieing.
 
-    """
-    if existing_qcfg := getattr(model.get_hf_model_config(), "quantization_config", None):
-        if not allow_quantized:
-            raise ValueError("Model is already quantized. Cannot quantize again using this pass.")
-        # Always work on a fresh copy: the underlying HF config holds the original object
-        # (dict or dataclass) and we mutate ``existing_qcfg`` heavily below.
-        existing_qcfg = deepcopy(existing_qcfg) if isinstance(existing_qcfg, dict) else existing_qcfg.to_dict()
-        if existing_qcfg.get("quant_method", None) != OliveHfQuantizationMethod.OLIVE:
-            raise ValueError("Model has an existing quantization configuration that is not compatible with this pass.")
+    Raises:
+        ValueError: If mixed-precision metadata requires MoE quantization and the first
+            MoE-capable consumer does not opt in.
 
+    """
+    existing_qcfg = _copy_existing_quantization_config(
+        getattr(model.get_hf_model_config(), "quantization_config", None)
+    )
+    if existing_qcfg is not None and existing_qcfg.get("quant_method", None) != OliveHfQuantizationMethod.OLIVE:
+        raise ValueError("Model has an existing quantization configuration that is not compatible with this pass.")
+    # Deliberately checked twice: prepare_model fails before loading, while
+    # get_quant_config repeats the requirement check for direct callers.
+    validate_moe_quantization_requirement(model, config, existing_qcfg)
+
+    if existing_qcfg is not None and not allow_quantized:
+        raise ValueError("Model is already quantized. Cannot quantize again using this pass.")
+
+    mp_info = _get_validated_mixed_precision_info(model)
     component_source_paths = _get_component_source_paths(model)
     component_attributes = model.model_attributes or {}
     component_name = component_attributes.get("component_name")
@@ -548,14 +730,12 @@ def prepare_model(
     selected_module_names = {_root_module_name(name, name_prefix) for name, _ in wrapper.model.named_modules()}
     fresh_qcfg = normalize_qkv_quant_config(
         wrapper,
-        get_quant_config(model, config),
+        get_quant_config(model, config, existing_qcfg),
         module_names=selected_module_names,
         name_prefix=name_prefix,
     )
 
     originally_tied_embeddings = getattr(wrapper.config, "tie_word_embeddings", False)
-    if fresh_qcfg.lm_head or fresh_qcfg.embeds:
-        wrapper.maybe_untie_word_embeddings()
 
     declared_head_name = _path_with_leaf(
         component_source_paths,
@@ -597,12 +777,14 @@ def prepare_model(
     def _iter_component_quant_targets(
         quant_cfg: OliveHfQuantizationConfig,
         module_skip_patterns: list[str],
+        *,
+        quantize_moe: bool | None = None,
     ):
         for module, pname, full_name in iter_quant_targets(
             wrapper.model,
             quantize_lm_head=quant_cfg.lm_head,
             quantize_embeds=quant_cfg.embeds,
-            quantize_moe=getattr(quant_cfg, "moe", False),
+            quantize_moe=getattr(quant_cfg, "moe", False) if quantize_moe is None else quantize_moe,
             quantize_vision=getattr(quant_cfg, "quantize_vision", False),
             extra_skip_modules=excluded_attn_inputs,
         ):
@@ -633,11 +815,9 @@ def prepare_model(
     # existing config's defaults (no explicit override entry).
     on_disk_overrides: set[str] = set()
     already_quantized: set[str] = set()
-    if existing_qcfg:
+    if existing_qcfg is not None:
         on_disk_overrides = set((existing_qcfg.get("overrides") or {}).keys())
-        already_quantized = {
-            _root_module_name(name, name_prefix) for name in _collect_already_quantized_names(wrapper.model)
-        }
+        already_quantized = _collect_already_quantized_names(root_model)
         merged = existing_qcfg
         merged["overrides"] = existing_qcfg.get("overrides") or {}
         for name in fresh_names:
@@ -672,12 +852,34 @@ def prepare_model(
         if pattern in fresh_skip_patterns or not any(match_skip(name, [pattern]) for name in fresh_names)
     ]
 
-    new_qargs: dict[str, dict[str, int | bool]] = {}
+    new_targets = list(
+        _iter_component_quant_targets(
+            qcfg,
+            selection_skip_patterns,
+            # A prior qcfg.moe=True describes reload behavior, not permission for a
+            # moe=False follow-up pass to quantize leftover float expert parameters.
+            quantize_moe=getattr(config, "moe", False),
+        )
+    )
+    new_qargs: dict[str, dict[str, int | bool]] = {
+        root_name: qcfg.get_qlinear_init_args(root_name) for _, _, root_name in new_targets
+    }
+    if mp_info is not None and mp_info.get("requires_moe") is True and hasattr(config, "moe"):
+        required_expert_names = _get_required_fused_expert_overrides(root_model, mp_info)
+        _validate_required_fused_expert_targets(
+            config=config,
+            required_names=required_expert_names,
+            new_target_names=set(new_qargs),
+            already_quantized_names=already_quantized,
+            has_compatible_existing_config=existing_qcfg is not None,
+        )
 
-    for module, pname, root_name in _iter_component_quant_targets(qcfg, selection_skip_patterns):
-        qargs = qcfg.get_qlinear_init_args(root_name)
-        new_qargs[root_name] = qargs
-        module._parameters[pname].quant_info = QuantInfo(quantizer=WeightQuantizer(**qargs))
+    # Everything above is discovery/validation. Mutate parameters only after all required
+    # final targets have been proven present.
+    if fresh_qcfg.lm_head or fresh_qcfg.embeds:
+        wrapper.maybe_untie_word_embeddings()
+    for module, pname, root_name in new_targets:
+        module._parameters[pname].quant_info = QuantInfo(quantizer=WeightQuantizer(**new_qargs[root_name]))
 
     quantized_names = already_quantized | set(new_qargs)
     reload_target_names = {
@@ -732,17 +934,30 @@ def prepare_model(
     return wrapper, qcfg, word_embeddings_eligible_for_tieing
 
 
-def get_quant_config(model: HfModelHandler, config: type[BasePassConfig]) -> OliveHfQuantizationConfig:
+def get_quant_config(
+    model: HfModelHandler,
+    config: type[BasePassConfig],
+    existing_quantization_config=_QUANTIZATION_CONFIG_NOT_PROVIDED,
+) -> OliveHfQuantizationConfig:
     """Get quantization configuration with mixed precision support.
 
     Args:
         model: The HuggingFace model to get configuration for.
         config: Configuration object containing quantization parameters.
+        existing_quantization_config: An optional previously read Hugging Face
+            quantization config used to validate follow-up passes.
 
     Returns:
         OliveHfQuantizationConfig object with quantization settings.
 
+    Raises:
+        ValueError: If mixed-precision metadata requires MoE quantization and the first
+            MoE-capable consumer explicitly disables it.
+
     """
+    validate_moe_quantization_requirement(model, config, existing_quantization_config)
+
+    mp_info = _get_validated_mixed_precision_info(model)
     quant_config = {
         "bits": config.bits,
         "symmetric": config.sym,
@@ -752,15 +967,17 @@ def get_quant_config(model: HfModelHandler, config: type[BasePassConfig]) -> Oli
         "moe": getattr(config, "moe", False),
         "quantize_vision": getattr(config, "quantize_vision", False),
         "modules_to_not_convert": getattr(config, "modules_to_not_convert", None) or [],
-        "overrides": config.overrides or {},
+        "overrides": deepcopy(config.overrides) if config.overrides is not None else {},
     }
-    if mp_info := (model.model_attributes or {}).get("mixed_precision_info"):
+    if mp_info is not None:
         for k, v in quant_config.items():
+            if k == "moe":
+                continue
             if mp_info["default"].get(k) is not None and v != mp_info["default"][k]:
                 logger.debug("Overriding %s with mixed precision info: %s", k, mp_info["default"][k])
                 quant_config[k] = mp_info["default"][k]
         # merge overrides, user provided overrides take precedence
-        for name, override in mp_info.get("overrides", {}).items():
+        for name, override in mp_info["overrides"].items():
             merged = override.copy()
             merged.update({k: v for k, v in quant_config["overrides"].get(name, {}).items() if v is not None})
             quant_config["overrides"][name] = merged

--- a/olive/passes/pytorch/quant_utils.py
+++ b/olive/passes/pytorch/quant_utils.py
@@ -626,18 +626,23 @@ def _get_required_fused_expert_overrides(root_model: torch.nn.Module, mp_info: d
     if mp_info is None or mp_info.get("requires_moe") is not True:
         return set()
 
-    fused_expert_targets = {
-        full_name
-        for module, pname, full_name in iter_quant_targets(
-            root_model,
-            quantize_lm_head=True,
-            quantize_embeds=True,
-            quantize_moe=True,
-            quantize_vision=True,
-            skip_already_quantized=False,
-        )
-        if not isinstance(module, (torch.nn.Linear, torch.nn.Embedding)) and module._parameters[pname].dim() == 3
-    }
+    fused_expert_targets = set()
+    for module, pname, full_name in iter_quant_targets(
+        root_model,
+        quantize_lm_head=True,
+        quantize_embeds=True,
+        quantize_moe=True,
+        quantize_vision=True,
+        skip_already_quantized=False,
+    ):
+        parameter = module._parameters.get(pname)
+        if (
+            parameter is not None
+            and not isinstance(module, (torch.nn.Linear, torch.nn.Embedding))
+            and parameter.dim() == 3
+        ):
+            fused_expert_targets.add(full_name)
+
     return {name for name in mp_info["overrides"] if name in fused_expert_targets}
 
 

--- a/olive/passes/pytorch/quant_utils.py
+++ b/olive/passes/pytorch/quant_utils.py
@@ -477,25 +477,29 @@ def _collect_excluded_attn_inputs(wrapper: ModelWrapper) -> set[torch.nn.Module]
     return excluded
 
 
-def _collect_already_quantized_names(model: torch.nn.Module) -> set[str]:
-    """Return override-key names of parameters already backed by a ``QuantTensor``.
+def _collect_already_quantized_targets(model: torch.nn.Module) -> dict[str, QuantTensor]:
+    """Return override-key names and tensors for parameters already backed by a ``QuantTensor``.
 
     Names follow the same convention as :func:`iter_quant_targets`: ``module_name`` for
     the ``weight`` parameter of ``nn.Linear`` / ``nn.Embedding`` and ``f"{name}.{pname}"``
-    otherwise. These names lock the corresponding modules against re-quantization and QKV
-    renormalization when merging with an existing checkpoint.
+    otherwise. These targets lock the corresponding modules against re-quantization and QKV
+    renormalization when merging with an existing checkpoint, while retaining the tensor's
+    actual quantization attributes for immutable-target validation.
     """
-    names: set[str] = set()
+    targets: dict[str, QuantTensor] = {}
     for name, module in model.named_modules():
         for pname, param in module.named_parameters(recurse=False):
             if param is None:
                 continue
-            if isinstance(param, QuantTensor) or isinstance(getattr(param, "data", None), QuantTensor):
-                if pname == "weight" and isinstance(module, (torch.nn.Linear, torch.nn.Embedding)):
-                    names.add(name)
-                else:
-                    names.add(f"{name}.{pname}" if name else pname)
-    return names
+            quant_tensor = param if isinstance(param, QuantTensor) else getattr(param, "data", None)
+            if not isinstance(quant_tensor, QuantTensor):
+                continue
+            if pname == "weight" and isinstance(module, (torch.nn.Linear, torch.nn.Embedding)):
+                target_name = name
+            else:
+                target_name = f"{name}.{pname}" if name else pname
+            targets[target_name] = quant_tensor
+    return targets
 
 
 def _get_hf_quantization_config_value(quantization_config, name: str, default=None):
@@ -621,11 +625,12 @@ def validate_moe_quantization_requirement(
     )
 
 
-def _get_required_fused_expert_overrides(root_model: torch.nn.Module, mp_info: dict | None) -> set[str]:
-    """Return exact SMP override names that refer to fused expert parameters."""
+def _get_required_fused_expert_overrides(root_model: torch.nn.Module, mp_info: dict | None) -> dict[str, dict]:
+    """Validate exact SMP override names and return those for fused expert parameters."""
     if mp_info is None or mp_info.get("requires_moe") is not True:
-        return set()
+        return {}
 
+    canonical_targets = set()
     fused_expert_targets = set()
     for module, pname, full_name in iter_quant_targets(
         root_model,
@@ -635,6 +640,7 @@ def _get_required_fused_expert_overrides(root_model: torch.nn.Module, mp_info: d
         quantize_vision=True,
         skip_already_quantized=False,
     ):
+        canonical_targets.add(full_name)
         parameter = module._parameters.get(pname)
         if (
             parameter is not None
@@ -643,30 +649,72 @@ def _get_required_fused_expert_overrides(root_model: torch.nn.Module, mp_info: d
         ):
             fused_expert_targets.add(full_name)
 
-    return {name for name in mp_info["overrides"] if name in fused_expert_targets}
+    stale_names = sorted(set(mp_info["overrides"]) - canonical_targets)
+    if stale_names:
+        raise ValueError(
+            "mixed_precision_info contains override names that are not canonical quantization "
+            f"targets in the loaded model. Stale override names: {stale_names}"
+        )
+
+    return {name: override for name, override in mp_info["overrides"].items() if name in fused_expert_targets}
 
 
 def _validate_required_fused_expert_targets(
     *,
     config: type[BasePassConfig],
-    required_names: set[str],
+    required_overrides: dict[str, dict],
     new_target_names: set[str],
-    already_quantized_names: set[str],
+    already_quantized_targets: dict[str, QuantTensor],
+    effective_qcfg: OliveHfQuantizationConfig,
     has_compatible_existing_config: bool,
 ) -> None:
     """Ensure a MoE-capable consumer really materializes every required expert override."""
     if not hasattr(config, "moe"):
         return
-    if not required_names:
+    if not required_overrides:
         raise ValueError(
             "mixed_precision_info.requires_moe is true, but no exact fused expert overrides "
             "could be resolved in the loaded model."
         )
 
-    materialized_names = already_quantized_names if has_compatible_existing_config else set()
-    if config.moe is True:
-        materialized_names = materialized_names | new_target_names
-    missing = sorted(required_names - materialized_names)
+    fulfilled_names = set(new_target_names) if config.moe is True else set()
+    if has_compatible_existing_config:
+        required_fields = ("bits", "symmetric", "group_size")
+        for name, required_override in required_overrides.items():
+            quant_tensor = already_quantized_targets.get(name)
+            if quant_tensor is None:
+                continue
+
+            actual_qargs = {field: getattr(quant_tensor, field) for field in required_fields}
+            configured_qargs = effective_qcfg.get_qlinear_init_args(name)
+            if actual_qargs != configured_qargs:
+                raise ValueError(
+                    "An already-materialized required fused expert target has quantization attributes "
+                    "that are inconsistent with its effective existing Olive quantization config. "
+                    f"Target {name!r}: QuantTensor={actual_qargs}, config={configured_qargs}"
+                )
+
+            explicitly_required = {
+                field: required_override[field] for field in required_fields if field in required_override
+            }
+            mismatched_required = {
+                field: {
+                    "required": value,
+                    "actual": actual_qargs[field],
+                    "config": configured_qargs[field],
+                }
+                for field, value in explicitly_required.items()
+                if actual_qargs[field] != value or configured_qargs[field] != value
+            }
+            if mismatched_required:
+                raise ValueError(
+                    "An already-materialized fused expert target does not satisfy its required "
+                    "mixed_precision_info override. "
+                    f"Target {name!r} mismatches: {mismatched_required}"
+                )
+            fulfilled_names.add(name)
+
+    missing = sorted(set(required_overrides) - fulfilled_names)
     if missing:
         raise ValueError(
             "The consuming quantization pass did not fulfill the required fused expert targets. "
@@ -748,8 +796,6 @@ def prepare_model(
 
     originally_tied_embeddings = getattr(wrapper.config, "tie_word_embeddings", False)
     wrapper.olive_originally_tied_embeddings = originally_tied_embeddings
-    if fresh_qcfg.lm_head or fresh_qcfg.embeds:
-        wrapper.maybe_untie_word_embeddings()
 
     declared_head_name = _path_with_leaf(
         component_source_paths,
@@ -828,10 +874,12 @@ def prepare_model(
     # a ``QuantTensor`` after load is on-disk-immutable, including those that used the
     # existing config's defaults (no explicit override entry).
     on_disk_overrides: set[str] = set()
+    already_quantized_targets: dict[str, QuantTensor] = {}
     already_quantized: set[str] = set()
     if existing_qcfg is not None:
         on_disk_overrides = set((existing_qcfg.get("overrides") or {}).keys())
-        already_quantized = _collect_already_quantized_names(root_model)
+        already_quantized_targets = _collect_already_quantized_targets(root_model)
+        already_quantized = set(already_quantized_targets)
         merged = existing_qcfg
         merged["overrides"] = existing_qcfg.get("overrides") or {}
         for name in fresh_names:
@@ -879,12 +927,13 @@ def prepare_model(
         root_name: qcfg.get_qlinear_init_args(root_name) for _, _, root_name in new_targets
     }
     if mp_info is not None and mp_info.get("requires_moe") is True and hasattr(config, "moe"):
-        required_expert_names = _get_required_fused_expert_overrides(root_model, mp_info)
+        required_expert_overrides = _get_required_fused_expert_overrides(root_model, mp_info)
         _validate_required_fused_expert_targets(
             config=config,
-            required_names=required_expert_names,
+            required_overrides=required_expert_overrides,
             new_target_names=set(new_qargs),
-            already_quantized_names=already_quantized,
+            already_quantized_targets=already_quantized_targets,
+            effective_qcfg=qcfg,
             has_compatible_existing_config=existing_qcfg is not None,
         )
 

--- a/olive/passes/pytorch/selective_mixed_precision.py
+++ b/olive/passes/pytorch/selective_mixed_precision.py
@@ -12,15 +12,18 @@ from typing import TYPE_CHECKING
 from warnings import warn
 
 import torch
+from torch import nn
 
 from olive.common.hf.wrapper import ModelWrapper
 from olive.common.quant.hf_utils import replace_matching_submodules, sort_layers_by_name
+from olive.common.quant.selection import iter_quant_targets
 from olive.common.quant.utils import WeightQuantizer
 from olive.common.utils import StrEnumBase, get_attr
 from olive.constants import PrecisionBits
 from olive.model import HfModelHandler
 from olive.passes import Pass
 from olive.passes.pass_config import BasePassConfig, PassConfigParam
+from olive.passes.pytorch.moe_support import check_moe_layout_support
 from olive.passes.pytorch.quant_utils import get_qkv_quantization_groups
 from olive.passes.pytorch.train_utils import get_calibration_dataset, kl_div_loss, load_hf_base_model
 from olive.search.search_parameter import Boolean, Categorical
@@ -642,6 +645,9 @@ class SelectiveMixedPrecision(Pass):
     they always share precision, which is required for ModelBuilder's GQA fusion: ONNX export
     fuses q/k/v into a single matmul, so the score-based algorithms aggregate per-projection
     stats into the score of the fused matmul before deciding which units to promote.
+
+    ``moe=True`` extends the fixed MLP heuristics to supported fused Qwen MoE expert output
+    projections. Score-based MoE selection is not supported.
     """
 
     class Algorithm(StrEnumBase):
@@ -765,6 +771,14 @@ class SelectiveMixedPrecision(Pass):
                     " ``offload`` also keeps teacher and student off device when not in use."
                 ),
             ),
+            "moe": PassConfigParam(
+                type_=bool,
+                default_value=False,
+                description=(
+                    "Whether fixed MLP heuristics should promote supported fused-MoE expert "
+                    "output projections. Score-based algorithms do not support MoE selection."
+                ),
+            ),
         }
 
     @classmethod
@@ -782,6 +796,10 @@ class SelectiveMixedPrecision(Pass):
 
         if not cls._is_heuristic_algorithm(config.algorithm) and (config.ratio is None or not (0 < config.ratio < 1)):
             logger.error("When using %s algorithm, ratio must be provided and between 0 and 1.", config.algorithm)
+            return False
+
+        if config.moe and not cls._is_heuristic_algorithm(config.algorithm):
+            logger.error("SelectiveMixedPrecision algorithm '%s' does not support MoE scoring.", config.algorithm)
             return False
 
         return True
@@ -804,15 +822,27 @@ class SelectiveMixedPrecision(Pass):
         if not isinstance(model, HfModelHandler):
             raise ValueError("SelectiveMixedPrecision pass currently only supports HfModelHandler.")
 
+        if config.moe and not self._is_heuristic_algorithm(config.algorithm):
+            raise ValueError(
+                f"SelectiveMixedPrecision algorithm '{config.algorithm}' does not support MoE scoring; "
+                "MoE selection is supported only for fixed heuristics."
+            )
+        if config.moe and config.algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD:
+            logger.warning(
+                "SelectiveMixedPrecision moe=True is a legal no-op with high_precision_lm_head; "
+                "no expert overrides will be emitted."
+            )
+
         # clear cached model
         model.model = None
         model_wrapper = ModelWrapper.from_model(load_hf_base_model(model))
 
         if self._is_heuristic_algorithm(config.algorithm):
-            default, overrides = self.get_high_precision_config(
-                model_wrapper, config.algorithm, config.bits, config.high_bits
+            default, overrides, requires_moe = self._get_high_precision_config(
+                model_wrapper, config.algorithm, config.bits, config.high_bits, config.moe
             )
         else:
+            requires_moe = False
             default, overrides = self.get_scored_config(
                 model,
                 model_wrapper,
@@ -838,10 +868,13 @@ class SelectiveMixedPrecision(Pass):
         # deepcopy is okay since loaded model is not cached
         output_model = deepcopy(model)
         output_model.model_attributes = output_model.model_attributes or {}
-        output_model.model_attributes["mixed_precision_info"] = {
+        mixed_precision_info = {
             "default": default,
             "overrides": overrides,
         }
+        if requires_moe:
+            mixed_precision_info["requires_moe"] = True
+        output_model.model_attributes["mixed_precision_info"] = mixed_precision_info
         return output_model
 
     @staticmethod
@@ -850,21 +883,41 @@ class SelectiveMixedPrecision(Pass):
         algorithm: SelectiveMixedPrecision.Algorithm | str,
         bits: PrecisionBits,
         high_bits: PrecisionBits,
+        moe: bool = False,
     ) -> tuple[dict, dict[str, dict]]:
-        """Get mixed precision config for layer-based high-precision heuristics."""
+        """Get mixed precision config for layer-based high-precision heuristics.
+
+        ``requires_moe`` is pass-emitted metadata and is intentionally not included in
+        this helper's two-value return shape.
+        """
+        default, overrides, _ = SelectiveMixedPrecision._get_high_precision_config(
+            model_wrapper, algorithm, bits, high_bits, moe
+        )
+        return default, overrides
+
+    @staticmethod
+    def _get_high_precision_config(
+        model_wrapper: ModelWrapper,
+        algorithm: SelectiveMixedPrecision.Algorithm | str,
+        bits: PrecisionBits,
+        high_bits: PrecisionBits,
+        moe: bool,
+    ) -> tuple[dict, dict[str, dict], bool]:
+        """Build fixed-heuristic config and report whether fused expert overrides were emitted."""
         algorithm = SelectiveMixedPrecision.Algorithm(algorithm)
         override_config = {"bits": high_bits}
         overrides = {model_wrapper.get_lm_head()[1]: override_config}
 
-        if algorithm != SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD:
+        # ``moe`` is intentionally a legal no-op for the LM-head-only heuristic. In
+        # particular, do not inspect or validate expert topology for this algorithm.
+        if algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_LM_HEAD:
+            return {"bits": bits}, overrides, False
+
+        if not moe:
             layer_prefix = model_wrapper.get_layers()[1]
             num_layers = model_wrapper.num_hidden_layers
             for layer_idx, layer_wrapper in enumerate(model_wrapper.get_layer_wrappers()):
-                if not (
-                    layer_idx < num_layers / 8
-                    or layer_idx >= 7 * num_layers / 8
-                    or ((layer_idx - num_layers // 8) % 3 == 2)
-                ):
+                if not SelectiveMixedPrecision._is_selected_heuristic_layer(layer_idx, num_layers):
                     continue
 
                 # Add qkv
@@ -876,7 +929,126 @@ class SelectiveMixedPrecision(Pass):
                 for attn_output_name in layer_wrapper.get_mlp_outputs(return_name=True)[1]:
                     overrides[f"{layer_prefix}.{layer_idx}.{attn_output_name}"] = override_config
 
-        return {"bits": bits}, overrides
+            return {"bits": bits}, overrides, False
+
+        expert_names, attention_names, dense_output_names = SelectiveMixedPrecision._validate_moe_heuristic_targets(
+            model_wrapper,
+            include_qkv=algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV,
+        )
+        fused_expert_override_emitted = False
+        layer_prefix = model_wrapper.get_layers()[1]
+        num_layers = model_wrapper.num_hidden_layers
+        for layer_idx, _ in enumerate(model_wrapper.get_layer_wrappers()):
+            if not SelectiveMixedPrecision._is_selected_heuristic_layer(layer_idx, num_layers):
+                continue
+
+            if algorithm == SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV:
+                for attn_input_name in attention_names[layer_idx]:
+                    overrides[f"{layer_prefix}.{layer_idx}.{attn_input_name}"] = override_config
+
+            if expert_names[layer_idx] is not None:
+                overrides[expert_names[layer_idx]] = override_config
+                fused_expert_override_emitted = True
+            else:
+                for output_name in dense_output_names[layer_idx]:
+                    overrides[f"{layer_prefix}.{layer_idx}.{output_name}"] = override_config
+
+        return {"bits": bits}, overrides, fused_expert_override_emitted
+
+    @staticmethod
+    def _is_selected_heuristic_layer(layer_idx: int, num_layers: int) -> bool:
+        return layer_idx < num_layers / 8 or layer_idx >= 7 * num_layers / 8 or ((layer_idx - num_layers // 8) % 3 == 2)
+
+    @staticmethod
+    def _validate_moe_heuristic_targets(
+        model_wrapper: ModelWrapper,
+        *,
+        include_qkv: bool,
+    ) -> tuple[list[str | None], list[list[str]], list[list[str]]]:
+        """Validate all MoE topology before returning any fixed-heuristic target names."""
+        layer_wrappers = model_wrapper.get_layer_wrappers()
+        experts_by_layer = [layer.get_experts(return_name=False) for layer in layer_wrappers]
+        resolved_experts = [experts for experts in experts_by_layer if experts is not None]
+        if not resolved_experts:
+            raise ValueError(
+                "MoE fixed heuristics require at least one resolved fused experts module; "
+                "LayerWrapper.get_experts() found none."
+            )
+
+        unresolved_layers = [
+            layer_idx
+            for layer_idx, (layer, experts) in enumerate(zip(layer_wrappers, experts_by_layer))
+            if experts is None and layer.get_router(return_name=False) is not None
+        ]
+        if unresolved_layers:
+            raise ValueError(
+                "MoE fixed heuristics found router/gate modules but could not resolve experts "
+                f"for decoder layers {unresolved_layers}; partial expert topology is unsupported."
+            )
+
+        module_lists = [type(experts).__name__ for experts in resolved_experts if isinstance(experts, nn.ModuleList)]
+        if module_lists:
+            raise ValueError(
+                "MoE fixed heuristics require fused experts with direct 3D parameters; "
+                f"per-expert ModuleList topology is unsupported ({module_lists})."
+            )
+
+        check_moe_layout_support(
+            resolved_experts,
+            model_type=model_wrapper.model_type,
+            operation="SelectiveMixedPrecision MoE fixed heuristics",
+        )
+
+        # ``iter_quant_targets`` owns canonical override naming. Resolve semantic parameters
+        # by identity rather than reconstructing experts dotted paths in this pass.
+        target_names = {
+            (id(owner), parameter_name): full_name
+            for owner, parameter_name, full_name in iter_quant_targets(
+                model_wrapper.model,
+                quantize_lm_head=True,
+                quantize_embeds=True,
+                quantize_moe=True,
+                skip_already_quantized=False,
+            )
+        }
+
+        expert_names: list[str | None] = []
+        attention_names: list[list[str]] = []
+        dense_output_names: list[list[str]] = []
+        for layer_idx, (layer, experts) in enumerate(zip(layer_wrappers, experts_by_layer)):
+            selected = SelectiveMixedPrecision._is_selected_heuristic_layer(layer_idx, model_wrapper.num_hidden_layers)
+            if experts is None:
+                expert_names.append(None)
+                # Resolving every expert-free layer's dense output distinguishes a legitimate
+                # hybrid dense layer from an unresolved expert block, even when the layer is
+                # not selected by this particular heuristic.
+                dense_output_names.append(layer.get_mlp_outputs(return_name=True)[1])
+            else:
+                _, parameter_name = layer.get_expert_output(return_name=True)
+                canonical_name = target_names.get((id(experts), parameter_name))
+                if canonical_name is None:
+                    raise ValueError(
+                        "The semantic fused expert output projection for decoder layer "
+                        f"{layer_idx} is missing from iter_quant_targets; refusing to emit "
+                        "a non-canonical override."
+                    )
+                expert_names.append(canonical_name)
+                dense_output_names.append([])
+
+            if not include_qkv or not selected:
+                attention_names.append([])
+                continue
+            if layer.attn is None:
+                if layer.get_mamba(return_name=False) is None:
+                    raise ValueError(
+                        f"Decoder layer {layer_idx} has no resolved attention or recognized "
+                        "linear-attention/Mamba module; QKV targets cannot be verified."
+                    )
+                attention_names.append([])
+                continue
+            attention_names.append(layer.get_attention_inputs(return_name=True)[1])
+
+        return expert_names, attention_names, dense_output_names
 
     @staticmethod
     def get_k_quant_config(
@@ -884,14 +1056,19 @@ class SelectiveMixedPrecision(Pass):
         algorithm: SelectiveMixedPrecision.Algorithm | str,
         bits: PrecisionBits,
         high_bits: PrecisionBits,
+        moe: bool = False,
     ) -> tuple[dict, dict[str, dict]]:
-        """Get a layer-based mixed precision config using the deprecated helper name."""
+        """Get a layer-based mixed precision config using the deprecated helper name.
+
+        ``requires_moe`` remains pass-emitted metadata and is not added to this helper's
+        established two-value return shape.
+        """
         warn(
             "SelectiveMixedPrecision.get_k_quant_config is deprecated; use get_high_precision_config instead.",
             FutureWarning,
             stacklevel=2,
         )
-        return SelectiveMixedPrecision.get_high_precision_config(model_wrapper, algorithm, bits, high_bits)
+        return SelectiveMixedPrecision.get_high_precision_config(model_wrapper, algorithm, bits, high_bits, moe)
 
     @staticmethod
     def get_overrides_from_scores(

--- a/olive/passes/pytorch/selective_mixed_precision.py
+++ b/olive/passes/pytorch/selective_mixed_precision.py
@@ -957,7 +957,11 @@ class SelectiveMixedPrecision(Pass):
 
     @staticmethod
     def _is_selected_heuristic_layer(layer_idx: int, num_layers: int) -> bool:
-        return layer_idx < num_layers / 8 or layer_idx >= 7 * num_layers / 8 or ((layer_idx - num_layers // 8) % 3 == 2)
+        return (
+            layer_idx < num_layers / 8
+            or layer_idx >= 7 * num_layers / 8
+            or (layer_idx - num_layers // 8) % 3 == 2
+        )
 
     @staticmethod
     def _validate_moe_heuristic_targets(

--- a/test/common/test_hf_wrapper.py
+++ b/test/common/test_hf_wrapper.py
@@ -3,10 +3,11 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import pytest
+import torch
 from torch import nn
 from transformers import PretrainedConfig
 
-from olive.common.hf.wrapper import ModelWrapper
+from olive.common.hf.wrapper import LayerWrapper, ModelWrapper
 from test.utils import get_tiny_phi3, make_local_tiny_llama
 
 
@@ -300,3 +301,60 @@ def test_hf_wrapper_vl_qwen3_5_moe_config_uses_nested_paths():
     assert model_wrapper.get_layers(False) is model.model.language_model.layers
     assert model_wrapper.get_embeds(False)[0] is model.model.language_model.embed_tokens
     assert model_wrapper.get_pre_head_layernorm(False) is model.model.language_model.norm
+
+
+class _FusedExperts(nn.Module):
+    def __init__(self, output=None):
+        super().__init__()
+        if output is not None:
+            self.down_proj = output
+
+
+def _expert_layer(experts):
+    layer = nn.Module()
+    layer.self_attn = nn.Module()
+    layer.mlp = nn.Module()
+    layer.mlp.experts = experts
+    return layer
+
+
+@pytest.mark.parametrize("model_type", ["qwen3_moe", "qwen3_5_moe", "qwen3_5_moe_text"])
+def test_layer_wrapper_resolves_supported_direct_3d_expert_output(model_type):
+    output = nn.Parameter(torch.empty(2, 8, 4))
+    wrapper = LayerWrapper(_expert_layer(_FusedExperts(output)), model_type)
+
+    parameter, parameter_name = wrapper.get_expert_output()
+
+    assert parameter is output
+    assert parameter_name == "down_proj"
+
+
+def test_layer_wrapper_rejects_unknown_expert_output_architecture():
+    wrapper = LayerWrapper(_expert_layer(_FusedExperts(nn.Parameter(torch.empty(2, 8, 4)))), "unknown_moe")
+
+    with pytest.raises(ValueError, match=r"does not recognize.*unknown_moe"):
+        wrapper.get_expert_output()
+
+
+@pytest.mark.parametrize(
+    ("experts", "message"),
+    [
+        (_FusedExperts(), "direct nn.Parameter"),
+        (nn.ModuleList([nn.Linear(4, 8, bias=False)]), "ModuleList"),
+        (_FusedExperts(nn.Parameter(torch.empty(8, 4))), "must be 3D"),
+    ],
+)
+def test_layer_wrapper_rejects_unsupported_expert_output_topology(experts, message):
+    wrapper = LayerWrapper(_expert_layer(experts), "qwen3_moe")
+
+    with pytest.raises(ValueError, match=message):
+        wrapper.get_expert_output()
+
+
+def test_layer_wrapper_rejects_indirect_expert_output_parameter():
+    experts = _FusedExperts()
+    experts.down_proj = nn.Linear(4, 8, bias=False)
+    wrapper = LayerWrapper(_expert_layer(experts), "qwen3_moe")
+
+    with pytest.raises(ValueError, match=r"direct nn\.Parameter"):
+        wrapper.get_expert_output()

--- a/test/passes/pytorch/test_quant_utils.py
+++ b/test/passes/pytorch/test_quant_utils.py
@@ -30,9 +30,11 @@ from olive.passes.pytorch import quant_utils as quant_utils_module
 from olive.passes.pytorch.quant_utils import (
     _quant_config_rank,
     finalize,
+    get_quant_config,
     normalize_qkv_quant_config,
     prepare_model,
     run_layerwise_quantization,
+    validate_moe_quantization_requirement,
 )
 from test.utils import get_tiny_phi3
 
@@ -58,6 +60,31 @@ def input_model_fixture(tmp_path_factory):
     return HfModelHandler(save_path)
 
 
+@pytest.fixture(name="moe_input_model", scope="module")
+def moe_input_model_fixture(tmp_path_factory):
+    from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+    save_path = tmp_path_factory.mktemp("quant-utils-moe-test")
+    model = Qwen3MoeForCausalLM(
+        Qwen3MoeConfig(  # pylint: disable=unexpected-keyword-arg
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=16,
+            moe_intermediate_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            num_experts=2,
+            num_experts_per_tok=1,
+            decoder_sparse_step=1,
+            head_dim=8,
+            experts_implementation="eager",
+        )
+    )
+    model.save_pretrained(save_path)
+    return HfModelHandler(save_path)
+
+
 def _baseline_pass_config(overrides=None, *, embeds=False):
     return SimpleNamespace(
         bits=PrecisionBits.BITS4,
@@ -67,6 +94,298 @@ def _baseline_pass_config(overrides=None, *, embeds=False):
         embeds=embeds,
         overrides=overrides,
     )
+
+
+def _with_required_moe_plan(model: HfModelHandler) -> HfModelHandler:
+    return HfModelHandler(
+        model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4},
+                "overrides": {
+                    "model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS8},
+                },
+                "requires_moe": True,
+            }
+        },
+    )
+
+
+def _load_uncached_model(model: HfModelHandler):
+    model.model = None
+    return model.load_model()
+
+
+def test_get_quant_config_requires_explicit_moe_opt_in(input_model):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4},
+                "overrides": {"model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS8}},
+                "requires_moe": True,
+            }
+        },
+    )
+    config = _baseline_pass_config()
+    config.moe = False
+
+    with pytest.raises(ValueError, match=r"requires MoE quantization.*moe=True"):
+        get_quant_config(model, config)
+
+
+def test_get_quant_config_accepts_requires_moe_with_explicit_consumer_opt_in(input_model):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4, "moe": False},
+                "overrides": {"model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS8}},
+                "requires_moe": True,
+            }
+        },
+    )
+    config = _baseline_pass_config(overrides={"model.layers.0.mlp.experts.down_proj": {"bits": 2}})
+    config.moe = True
+
+    qcfg = get_quant_config(model, config)
+
+    assert qcfg.moe is True
+    assert qcfg.get_qlinear_init_args("model.layers.0.mlp.experts.down_proj")["bits"] == 2
+
+
+def test_get_quant_config_metadata_default_cannot_enable_consumer_moe(input_model):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4, "moe": True},
+                "overrides": {"model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS8}},
+            }
+        },
+    )
+    config = _baseline_pass_config()
+    config.moe = False
+
+    qcfg = get_quant_config(model, config)
+
+    assert qcfg.moe is False
+    assert qcfg.get_qlinear_init_args("model.layers.0.mlp.experts.down_proj")["bits"] == PrecisionBits.BITS8
+
+
+def test_get_quant_config_allows_consumer_without_moe_field(input_model):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4},
+                "overrides": {},
+                "requires_moe": True,
+            }
+        },
+    )
+
+    qcfg = get_quant_config(model, _baseline_pass_config())
+
+    assert qcfg.moe is False
+
+
+@pytest.mark.parametrize(
+    "existing_qcfg",
+    [
+        {"quant_method": "olive", "moe": True},
+        OliveHfQuantizationConfig(
+            bits=PrecisionBits.BITS4,
+            symmetric=False,
+            group_size=16,
+            moe=True,
+        ),
+    ],
+)
+def test_validate_moe_requirement_allows_follow_up_after_existing_moe_quantization(input_model, existing_qcfg):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4},
+                "overrides": {},
+                "requires_moe": True,
+            }
+        },
+    )
+    config = _baseline_pass_config()
+    config.moe = False
+
+    validate_moe_quantization_requirement(model, config, existing_qcfg)
+
+
+def test_prepare_model_rejects_unfulfilled_moe_requirement_before_model_load(input_model, monkeypatch):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {"bits": PrecisionBits.BITS4},
+                "overrides": {},
+                "requires_moe": True,
+            }
+        },
+    )
+    config = _baseline_pass_config()
+    config.moe = False
+    monkeypatch.setattr(
+        quant_utils_module,
+        "load_hf_base_model",
+        lambda *_args, **_kwargs: pytest.fail("model loading must not be reached"),
+    )
+
+    with pytest.raises(ValueError, match=r"requires MoE quantization.*moe=True"):
+        prepare_model(model, config)
+
+
+@pytest.mark.parametrize("requires_moe", ["false", 1, [], {}])
+def test_get_quant_config_rejects_non_bool_requires_moe(input_model, requires_moe):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={
+            "mixed_precision_info": {
+                "default": {},
+                "overrides": {},
+                "requires_moe": requires_moe,
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match=r"requires_moe must be a bool"):
+        get_quant_config(model, _baseline_pass_config())
+
+
+@pytest.mark.parametrize(
+    "mixed_precision_info",
+    [
+        [],
+        {"default": [], "overrides": {}},
+        {"default": {}, "overrides": []},
+        {"default": {}, "overrides": {"model.layers.0.mlp.down_proj": []}},
+    ],
+)
+def test_get_quant_config_rejects_malformed_mixed_precision_mappings(input_model, mixed_precision_info):
+    model = HfModelHandler(
+        input_model.model_path,
+        model_attributes={"mixed_precision_info": mixed_precision_info},
+    )
+
+    with pytest.raises(ValueError, match=r"mixed_precision_info.*must be a mapping"):
+        get_quant_config(model, _baseline_pass_config())
+
+
+@pytest.mark.parametrize("moe", ["false", 1, []])
+def test_prepare_model_rejects_non_bool_existing_olive_moe_before_load(input_model, monkeypatch, moe):
+    existing = {
+        "quant_method": "olive",
+        "bits": PrecisionBits.BITS4,
+        "symmetric": False,
+        "group_size": 16,
+        "moe": moe,
+    }
+    _with_existing_quantization_config(monkeypatch, existing)
+    monkeypatch.setattr(
+        quant_utils_module,
+        "load_hf_base_model",
+        lambda *_args, **_kwargs: pytest.fail("model loading must not be reached"),
+    )
+
+    with pytest.raises(ValueError, match=r"quantization_config\.moe must be a bool"):
+        prepare_model(input_model, _baseline_pass_config(), allow_quantized=True)
+
+
+def test_prepare_model_required_moe_target_excluded_fails_without_parameter_mutation(moe_input_model, monkeypatch):
+    root_model = _load_uncached_model(moe_input_model)
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config()
+    config.moe = True
+    config.modules_to_not_convert = ["model.layers.0.mlp.experts.down_proj"]
+
+    with pytest.raises(ValueError, match=r"Missing required names:.*experts\.down_proj"):
+        prepare_model(model, config)
+
+    assert all(not hasattr(param, "quant_info") for param in root_model.parameters())
+
+
+def test_prepare_model_required_moe_target_selected_by_current_pass(moe_input_model, monkeypatch):
+    root_model = _load_uncached_model(moe_input_model)
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config(overrides={"model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS2}})
+    config.moe = True
+
+    _, qcfg, _ = prepare_model(model, config)
+
+    down_proj = root_model.model.layers[0].mlp.experts.down_proj
+    assert down_proj.quant_info.quantizer.bits == PrecisionBits.BITS2
+    assert qcfg.get_qlinear_init_args("model.layers.0.mlp.experts.down_proj")["bits"] == PrecisionBits.BITS2
+
+
+def test_prepare_model_required_moe_target_already_materialized(moe_input_model, monkeypatch):
+    existing = {
+        "quant_method": "olive",
+        "bits": PrecisionBits.BITS4,
+        "symmetric": False,
+        "group_size": 4,
+        "lm_head": False,
+        "embeds": False,
+        "moe": True,
+        "overrides": {},
+    }
+    _with_existing_quantization_config(monkeypatch, existing)
+    root_model = _load_uncached_model(moe_input_model)
+    experts = root_model.model.layers[0].mlp.experts
+    for parameter_name in ("gate_up_proj", "down_proj"):
+        parameter = getattr(experts, parameter_name)
+        install_quant_tensor_param(
+            experts,
+            parameter_name,
+            QuantTensor.from_float(
+                parameter.detach(),
+                bits=4,
+                symmetric=False,
+                group_size=4,
+            ),
+        )
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config()
+    config.moe = False
+
+    _, qcfg, _ = prepare_model(model, config, allow_quantized=True)
+
+    assert isinstance(experts.down_proj, QuantTensor)
+    assert isinstance(experts.gate_up_proj, QuantTensor)
+    assert qcfg.moe is True
+
+
+def test_prepare_model_stale_existing_moe_flag_with_float_expert_fails_without_mutation(moe_input_model, monkeypatch):
+    existing = {
+        "quant_method": "olive",
+        "bits": PrecisionBits.BITS4,
+        "symmetric": False,
+        "group_size": 16,
+        "lm_head": False,
+        "embeds": False,
+        "moe": True,
+        "overrides": {},
+    }
+    _with_existing_quantization_config(monkeypatch, existing)
+    root_model = _load_uncached_model(moe_input_model)
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config()
+    config.moe = False
+
+    with pytest.raises(ValueError, match=r"Missing required names:.*experts\.down_proj"):
+        prepare_model(model, config, allow_quantized=True)
+
+    assert all(not hasattr(param, "quant_info") for param in root_model.parameters())
 
 
 def test_resolve_layerwise_device_warns_when_falling_back_to_cpu(monkeypatch):

--- a/test/passes/pytorch/test_quant_utils.py
+++ b/test/passes/pytorch/test_quant_utils.py
@@ -133,15 +133,17 @@ def _baseline_pass_config(overrides=None, *, embeds=False):
     )
 
 
-def _with_required_moe_plan(model: HfModelHandler) -> HfModelHandler:
+def _with_required_moe_plan(model: HfModelHandler, additional_overrides=None) -> HfModelHandler:
+    overrides = {
+        "model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS8},
+        **(additional_overrides or {}),
+    }
     return HfModelHandler(
         model.model_path,
         model_attributes={
             "mixed_precision_info": {
                 "default": {"bits": PrecisionBits.BITS4},
-                "overrides": {
-                    "model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS8},
-                },
+                "overrides": overrides,
                 "requires_moe": True,
             }
         },
@@ -352,7 +354,10 @@ def test_prepare_model_required_moe_target_excluded_fails_without_parameter_muta
 def test_prepare_model_required_moe_target_selected_by_current_pass(moe_input_model, monkeypatch):
     root_model = _load_uncached_model(moe_input_model)
     monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
-    model = _with_required_moe_plan(moe_input_model)
+    model = _with_required_moe_plan(
+        moe_input_model,
+        {"model.layers.0.self_attn.q_proj": {"bits": PrecisionBits.BITS8}},
+    )
     config = _baseline_pass_config(overrides={"model.layers.0.mlp.experts.down_proj": {"bits": PrecisionBits.BITS2}})
     config.moe = True
 
@@ -361,13 +366,28 @@ def test_prepare_model_required_moe_target_selected_by_current_pass(moe_input_mo
     down_proj = root_model.model.layers[0].mlp.experts.down_proj
     assert down_proj.quant_info.quantizer.bits == PrecisionBits.BITS2
     assert qcfg.get_qlinear_init_args("model.layers.0.mlp.experts.down_proj")["bits"] == PrecisionBits.BITS2
+    assert qcfg.get_qlinear_init_args("model.layers.0.self_attn.q_proj")["bits"] == PrecisionBits.BITS8
+
+
+def test_prepare_model_required_moe_plan_rejects_stale_override_name(moe_input_model, monkeypatch):
+    root_model = _load_uncached_model(moe_input_model)
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    stale_name = "model.layers.0.mlp.experts.removed_proj"
+    model = _with_required_moe_plan(moe_input_model, {stale_name: {"bits": PrecisionBits.BITS8}})
+    config = _baseline_pass_config()
+    config.moe = True
+
+    with pytest.raises(ValueError, match=r"Stale override names:.*experts\.removed_proj"):
+        prepare_model(model, config)
+
+    assert all(not hasattr(param, "quant_info") for param in root_model.parameters())
 
 
 def test_prepare_model_required_moe_target_already_materialized(moe_input_model, monkeypatch):
     existing = {
         "quant_method": "olive",
-        "bits": PrecisionBits.BITS4,
-        "symmetric": False,
+        "bits": PrecisionBits.BITS8,
+        "symmetric": True,
         "group_size": 4,
         "lm_head": False,
         "embeds": False,
@@ -384,13 +404,22 @@ def test_prepare_model_required_moe_target_already_materialized(moe_input_model,
             parameter_name,
             QuantTensor.from_float(
                 parameter.detach(),
-                bits=4,
-                symmetric=False,
+                bits=8,
+                symmetric=True,
                 group_size=4,
             ),
         )
     monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
-    model = _with_required_moe_plan(moe_input_model)
+    model = _with_required_moe_plan(
+        moe_input_model,
+        {
+            "model.layers.0.mlp.experts.down_proj": {
+                "bits": PrecisionBits.BITS8,
+                "symmetric": True,
+                "group_size": 4,
+            }
+        },
+    )
     config = _baseline_pass_config()
     config.moe = False
 
@@ -399,6 +428,78 @@ def test_prepare_model_required_moe_target_already_materialized(moe_input_model,
     assert isinstance(experts.down_proj, QuantTensor)
     assert isinstance(experts.gate_up_proj, QuantTensor)
     assert qcfg.moe is True
+
+
+def test_prepare_model_required_moe_target_already_materialized_with_required_mismatch_fails(
+    moe_input_model, monkeypatch
+):
+    existing = {
+        "quant_method": "olive",
+        "bits": PrecisionBits.BITS4,
+        "symmetric": False,
+        "group_size": 4,
+        "lm_head": False,
+        "embeds": False,
+        "moe": True,
+        "overrides": {},
+    }
+    _with_existing_quantization_config(monkeypatch, existing)
+    root_model = _load_uncached_model(moe_input_model)
+    experts = root_model.model.layers[0].mlp.experts
+    install_quant_tensor_param(
+        experts,
+        "down_proj",
+        QuantTensor.from_float(
+            experts.down_proj.detach(),
+            bits=4,
+            symmetric=False,
+            group_size=4,
+        ),
+    )
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config()
+    config.moe = False
+
+    with pytest.raises(ValueError, match=r"does not satisfy.*mixed_precision_info override"):
+        prepare_model(model, config, allow_quantized=True)
+
+    assert not hasattr(experts.gate_up_proj, "quant_info")
+
+
+def test_prepare_model_required_moe_target_rejects_quant_tensor_inconsistent_with_qcfg(moe_input_model, monkeypatch):
+    existing = {
+        "quant_method": "olive",
+        "bits": PrecisionBits.BITS8,
+        "symmetric": True,
+        "group_size": 4,
+        "lm_head": False,
+        "embeds": False,
+        "moe": True,
+        "overrides": {},
+    }
+    _with_existing_quantization_config(monkeypatch, existing)
+    root_model = _load_uncached_model(moe_input_model)
+    experts = root_model.model.layers[0].mlp.experts
+    install_quant_tensor_param(
+        experts,
+        "down_proj",
+        QuantTensor.from_float(
+            experts.down_proj.detach(),
+            bits=4,
+            symmetric=True,
+            group_size=4,
+        ),
+    )
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config()
+    config.moe = False
+
+    with pytest.raises(ValueError, match=r"inconsistent with its effective existing Olive quantization config"):
+        prepare_model(model, config, allow_quantized=True)
+
+    assert not hasattr(experts.gate_up_proj, "quant_info")
 
 
 def test_prepare_model_stale_existing_moe_flag_with_float_expert_fails_without_mutation(moe_input_model, monkeypatch):
@@ -423,6 +524,27 @@ def test_prepare_model_stale_existing_moe_flag_with_float_expert_fails_without_m
         prepare_model(model, config, allow_quantized=True)
 
     assert all(not hasattr(param, "quant_info") for param in root_model.parameters())
+
+
+def test_prepare_model_required_moe_failure_does_not_untie_embeddings(moe_input_model, monkeypatch):
+    root_model = _load_uncached_model(moe_input_model)
+    root_model.config.tie_word_embeddings = True
+    root_model.tie_weights()
+    tied_weight = root_model.get_input_embeddings().weight
+    assert root_model.get_output_embeddings().weight is tied_weight
+    monkeypatch.setattr(quant_utils_module, "load_hf_base_model", lambda _: root_model)
+    model = _with_required_moe_plan(moe_input_model)
+    config = _baseline_pass_config(embeds=True)
+    config.lm_head = True
+    config.moe = True
+    config.modules_to_not_convert = ["model.layers.0.mlp.experts.down_proj"]
+
+    with pytest.raises(ValueError, match=r"Missing required names:.*experts\.down_proj"):
+        prepare_model(model, config)
+
+    assert root_model.config.tie_word_embeddings is True
+    assert root_model.get_input_embeddings().weight is tied_weight
+    assert root_model.get_output_embeddings().weight is tied_weight
 
 
 def test_resolve_layerwise_device_warns_when_falling_back_to_cpu(monkeypatch):

--- a/test/passes/pytorch/test_selective_mixed_precision.py
+++ b/test/passes/pytorch/test_selective_mixed_precision.py
@@ -8,6 +8,7 @@ import math
 import sys
 import warnings
 from copy import deepcopy
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -15,12 +16,16 @@ import torch
 from transformers import LlamaConfig, LlamaForCausalLM
 
 from olive.common.hf.wrapper import ModelWrapper
+from olive.common.quant.selection import iter_quant_targets
+from olive.common.quant.tensor import QuantTensor
 from olive.common.quant.utils import WeightQuantizer
 from olive.constants import PrecisionBits
 from olive.model import HfModelHandler
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.pytorch import selective_mixed_precision as smp_module
+from olive.passes.pytorch.moe_support import MoeSupportError
 from olive.passes.pytorch.quant_utils import get_qkv_quantization_groups
+from olive.passes.pytorch.rtn import Rtn
 from olive.passes.pytorch.selective_mixed_precision import (
     KldMemoryMode,
     SelectiveMixedPrecision,
@@ -189,6 +194,63 @@ def input_model_fixture(tmp_path_factory):
     return HfModelHandler(save_path)
 
 
+def _make_tiny_qwen3_moe(num_hidden_layers=4):
+    from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+    config = Qwen3MoeConfig(  # pylint: disable=unexpected-keyword-arg
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=16,
+        moe_intermediate_size=8,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_experts=2,
+        num_experts_per_tok=1,
+        decoder_sparse_step=1,
+        head_dim=8,
+        experts_implementation="eager",
+    )
+    return Qwen3MoeForCausalLM(config)
+
+
+def _make_tiny_qwen3_5_moe(layer_types=None):
+    from transformers import Qwen3_5MoeForCausalLM, Qwen3_5MoeTextConfig
+
+    config = Qwen3_5MoeTextConfig(  # pylint: disable=unexpected-keyword-arg
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=16,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_experts=2,
+        num_experts_per_tok=1,
+        head_dim=8,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        layer_types=layer_types,
+        experts_implementation="eager",
+    )
+    return Qwen3_5MoeForCausalLM(config)
+
+
+def _save_tiny_moe(model, save_path: Path) -> HfModelHandler:
+    from tokenizers import Tokenizer, models, pre_tokenizers
+    from transformers import PreTrainedTokenizerFast
+
+    save_path.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(save_path)
+    tokenizer = Tokenizer(models.WordLevel({f"t{i}": i for i in range(32)}, unk_token="t0"))
+    tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    PreTrainedTokenizerFast(tokenizer_object=tokenizer, unk_token="t0", pad_token="t0").save_pretrained(save_path)
+    return HfModelHandler(model_path=str(save_path))
+
+
 # ---------------------------------------------------------------------------
 # End-to-end pass behavior
 # ---------------------------------------------------------------------------
@@ -232,6 +294,312 @@ def test_selective_mixed_precision_heuristic(algorithm, expected_layer_indices, 
             }
         )
     assert output_model.model_attributes["mixed_precision_info"] == expected_mp_info
+
+
+def test_selective_mixed_precision_moe_false_preserves_dense_metadata(input_model, tmp_path):
+    p = create_pass_from_dict(
+        SelectiveMixedPrecision,
+        {"algorithm": "high_precision_mlp_down", "moe": False},
+        disable_search=True,
+    )
+
+    output_model = p.run(input_model, str(tmp_path))
+
+    assert "requires_moe" not in output_model.model_attributes["mixed_precision_info"]
+    assert output_model.model_attributes["mixed_precision_info"]["default"] == {"bits": PrecisionBits.BITS4}
+    assert set(output_model.model_attributes["mixed_precision_info"]["overrides"]) == {
+        "lm_head",
+        "model.layers.0.mlp.down_proj",
+        "model.layers.3.mlp.down_proj",
+        "model.layers.6.mlp.down_proj",
+        "model.layers.7.mlp.down_proj",
+    }
+
+
+def test_selective_mixed_precision_lm_head_moe_true_is_noop_without_experts(input_model, tmp_path, monkeypatch):
+    p = create_pass_from_dict(
+        SelectiveMixedPrecision,
+        {"algorithm": "high_precision_lm_head", "moe": True},
+        disable_search=True,
+    )
+    warning_messages = []
+    monkeypatch.setattr(
+        smp_module.logger,
+        "warning",
+        lambda message, *args: warning_messages.append(message % args),
+    )
+
+    output_model = p.run(input_model, str(tmp_path))
+
+    assert output_model.model_attributes["mixed_precision_info"] == {
+        "default": {"bits": PrecisionBits.BITS4},
+        "overrides": {"lm_head": {"bits": PrecisionBits.BITS8}},
+    }
+    assert len(warning_messages) == 1
+    assert "legal no-op" in warning_messages[0]
+    assert "no expert overrides" in warning_messages[0]
+
+
+@pytest.mark.parametrize("algorithm", ["snr", "snr_relative", "iqe", "iqe_relative", "kld_gradient"])
+def test_selective_mixed_precision_rejects_moe_scoring_before_model_load(algorithm, monkeypatch):
+    p = create_pass_from_dict(
+        SelectiveMixedPrecision,
+        {"algorithm": algorithm, "ratio": 0.5, "moe": True},
+        disable_search=True,
+    )
+    model = object.__new__(HfModelHandler)
+    monkeypatch.setattr(
+        smp_module,
+        "load_hf_base_model",
+        lambda *_args, **_kwargs: pytest.fail("model loading/scoring must not be reached"),
+    )
+
+    with pytest.raises(ValueError, match=r"does not support MoE scoring.*fixed heuristics"):
+        p.run(model, "unused")
+
+
+def test_selective_mixed_precision_moe_uses_exact_fused_output_targets_and_marker():
+    wrapper = ModelWrapper.from_model(_make_tiny_qwen3_moe())
+    canonical_targets = {
+        full_name
+        for _, _, full_name in iter_quant_targets(
+            wrapper.model,
+            quantize_lm_head=True,
+            quantize_embeds=True,
+            quantize_moe=True,
+        )
+    }
+
+    default, overrides, requires_moe = SelectiveMixedPrecision._get_high_precision_config(
+        wrapper,
+        SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+        PrecisionBits.BITS4,
+        PrecisionBits.BITS8,
+        True,
+    )
+
+    assert default == {"bits": PrecisionBits.BITS4}
+    assert requires_moe
+    assert set(overrides) == {
+        "lm_head",
+        "model.layers.0.mlp.experts.down_proj",
+        "model.layers.2.mlp.experts.down_proj",
+    }
+    assert set(overrides) - {"lm_head"} <= canonical_targets
+    assert all("gate_up_proj" not in name for name in overrides)
+
+
+def test_selective_mixed_precision_moe_qkv_skips_recognized_linear_attention():
+    wrapper = ModelWrapper.from_model(
+        _make_tiny_qwen3_5_moe(["full_attention", "linear_attention", "linear_attention", "full_attention"])
+    )
+
+    _, overrides = SelectiveMixedPrecision.get_high_precision_config(
+        wrapper,
+        SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV,
+        PrecisionBits.BITS4,
+        PrecisionBits.BITS8,
+        moe=True,
+    )
+
+    assert set(overrides) == {
+        "lm_head",
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.0.self_attn.k_proj",
+        "model.layers.0.self_attn.v_proj",
+        "model.layers.0.mlp.experts.down_proj",
+        "model.layers.2.mlp.experts.down_proj",
+    }
+
+
+def test_selective_mixed_precision_moe_supports_hybrid_dense_and_expert_layers():
+    model = _make_tiny_qwen3_moe()
+    dense_mlp = torch.nn.Module()
+    dense_mlp.gate_proj = torch.nn.Linear(16, 16, bias=False)
+    dense_mlp.up_proj = torch.nn.Linear(16, 16, bias=False)
+    dense_mlp.down_proj = torch.nn.Linear(16, 16, bias=False)
+    model.model.layers[2].mlp = dense_mlp
+    wrapper = ModelWrapper.from_model(model)
+
+    _, overrides = SelectiveMixedPrecision.get_high_precision_config(
+        wrapper,
+        SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+        PrecisionBits.BITS4,
+        PrecisionBits.BITS8,
+        moe=True,
+    )
+
+    assert set(overrides) == {
+        "lm_head",
+        "model.layers.0.mlp.experts.down_proj",
+        "model.layers.2.mlp.down_proj",
+    }
+
+
+def test_selective_mixed_precision_moe_rejects_no_experts(input_model):
+    wrapper = ModelWrapper.from_model(input_model.load_model())
+
+    with pytest.raises(ValueError, match="at least one resolved fused experts"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_moe_rejects_module_list_experts():
+    model = _make_tiny_qwen3_moe(num_hidden_layers=1)
+    model.model.layers[0].mlp.experts = torch.nn.ModuleList([torch.nn.Linear(8, 16, bias=False)])
+    wrapper = ModelWrapper.from_model(model)
+
+    with pytest.raises(ValueError, match="ModuleList topology is unsupported"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+@pytest.mark.parametrize(("layout", "message"), [(True, "transposed"), (None, "cannot verify")])
+def test_selective_mixed_precision_moe_rejects_unverified_layout(layout, message):
+    model = _make_tiny_qwen3_moe(num_hidden_layers=1)
+    experts = model.model.layers[0].mlp.experts
+    if layout is None:
+        del experts.is_transposed
+    else:
+        experts.is_transposed = layout
+    wrapper = ModelWrapper.from_model(model)
+
+    with pytest.raises(MoeSupportError, match=message):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_moe_rejects_unknown_architecture():
+    wrapper = ModelWrapper.from_model(_make_tiny_qwen3_moe(num_hidden_layers=1))
+    wrapper.model_type = "unknown_moe"
+    for layer in wrapper.get_layer_wrappers():
+        layer.model_type = "unknown_moe"
+
+    with pytest.raises(ValueError, match=r"does not recognize.*unknown_moe"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_moe_rejects_partially_resolved_experts():
+    model = _make_tiny_qwen3_moe(num_hidden_layers=2)
+    del model.model.layers[1].mlp.experts
+    wrapper = ModelWrapper.from_model(model)
+
+    with pytest.raises(ValueError, match="partial expert topology"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_moe_rejects_missing_expert_output():
+    model = _make_tiny_qwen3_moe(num_hidden_layers=1)
+    del model.model.layers[0].mlp.experts.down_proj
+    wrapper = ModelWrapper.from_model(model)
+
+    with pytest.raises(ValueError, match=r"must be a direct nn\.Parameter"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_moe_rejects_missing_canonical_target(monkeypatch):
+    wrapper = ModelWrapper.from_model(_make_tiny_qwen3_moe(num_hidden_layers=1))
+    monkeypatch.setattr(smp_module, "iter_quant_targets", lambda *_args, **_kwargs: iter(()))
+
+    with pytest.raises(ValueError, match="missing from iter_quant_targets"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_moe_qkv_rejects_unresolved_expected_attention():
+    model = _make_tiny_qwen3_moe(num_hidden_layers=1)
+    del model.model.layers[0].self_attn
+    wrapper = ModelWrapper.from_model(model)
+
+    with pytest.raises(ValueError, match="no resolved attention or recognized"):
+        SelectiveMixedPrecision.get_high_precision_config(
+            wrapper,
+            SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN_QKV,
+            PrecisionBits.BITS4,
+            PrecisionBits.BITS8,
+            moe=True,
+        )
+
+
+def test_selective_mixed_precision_to_rtn_moe_roundtrip_and_double_opt_in(tmp_path):
+    input_model = _save_tiny_moe(_make_tiny_qwen3_5_moe(), tmp_path / "input_model")
+    planner = create_pass_from_dict(
+        SelectiveMixedPrecision,
+        {"algorithm": "high_precision_mlp_down", "bits": 4, "high_bits": 8, "moe": True},
+        disable_search=True,
+    )
+    planned = planner.run(input_model, str(tmp_path / "smp"))
+    assert planned.model_attributes["mixed_precision_info"]["requires_moe"] is True
+    assert "moe" not in planned.model_attributes["mixed_precision_info"]["default"]
+
+    disabled_rtn = create_pass_from_dict(Rtn, {"moe": False, "group_size": -1}, disable_search=True)
+    disabled_output = tmp_path / "rtn_disabled"
+    with pytest.raises(ValueError, match=r"requires MoE quantization.*moe=True"):
+        disabled_rtn.run(planned, str(disabled_output))
+    assert not disabled_output.exists()
+
+    enabled_rtn = create_pass_from_dict(Rtn, {"moe": True, "group_size": -1}, disable_search=True)
+    output = enabled_rtn.run(planned, str(tmp_path / "rtn"))
+    loaded = output.load_model()
+
+    for layer_idx, layer in enumerate(loaded.model.layers):
+        expected_down_bits = 8 if layer_idx in (0, 2) else 4
+        assert isinstance(layer.mlp.experts.down_proj.data, QuantTensor)
+        assert layer.mlp.experts.down_proj.data.bits == expected_down_bits
+        assert isinstance(layer.mlp.experts.gate_up_proj.data, QuantTensor)
+        assert layer.mlp.experts.gate_up_proj.data.bits == 4
+        assert isinstance(layer.mlp.shared_expert.down_proj.weight.data, QuantTensor)
+        assert layer.mlp.shared_expert.down_proj.weight.data.bits == 4
+        assert all(not isinstance(parameter.data, QuantTensor) for parameter in layer.mlp.gate.parameters())
+        assert all(
+            not isinstance(parameter.data, QuantTensor) for parameter in layer.mlp.shared_expert_gate.parameters()
+        )
+
+    follow_up = create_pass_from_dict(
+        Rtn,
+        {"moe": False, "lm_head": True, "group_size": -1},
+        disable_search=True,
+    )
+    follow_up_output = follow_up.run(output, str(tmp_path / "rtn_follow_up"))
+    assert isinstance(follow_up_output.load_model().lm_head.weight.data, QuantTensor)
 
 
 @pytest.mark.parametrize(
@@ -313,6 +681,31 @@ def test_selective_mixed_precision_requires_algorithm_even_when_ratio_is_set(mon
     assert errors == ["SelectiveMixedPrecision config field 'algorithm' must be specified."]
 
 
+@pytest.mark.parametrize("algorithm", ["snr", "snr_relative", "iqe", "iqe_relative", "kld_gradient"])
+def test_selective_mixed_precision_validate_config_rejects_moe_scoring(algorithm):
+    pass_instance = create_pass_from_dict(
+        SelectiveMixedPrecision,
+        {"algorithm": algorithm, "ratio": 0.5, "moe": True},
+        disable_search=True,
+    )
+
+    assert not SelectiveMixedPrecision.validate_config(pass_instance.config, pass_instance.accelerator_spec)
+
+
+@pytest.mark.parametrize(
+    "algorithm",
+    ["high_precision_lm_head", "high_precision_mlp_down", "high_precision_mlp_down_qkv"],
+)
+def test_selective_mixed_precision_validate_config_accepts_moe_fixed_heuristics(algorithm):
+    pass_instance = create_pass_from_dict(
+        SelectiveMixedPrecision,
+        {"algorithm": algorithm, "moe": True},
+        disable_search=True,
+    )
+
+    assert SelectiveMixedPrecision.validate_config(pass_instance.config, pass_instance.accelerator_spec)
+
+
 def test_selective_mixed_precision_run_requires_algorithm_before_loading_or_scoring(monkeypatch):
     pass_instance = create_pass_from_dict(SelectiveMixedPrecision, {}, disable_search=True)
     input_model = object.__new__(HfModelHandler)
@@ -340,8 +733,8 @@ def test_get_k_quant_config_warns_and_delegates(monkeypatch):
     expected = ({"bits": PrecisionBits.BITS4}, {"lm_head": {"bits": PrecisionBits.BITS8}})
     calls = []
 
-    def fake_get_high_precision_config(received_wrapper, algorithm, bits, high_bits):
-        calls.append((received_wrapper, algorithm, bits, high_bits))
+    def fake_get_high_precision_config(received_wrapper, algorithm, bits, high_bits, moe=False):
+        calls.append((received_wrapper, algorithm, bits, high_bits, moe))
         return expected
 
     monkeypatch.setattr(SelectiveMixedPrecision, "get_high_precision_config", fake_get_high_precision_config)
@@ -355,6 +748,7 @@ def test_get_k_quant_config_warns_and_delegates(monkeypatch):
             SelectiveMixedPrecision.Algorithm.K_QUANT_DOWN,
             PrecisionBits.BITS4,
             PrecisionBits.BITS8,
+            moe=True,
         )
 
     assert actual is expected
@@ -364,6 +758,7 @@ def test_get_k_quant_config_warns_and_delegates(monkeypatch):
             SelectiveMixedPrecision.Algorithm.HIGH_PRECISION_MLP_DOWN,
             PrecisionBits.BITS4,
             PrecisionBits.BITS8,
+            True,
         )
     ]
 


### PR DESCRIPTION
## Describe your changes

Add explicit, fail-closed fused-MoE support to the fixed `SelectiveMixedPrecision` heuristics.

- Add `moe: true` support to `high_precision_mlp_down` and `high_precision_mlp_down_qkv` for explicitly recognized Qwen3/Qwen3.5 fused K-last expert layouts.
- Resolve the routed expert output projection through `LayerWrapper` and canonical `iter_quant_targets` identities, emitting whole per-layer `experts.down_proj` overrides rather than per-expert precision.
- Keep `high_precision_lm_head` as a legal MoE no-op, and reject score-based algorithms with `moe: true` until their parameter-level scoring is implemented separately.
- Add `mixed_precision_info.requires_moe` and require an explicit `moe: true` on the first MoE-capable RTN, GPTQ, or KQuant consumer. Validate that required expert overrides survive skip/component selection and are actually selected or already materialized before mutating parameters.
- Preserve AutoClip and follow-up category-pass composition, prevent persisted metadata from enabling/disabling the consumer’s MoE setting, and reject malformed or stale MoE metadata.
- Keep routers and shared-expert gates unquantized; shared-expert MLP weights remain at the default precision. ModuleList experts, unknown/transposed layouts, score-based MoE selection, and ONNX/Mobius export are intentionally out of scope.

This is the first implementation stage for #2638. A follow-up will generalize SNR/IQE scoring to fused parameter targets; KLD-gradient requires separate routing/gradient/memory design.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [x] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`.
- [x] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

Release note: `SelectiveMixedPrecision` fixed heuristics can now plan higher precision for supported fused Qwen MoE expert output projections with explicit downstream MoE opt-in and fail-closed validation.

## (Optional) Issue link

Part of #2638.