### PR TITLE
Fix boolean parsing for capture-onnx-graph options

### DIFF
--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -37,6 +37,19 @@ def parse_dim_dict(s):
         raise argparse.ArgumentTypeError("Format must be key=value,... with positive integers as values") from exc
 
 
+def parse_bool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in {"true", "1", "yes", "on"}:
+        return True
+    if normalized in {"false", "0", "no", "off"}:
+        return False
+
+    raise argparse.ArgumentTypeError(f"invalid boolean value: {value!r}")
+
+
 class CaptureOnnxGraphCommand(BaseOliveCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
@@ -147,21 +160,21 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
         )
         mb_group.add_argument(
             "--exclude_embeds",
-            type=bool,
+            type=parse_bool,
             default=False,
             required=False,
             help="Remove embedding layer from your ONNX model.",
         )
         mb_group.add_argument(
             "--exclude_lm_head",
-            type=bool,
+            type=parse_bool,
             default=False,
             required=False,
             help="Remove language modeling head from your ONNX model.",
         )
         mb_group.add_argument(
             "--enable_cuda_graph",
-            type=bool,
+            type=parse_bool,
             default=None,  # Explicitly setting to None to differentiate between user intent and default.
             required=False,
             help=(

--- a/olive/cli/capture_onnx.py
+++ b/olive/cli/capture_onnx.py
@@ -37,19 +37,6 @@ def parse_dim_dict(s):
         raise argparse.ArgumentTypeError("Format must be key=value,... with positive integers as values") from exc
 
 
-def parse_bool(value):
-    if isinstance(value, bool):
-        return value
-
-    normalized = value.lower()
-    if normalized in {"true", "1", "yes", "on"}:
-        return True
-    if normalized in {"false", "0", "no", "off"}:
-        return False
-
-    raise argparse.ArgumentTypeError(f"invalid boolean value: {value!r}")
-
-
 class CaptureOnnxGraphCommand(BaseOliveCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
@@ -160,23 +147,18 @@ class CaptureOnnxGraphCommand(BaseOliveCLICommand):
         )
         mb_group.add_argument(
             "--exclude_embeds",
-            type=parse_bool,
-            default=False,
-            required=False,
+            action="store_true",
             help="Remove embedding layer from your ONNX model.",
         )
         mb_group.add_argument(
             "--exclude_lm_head",
-            type=parse_bool,
-            default=False,
-            required=False,
+            action="store_true",
             help="Remove language modeling head from your ONNX model.",
         )
         mb_group.add_argument(
             "--enable_cuda_graph",
-            type=parse_bool,
+            action="store_true",
             default=None,  # Explicitly setting to None to differentiate between user intent and default.
-            required=False,
             help=(
                 "The model can use CUDA graph capture for CUDA execution provider. "
                 "If enabled, all nodes being placed on the CUDA EP is the prerequisite "

--- a/test/cli/test_capture_onnx_args.py
+++ b/test/cli/test_capture_onnx_args.py
@@ -1,0 +1,49 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import argparse
+
+import pytest
+
+from olive.cli.capture_onnx import CaptureOnnxGraphCommand
+
+
+def _parse_capture_args(*args):
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers()
+    CaptureOnnxGraphCommand.register_subcommand(commands)
+    return parser.parse_args(["capture-onnx-graph", *args])
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_capture_onnx_boolean_arguments(value, expected):
+    args = _parse_capture_args(
+        "--exclude_embeds",
+        value,
+        "--exclude_lm_head",
+        value,
+        "--enable_cuda_graph",
+        value,
+    )
+
+    assert args.exclude_embeds is expected
+    assert args.exclude_lm_head is expected
+    assert args.enable_cuda_graph is expected
+
+
+def test_capture_onnx_boolean_arguments_reject_invalid_value():
+    with pytest.raises(SystemExit):
+        _parse_capture_args("--exclude_embeds", "not-a-bool")

--- a/test/cli/test_capture_onnx_args.py
+++ b/test/cli/test_capture_onnx_args.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------
 import argparse
 
-import pytest
-
 from olive.cli.capture_onnx import CaptureOnnxGraphCommand
 
 
@@ -16,34 +14,21 @@ def _parse_capture_args(*args):
     return parser.parse_args(["capture-onnx-graph", *args])
 
 
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("true", True),
-        ("1", True),
-        ("yes", True),
-        ("on", True),
-        ("false", False),
-        ("0", False),
-        ("no", False),
-        ("off", False),
-    ],
-)
-def test_capture_onnx_boolean_arguments(value, expected):
+def test_capture_onnx_boolean_flags_default_to_disabled():
+    args = _parse_capture_args()
+
+    assert args.exclude_embeds is False
+    assert args.exclude_lm_head is False
+    assert args.enable_cuda_graph is None
+
+
+def test_capture_onnx_boolean_flags_enable_on_presence():
     args = _parse_capture_args(
         "--exclude_embeds",
-        value,
         "--exclude_lm_head",
-        value,
         "--enable_cuda_graph",
-        value,
     )
 
-    assert args.exclude_embeds is expected
-    assert args.exclude_lm_head is expected
-    assert args.enable_cuda_graph is expected
-
-
-def test_capture_onnx_boolean_arguments_reject_invalid_value():
-    with pytest.raises(SystemExit):
-        _parse_capture_args("--exclude_embeds", "not-a-bool")
+    assert args.exclude_embeds is True
+    assert args.exclude_lm_head is True
+    assert args.enable_cuda_graph is True


### PR DESCRIPTION
## Describe your changes

Fixes boolean argument parsing for `capture-onnx-graph`.

The `--exclude_embeds`, `--exclude_lm_head`, and `--enable_cuda_graph` options used `type=bool`. With argparse, values such as `false` are non-empty strings and therefore evaluate to `True`.

These options now use argparse's standard `store_true` flag semantics: absence leaves the option disabled (or `None` for `enable_cuda_graph`, preserving its existing tri-state default), while presence enables it.

Regression tests cover both default and enabled states.

## Checklist before requesting a review
- [x] Add unit tests for this change.
- [x] Make sure focused validation passes (`ruff` and direct parser smoke test).
- [x] Update documents if necessary. No documentation change required.
