### PR TITLE
Support current GenAI composite model exports

### DIFF
--- a/olive/passes/onnx/common.py
+++ b/olive/passes/onnx/common.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import re
+import shutil
 from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import Path
@@ -339,6 +340,22 @@ def change_external_data_location(model_proto: onnx.ModelProto, new_location: st
             tensor.ClearField("raw_data")
 
 
+def change_external_data_locations(model_proto: onnx.ModelProto, locations: dict[str, str]):
+    """Change each external data location according to a source-to-destination mapping."""
+    for tensor in external_data_helper._get_all_tensors(model_proto):  # pylint: disable=W0212
+        if external_data_helper.uses_external_data(tensor):
+            info = external_data_helper.ExternalDataInfo(tensor)
+            tensor.raw_data = b""
+            external_data_helper.set_external_data(
+                tensor,
+                locations[info.location],
+                offset=info.offset,
+                length=info.length,
+                checksum=info.checksum,
+            )
+            tensor.ClearField("raw_data")
+
+
 def get_context_bin_file_names(model_path: Union[str, Path]) -> list[str]:
     """Get the context binary file names from the model.
 
@@ -440,8 +457,24 @@ def resave_model(
         return has_cb_files or False
 
     if len(external_file_names) > 1:
-        # save the model with single external data file
-        model_proto_to_file(onnx.load(model_path), new_model_path, save_as_external_data=True)
+        new_locations = {}
+        used_names = set(saved_external_files.values())
+        for index, external_file_name in enumerate(sorted(external_file_names)):
+            external_file_path = str((model_path.parent / external_file_name).resolve())
+            if external_file_path in saved_external_files:
+                new_external_file_name = saved_external_files[external_file_path]
+            else:
+                new_external_file_name = Path(external_file_name).name
+                if new_external_file_name in used_names:
+                    new_external_file_name = f"{new_model_path.stem}.{index}.{new_external_file_name}"
+                shutil.copy2(external_file_path, new_model_path.parent / new_external_file_name)
+                saved_external_files[external_file_path] = new_external_file_name
+                used_names.add(new_external_file_name)
+            new_locations[external_file_name] = new_external_file_name
+
+        model_proto = onnx.load(model_path, load_external_data=False)
+        change_external_data_locations(model_proto, new_locations)
+        model_proto_to_file(model_proto, new_model_path)
         return True
 
     external_file_path = str(model_path.parent / external_file_names[0])
@@ -451,7 +484,7 @@ def resave_model(
     else:
         new_external_file_name = f"{new_model_path.name}.data"
         # copy the external data file to the new location
-        hardlink_copy_file(external_file_path, new_model_path.parent / new_external_file_name)
+        shutil.copy2(external_file_path, new_model_path.parent / new_external_file_name)
         # update the saved external files mapping
         saved_external_files[external_file_path] = new_external_file_name
 

--- a/olive/passes/onnx/model_builder.py
+++ b/olive/passes/onnx/model_builder.py
@@ -494,7 +494,13 @@ class ModelBuilder(Pass):
         if version.parse(genai_version) < version.parse("0.9.0"):
             return
 
-        quantized_model = importlib.import_module("onnxruntime_genai.models.quantized_model")
+        try:
+            quantized_model = importlib.import_module("onnxruntime_genai.models.quantized_model")
+        except ModuleNotFoundError as exc:
+            if exc.name != "onnxruntime_genai.models.quantized_model":
+                raise
+            logger.debug("Skipping the legacy quantized-model patch for onnxruntime-genai %s", genai_version)
+            return
         quantized_model.OliveModel.__init__ = OliveQuantizedModel.__init__
 
         # base.py uses "from quantized_model import QuantModel" which resolves to a different module

--- a/test/passes/onnx/test_common.py
+++ b/test/passes/onnx/test_common.py
@@ -3,6 +3,9 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import os
+
+import numpy as np
 import onnx
 import pytest
 
@@ -10,6 +13,7 @@ from olive.common.utils import is_hardlink
 from olive.passes.olive_pass import create_pass_from_dict
 from olive.passes.onnx.common import (
     add_version_metadata_to_model_proto,
+    get_external_data_file_names,
     model_proto_to_olive_model,
     resave_model,
 )
@@ -56,6 +60,7 @@ def test_resave_model(has_external_data, tmp_path):
     assert resave_path.exists()
     if has_external_data:
         assert (resave_path.parent / "resave.onnx.data").exists()
+        assert not is_hardlink(resave_path.parent / "resave.onnx.data")
 
     input_model = onnx.load(input_model.model_path)
     resaved_model = onnx.load(resave_path)
@@ -64,3 +69,30 @@ def test_resave_model(has_external_data, tmp_path):
         input_model = add_version_metadata_to_model_proto(input_model)
 
     assert resaved_model == input_model
+
+
+def test_resave_model_preserves_multiple_external_files(tmp_path):
+    input_path = tmp_path / "input" / "model.onnx"
+    input_path.parent.mkdir()
+    first = onnx.numpy_helper.from_array(np.ones((2, 2), dtype="float32"), "first")
+    second = onnx.numpy_helper.from_array(np.ones((2, 2), dtype="float32"), "second")
+    graph = onnx.helper.make_graph([], "external", [], [], initializer=[first, second])
+    model = onnx.helper.make_model(graph)
+    onnx.save_model(
+        model,
+        input_path,
+        save_as_external_data=True,
+        all_tensors_to_one_file=False,
+        size_threshold=0,
+    )
+    input_external_files = get_external_data_file_names(input_path)
+    os.link(input_path.parent / input_external_files[0], tmp_path / "hardlink")
+
+    output_path = tmp_path / "output" / "model.onnx"
+    resave_model(input_path, output_path)
+
+    external_files = get_external_data_file_names(output_path)
+    assert len(external_files) == 2
+    assert all((output_path.parent / name).exists() for name in external_files)
+    assert all(not is_hardlink(output_path.parent / name) for name in external_files)
+    onnx.load(output_path)

--- a/test/passes/onnx/test_model_builder.py
+++ b/test/passes/onnx/test_model_builder.py
@@ -44,6 +44,21 @@ def _mock_genai_builder(monkeypatch, create_model_fn, check_extra_options_fn=Non
     monkeypatch.setattr(ModelBuilder, "maybe_patch_quant", staticmethod(lambda: None))
 
 
+def test_model_builder_skips_removed_legacy_quantized_model(monkeypatch):
+    genai_module = types.ModuleType("onnxruntime_genai")
+    genai_module.__version__ = "0.16.0-dev"
+    monkeypatch.setitem(sys.modules, "onnxruntime_genai", genai_module)
+
+    with patch(
+        "olive.passes.onnx.model_builder.importlib.import_module",
+        side_effect=ModuleNotFoundError(
+            "No module named 'onnxruntime_genai.models.quantized_model'",
+            name="onnxruntime_genai.models.quantized_model",
+        ),
+    ):
+        ModelBuilder.maybe_patch_quant()
+
+
 @pytest.mark.parametrize("metadata_only", [True, False])
 def test_model_builder(tmp_path, metadata_only):
     input_model = make_local_tiny_llama(tmp_path / "input_model", "onnx" if metadata_only else "hf")


### PR DESCRIPTION
## Summary

- skip Olive's legacy quantized-model monkey patch when current ONNX Runtime GenAI no longer provides that exact module
- preserve and independently copy multiple ONNX external-data files when materializing composite models
- avoid hardlinking external payloads so ONNX security checks accept artifacts whose source payload already has another hardlink

## Validation

- exported Qwen3.8-27B with INT4 weights, INT4 per-channel paged KV, and an INT4 DFlash2 drafter through Olive 0.11 + current GenAI
- `test_resave_model_preserves_multiple_external_files`: 1 passed
- `test_model_builder_skips_removed_legacy_quantized_model`: 1 passed
- standalone one-file and two-file external-data reproductions pass; output payloads have link count 1 and reload with `onnx.load`
- exact missing legacy module is skipped; nested `ModuleNotFoundError` still propagates
- Ruff check (excluding unchanged repository `CPY001` header findings) and Ruff format check pass

The focused tests use `--confcutdir=test/passes/onnx` in the export environment to avoid the repository's unrelated optional top-level `peft` fixture.