### PR TITLE
Fix shared-cache option naming consistency

### DIFF
--- a/olive/cli/shared_cache.py
+++ b/olive/cli/shared_cache.py
@@ -32,12 +32,14 @@ class SharedCacheCommand(BaseOliveCLICommand):
             help="Confirm the deletion without prompting for confirmation.",
         )
         sub_parser.add_argument(
+            "--account_name",
             "--account",
             type=str,
             required=True,
             help="The account name for the shared cache.",
         )
         sub_parser.add_argument(
+            "--container_name",
             "--container",
             type=str,
             required=True,
@@ -53,7 +55,7 @@ class SharedCacheCommand(BaseOliveCLICommand):
 
     @action
     def run(self):
-        container_client_factory = AzureContainerClientFactory(self.args.account, self.args.container)
+        container_client_factory = AzureContainerClientFactory(self.args.account_name, self.args.container_name)
         if self.args.delete:
             if self.args.all:
                 if self.args.yes:

--- a/olive/cli/shared_cache.py
+++ b/olive/cli/shared_cache.py
@@ -65,4 +65,6 @@ class SharedCacheCommand(BaseOliveCLICommand):
                     if confirm.lower() == "y":
                         container_client_factory.delete_all()
             else:
+                if not self.args.model_hash:
+                    raise ValueError("--model_hash is required when --delete is used without --all")
                 container_client_factory.delete_blob(self.args.model_hash)

--- a/test/cli/test_shared_cache.py
+++ b/test/cli/test_shared_cache.py
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from argparse import ArgumentParser
+
+import pytest
+
+from olive.cli.shared_cache import SharedCacheCommand
+
+
+def _parse_shared_cache_args(*args: str):
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers()
+    SharedCacheCommand.register_subcommand(subparsers)
+    return parser.parse_args(["shared-cache", *args])
+
+
+@pytest.mark.parametrize(
+    "account_option,container_option",
+    [
+        ("--account_name", "--container_name"),
+        ("--account", "--container"),
+    ],
+)
+def test_shared_cache_accepts_consistent_and_legacy_option_names(account_option: str, container_option: str):
+    args = _parse_shared_cache_args(account_option, "account", container_option, "container")
+
+    assert args.account_name == "account"
+    assert args.container_name == "container"

--- a/test/cli/test_shared_cache.py
+++ b/test/cli/test_shared_cache.py
@@ -28,3 +28,18 @@ def test_shared_cache_accepts_consistent_and_legacy_option_names(account_option:
 
     assert args.account_name == "account"
     assert args.container_name == "container"
+
+
+def test_shared_cache_delete_requires_model_hash():
+    args = _parse_shared_cache_args(
+        "--delete",
+        "--account_name",
+        "account",
+        "--container_name",
+        "container",
+    )
+    command = object.__new__(SharedCacheCommand)
+    command.args = args
+
+    with pytest.raises(ValueError, match="--model_hash is required"):
+        command.run()

--- a/test/cli/test_shared_cache.py
+++ b/test/cli/test_shared_cache.py
@@ -17,7 +17,7 @@ def _parse_shared_cache_args(*args: str):
 
 
 @pytest.mark.parametrize(
-    "account_option,container_option",
+    ("account_option", "container_option"),
     [
         ("--account_name", "--container_name"),
         ("--account", "--container"),


### PR DESCRIPTION
## Describe your changes

The standalone `olive shared-cache` command uses `--account` and `--container`, while Olive's shared-cache options elsewhere use `--account_name` and `--container_name`. Equivalent shared-cache configuration therefore uses different CLI names depending on the command.

This change makes `--account_name` and `--container_name` the canonical option names for `shared-cache` while retaining `--account` and `--container` as backward-compatible aliases, so existing scripts continue to work.

This addresses the shared-cache CLI consistency finding in #2516.

## Tests

Adds parser coverage for both the consistent option names and the legacy aliases.

## Checklist before requesting a review

- [x] Add unit tests for this change.
- [ ] Make sure all tests can pass.
- [x] Update documents if necessary. No documentation change required.