### PR TITLE
Update Olive version

### DIFF
--- a/olive/version.py
+++ b/olive/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.0.dev0"
+__version__ = "0.13.0.dev0"


### PR DESCRIPTION
## Update Olive version

The version identifier in Olvie doesn't seem to have been update since the last release. v0.11.0 wasn't compatible with Python v3.12 and caused the docs build to fail.

Updating it to next dev build release identifier.

## Checklist before requesting a review
- [ ] Add unit tests for this change.
- [x] Make sure all tests can pass.
- [ ] Update documents if necessary.
- [x] Lint and apply fixes to your code by running `lintrunner -a`
- [ ] Is this a user-facing change? If yes, give a description of this change to be included in the release notes.

## (Optional) Issue link
