### PR TITLE
Fix run-pass list failure exit status

### DIFF
--- a/olive/cli/run_pass.py
+++ b/olive/cli/run_pass.py
@@ -198,6 +198,7 @@ class RunPassCommand(BaseOliveCLICommand):
         except Exception as e:
             print(f"Error loading pass configurations: {e}")
             print("Unable to list available passes.")
+            raise SystemExit(1) from e
 
 
 # Template configuration for the one command

--- a/test/cli/test_run_pass_exit_status.py
+++ b/test/cli/test_run_pass_exit_status.py
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from argparse import ArgumentParser
+from unittest.mock import patch
+
+import pytest
+
+from olive.cli.run_pass import RunPassCommand
+
+
+def test_list_passes_failure_exits_nonzero():
+    parser = ArgumentParser()
+    sub_parsers = parser.add_subparsers()
+    RunPassCommand.register_subcommand(sub_parsers)
+    args = parser.parse_args(["run-pass", "--list-passes"])
+    command = RunPassCommand(parser, args)
+
+    with patch("olive.package_config.OlivePackageConfig.load_default_config", side_effect=RuntimeError("broken config")):
+        with pytest.raises(SystemExit) as exc_info:
+            command._list_passes()
+
+    assert exc_info.value.code == 1

--- a/test/cli/test_run_pass_exit_status.py
+++ b/test/cli/test_run_pass_exit_status.py
@@ -17,8 +17,10 @@ def test_list_passes_failure_exits_nonzero():
     args = parser.parse_args(["run-pass", "--list-passes"])
     command = RunPassCommand(parser, args)
 
-    with patch("olive.package_config.OlivePackageConfig.load_default_config", side_effect=RuntimeError("broken config")):
-        with pytest.raises(SystemExit) as exc_info:
-            command.run()
+    config_error = patch(
+        "olive.package_config.OlivePackageConfig.load_default_config", side_effect=RuntimeError("broken config")
+    )
+    with config_error, pytest.raises(SystemExit) as exc_info:
+        command.run()
 
     assert exc_info.value.code == 1

--- a/test/cli/test_run_pass_exit_status.py
+++ b/test/cli/test_run_pass_exit_status.py
@@ -19,6 +19,6 @@ def test_list_passes_failure_exits_nonzero():
 
     with patch("olive.package_config.OlivePackageConfig.load_default_config", side_effect=RuntimeError("broken config")):
         with pytest.raises(SystemExit) as exc_info:
-            command._list_passes()
+            command.run()
 
     assert exc_info.value.code == 1


### PR DESCRIPTION
## Describe your changes

`olive run-pass --list-passes` catches errors while loading the pass configuration, prints an error, and then returns normally. The CLI therefore exits with status 0 even though the requested operation failed, which can make scripts and CI treat a failure as success.

This change preserves the existing diagnostics but exits with status 1 when pass configuration loading fails.

## Tests

Adds a regression test that simulates a configuration-loading failure and asserts a non-zero exit status.

## Checklist before requesting a review

- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary. No documentation change required.